### PR TITLE
ci: add trusted npm release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,71 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    concurrency:
+      group: npm-release-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+          cache: npm
+
+      - name: Verify tag matches package version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) must match package.json version ($PKG_VERSION)."
+            exit 1
+          fi
+
+      - name: Verify release commit is on main
+        run: |
+          git fetch origin main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" "origin/main"; then
+            echo "Release tag commit is not contained in origin/main."
+            exit 1
+          fi
+
+      - run: npm ci
+
+      - name: Guard against duplicate publish
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          if npm view "open-agreements@$VERSION" version >/dev/null 2>&1; then
+            echo "open-agreements@$VERSION already exists on npm."
+            exit 1
+          fi
+          echo "Version $VERSION not yet published."
+
+      - name: Build
+        run: npm run build
+
+      - name: Validate templates
+        run: npm run validate
+
+      - name: Run tests (includes OpenSpec traceability check)
+        run: npm run test:run
+
+      - name: Verify package contents
+        run: npm pack --dry-run
+
+      - name: Publish to npm (trusted publishing + provenance)
+        run: npm publish --provenance --access public

--- a/README.md
+++ b/README.md
@@ -190,6 +190,20 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for how to add templates, recipes, and ot
 - [Adding templates](docs/adding-templates.md) (CC BY 4.0 / CC0 sources)
 - [Adding recipes](docs/adding-recipes.md) (non-redistributable sources)
 
+## Releasing
+
+Releases are automated through GitHub Actions using npm trusted publishing (OIDC) with provenance enabled.
+
+1. Update version with `npm version patch` (or `minor` / `major`)
+2. Push commit + tag with `git push origin main --tags`
+3. The `Release` workflow publishes from the tag after running build, validation, tests, and package checks
+
+Workflow guardrails:
+
+- tag must match `package.json` version (for example, `v0.1.1`)
+- release commit must be contained in `origin/main`
+- publish fails if that npm version already exists
+
 ## Architecture
 
 - **Language**: TypeScript


### PR DESCRIPTION
## Summary
- add tag-triggered `Release` workflow at `.github/workflows/release.yml`
- use npm trusted publishing with OIDC and provenance (`npm publish --provenance`)
- enforce guardrails before publish:
  - tag version must match `package.json` version
  - release commit must be on `origin/main`
  - version must not already exist on npm
  - build, template validation, tests, and package dry-run must pass
- document release steps in `README.md`

## Why this is the safer path
- no long-lived npm token required
- provenance attestation on published package
- deterministic, tag-driven release gate
