### PR TITLE
Update init CLI to suggest-only mode with topic-first planning

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ This package is intentionally separate from `open-agreements` so teams can adopt
 
 Core workspace features:
 
-- lifecycle-first `init` (`forms/`, `drafts/`, `incoming/`, `executed/`, `archive/`)
+- topic-first `init` planning (minimal suggested structure with top-level domains)
 - forms catalog with URL + SHA-256 validation
 - YAML status indexing and linting with filename-driven `_executed` status
 

--- a/docs/contracts-workspace.md
+++ b/docs/contracts-workspace.md
@@ -10,7 +10,7 @@ The contracts workspace CLI is a separate package focused on filesystem-based co
 
 `open-agreements` is optimized for template/recipe filling. The workspace CLI handles repository-level workflows:
 
-- lifecycle-first folder scaffolding
+- topic-first structure planning/suggestions
 - forms catalog validation/download (URL + checksum)
 - filename-driven execution status
 - YAML status indexing + linting
@@ -21,18 +21,20 @@ Teams can use one package without requiring the other.
 
 ### `init`
 
-Scaffold a workspace in the current directory.
+Preview a workspace setup in the current directory. This command does not create folders/files automatically.
 
 ```bash
 open-agreements-workspace init --agents claude,gemini
 ```
 
-Creates:
+Suggests:
 
-- `forms/`, `drafts/`, `incoming/`, `executed/`, `archive/`
-- topic folders under `forms/`
+- top-level topic folders
 - `CONTRACTS.md`
 - `forms-catalog.yaml`
+- `WORKSPACE.md`
+- `.contracts-workspace/conventions.yaml`
+- `contracts-index.yaml` (generate with `status generate`)
 - optional snippets under `.contracts-workspace/agents/`
 
 ### `catalog validate`
@@ -110,6 +112,6 @@ claude mcp add --transport stdio open-agreements-workspace-mcp -- node /ABSOLUTE
 ### Demo flow
 
 1. Create a demo folder (for example, `/tmp/oa-demo-workspace`).
-2. Call `workspace_init` with `{"root_dir":"/tmp/oa-demo-workspace","agents":["claude","gemini"]}`.
+2. Call `workspace_init` with `{"root_dir":"/tmp/oa-demo-workspace","agents":["claude","gemini"]}` and create the suggested folders/files.
 3. Call `status_generate` with `{"root_dir":"/tmp/oa-demo-workspace"}`.
-4. Add a sample file in `forms/` and call `status_lint` to show rule detection.
+4. Add a sample file in a topic folder and call `status_lint` to show rule detection.

--- a/packages/contracts-workspace/README.md
+++ b/packages/contracts-workspace/README.md
@@ -1,12 +1,12 @@
 # @open-agreements/contracts-workspace
 
-Lifecycle-first workspace CLI for organizing, cataloging, and tracking contract files.
+Topic-first workspace CLI for organizing, cataloging, and tracking contract files.
 
 ## Scope
 
 This package focuses on repository/workspace operations:
 
-- `init` scaffolds lifecycle folders and `CONTRACTS.md`
+- `init` previews a minimal topic-first structure and suggests setup actions (no auto-write)
 - `catalog` validates and fetches forms from URL + checksum catalog entries
 - `status` generates `contracts-index.yaml` and lints workspace structure
 
@@ -29,12 +29,14 @@ open-agreements-workspace status generate
 open-agreements-workspace status lint
 ```
 
-## Files Created by `init`
+## Structure Suggested by `init`
 
-- `forms/`, `drafts/`, `incoming/`, `executed/`, `archive/`
-- topic folders under `forms/`
+- top-level topic folders (for example, `Vendor Agreements/`, `Employment and Human Resources/`)
 - `CONTRACTS.md`
 - `forms-catalog.yaml`
+- `WORKSPACE.md`
+- `.contracts-workspace/conventions.yaml`
+- `contracts-index.yaml` (generated via `status generate`)
 - optional snippets under `.contracts-workspace/agents/`
 
 ## Status Conventions

--- a/packages/contracts-workspace/src/commands/init.ts
+++ b/packages/contracts-workspace/src/commands/init.ts
@@ -1,35 +1,60 @@
 import { resolve } from 'node:path';
 import type { Command } from 'commander';
-import { initializeWorkspace } from '../core/workspace-structure.js';
+import { planWorkspaceInitialization } from '../core/workspace-structure.js';
 import type { AgentName } from '../core/types.js';
 
 export function registerInitCommand(program: Command): void {
   program
     .command('init')
-    .description('Initialize a lifecycle-first contracts workspace in the current directory')
+    .description('Preview topic-first contracts workspace structure and suggested setup actions')
     .option('--agents <agents>', 'Comma-separated agent setup snippets to generate (claude,gemini)')
-    .option('--topics <topics>', 'Comma-separated topic folders to scaffold under forms/')
+    .option('--topics <topics>', 'Comma-separated top-level topic folders to suggest')
     .action((opts: { agents?: string; topics?: string }) => {
       const rootDir = process.cwd();
       const agents = parseAgents(opts.agents);
       const topics = parseCsv(opts.topics);
 
-      const result = initializeWorkspace(rootDir, {
+      const result = planWorkspaceInitialization(rootDir, {
         agents,
         topics: topics.length > 0 ? topics : undefined,
       });
 
-      console.log(`Initialized contracts workspace at ${resolve(rootDir)}`);
-      console.log(`Created directories: ${result.createdDirectories.length}`);
-      console.log(`Created files: ${result.createdFiles.length}`);
+      console.log(`Workspace initialization preview for ${resolve(rootDir)}`);
+      console.log('No files or directories were created.');
+      console.log(`Missing directories: ${result.missingDirectories.length}`);
+      console.log(`Missing files: ${result.missingFiles.length}`);
+
+      if (result.missingDirectories.length > 0) {
+        console.log('Suggested directories to create:');
+        for (const directory of result.missingDirectories) {
+          console.log(`- ${directory}`);
+        }
+      }
+
+      if (result.missingFiles.length > 0) {
+        console.log('Suggested files to create or generate:');
+        for (const file of result.missingFiles) {
+          console.log(`- ${file}`);
+        }
+      }
+
       if (result.agentInstructions.length > 0) {
         console.log('Agent setup snippets:');
         for (const line of result.agentInstructions) {
           console.log(`- ${line}`);
         }
       }
-      if (result.createdDirectories.length === 0 && result.createdFiles.length === 0) {
-        console.log('Workspace already initialized; no new files were created.');
+
+      console.log(`Lint findings: ${result.lint.errorCount} errors, ${result.lint.warningCount} warnings`);
+      if (result.suggestedCommands.length > 0) {
+        console.log('Suggested next commands:');
+        for (const command of result.suggestedCommands) {
+          console.log(`- ${command}`);
+        }
+      }
+
+      if (result.missingDirectories.length === 0 && result.missingFiles.length === 0) {
+        console.log('Workspace already matches the expected structure.');
       }
     });
 }

--- a/packages/contracts-workspace/src/core/types.ts
+++ b/packages/contracts-workspace/src/core/types.ts
@@ -16,6 +16,19 @@ export interface InitWorkspaceResult {
   agentInstructions: string[];
 }
 
+export interface InitWorkspacePlanResult {
+  rootDir: string;
+  suggestedDirectories: string[];
+  existingDirectories: string[];
+  missingDirectories: string[];
+  suggestedFiles: string[];
+  existingFiles: string[];
+  missingFiles: string[];
+  agentInstructions: string[];
+  suggestedCommands: string[];
+  lint: LintReport;
+}
+
 export interface LintFinding {
   code: string;
   severity: 'error' | 'warning';

--- a/packages/contracts-workspace/src/index.ts
+++ b/packages/contracts-workspace/src/index.ts
@@ -1,4 +1,10 @@
-export { initializeWorkspace, inferLifecycle, buildWorkspaceMd, buildFolderMd } from './core/workspace-structure.js';
+export {
+  initializeWorkspace,
+  planWorkspaceInitialization,
+  inferLifecycle,
+  buildWorkspaceMd,
+  buildFolderMd,
+} from './core/workspace-structure.js';
 export { validateCatalog, loadCatalog, writeCatalog, fetchCatalogEntries, checksumSha256 } from './core/catalog.js';
 export { lintWorkspace } from './core/lint.js';
 export { collectWorkspaceDocuments, buildStatusIndex, writeStatusIndex, hasExecutedMarker, hasPartiallyExecutedMarker } from './core/indexer.js';
@@ -10,6 +16,7 @@ export { scanExistingConventions } from './core/convention-scanner.js';
 export type {
   AgentName,
   InitWorkspaceOptions,
+  InitWorkspacePlanResult,
   InitWorkspaceResult,
   LintFinding,
   LintReport,


### PR DESCRIPTION
## Summary
- CLI `init` command now calls `planWorkspaceInitialization` instead of `initializeWorkspace`
- Prints suggested directories, files, lint findings, and next commands without creating anything
- Adds `InitWorkspacePlanResult` type and exports it from the package
- Updates README and docs to reflect topic-first structure ("suggest" instead of "scaffold")

Companion to PR #18 which changed the core init to stop auto-creating lifecycle directories.

## Test plan
- [x] All 361 tests pass
- [x] Build succeeds
- [x] Spec coverage passes (66 scenarios)