### PR TITLE
Add code of conduct and community policy docs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,48 @@
+# Code of Conduct
+
+By contributing to OpenAgreements, you agree to comply with this Code of Conduct.
+
+You are free to contribute to this repository or participate in discussions relating to this repository as you see fit, so long as you are a good human, act responsibly, comply with the law, do not harm people or property, and respect our guardrails.
+
+## Legal and Responsible Use
+
+Do not use this project for unlawful or abusive conduct, including:
+
+- Violating copyright, trademark, or other intellectual property law
+- Violating a person's privacy or right of publicity
+- The sexualization or exploitation of children
+- Operating in a regulated industry or region without required compliance
+- Defrauding, defaming, scamming, or spamming
+- Espionage, spying, stalking, trespassing, or phishing
+
+## Do Not Harm People or Property
+
+Do not use this project to:
+
+- Critically harm, or promote critically harming, human life (yours or anyone else's)
+- Take unauthorized actions on behalf of others
+- Destroy property
+
+## Respect Guardrails and Do Not Mislead
+
+- Do not circumvent safeguards unless you are part of an official red-team engagement or otherwise have explicit maintainer approval.
+- Do not mislead people about the nature or source of outputs, including images.
+- Be transparent about AI assistance and potential limitations when relevant.
+
+## Enforcement
+
+Maintainers may remove content, lock threads, or block contributors who violate this Code.
+
+## Reporting
+
+Report concerns to `steven@usejunior.com`.
+
+## License
+
+Copyright (c) OpenAgreements contributors.
+
+This Code of Conduct is licensed under Creative Commons Attribution 4.0 International (CC BY 4.0): https://creativecommons.org/licenses/by/4.0/
+
+## Source
+
+Adapted from xAI Acceptable Use Policy (effective January 2, 2025): https://x.ai/legal/acceptable-use-policy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Thanks for your interest in contributing! OpenAgreements is an open-source tool for filling standard legal agreement templates. Contributions of new templates, recipe improvements, bug fixes, and documentation are welcome.
 
+Please follow our [Code of Conduct](CODE_OF_CONDUCT.md) in all project spaces.
+
 ## Ways to Contribute
 
 ### Add a Template

--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for how to add templates, recipes, and ot
 - [Adding templates](docs/adding-templates.md) (CC BY 4.0 / CC0 sources)
 - [Adding recipes](docs/adding-recipes.md) (non-redistributable sources)
 - [Employment source policy](docs/employment-source-policy.md) (trust and terms classifications)
+- [Code of Conduct](CODE_OF_CONDUCT.md) (community expectations and enforcement)
 
 ## Releasing
 


### PR DESCRIPTION
## Summary
- Add CODE_OF_CONDUCT.md based on the Contributor Covenant
- Link the code of conduct from CONTRIBUTING.md and README.md so contributors can find it easily

## Test plan
- [ ] Verify CODE_OF_CONDUCT.md renders correctly on GitHub
- [ ] Verify links in CONTRIBUTING.md and README.md point to the code of conduct