### PR TITLE
Validate MCP args with Zod and support structured fill values

### DIFF
--- a/api/_shared.ts
+++ b/api/_shared.ts
@@ -137,7 +137,7 @@ function mapFields(
 
 export async function handleFill(
   template: string,
-  values: Record<string, string>,
+  values: Record<string, unknown>,
 ): Promise<FillOutcome> {
   const internalDir = findTemplateDir(template);
   const externalDir = !internalDir ? findExternalDir(template) : undefined;
@@ -247,7 +247,7 @@ export interface DownloadPayload {
   /** template ID */
   t: string;
   /** field values */
-  v: Record<string, string>;
+  v: Record<string, unknown>;
   /** expiry (epoch ms) */
   e: number;
 }
@@ -255,7 +255,7 @@ export interface DownloadPayload {
 /** Create a signed download token encoding template + values + expiry. */
 export function createDownloadToken(
   template: string,
-  values: Record<string, string>,
+  values: Record<string, unknown>,
 ): string {
   const payload: DownloadPayload = {
     t: template,

--- a/integration-tests/api-endpoints.test.ts
+++ b/integration-tests/api-endpoints.test.ts
@@ -415,7 +415,7 @@ describe('MCP endpoint — api/mcp.ts', () => {
 
     const result = (res.body as any).result;
     expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain('required');
+    expect(result.content[0].text.toLowerCase()).toContain('required');
   });
 
   it('returns error for fill_template when handleFill fails', async () => {


### PR DESCRIPTION
## Summary
- Add Zod validation for MCP tool arguments in the API layer
- Support structured (nested object) fill values alongside flat string values
- Update API shared utilities to handle the new value shapes

## Test plan
- [ ] Run `npx vitest integration-tests/api-endpoints.test.ts` to verify API endpoint behavior
- [ ] Test MCP fill tool with both flat string values and structured object values
- [ ] Verify invalid arguments are rejected with descriptive Zod validation errors