### PR TITLE
feat(site): expose Other template category and harden live status pill

### DIFF
--- a/site/_data/catalog.js
+++ b/site/_data/catalog.js
@@ -64,6 +64,13 @@ const CATEGORIES = [
       "NVCA model documents for Series A and later rounds.",
     match: (id) => id.startsWith("nvca-"),
   },
+  {
+    slug: "other",
+    label: "Other",
+    description: "Additional templates that do not map to the primary categories.",
+    // Catch-all bucket populated via fallback category assignment.
+    match: () => false,
+  },
 ];
 
 const LICENSE_FLAGS = {

--- a/site/index.njk
+++ b/site/index.njk
@@ -16,32 +16,37 @@ description: "Fill legal agreement templates with coding agents or local CLI exe
           <a class="btn btn-primary" href="#start">Installation instructions</a>
           <a class="btn btn-ghost" href="/templates">Browse templates</a>
         </div>
-        <div class="badge-row" id="trust">
-          <a class="trust-badge trust-badge-shield" href="https://www.npmjs.com/package/open-agreements" target="_blank" rel="noreferrer">
-            <span class="shield-segment shield-label">downloads</span>
-            <span class="shield-segment shield-value" data-npm-downloads>loading…</span>
-          </a>
-          <a class="trust-badge" href="https://www.npmjs.com/package/open-agreements" target="_blank" rel="noreferrer">
-            <img src="https://img.shields.io/npm/v/open-agreements?logo=npm&label=npm" alt="npm version" height="20" loading="lazy" />
-          </a>
-          <a class="trust-badge" href="https://github.com/open-agreements/open-agreements/actions/workflows/ci.yml?query=branch%3Amain" target="_blank" rel="noreferrer">
-            <img src="https://github.com/open-agreements/open-agreements/actions/workflows/ci.yml/badge.svg" alt="CI status" height="20" loading="lazy" />
-          </a>
-          <a class="trust-badge" href="https://github.com/open-agreements/open-agreements/actions/workflows/validate.yml?query=branch%3Amain" target="_blank" rel="noreferrer">
-            <img src="https://github.com/open-agreements/open-agreements/actions/workflows/validate.yml/badge.svg" alt="Template validation status" height="20" loading="lazy" />
-          </a>
-          <a class="trust-badge" href="https://app.codecov.io/gh/open-agreements/open-agreements" target="_blank" rel="noreferrer">
-            <img src="https://codecov.io/gh/open-agreements/open-agreements/graph/badge.svg" alt="Coverage status" height="20" loading="lazy" />
-          </a>
-          <a class="trust-badge" href="https://openagreements.openstatus.dev/" target="_blank" rel="noreferrer">
-            <img src="https://openagreements.openstatus.dev/badge/v2?variant=outline" alt="Live MCP status (OpenStatus)" height="20" loading="lazy" />
-          </a>
-          <a class="trust-badge" href="https://github.com/open-agreements/open-agreements" target="_blank" rel="noreferrer">
-            <img src="https://img.shields.io/badge/GitHub-open--agreements%2Fopen--agreements-181717?logo=github&logoColor=white" alt="GitHub repository" height="20" loading="lazy" />
-          </a>
-          <a class="trust-badge" href="https://github.com/open-agreements/open-agreements/stargazers" target="_blank" rel="noreferrer">
-            <img src="https://img.shields.io/github/stars/open-agreements/open-agreements?style=social&label=Star" alt="GitHub stargazers" height="20" loading="lazy" />
-          </a>
+        <div class="badge-stack" id="trust">
+          <div class="badge-row">
+            <a class="trust-badge trust-badge-shield" href="https://www.npmjs.com/package/open-agreements" target="_blank" rel="noreferrer">
+              <span class="shield-segment shield-label">downloads</span>
+              <span class="shield-segment shield-value" data-npm-downloads>loading…</span>
+            </a>
+            <a class="trust-badge" href="https://www.npmjs.com/package/open-agreements" target="_blank" rel="noreferrer">
+              <img src="https://img.shields.io/npm/v/open-agreements?logo=npm&label=npm" alt="npm version" height="20" loading="lazy" />
+            </a>
+            <a class="trust-badge" href="https://github.com/open-agreements/open-agreements/actions/workflows/ci.yml?query=branch%3Amain" target="_blank" rel="noreferrer">
+              <img src="https://github.com/open-agreements/open-agreements/actions/workflows/ci.yml/badge.svg" alt="CI status" height="20" loading="lazy" />
+            </a>
+            <a class="trust-badge" href="https://github.com/open-agreements/open-agreements/actions/workflows/validate.yml?query=branch%3Amain" target="_blank" rel="noreferrer">
+              <img src="https://github.com/open-agreements/open-agreements/actions/workflows/validate.yml/badge.svg" alt="Template validation status" height="20" loading="lazy" />
+            </a>
+            <a class="trust-badge" href="https://app.codecov.io/gh/open-agreements/open-agreements" target="_blank" rel="noreferrer">
+              <img src="https://codecov.io/gh/open-agreements/open-agreements/graph/badge.svg" alt="Coverage status" height="20" loading="lazy" />
+            </a>
+          </div>
+          <div class="badge-row">
+            <a class="trust-badge" href="https://github.com/open-agreements/open-agreements" target="_blank" rel="noreferrer">
+              <img src="https://img.shields.io/badge/GitHub-open--agreements%2Fopen--agreements-181717?logo=github&logoColor=white" alt="GitHub repository" height="20" loading="lazy" />
+            </a>
+            <a class="trust-badge" href="https://github.com/open-agreements/open-agreements/stargazers" target="_blank" rel="noreferrer">
+              <img src="https://img.shields.io/github/stars/open-agreements/open-agreements?style=social&label=Star" alt="GitHub stargazers" height="20" loading="lazy" />
+            </a>
+            <a class="trust-badge trust-badge-shield" data-live-status-pill href="https://openagreements.openstatus.dev/" target="_blank" rel="noreferrer">
+              <span class="shield-segment shield-label">Live MCP status</span>
+              <span class="shield-segment shield-value status-value is-checking" data-live-status-value aria-live="polite">checking…</span>
+            </a>
+          </div>
         </div>
       </section>
 

--- a/site/main.js
+++ b/site/main.js
@@ -46,6 +46,134 @@ fetchDownloadStats().catch(() => {
   });
 });
 
+// Live MCP status pill
+const statusPill = document.querySelector('[data-live-status-pill]');
+const statusValue = document.querySelector('[data-live-status-value]');
+let statusState = 'checking';
+let statusLastCheckedAt = null;
+
+function formatRelativeMinuteTime(date) {
+  const elapsedMinutes = Math.max(1, Math.floor((Date.now() - date.getTime()) / 60_000));
+  return `${elapsedMinutes} min ago`;
+}
+
+function renderStatusPill() {
+  if (!statusPill || !statusValue) return;
+
+  const stateText = {
+    checking: 'checking…',
+    good: 'operational',
+    bad: 'degraded',
+    unknown: 'unverified',
+  }[statusState] ?? 'unverified';
+
+  statusValue.classList.remove('is-checking', 'is-good', 'is-bad', 'is-unknown');
+  statusValue.classList.add(`is-${statusState}`);
+
+  if (statusLastCheckedAt) {
+    statusValue.textContent = `${stateText} • ${formatRelativeMinuteTime(statusLastCheckedAt)}`;
+    statusPill.title = `Last checked ${statusLastCheckedAt.toLocaleString()}`;
+  } else {
+    statusValue.textContent = stateText;
+    statusPill.title = 'Checking service status';
+  }
+}
+
+function setStatusState(nextState, checkedAt = new Date()) {
+  statusState = nextState;
+  statusLastCheckedAt = checkedAt;
+  renderStatusPill();
+}
+
+async function fetchStatusFromApiStatus(baseOrigin = '') {
+  try {
+    const res = await fetch(`${baseOrigin}/api/status`, { method: 'GET' });
+    if (!res.ok) return null;
+    const data = await res.json();
+    const state = typeof data?.status === 'string' ? data.status : '';
+
+    if (state === 'operational') return 'good';
+    if (state === 'degraded') return 'bad';
+    return 'unknown';
+  } catch {
+    return null;
+  }
+}
+
+async function fetchStatusFromMcp(baseOrigin = '') {
+  try {
+    const request = {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'ping' }),
+    };
+    if (typeof AbortSignal !== 'undefined' && typeof AbortSignal.timeout === 'function') {
+      request.signal = AbortSignal.timeout(5000);
+    }
+
+    const res = await fetch(`${baseOrigin}/api/mcp`, request);
+    if (res.ok) return 'good';
+    if (res.status === 404 || res.status === 405 || res.status === 501) return 'unknown';
+    return 'bad';
+  } catch {
+    return null;
+  }
+}
+
+function getStatusOrigins() {
+  const origins = [''];
+  const canonical = 'https://openagreements.ai';
+
+  if (typeof window !== 'undefined' && window.location.origin !== canonical) {
+    origins.push(canonical);
+  }
+
+  return origins;
+}
+
+async function checkMcpStatus() {
+  if (!statusPill) return;
+
+  if (!statusLastCheckedAt) {
+    statusState = 'checking';
+    renderStatusPill();
+  }
+
+  const checkedAt = new Date();
+  const origins = getStatusOrigins();
+  let fallbackUnknown = false;
+
+  for (const origin of origins) {
+    const apiStatusState = await fetchStatusFromApiStatus(origin);
+    if (apiStatusState === 'good' || apiStatusState === 'bad') {
+      setStatusState(apiStatusState, checkedAt);
+      return;
+    }
+    if (apiStatusState === 'unknown') {
+      fallbackUnknown = true;
+    }
+
+    const mcpState = await fetchStatusFromMcp(origin);
+    if (mcpState === 'good' || mcpState === 'bad') {
+      setStatusState(mcpState, checkedAt);
+      return;
+    }
+    if (mcpState === 'unknown') {
+      fallbackUnknown = true;
+    }
+  }
+
+  setStatusState(fallbackUnknown ? 'unknown' : 'checking', checkedAt);
+}
+
+if (statusPill) {
+  checkMcpStatus();
+  setInterval(checkMcpStatus, 60_000);
+  setInterval(() => {
+    if (statusLastCheckedAt) renderStatusPill();
+  }, 60_000);
+}
+
 // Template-aware install section: react to ?template= param
 (function () {
   // Preferred: /?template=<id>#install (standard query param)

--- a/site/src/input.css
+++ b/site/src/input.css
@@ -704,12 +704,20 @@
   }
 
   /* Badge row */
+  .badge-stack {
+    margin-top: 20px;
+  }
+
   .badge-row {
     display: flex;
     flex-wrap: wrap;
     gap: 8px;
-    margin-top: 12px;
+    margin-top: 0;
     align-items: center;
+  }
+
+  .badge-stack .badge-row + .badge-row {
+    margin-top: 8px;
   }
 
   .trust-badge {
@@ -757,6 +765,22 @@
   }
 
   .shield-value {
+    background: #6b7280;
+  }
+
+  .status-value.is-checking {
+    background: #6b7280;
+  }
+
+  .status-value.is-good {
+    background: #238636;
+  }
+
+  .status-value.is-bad {
+    background: #cf222e;
+  }
+
+  .status-value.is-unknown {
     background: #6b7280;
   }
 }


### PR DESCRIPTION
## Summary
- add an explicit Other catalog category so uncategorized templates (for example closing-checklist) show up under a visible filter tab
- restore the custom Live MCP status shield pill on the homepage and place it in a second trust-badge row with GitHub and Star badges
- update live status polling text to minute granularity and keep color-coded state classes in CSS
- treat local preview MCP responses 404/405/501 as unknown so checks fall through to https://openagreements.ai before declaring degraded

## Validation
- pre-push checks passed locally
- test suite: 412/412 passing
