### PR TITLE
fix: restore template download buttons on site

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,11 +57,12 @@
     "test:run": "npm run build && npm run check:spec-coverage && vitest run",
     "lint": "eslint src/",
     "validate": "node bin/open-agreements.js validate",
+    "build:downloads": "node scripts/prepare_site_downloads.mjs",
     "build:css": "npx tailwindcss -i site/src/input.css -o site/styles.css --minify",
     "build:docs": "mkdir -p site/docs && cp docs/getting-started.md docs/adding-templates.md docs/adding-recipes.md docs/licensing.md docs/trust-checklist.md docs/contracts-workspace.md docs/supported-tools.md docs/assumptions.md docs/template-branding-pipeline.md docs/employment-source-policy.md site/docs/",
     "build:html": "npx @11ty/eleventy",
     "build:site:indexes": "node scripts/generate_site_indexes.mjs",
-    "build:site": "npm run check:template-previews && npm run build:css && npm run build:docs && npm run build:html && npm run build:site:indexes",
+    "build:site": "npm run build:downloads && npm run check:template-previews && npm run build:css && npm run build:docs && npm run build:html && npm run build:site:indexes",
     "prepare": "npm run build",
     "report:allure": "rm -rf ./allure-report && npx allure awesome ./allure-results --output ./allure-report --group-by epic,feature,story",
     "report:allure:open": "npx allure open ./allure-report"

--- a/scripts/prepare_site_downloads.mjs
+++ b/scripts/prepare_site_downloads.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+import { existsSync, readdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import buildCatalog from "../site/_data/catalog.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, "..");
+const downloadsDir = resolve(root, "site", "downloads");
+
+const catalog = buildCatalog();
+if (!existsSync(downloadsDir)) {
+  console.error("Failed to prepare site/downloads: directory was not created.");
+  process.exit(1);
+}
+
+const files = readdirSync(downloadsDir)
+  .filter((name) => name.endsWith(".docx") || name.endsWith(".md"))
+  .sort();
+
+if (files.length === 0) {
+  console.error("Failed to prepare site/downloads: no download files were generated.");
+  process.exit(1);
+}
+
+console.log(
+  `Prepared ${files.length} download file(s) for ${catalog.previewTemplates.length} template detail page(s).`
+);

--- a/site/template-detail.njk
+++ b/site/template-detail.njk
@@ -26,8 +26,10 @@ eleventyComputed:
         <p class="template-fields" style="margin: 12px 0 24px;">{{ t.totalFields }} total field{{ "s" if t.totalFields != 1 }}</p>
 
         <div class="template-detail-actions" style="margin-bottom: 24px;">
-          {% if t.distributable %}
+          {% if t.hasDocxDownload %}
           <a class="btn btn-ghost" href="/downloads/{{ t.id }}.docx" download>Download blank DOCX</a>
+          {% endif %}
+          {% if t.hasMarkdownDownload %}
           <a class="btn btn-ghost" href="/downloads/{{ t.id }}.md" download>Download markdown</a>
           {% endif %}
           <a class="btn btn-primary" href="/?template={{ t.id }}#start">Installation instructions</a>


### PR DESCRIPTION
## Summary
- generate `site/downloads` before Eleventy starts so passthrough copy includes download assets
- add per-template download capability flags and only render buttons for files that actually exist
- prevent markdown button on templates without `template.md` (for example `closing-checklist`)

## Root cause
Eleventy passthrough copied `site/downloads` before `catalog.js` side-effects generated files, so `_site/downloads/*` was missing in fresh Vercel builds, causing 404s.

## Verification
- `rm -rf _site site/downloads && npm run build:site`
- confirmed `_site/downloads/closing-checklist.docx` exists
- confirmed closing checklist detail page no longer renders markdown download button
