### PR TITLE
feat(openspec): publish clause similarity provenance spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ coverage/
 # Draft change proposals (unimplemented roadmap — keep private until shipped)
 # Archived (implemented) changes are safe to track
 openspec/changes/add-*/
+!openspec/changes/add-clause-similarity-provenance/
 !openspec/changes/archive/
 .vercel
 

--- a/openspec/changes/add-clause-similarity-provenance/design.md
+++ b/openspec/changes/add-clause-similarity-provenance/design.md
@@ -1,0 +1,142 @@
+## Context
+
+Users and AI agents need to evaluate how closely our templates' provisions
+match trusted external forms. The transcript vision is "Law Insider-style"
+sentence-level similarity, but open, free, and pre-computed. The result must
+serve three audiences: humans browsing the landing page (heat map + tooltips),
+AI agents reading `llms.txt` (TSV similarity table), and developers querying
+via CLI.
+
+Initial comparison sources: Cooley Series Seed governance consents (CC0),
+SBA Form 160 (U.S. Government work), and templates already in the repo.
+
+## Goals / Non-Goals
+
+- Goals:
+  - Pre-computed clause-level cosine similarity against configurable sources
+  - Interactive heat map on landing page with mouseover and click-to-redline
+  - Machine-readable similarity data in `llms.txt` and JSON index
+  - Pluggable embedding model (no lock-in to a specific transformer)
+  - Zero runtime compute cost for end users
+
+- Non-Goals:
+  - Real-time embedding or scoring
+  - Distributing proprietary source document text
+  - LLM-based semantic analysis
+  - Cross-language support
+
+## Decisions
+
+### Embedding provider is a pluggable interface
+
+**Decision**: Define `EmbeddingProvider` interface with `embed(texts: string[]): Promise<number[][]>`.
+Ship a default implementation using a sentence-transformer model
+(e.g., all-MiniLM-L6-v2 via `@xenova/transformers` for Node.js or a Python
+subprocess calling `sentence-transformers`).
+
+**Alternatives considered**:
+- Hard-code a specific model: Rejected — locks users into one model and makes
+  testing harder.
+- TF-IDF baseline: Rejected as default — misses semantic similarity (e.g.,
+  "terminate" vs. "cancel"). Could be offered as a fallback provider.
+- OpenAI embeddings: Rejected as default — adds API cost and external dependency.
+  Could be offered as an optional provider.
+
+### Similarity index is a separate artifact, not inline
+
+**Decision**: Each template gets a `similarity-index.json` file in
+`content/similarity/<template-id>/`. The clause JSON representation is not
+modified.
+
+**Rationale**: Keeps the clause JSON clean and focused on template structure.
+Similarity data can be rebuilt independently. Different source corpora can
+produce different indexes without touching clause definitions.
+
+### Clause extraction uses paragraph-level granularity
+
+**Decision**: Extract clauses at the DOCX paragraph level, grouped by heading.
+Each clause gets a stable ID derived from its heading hierarchy and paragraph
+index (e.g., `section-3.2-para-1`).
+
+**Alternatives considered**:
+- Sentence-level: Too granular for legal text where provisions span multiple
+  sentences. Could produce noisy scores.
+- Section-level: Too coarse — misses variation within sections.
+- Paragraph-level grouped by heading: Best balance. Matches how lawyers
+  think about provisions.
+
+### Heat map renders on the landing page with mouseover + click-to-redline
+
+**Decision**: Full-stack UI. Each template page on the landing site shows
+clauses with a color-coded similarity band. Mouseover shows a tooltip with
+per-source scores. Clicking a source opens a red-line diff view (integrating
+with the `add-docx-comparison-redline` pipeline).
+
+**Implementation**: Static data from `similarity-index.json` loaded at build
+time. Heat map colors computed from aggregate similarity. No runtime API calls.
+
+### `llms.txt` includes per-clause similarity table
+
+**Decision**: Append a TSV-like section to `llms.txt` for each template:
+```
+## Clause Similarity: common-paper-mutual-nda
+clause_id	excerpt	source_1	sim_1	source_2	sim_2	source_3	sim_3
+section-1-para-1	"This Agreement is entered..."	cooley-series-seed	0.92	nvca-spa	0.87	yc-safe	0.81
+```
+
+**Rationale**: AI agents can read the form and immediately see provenance
+scores without re-embedding. The TSV format is trivially parseable.
+
+## Similarity Index Schema
+
+```jsonc
+{
+  "schema_version": "1.0",
+  "template_id": "common-paper-mutual-nda",
+  "generated_at": "2026-02-19T00:00:00Z",
+  "embedding_model": "all-MiniLM-L6-v2",
+  "sources": [
+    { "id": "cooley-series-seed", "name": "Cooley Series Seed Board Consent", "version": "2024" }
+  ],
+  "clauses": [
+    {
+      "clause_id": "section-1-para-1",
+      "heading": "1. Definition of Confidential Information",
+      "excerpt": "\"Confidential Information\" means any information...",
+      "origin": { "template": "common-paper-mutual-nda", "version": "2.0" },
+      "similarities": [
+        { "source_id": "cooley-series-seed", "clause_ref": "section-2-para-1", "score": 0.92 },
+        { "source_id": "nvca-spa", "clause_ref": "section-5-para-3", "score": 0.87 }
+      ]
+    }
+  ]
+}
+```
+
+## Risks / Trade-offs
+
+- **Embedding model size**: Sentence-transformer models are 20-90 MB. Shipping
+  one in the npm package is impractical → download on first use or use a Python
+  subprocess. Mitigation: pre-computed indexes ship in the package; the
+  embedding model is only needed for rebuilding.
+- **Source document licensing**: We cannot distribute proprietary source text.
+  Mitigation: similarity scores are derived facts (not copyrightable expression).
+  Red-line diffs require the user to have a legal copy of the source document
+  (same model as recipes).
+- **Stale indexes**: If a source document updates, pre-computed scores become
+  stale. Mitigation: version-pin sources in the index metadata; CI can
+  flag when a source version changes.
+- **Paragraph segmentation instability**: Different DOCX editing histories may
+  produce different paragraph boundaries. Mitigation: use heading-based
+  grouping as the primary anchor, with paragraph index as tiebreaker.
+
+## Open Questions
+
+- Should the pre-computation pipeline run in CI (GitHub Actions) or only
+  locally? CI would ensure indexes are always fresh but adds build time.
+- What is the minimum number of sources needed before the heat map is
+  meaningful? Proposal says 3, but some templates may only have 1-2
+  comparable sources initially.
+- Should the click-to-redline feature require the user to supply the source
+  document (like recipes), or can we show a text-only diff from our
+  pre-extracted clause text?

--- a/openspec/changes/add-clause-similarity-provenance/proposal.md
+++ b/openspec/changes/add-clause-similarity-provenance/proposal.md
@@ -1,0 +1,86 @@
+# Change: Add Clause-Level Similarity Scoring and Provenance
+
+## Why
+
+People evaluating a legal form need to answer one core question: *does this
+include the types of provisions that are in other forms I trust?* Today the
+only way to answer that is to manually red-line two documents side by side.
+That is slow, opaque, and inaccessible to non-lawyers.
+
+By pre-computing cosine similarity scores (via sentence embeddings) between
+every clause in our templates and provisions in trusted external sources — SEC
+filings, Cooley Series Seed, NVCA models, etc. — we can give users an
+immediate, visual answer. A heat map on the landing page. Mouseover a
+provision, see similarity scores against 3+ trusted sources. Click through to
+an exact red-line comparison. This is the Law Insider model applied at the
+clause level, but open and pre-computed so it costs nothing at query time.
+
+The first concrete use case: Joey Tsang (Harvard Law JD '21) is contributing
+board resolution templates derived from the Cooley Series Seed governance
+consents (CC0) and SBA Form 160 (U.S. Government work, 17 U.S.C. § 105).
+Similarity scoring lets users immediately see how our generalized board
+resolution template compares clause-by-clause to the original Cooley and SBA
+source forms.
+
+The machine-readable layer matters equally. Each template's clause JSON gets a
+companion `similarity-index.json` with per-clause scores against the top
+sources. The `llms.txt` output includes a TSV-like table so AI agents can
+read a clause, see its similarity to 3+ trusted sources, and gain confidence
+in provenance without re-embedding anything.
+
+## What Changes
+
+- **Pluggable embedding provider**: `EmbeddingProvider` interface with a default
+  implementation (e.g., all-MiniLM-L6-v2 sentence-transformer). Swappable for
+  any model that produces fixed-dimension vectors.
+- **Pre-computation pipeline**: A build-time script that extracts clauses from
+  DOCX templates, embeds them, computes pairwise cosine similarity against a
+  configurable source corpus, and writes `similarity-index.json` per template.
+- **Source corpus interface**: Open-ended. Any document set can be registered as
+  a comparison source. Initial sources: templates already in the repo (NVCA,
+  YC SAFE, Common Paper, Bonterms) plus Cooley Series Seed governance consents
+  and SBA Form 160.
+- **Similarity index artifact**: A separate `similarity-index.json` per template,
+  keyed by clause ID, containing the top-N similarity scores and source
+  references. Does not pollute the clause JSON itself.
+- **Landing page heat map UI**: Interactive heat map on template pages. Each
+  clause gets a color band reflecting aggregate similarity. On mouseover,
+  a tooltip shows per-source similarity scores. On click, shows an exact
+  red-line diff against the selected source (integrates with the existing
+  `add-docx-comparison-redline` pipeline).
+- **`llms.txt` similarity table**: Machine-readable per-clause similarity output
+  with columns for clause ID, clause text excerpt, and similarity scores
+  against the top 3 sources.
+- **CLI command**: `open-agreements similarity <template>` to query similarity
+  data from the pre-computed index.
+- **Provenance tracking**: Each clause in the similarity index includes an
+  `origin` field tracing the provision's source template and version.
+
+## Scope Boundaries
+
+### In scope
+- Pluggable embedding provider interface and default implementation
+- Pre-computation pipeline (build-time, not runtime)
+- Similarity index JSON artifact per template
+- Landing page interactive heat map with mouseover scores and click-to-redline
+- `llms.txt` machine-readable similarity table
+- CLI similarity query command
+- Clause provenance metadata
+- Integration with redline comparison pipeline
+
+### Out of scope
+- Real-time (on-the-fly) similarity computation — precomputed only
+- LLM-based semantic analysis (embeddings only, no generative AI in the loop)
+- Cross-language clause comparison
+- Distributing full text of proprietary source documents (similarity scores
+  and red-line diffs against user-obtained copies only)
+
+## Impact
+- Affected specs: `open-agreements`
+- Affected code:
+  - `src/core/similarity/` (new module: provider interface, scorer, index builder)
+  - `scripts/build-similarity-index.ts` (pre-computation pipeline)
+  - `site/` (heat map UI components, `llms.txt` generation)
+  - `src/commands/similarity.ts` (CLI command)
+  - `content/similarity/` (pre-computed index artifacts)
+- Compatibility: additive, no breaking changes

--- a/openspec/changes/add-clause-similarity-provenance/specs/open-agreements/spec.md
+++ b/openspec/changes/add-clause-similarity-provenance/specs/open-agreements/spec.md
@@ -1,0 +1,135 @@
+## ADDED Requirements
+
+### Requirement: Embedding Provider Interface
+The system SHALL define a pluggable `EmbeddingProvider` interface that accepts
+an array of text strings and returns an array of fixed-dimension numeric
+vectors. A default implementation SHALL be provided. The provider SHALL be
+configurable so that alternative embedding models can be swapped without
+modifying core similarity logic.
+
+#### Scenario: [OA-067] Default provider produces embeddings
+- **WHEN** the default `EmbeddingProvider` is called with `["This agreement is entered into...", "Confidential Information means..."]`
+- **THEN** it returns an array of two numeric vectors of equal dimension
+- **AND** each vector has non-zero magnitude
+
+#### Scenario: [OA-068] Custom provider can be substituted
+- **WHEN** a custom `EmbeddingProvider` implementation is registered
+- **THEN** the similarity pipeline uses the custom provider instead of the default
+- **AND** the rest of the pipeline (scoring, index generation) works unchanged
+
+### Requirement: Pre-Computed Similarity Index
+The system SHALL provide a build-time pipeline that extracts clauses from
+template DOCX files, embeds them via the configured `EmbeddingProvider`,
+computes pairwise cosine similarity against a configurable source corpus,
+and writes a `similarity-index.json` artifact per template. The index SHALL
+NOT be computed at runtime. The index SHALL include the embedding model
+identifier and generation timestamp for reproducibility.
+
+#### Scenario: [OA-069] Build similarity index for a template
+- **WHEN** `build-similarity-index` runs for template `common-paper-mutual-nda`
+- **THEN** a `similarity-index.json` is written to `content/similarity/common-paper-mutual-nda/`
+- **AND** the file contains a `clauses` array with one entry per extracted clause
+- **AND** each entry includes `clause_id`, `heading`, `excerpt`, and `similarities` array
+
+#### Scenario: [OA-070] Index includes model metadata
+- **WHEN** the similarity index is generated
+- **THEN** the index JSON includes `embedding_model`, `schema_version`, `template_id`, and `generated_at` fields
+
+### Requirement: Source Corpus Configuration
+The system SHALL support a configurable set of comparison sources. Each source
+SHALL have an `id`, `name`, and `version`. Sources MAY be templates already in
+the repo, external templates, or separately registered document sets. The
+source configuration SHALL be open-ended so that new sources can be added
+without modifying core code.
+
+#### Scenario: [OA-071] Register a new comparison source
+- **WHEN** a new source `cooley-series-seed` is added to the source corpus configuration
+- **THEN** the next similarity index build includes scores against `cooley-series-seed` clauses
+- **AND** existing source scores are preserved
+
+#### Scenario: [OA-072] Source version tracking
+- **WHEN** a source document is updated to a new version
+- **THEN** the source configuration reflects the new version
+- **AND** re-running the build pipeline produces updated similarity scores
+
+### Requirement: Clause Extraction
+The system SHALL extract clauses from DOCX templates at paragraph-level
+granularity, grouped by heading. Each clause SHALL receive a stable identifier
+derived from its heading hierarchy and paragraph index. The extraction SHALL
+handle standard legal document structure (numbered sections, lettered
+subsections, definition lists).
+
+#### Scenario: [OA-073] Paragraph-level extraction with stable IDs
+- **WHEN** a DOCX template with headings "1. Definitions", "2. Obligations" is processed
+- **THEN** each paragraph under each heading is extracted as a separate clause
+- **AND** each clause receives a deterministic ID like `section-1-para-1`
+
+#### Scenario: [OA-074] Re-extraction produces identical IDs
+- **WHEN** the same unmodified DOCX is extracted twice
+- **THEN** the clause IDs are identical across both runs
+
+### Requirement: Similarity CLI Command
+The CLI SHALL provide `open-agreements similarity <template>` to query
+pre-computed similarity data. The command SHALL output per-clause similarity
+scores against configured sources. The command SHALL support `--json` for
+machine-readable output and human-readable table output by default.
+
+#### Scenario: [OA-075] Query similarity for a template
+- **WHEN** `open-agreements similarity common-paper-mutual-nda`
+- **THEN** the CLI outputs a table with columns: clause ID, excerpt, and similarity scores per source
+- **AND** clauses are listed in document order
+
+#### Scenario: [OA-076] JSON output for programmatic access
+- **WHEN** `open-agreements similarity common-paper-mutual-nda --json`
+- **THEN** the output is valid JSON matching the `similarity-index.json` schema
+
+### Requirement: Landing Page Heat Map
+The landing site SHALL display an interactive heat map on template detail
+pages. Each clause SHALL be rendered with a color band reflecting its
+aggregate similarity score across sources. The heat map data SHALL be loaded
+from the pre-computed `similarity-index.json` at build time, with zero
+runtime API calls.
+
+#### Scenario: [OA-077] Heat map renders with color bands
+- **WHEN** a user views a template detail page
+- **THEN** each clause is displayed with a color band (green = high similarity, yellow = moderate, red = low)
+- **AND** the color is derived from the highest similarity score across all sources
+
+#### Scenario: [OA-078] Mouseover shows per-source scores
+- **WHEN** a user hovers over a clause in the heat map
+- **THEN** a tooltip appears showing similarity scores against each source
+- **AND** scores are displayed as percentages with source names
+
+#### Scenario: [OA-079] Click opens redline comparison
+- **WHEN** a user clicks a source name in the similarity tooltip
+- **THEN** a redline diff view opens comparing the clause text against the matching source clause
+- **AND** additions and deletions are visually distinguished
+
+### Requirement: Machine-Readable Similarity in llms.txt
+The system SHALL include per-clause similarity data in `llms.txt` output as a
+TSV-formatted section per template. Each row SHALL contain the clause ID,
+a text excerpt, and similarity scores against the top 3 sources. This enables
+AI agents to assess clause provenance without re-embedding.
+
+#### Scenario: [OA-080] llms.txt includes similarity table
+- **WHEN** `llms.txt` is generated for a template with a similarity index
+- **THEN** the file includes a `## Clause Similarity: <template-id>` section
+- **AND** each row contains clause_id, excerpt, and at least one source similarity score
+
+#### Scenario: [OA-081] AI agent reads similarity context
+- **WHEN** an AI agent reads `llms.txt` for a template
+- **THEN** the agent can determine that clause `section-3-para-1` is 92% similar to `cooley-series-seed` section 2
+- **AND** the agent can use this information to assess provenance confidence
+
+### Requirement: Clause Provenance Tracking
+Each clause in the similarity index SHALL include an `origin` field recording
+the source template, version, and any modifications applied. This provides an
+audit trail for every provision in the template.
+
+#### Scenario: [OA-082] Clause origin is recorded
+- **WHEN** a similarity index is built for a template
+- **THEN** each clause entry includes `origin.template` and `origin.version`
+
+#### Scenario: [OA-083] Provenance traces modification history
+- **WHEN** a clause was adapted from another template (e.g., generalized from Cooley Series Seed)
+- **THEN** the `origin` field includes the source template ID and a note about the adaptation

--- a/openspec/changes/add-clause-similarity-provenance/tasks.md
+++ b/openspec/changes/add-clause-similarity-provenance/tasks.md
@@ -1,0 +1,46 @@
+## 1. Embedding Provider
+- [ ] 1.1 Define `EmbeddingProvider` interface in `src/core/similarity/types.ts`
+- [ ] 1.2 Implement default provider (sentence-transformer via `@xenova/transformers` or Python subprocess)
+- [ ] 1.3 Add provider configuration in project settings
+- [ ] 1.4 Unit tests for default provider (produces vectors, correct dimensions)
+
+## 2. Clause Extraction
+- [ ] 2.1 Build clause extractor from DOCX paragraphs grouped by heading
+- [ ] 2.2 Implement stable clause ID generation (heading hierarchy + paragraph index)
+- [ ] 2.3 Unit tests for extraction determinism (same DOCX → same IDs)
+
+## 3. Source Corpus
+- [ ] 3.1 Define source corpus configuration schema (id, name, version, path or URL)
+- [ ] 3.2 Register initial sources: repo templates + Cooley Series Seed + SBA Form 160
+- [ ] 3.3 Extract and embed source document clauses
+
+## 4. Similarity Scoring Pipeline
+- [ ] 4.1 Implement cosine similarity scorer between clause embedding vectors
+- [ ] 4.2 Build `similarity-index.json` writer with schema version, model metadata, and per-clause scores
+- [ ] 4.3 Create `scripts/build-similarity-index.ts` build-time pipeline
+- [ ] 4.4 Generate initial similarity indexes for all templates in the repo
+- [ ] 4.5 Unit tests for cosine similarity correctness
+- [ ] 4.6 Integration test: full pipeline from DOCX → index JSON
+
+## 5. CLI Command
+- [ ] 5.1 Add `similarity <template>` command to CLI
+- [ ] 5.2 Implement human-readable table output (clause ID, excerpt, scores)
+- [ ] 5.3 Implement `--json` output matching index schema
+- [ ] 5.4 Tests for CLI output format
+
+## 6. Landing Page Heat Map UI
+- [ ] 6.1 Load `similarity-index.json` at site build time
+- [ ] 6.2 Render clause color bands based on aggregate similarity scores
+- [ ] 6.3 Implement mouseover tooltip showing per-source scores with percentages
+- [ ] 6.4 Implement click-to-redline: open diff view against selected source clause
+- [ ] 6.5 Integrate with `add-docx-comparison-redline` pipeline for diff rendering
+
+## 7. Machine-Readable Output
+- [ ] 7.1 Add per-clause similarity TSV section to `llms.txt` generation
+- [ ] 7.2 Include clause_id, excerpt, and top-3 source similarity scores
+- [ ] 7.3 Test that generated `llms.txt` is parseable and correct
+
+## 8. Provenance
+- [ ] 8.1 Add `origin` field to similarity index clause entries
+- [ ] 8.2 Populate origin data for existing templates
+- [ ] 8.3 Document provenance schema in `docs/similarity.md`


### PR DESCRIPTION
## Summary
- Publishes the full design spec for clause-level cosine similarity scoring and provenance tracking
- Adds `.gitignore` exception for this specific proposal so external contributors can review the architecture
- Includes proposal, design doc, spec (OA-067 through OA-083), and task breakdown

## Context
Joey Tsang is contributing board resolution templates derived from Cooley Series Seed governance consents. She's asked detailed questions about the similarity scoring architecture and offered to help with infrastructure beyond template drafting. Publishing this spec lets her review the full design and contribute to open questions (e.g., boilerplate vs. substantive clause weighting).

## Files
- `openspec/changes/add-clause-similarity-provenance/proposal.md` — motivation and scope
- `openspec/changes/add-clause-similarity-provenance/design.md` — technical decisions, schema, risks, open questions
- `openspec/changes/add-clause-similarity-provenance/specs/open-agreements/spec.md` — requirements (OA-067–OA-083)
- `openspec/changes/add-clause-similarity-provenance/tasks.md` — implementation task breakdown

## Test plan
- [ ] Verify spec files render correctly on GitHub
- [ ] Confirm no other gitignored proposals were accidentally exposed