### PR TITLE
fix(publish): add repository field to MCP sub-packages, bump 0.3.1

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "open-agreements",
   "displayName": "OpenAgreements",
   "description": "Open-source legal template automation for DOCX with MCP tooling.",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": {
     "name": "Open Agreements",
     "email": "steven@usejunior.com"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "open-agreements",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Local MCP extension for OpenAgreements workspace organization and contract template drafting.",
   "contextFileName": "GEMINI.md",
   "entrypoint": "GEMINI.md",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-agreements",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-agreements",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "workspaces": [
         "packages/allure-test-factory",
@@ -6322,7 +6322,7 @@
     },
     "packages/contract-templates-mcp": {
       "name": "@open-agreements/contract-templates-mcp",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "open-agreements": "^0.2.2",
@@ -6353,7 +6353,7 @@
     },
     "packages/contracts-workspace-mcp": {
       "name": "@open-agreements/contracts-workspace-mcp",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-agreements",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "workspaces": [
     "packages/allure-test-factory",
     "packages/contract-templates-mcp",

--- a/packages/contract-templates-mcp/package.json
+++ b/packages/contract-templates-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agreements/contract-templates-mcp",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Local stdio MCP server for OpenAgreements template discovery and filling",
   "type": "module",
   "bin": {
@@ -26,6 +26,11 @@
   },
   "engines": {
     "node": ">=20"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/open-agreements/open-agreements.git",
+    "directory": "packages/contract-templates-mcp"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/contracts-workspace-mcp/package.json
+++ b/packages/contracts-workspace-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agreements/contracts-workspace-mcp",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Local stdio MCP server for contracts workspace operations",
   "type": "module",
   "bin": {
@@ -26,6 +26,11 @@
   },
   "engines": {
     "node": ">=20"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/open-agreements/open-agreements.git",
+    "directory": "packages/contracts-workspace-mcp"
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
## Summary
- Add missing `repository` field to both MCP sub-package `package.json` files (`contracts-workspace-mcp`, `contract-templates-mcp`)
- Bump all 5 version files from 0.3.0 to 0.3.1

## Context
The v0.3.0 release partially failed — `open-agreements` and `@open-agreements/open-agreements` published successfully, but both MCP sub-packages got E422 from npm's trusted publishing provenance check because their `package.json` lacked `repository.url`. The release workflow already handles partial re-publishes (skips already-published packages), so v0.3.1 will only publish the two MCP packages.

## Test plan
- [ ] CI passes (validate, tests, coverage)
- [ ] After merge + tag, release workflow publishes `@open-agreements/contracts-workspace-mcp@0.3.1` and `@open-agreements/contract-templates-mcp@0.3.1`
- [ ] Root packages skipped (already at 0.3.0 on npm, 0.3.1 will publish fresh)