### PR TITLE
feat(changelog): format release notes with grouped conventional commit categories

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -4,6 +4,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 const md = markdownIt({ html: true, linkify: true });
+const mdSafe = markdownIt({ html: false, linkify: false });
 
 export default function (eleventyConfig) {
   eleventyConfig.addPlugin(syntaxHighlight);
@@ -12,6 +13,155 @@ export default function (eleventyConfig) {
   eleventyConfig.addNunjucksFilter("renderMarkdown", function (value) {
     if (!value || typeof value !== "string") return "";
     return md.render(value);
+  });
+
+  // formatReleaseNotes filter: parse GitHub release notes into grouped, clean HTML
+  eleventyConfig.addNunjucksFilter("formatReleaseNotes", function (notes) {
+    if (!notes || typeof notes !== "string") return "";
+
+    const TYPE_LABELS = [
+      ["feat", "Features"],
+      ["fix", "Bug Fixes"],
+      ["docs", "Documentation"],
+      ["refactor", "Refactoring"],
+      ["perf", "Performance"],
+      ["test", "Tests"],
+      ["build", "Build"],
+      ["ci", "CI"],
+      ["chore", "Chores"],
+      ["style", "Style"],
+    ];
+
+    // GitHub PR entry: * TITLE by @AUTHOR in URL-or-#N
+    const PR_LINE_RE =
+      /^\* (.+?) by @[\w.-]+(?:\[bot\])? in (?:https?:\/\/\S+|#\d+)$/;
+    const PR_NUM_RE =
+      /by @[\w.-]+(?:\[bot\])? in (?:https?:\/\/[^\s]+\/pull\/(\d+)|#(\d+))$/;
+    const CC_RE = /^(\w+)(?:\(([^)]+)\))?: (.+)$/;
+
+    const lines = notes.split("\n");
+
+    // If no PR entry lines found, fall back to safe markdown rendering
+    if (!lines.some((l) => PR_LINE_RE.test(l.trim()))) {
+      return mdSafe.render(notes);
+    }
+
+    const warnings = [];
+    const groups = {};
+    const passthrough = [];
+    let skipSection = false;
+    let inCustomSection = false;
+    let customSectionLines = [];
+
+    function flushCustomSection() {
+      if (customSectionLines.length) {
+        passthrough.push(mdSafe.render(customSectionLines.join("\n")));
+        customSectionLines = [];
+      }
+      inCustomSection = false;
+    }
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+
+      if (trimmed.startsWith("## ")) {
+        flushCustomSection();
+        const heading = trimmed.slice(3).trim();
+        if (heading === "What's Changed") {
+          skipSection = false;
+          inCustomSection = false;
+        } else if (heading === "New Contributors") {
+          skipSection = true;
+          inCustomSection = false;
+        } else {
+          skipSection = false;
+          inCustomSection = true;
+          customSectionLines.push(line);
+        }
+        continue;
+      }
+
+      if (skipSection) continue;
+      if (trimmed.startsWith("**Full Changelog**")) continue;
+
+      if (trimmed.startsWith("> ")) {
+        warnings.push(trimmed.slice(2).trim());
+        continue;
+      }
+
+      if (PR_LINE_RE.test(trimmed)) {
+        const titleMatch = trimmed.match(/^\* (.+?) by @/);
+        const prNumMatch = trimmed.match(PR_NUM_RE);
+        if (!titleMatch) continue;
+
+        const title = titleMatch[1].trim();
+        const prNum = prNumMatch ? (prNumMatch[1] || prNumMatch[2]) : null;
+        const ccMatch = title.match(CC_RE);
+
+        if (ccMatch) {
+          const [, type, scope, description] = ccMatch;
+          const key = type.toLowerCase();
+          if (!groups[key]) groups[key] = [];
+          groups[key].push({ scope: scope || null, description, pr: prNum });
+        } else {
+          if (!groups["other"]) groups["other"] = [];
+          groups["other"].push({ scope: null, description: title, pr: prNum });
+        }
+        continue;
+      }
+
+      if (inCustomSection) {
+        customSectionLines.push(line);
+      }
+    }
+
+    flushCustomSection();
+
+    let html = "";
+
+    if (warnings.length) {
+      const warningContent = warnings
+        .map((w) => mdSafe.renderInline(w))
+        .join("<br>");
+      html += `<div class="cl-warning">${warningContent}</div>\n`;
+    }
+
+    const orderedEntries = [];
+    const seenKeys = new Set();
+
+    for (const [key, label] of TYPE_LABELS) {
+      if (groups[key]) {
+        orderedEntries.push([label, groups[key]]);
+        seenKeys.add(key);
+      }
+    }
+    for (const key of Object.keys(groups)) {
+      if (!seenKeys.has(key) && key !== "other") {
+        orderedEntries.push([key, groups[key]]);
+      }
+    }
+    if (groups["other"]) {
+      orderedEntries.push(["Other", groups["other"]]);
+    }
+
+    for (const [label, entries] of orderedEntries) {
+      html += `<div class="cl-group">\n<span class="cl-type-label">${mdSafe.utils.escapeHtml(label)}</span>\n<ul class="cl-entries">\n`;
+      for (const { scope, description, pr } of entries) {
+        const scopeHtml = scope
+          ? `<span class="cl-scope">${mdSafe.utils.escapeHtml(scope)}</span> `
+          : "";
+        const descHtml = mdSafe.renderInline(description);
+        const prHtml = pr ? ` <span class="cl-pr">#${pr}</span>` : "";
+        html += `<li>${scopeHtml}${descHtml}${prHtml}</li>\n`;
+      }
+      html += `</ul>\n</div>\n`;
+    }
+
+    for (const block of passthrough) {
+      html += `<div class="cl-passthrough">${block}</div>\n`;
+    }
+
+    return html;
   });
 
   // rawMarkdown filter: reads the source .md and strips frontmatter

--- a/site/trust/changelog.njk
+++ b/site/trust/changelog.njk
@@ -4,6 +4,61 @@ title: Changelog | OpenAgreements
 description: Public release history with auto-generated notes from GitHub releases.
 ---
 
+<style>
+.cl-warning {
+  background: var(--accent-soft);
+  border-left: 3px solid var(--accent-deep);
+  padding: 10px 14px;
+  margin: 0 0 16px;
+  font-size: 0.88rem;
+  color: var(--ink);
+}
+.cl-group {
+  display: grid;
+  grid-template-columns: 130px 1fr;
+  gap: 4px 12px;
+  align-items: start;
+  margin: 5px 0;
+}
+.cl-type-label {
+  color: var(--ink-soft);
+  font-size: 0.76rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  padding-top: 3px;
+  white-space: nowrap;
+}
+.cl-entries {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.cl-entries li {
+  margin: 2px 0;
+  font-size: 0.9rem;
+  padding-left: 14px;
+  position: relative;
+}
+.cl-entries li::before {
+  content: "•";
+  position: absolute;
+  left: 0;
+  color: var(--ink-soft);
+}
+.cl-scope {
+  color: var(--ink-soft);
+  font-size: 0.84rem;
+}
+.cl-scope::before { content: "("; }
+.cl-scope::after  { content: ")"; }
+.cl-pr {
+  color: var(--ink-soft);
+  font-size: 0.82rem;
+  font-family: monospace;
+}
+</style>
+
 <main class="main-wrap">
   <section class="section" style="padding: clamp(32px, 5vw, 56px) clamp(16px, 4vw, 48px);">
     <h1>Changelog</h1>
@@ -50,7 +105,7 @@ description: Public release history with auto-generated notes from GitHub releas
             <details{% if loop.index0 == 0 %} open{% endif %}>
               <summary style="cursor: pointer; color: var(--ink); font-weight: 600;">Release notes</summary>
               <div class="release-notes" style="margin: 12px 0 0; font-size: 0.9rem; line-height: 1.55;">
-                {{ release.notes | renderMarkdown | safe }}
+                {{ release.notes | formatReleaseNotes | safe }}
               </div>
             </details>
           {% else %}


### PR DESCRIPTION
## Summary

- Adds `formatReleaseNotes` Eleventy/Nunjucks filter in `eleventy.config.js` that transforms raw GitHub release notes markdown into grouped, readable HTML
- Strips boilerplate (`## What's Changed`, `## New Contributors`, `**Full Changelog**` footer) and noisy author handles / full PR URLs
- Groups entries by conventional commit type (feat → Features, fix → Bug Fixes, docs → Documentation, etc.) in a consistent display order
- Renders blockquote lines as a highlighted `.cl-warning` box (used by v0.3.0 caveat)
- Short PR refs (`#77`) shown in muted monospace; scopes rendered in `(parentheses)`
- Falls back to safe `mdSafe.render()` for releases not using GitHub's PR-entry format
- Security: `scope` escaped via `mdSafe.utils.escapeHtml()`; `description` rendered via `mdSafe.renderInline()` with `html:false` to neutralise raw HTML while preserving backtick code spans
- Adds scoped `<style>` block to `changelog.njk` for `.cl-*` rules using existing CSS variables
- Replaces `renderMarkdown` with `formatReleaseNotes` on the release notes output line

## Test plan

- [x] `npm run build:site` passes (24 files written, 0 errors)
- [x] v0.3.0 blockquote caveat renders as `.cl-warning` box
- [x] Entries grouped under Features / Bug Fixes / Documentation / Chores / Other
- [x] No author handles or raw PR URLs in output — only `#N` refs
- [x] Scopes rendered in `(parentheses)` via `.cl-scope`
- [ ] After merge: run `gh release create` for v0.2.0 and v0.1.1, then regenerate `changelog.json`