### PR TITLE
fix(seo): use 301 redirects for Google Search Console compatibility

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -7,16 +7,16 @@
   "cleanUrls": true,
   "trailingSlash": false,
   "redirects": [
-    { "source": "/", "destination": "https://usejunior.com/developer-tools/open-agreements", "permanent": true },
-    { "source": "/templates", "destination": "https://usejunior.com/developer-tools/open-agreements/templates", "permanent": true },
-    { "source": "/templates/:name", "destination": "https://usejunior.com/developer-tools/open-agreements/templates/:name", "permanent": true },
-    { "source": "/docs", "destination": "https://usejunior.com/developer-tools/open-agreements", "permanent": true },
-    { "source": "/docs/:slug", "destination": "https://usejunior.com/developer-tools/open-agreements", "permanent": true },
-    { "source": "/trust", "destination": "https://usejunior.com/developer-tools/open-agreements", "permanent": true },
-    { "source": "/trust/system-card", "destination": "https://usejunior.com/developer-tools/open-agreements", "permanent": true },
-    { "source": "/trust/template-evidence", "destination": "https://usejunior.com/developer-tools/open-agreements", "permanent": true },
-    { "source": "/trust/evidence-story", "destination": "https://usejunior.com/developer-tools/open-agreements", "permanent": true },
-    { "source": "/trust/changelog", "destination": "https://usejunior.com/developer-tools/open-agreements", "permanent": true }
+    { "source": "/", "destination": "https://usejunior.com/developer-tools/open-agreements", "statusCode": 301 },
+    { "source": "/templates", "destination": "https://usejunior.com/developer-tools/open-agreements/templates", "statusCode": 301 },
+    { "source": "/templates/:name", "destination": "https://usejunior.com/developer-tools/open-agreements/templates/:name", "statusCode": 301 },
+    { "source": "/docs", "destination": "https://usejunior.com/developer-tools/open-agreements", "statusCode": 301 },
+    { "source": "/docs/:slug", "destination": "https://usejunior.com/developer-tools/open-agreements", "statusCode": 301 },
+    { "source": "/trust", "destination": "https://usejunior.com/developer-tools/open-agreements", "statusCode": 301 },
+    { "source": "/trust/system-card", "destination": "https://usejunior.com/developer-tools/open-agreements", "statusCode": 301 },
+    { "source": "/trust/template-evidence", "destination": "https://usejunior.com/developer-tools/open-agreements", "statusCode": 301 },
+    { "source": "/trust/evidence-story", "destination": "https://usejunior.com/developer-tools/open-agreements", "statusCode": 301 },
+    { "source": "/trust/changelog", "destination": "https://usejunior.com/developer-tools/open-agreements", "statusCode": 301 }
   ],
   "functions": {
     "api/a2a.ts": {


### PR DESCRIPTION
## Summary
- Switch from `"permanent": true` (308) to `"statusCode": 301` for all redirects
- GSC's Change of Address tool requires 301 specifically — 308 causes "Couldn't fetch the page" validation failure

## Test plan
- [ ] Verify `curl -sI https://openagreements.ai/` returns `HTTP/2 301` (not 308)
- [ ] Retry GSC Change of Address validation after deploy