### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-agreements",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "workspaces": [
     "packages/allure-test-factory",
     "packages/contract-templates-mcp",


### PR DESCRIPTION
## Summary

- Bump version from 0.4.0 to 0.5.0

**Breaking change**: `required_fields` renamed to `priority_fields` across all metadata schemas and pipeline interfaces. Missing priority fields now produce a soft warning instead of blocking the fill.

### Changes since v0.4.0
- feat(patcher): context keys for paragraphs, remove #N syntax (#99)
- fix(nvca): 8 fill regressions for attorney-ready output (#100)
- fix(nvca): COI quality sprint — cover page, brackets, selections (#101)
- feat: architectural audit — priority_fields, smart quotes, recipe auditor (#102)

## Test plan
- [x] All 1,988 tests pass
- [x] CI green on #102