### PR TITLE
Replace patcher's replaceAtPosition with docx-core; NVCA hardening batch

### DIFF
--- a/scripts/lib/codex-prompt.ts
+++ b/scripts/lib/codex-prompt.ts
@@ -122,7 +122,7 @@ Fixture files go in: integration-tests/fixtures/`);
 8. When adding new fields to metadata.yaml, always include: name, type, description, and default.
 9. Do NOT invent synthetic helper fields (e.g. "optional_blank_value"). Only use fields already defined in metadata.yaml. If a new field is genuinely needed, it must represent real deal-term data, not a formatting workaround.
 10. Multi-paragraph bracketed sections (e.g. ["DPA" means...], [Foreign Person...], [Limitation on...]) are OPTIONAL CLAUSES, not fill placeholders. Handle them with clean.json \`removeRanges\` (start/end pattern) or computed.json toggles — NEVER add them to replacements.json.
-11. F3 formatting anomalies (single-char underlined runs) are a known patcher limitation in the engine. You cannot fix them by editing recipe files. Skip F3 and focus on other failing checks.`);
+11. F3 formatting anomalies (single-char underlined runs) are baselined against the cleaned source — the verifier only flags NEW anomalies introduced by fill/patch. If F3 fails, investigate whether recipe edits are introducing formatting corruption.`);
 
   // Verify command
   sections.push(`## Verify Your Changes:
@@ -238,7 +238,7 @@ function getCategoryGuidance(
         lines.push('- Fix full-values fill: ensure all fixture values appear in the output and no placeholders remain');
       }
       if (fFailures.some((c) => c.id === 'F3')) {
-        lines.push('- SKIP F3 (formatting anomalies) — this is a patcher engine limitation you cannot fix via recipe files. Focus on F1, F2, F4 instead.');
+        lines.push('- Fix F3 (formatting anomalies) — the verifier now baselines against the source, so failures mean fill/patch introduced new anomalies. Check if replacement values or computed rules are corrupting run-level formatting.');
       }
       if (fFailures.some((c) => c.id === 'F4')) {
         lines.push(`- Fix zero-match keys: ${scorecard.zero_match_keys.slice(0, 5).join(', ')}`);

--- a/scripts/lib/recipe-grader.ts
+++ b/scripts/lib/recipe-grader.ts
@@ -424,10 +424,16 @@ async function checkF1DefaultFill(
       values: defaults,
     });
 
+    // Clean source for formatting anomaly baseline
+    const meta = loadRecipeMetadata(recipeDir);
+    const cleanConfig = loadCleanConfig(recipeDir);
+    const sourcePath = await ensureSourceDocx(recipeId, meta);
+    const cleanedSourcePath = join(tempDir, 'cleaned-source.docx');
+    await cleanDocument(sourcePath, cleanedSourcePath, cleanConfig);
+
     const replacementsPath = join(recipeDir, 'replacements.json');
     const replacements: Record<string, string> = JSON.parse(readFileSync(replacementsPath, 'utf-8'));
-    const cleanConfig = loadCleanConfig(recipeDir);
-    const result = await verifyOutput(outPath, defaults, replacements, cleanConfig);
+    const result = await verifyOutput(outPath, defaults, replacements, cleanConfig, cleanedSourcePath);
 
     const failedChecks = result.checks.filter((c) => !c.passed);
     const totalVerify = result.checks.length;
@@ -473,6 +479,7 @@ async function checkF2FullFill(
     };
   }
 
+  const tempDir = mkdtempSync(join(tmpdir(), `grader-f2-${recipeId}-`));
   try {
     const defaults = buildDefaultValues(recipeDir);
     const merged = { ...defaults, ...fixtureValues };
@@ -483,10 +490,16 @@ async function checkF2FullFill(
       values: merged,
     });
 
+    // Clean source for formatting anomaly baseline
+    const meta = loadRecipeMetadata(recipeDir);
+    const cleanConfig = loadCleanConfig(recipeDir);
+    const sourcePath = await ensureSourceDocx(recipeId, meta);
+    const cleanedSourcePath = join(tempDir, 'cleaned-source.docx');
+    await cleanDocument(sourcePath, cleanedSourcePath, cleanConfig);
+
     const replacementsPath = join(recipeDir, 'replacements.json');
     const replacements: Record<string, string> = JSON.parse(readFileSync(replacementsPath, 'utf-8'));
-    const cleanConfig = loadCleanConfig(recipeDir);
-    const result = await verifyOutput(outPath, merged, replacements, cleanConfig);
+    const result = await verifyOutput(outPath, merged, replacements, cleanConfig, cleanedSourcePath);
 
     const failedChecks = result.checks.filter((c) => !c.passed);
     const totalVerify = result.checks.length;
@@ -509,6 +522,8 @@ async function checkF2FullFill(
       check: { id: 'F2', name: 'Full-values fill', passed: false, score: 0, details: `Error: ${(err as Error).message}` },
       verifyResult: null,
     };
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
   }
 }
 
@@ -531,11 +546,18 @@ async function checkF3FormattingAnomalies(
     }
   }
 
+  const tempDir = mkdtempSync(join(tmpdir(), `grader-f3-${recipeId}-`));
   try {
+    // Clean the source to establish baseline anomaly count
+    const meta = loadRecipeMetadata(recipeDir);
+    const cleanConfig = loadCleanConfig(recipeDir);
+    const sourcePath = await ensureSourceDocx(recipeId, meta);
+    const cleanedSourcePath = join(tempDir, 'cleaned-source.docx');
+    await cleanDocument(sourcePath, cleanedSourcePath, cleanConfig);
+
     const replacementsPath = join(recipeDir, 'replacements.json');
     const replacements: Record<string, string> = JSON.parse(readFileSync(replacementsPath, 'utf-8'));
-    const cleanConfig = loadCleanConfig(recipeDir);
-    const result = await verifyOutput(outPath, {}, replacements, cleanConfig);
+    const result = await verifyOutput(outPath, {}, replacements, cleanConfig, cleanedSourcePath);
     const anomalyCheck = result.checks.find((c) => c.name === 'No formatting anomalies');
     return {
       id: 'F3',
@@ -545,6 +567,8 @@ async function checkF3FormattingAnomalies(
     };
   } catch (err) {
     return { id: 'F3', name: 'Formatting anomalies', passed: false, details: `Error: ${(err as Error).message}` };
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
   }
 }
 
@@ -653,7 +677,7 @@ function generateRecommendations(checks: CheckResult[], coverage: { uncovered: s
         recs.push(`Full-values fill has issues: ${check.details}`);
         break;
       case 'F3':
-        recs.push('SKIP F3 — formatting anomalies are a patcher engine limitation, not fixable via recipe files');
+        recs.push(`Formatting anomalies introduced by fill/patch: ${check.details}`);
         break;
       case 'F4':
         if (zeroMatchKeys.length > 0) {

--- a/scripts/overnight-hardening.ts
+++ b/scripts/overnight-hardening.ts
@@ -183,6 +183,7 @@ interface RecipeReport {
   exitReason: 'perfect' | 'max_loops' | 'stalled' | 'error';
   newFixtures: number;
   scorecards: RecipeScorecard[];
+  bestScorecard?: RecipeScorecard;  // last kept scorecard (not reverted)
   errors: string[];
   policyViolations: string[];
 }
@@ -608,6 +609,17 @@ async function hardenRecipe(
   }
 
   const startContinuous = scorecard.continuous_total;
+
+  // Unified accepted state — tracks the last KEPT scorecard + commit.
+  // Only kept/same-score iterations update this; reverted iterations do not.
+  let accepted = {
+    scorecard,
+    commitSha: execSync('git rev-parse HEAD', { cwd: PROJECT_ROOT }).toString().trim(),
+    continuous: scorecard.continuous_total,
+    score: scorecard.total_numeric,
+  };
+  // keptScorecards excludes reverted attempts so Pareto high-water is accurate.
+  const keptScorecards: RecipeScorecard[] = [scorecard];
   let bestContinuous = startContinuous;
 
   // Log baseline convergence point
@@ -643,6 +655,7 @@ async function hardenRecipe(
       exitReason: 'perfect',
       newFixtures: 0,
       scorecards,
+      bestScorecard: scorecard,
       errors,
       policyViolations,
     };
@@ -665,6 +678,7 @@ async function hardenRecipe(
       exitReason: 'stalled',
       newFixtures: 0,
       scorecards,
+      bestScorecard: scorecard,
       errors,
       policyViolations,
     };
@@ -692,7 +706,8 @@ async function hardenRecipe(
   }
 
   let bestScore = scorecard.total_numeric;
-  let bestCommitSha = execSync('git rev-parse HEAD', { cwd: PROJECT_ROOT }).toString().trim();
+  // bestCommitSha is now derived from accepted.commitSha — kept for backward compat
+  let bestCommitSha = accepted.commitSha;
   let noImprovementCount = 0;
   let cumulativeGain = 0;
   const startScore = scorecard.total_numeric;
@@ -774,7 +789,8 @@ async function hardenRecipe(
 
     if (!regrade) {
       console.log('  Re-grade failed — Codex likely broke metadata, reverting');
-      revertToCommit(bestCommitSha, recipeId);
+      revertToCommit(accepted.commitSha, recipeId);
+      scorecard = accepted.scorecard; // reset in-memory scorecard to last kept
       noImprovementCount++;
 
       // Log invalid experiment
@@ -834,8 +850,8 @@ async function hardenRecipe(
       }
     }
 
-    // Check Pareto protection
-    const highWater = buildCheckHighWater(scorecards.slice(0, -1));
+    // Check Pareto protection — only kept scorecards inform the high-water mark
+    const highWater = buildCheckHighWater(keptScorecards.slice(0, -1));
     const regressed = findRegressedChecks(highWater, scorecard);
     if (regressed.length > 0) {
       console.log(`  Pareto regression on: ${regressed.join(', ')}`);
@@ -853,6 +869,8 @@ async function hardenRecipe(
       bestScore = newScore;
       bestContinuous = newContinuous;
       bestCommitSha = gitCheckpoint(recipeId, i, newScore, newContinuous);
+      keptScorecards.push(scorecard);
+      accepted = { scorecard, commitSha: bestCommitSha, continuous: newContinuous, score: newScore };
 
       // Log experiment
       const checksImproved = scorecard.checks
@@ -907,6 +925,7 @@ async function hardenRecipe(
         exitReason: 'perfect',
         newFixtures: countFixtures(recipeId) - initialFixtureCount,
         scorecards,
+        bestScorecard: accepted.scorecard,
         errors,
         policyViolations,
       };
@@ -919,6 +938,8 @@ async function hardenRecipe(
       bestScore = Math.max(bestScore, newScore);
       bestContinuous = newContinuous;
       bestCommitSha = gitCheckpoint(recipeId, i, newScore, newContinuous);
+      keptScorecards.push(scorecard);
+      accepted = { scorecard, commitSha: bestCommitSha, continuous: newContinuous, score: newScore };
       outcome = 'kept';
       console.log(`  New best: ${newContinuous.toFixed(3)}/${scorecard.max_applicable} (committed ${bestCommitSha.slice(0, 8)})`);
 
@@ -930,17 +951,20 @@ async function hardenRecipe(
         noImprovementCount++;
       }
     } else if (newContinuous < bestContinuous - EPS_KEEP || regressed.length > 0) {
-      // Regression or Pareto violation
+      // Regression or Pareto violation — revert to accepted state
       const reason = regressed.length > 0
         ? `Pareto regression on ${regressed.join(', ')}`
         : `continuous ${newContinuous.toFixed(3)} < best ${bestContinuous.toFixed(3)}`;
       console.log(`  Reverting: ${reason}`);
-      revertToCommit(bestCommitSha, recipeId);
+      revertToCommit(accepted.commitSha, recipeId);
+      scorecard = accepted.scorecard; // reset in-memory scorecard to last kept
       outcome = 'reverted';
       noImprovementCount++;
     } else {
       // Same score — still commit if there are improvements in details
-      gitCheckpoint(recipeId, i, newScore, newContinuous);
+      const sha = gitCheckpoint(recipeId, i, newScore, newContinuous);
+      keptScorecards.push(scorecard);
+      accepted = { scorecard, commitSha: sha, continuous: newContinuous, score: newScore };
       outcome = 'kept';
       noImprovementCount++;
       console.log(`  No improvement (${noImprovementCount}/${STALL_LIMIT} before stall)`);
@@ -1005,6 +1029,7 @@ async function hardenRecipe(
         exitReason: 'stalled',
         newFixtures: countFixtures(recipeId) - initialFixtureCount,
         scorecards,
+        bestScorecard: accepted.scorecard,
         errors,
         policyViolations,
       };
@@ -1022,6 +1047,7 @@ async function hardenRecipe(
     exitReason: 'max_loops',
     newFixtures: countFixtures(recipeId) - initialFixtureCount,
     scorecards,
+    bestScorecard: accepted.scorecard,
     errors,
     policyViolations,
   };
@@ -1114,7 +1140,7 @@ function updateQualityTracker(reports: RecipeReport[]): void {
   const today = new Date().toISOString().slice(0, 10);
 
   for (const report of reports) {
-    const lastScorecard = report.scorecards[report.scorecards.length - 1];
+    const lastScorecard = report.bestScorecard ?? report.scorecards[report.scorecards.length - 1];
     if (!lastScorecard) continue;
 
     const { structural, behavioral, fill } = lastScorecard.scores;

--- a/src/core/recipe/index.ts
+++ b/src/core/recipe/index.ts
@@ -111,7 +111,7 @@ export { cleanDocument } from './cleaner.js';
 export type { CleanResult, CleanOptions } from './cleaner.js';
 export { patchDocument } from './patcher.js';
 export type { PatchResult } from './patcher.js';
-export { verifyOutput, normalizeText, extractAllText } from './verifier.js';
+export { verifyOutput, normalizeText, extractAllText, countFormattingAnomalies } from './verifier.js';
 export { ensureSourceDocx } from './downloader.js';
 export { checkRecipeSourceDrift, computeSourceStructureSignature } from './source-drift.js';
 export { enumerateTextParts, getGeneralTextPartNames } from './ooxml-parts.js';

--- a/src/core/recipe/patcher.test.ts
+++ b/src/core/recipe/patcher.test.ts
@@ -417,6 +417,165 @@ describe('patchDocument', () => {
   });
 });
 
+describe('patchDocument — formatting preservation (docx-core)', () => {
+  /**
+   * Helper: extract raw run XML from the first <w:p> in a DOCX.
+   * Returns an array of { text, hasBold } per run.
+   */
+  function extractRunInfo(docxPath: string): Array<{ text: string; bold: boolean }> {
+    const zip = new AdmZip(docxPath);
+    const entry = zip.getEntry('word/document.xml');
+    if (!entry) return [];
+    const xml = entry.getData().toString('utf-8');
+    const doc = new DOMParser().parseFromString(xml, 'text/xml');
+    const runs = doc.getElementsByTagNameNS(W_NS, 'r');
+    const result: Array<{ text: string; bold: boolean }> = [];
+    for (let i = 0; i < runs.length; i++) {
+      const run = runs[i];
+      const tElements = run.getElementsByTagNameNS(W_NS, 't');
+      let text = '';
+      for (let j = 0; j < tElements.length; j++) {
+        text += tElements[j].textContent ?? '';
+      }
+      if (!text) continue;
+      const rPr = run.getElementsByTagNameNS(W_NS, 'rPr');
+      let bold = false;
+      if (rPr.length > 0) {
+        bold = rPr[0].getElementsByTagNameNS(W_NS, 'b').length > 0;
+      }
+      result.push({ text, bold });
+    }
+    return result;
+  }
+
+  it.openspec('OA-RCP-035')('no mid-word formatting split on cross-run replacement with common prefix', async () => {
+    // Regression: surgical optimization caused "clause" (bold) + "(s)" (plain) split
+    // when replacing "clause[(s)]" → "clause(s)" across formatting boundaries.
+    const xml =
+      '<?xml version="1.0" encoding="UTF-8"?>' +
+      `<w:document xmlns:w="${W_NS}"><w:body>` +
+      '<w:p>' +
+      '<w:r><w:rPr><w:b/></w:rPr><w:t>The clause</w:t></w:r>' +
+      '<w:r><w:t>[(s)] of the agreement</w:t></w:r>' +
+      '</w:p>' +
+      '</w:body></w:document>';
+
+    const inputPath = buildMinimalDocx(xml);
+    const outputPath = inputPath.replace('test.docx', 'output.docx');
+
+    await patchDocument(inputPath, outputPath, {
+      'clause[(s)]': 'clause(s)',
+    });
+
+    const text = extractText(outputPath);
+    expect(text).toBe('The clause(s) of the agreement');
+
+    // The key assertion: "clause(s)" must NOT be split across runs with different formatting.
+    // docx-core places the full replacement in a single new run, preventing mid-word splits.
+    const runInfo = extractRunInfo(outputPath);
+    // Find which run(s) contain "clause(s)"
+    const clauseRuns = runInfo.filter(r => r.text.includes('clause(s)') || r.text.includes('clause'));
+    // "clause(s)" should be fully within a single run or contiguous runs with the same formatting
+    const fullClauseText = clauseRuns.map(r => r.text).join('');
+    expect(fullClauseText).toContain('clause(s)');
+    // Verify no single-char split like "p" + "rovided" or "clause" + "(s)" with different formatting
+    for (const r of runInfo) {
+      if (r.text === '(s)' || r.text === '(s' || r.text === 's)') {
+        // If "(s)" is in its own run, it must have same formatting as "clause" run
+        const clauseRun = runInfo.find(cr => cr.text.includes('clause'));
+        if (clauseRun) {
+          expect(r.bold).toBe(clauseRun.bold);
+        }
+      }
+    }
+
+    rmSync(inputPath.replace('/test.docx', ''), { recursive: true, force: true });
+  });
+
+  it.openspec('OA-RCP-035')('container-boundary replacement uses fallback without throwing', async () => {
+    // Replacement spans from direct paragraph run into <w:hyperlink> child run.
+    // docx-core throws UNSAFE_CONTAINER_BOUNDARY; patcher falls back to legacy charMap.
+    const xml =
+      '<?xml version="1.0" encoding="UTF-8"?>' +
+      `<w:document xmlns:w="${W_NS}"><w:body>` +
+      '<w:p>' +
+      '<w:r><w:t>[Company</w:t></w:r>' +
+      '<w:hyperlink>' +
+      '<w:r><w:t> Name]</w:t></w:r>' +
+      '</w:hyperlink>' +
+      '</w:p>' +
+      '</w:body></w:document>';
+
+    const inputPath = buildMinimalDocx(xml);
+    const outputPath = inputPath.replace('test.docx', 'output.docx');
+
+    // Should NOT throw — falls back to legacy
+    await patchDocument(inputPath, outputPath, {
+      '[Company Name]': '{company_name}',
+    });
+
+    const text = extractText(outputPath);
+    expect(text).toBe('{company_name}');
+
+    rmSync(inputPath.replace('/test.docx', ''), { recursive: true, force: true });
+  });
+
+  it.openspec('OA-RCP-035')('tab before match does not shift replacement offset', async () => {
+    // Paragraph with <w:tab/> before the match; docx-core counts tabs as visible chars
+    const xml =
+      '<?xml version="1.0" encoding="UTF-8"?>' +
+      `<w:document xmlns:w="${W_NS}"><w:body>` +
+      '<w:p>' +
+      '<w:r><w:t>Item</w:t><w:tab/><w:t>[Amount]</w:t></w:r>' +
+      '</w:p>' +
+      '</w:body></w:document>';
+
+    const inputPath = buildMinimalDocx(xml);
+    const outputPath = inputPath.replace('test.docx', 'output.docx');
+
+    await patchDocument(inputPath, outputPath, {
+      '[Amount]': '{amount}',
+    });
+
+    // Verify the replacement happened correctly
+    const zip = new AdmZip(outputPath);
+    const outputXml = zip.getEntry('word/document.xml')!.getData().toString('utf-8');
+    expect(outputXml).toContain('{amount}');
+    expect(outputXml).not.toContain('[Amount]');
+    // Tab element should be preserved
+    expect(outputXml).toContain('<w:tab');
+
+    rmSync(inputPath.replace('/test.docx', ''), { recursive: true, force: true });
+  });
+
+  it.openspec('OA-RCP-035')('replacementColor applied via addRunProps.color', async () => {
+    const xml =
+      '<?xml version="1.0" encoding="UTF-8"?>' +
+      `<w:document xmlns:w="${W_NS}"><w:body>` +
+      '<w:p><w:r><w:t>[Company Name]</w:t></w:r></w:p>' +
+      '</w:body></w:document>';
+
+    const inputPath = buildMinimalDocx(xml);
+    const outputPath = inputPath.replace('test.docx', 'output.docx');
+
+    await patchDocument(inputPath, outputPath, {
+      '[Company Name]': 'Acme Corp',
+    }, { replacementColor: '000000' });
+
+    const zip = new AdmZip(outputPath);
+    const outputXml = zip.getEntry('word/document.xml')!.getData().toString('utf-8');
+    expect(outputXml).toContain('Acme Corp');
+    // Color should be set on the replacement run
+    expect(outputXml).toContain('000000');
+    // Verify it's in a <w:color> element
+    const doc = new DOMParser().parseFromString(outputXml, 'text/xml');
+    const colorEls = doc.getElementsByTagNameNS(W_NS, 'color');
+    expect(colorEls.length).toBeGreaterThan(0);
+
+    rmSync(inputPath.replace('/test.docx', ''), { recursive: true, force: true });
+  });
+});
+
 describe('isRunSafeToRemove', () => {
   const parser = new DOMParser();
 

--- a/src/core/recipe/patcher.ts
+++ b/src/core/recipe/patcher.ts
@@ -2,6 +2,11 @@ import AdmZip from 'adm-zip';
 import { writeFileSync } from 'node:fs';
 import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
 import type { Document, Element, Node } from '@xmldom/xmldom';
+import {
+  replaceParagraphTextRange,
+  getParagraphText,
+  SafeDocxError,
+} from '@usejunior/docx-core';
 import { enumerateTextParts, getGeneralTextPartNames } from './ooxml-parts.js';
 import { parseReplacementKey } from './replacement-keys.js';
 import type { ParsedKey } from './replacement-keys.js';
@@ -135,21 +140,19 @@ export async function patchDocument(
 
     // Collect paragraph text before any replacements for zero-match detection
     for (let i = 0; i < allParagraphs.length; i++) {
-      const runs = getRunElements(allParagraphs[i]);
-      if (runs.length === 0) continue;
-      const { fullText } = buildCharMap(runs);
-      preMatchTexts.push(normalizeQuotes(fullText));
+      const text = getParagraphText(allParagraphs[i] as unknown as globalThis.Element);
+      if (!text) continue;
+      preMatchTexts.push(normalizeQuotes(text));
     }
 
     // Phase 1: Context keys
     for (const ck of contextKeys) {
       for (let i = 0; i < allParagraphs.length; i++) {
         const para = allParagraphs[i];
-        const runs = getRunElements(para);
-        if (runs.length === 0) continue;
+        const paraText = getParagraphText(para as unknown as globalThis.Element);
+        if (!paraText) continue;
 
-        const { fullText } = buildCharMap(runs);
-        const normalizedText = normalizeQuotes(fullText);
+        const normalizedText = normalizeQuotes(paraText);
         if (!normalizedText.includes(ck.searchText)) continue;
 
         const rowContext = getTableRowContext(para);
@@ -374,33 +377,13 @@ export function isRunSafeToRemove(run: Element): boolean {
 }
 
 /**
- * Compute the length of the common prefix between two strings.
- */
-function commonPrefixLen(a: string, b: string): number {
-  let i = 0;
-  while (i < a.length && i < b.length && a[i] === b[i]) i++;
-  return i;
-}
-
-/**
- * Compute the length of the common suffix between two strings,
- * not overlapping with a known common prefix.
- */
-function commonSuffixLen(a: string, b: string, prefixLen: number): number {
-  let i = 0;
-  while (
-    i < a.length - prefixLen &&
-    i < b.length - prefixLen &&
-    a[a.length - 1 - i] === b[b.length - 1 - i]
-  ) i++;
-  return i;
-}
-
-/**
- * Low-level charMap-based splice: replace `searchTextLength` characters starting at
+ * Legacy charMap-based splice: replace `searchTextLength` characters starting at
  * `matchStart` with `value`, cleaning up empty runs afterwards.
+ * Used as a fallback when replaceParagraphTextRange throws UNSAFE_CONTAINER_BOUNDARY
+ * (e.g. replacements spanning across hyperlinks or SDTs) or UNSUPPORTED_EDIT
+ * (e.g. replacement spans field results).
  */
-function replaceAtPosition(
+function replaceAtPositionLegacy(
   runs: Element[],
   charMap: CharMapEntry[],
   matchStart: number,
@@ -443,6 +426,8 @@ function replaceAtPosition(
 /**
  * Perform a single replacement of searchText with value in the paragraph.
  * Does NOT loop — replaces only the first match found.
+ * Uses docx-core's replaceParagraphTextRange for correct formatting preservation,
+ * with a legacy charMap fallback for container-boundary cases (hyperlinks, SDTs).
  */
 function replaceInParagraphOnce(
   para: Element,
@@ -450,17 +435,36 @@ function replaceInParagraphOnce(
   value: string,
   replacementColor?: string,
 ): void {
-  const runs = getRunElements(para);
-  if (runs.length === 0) return;
-  const { fullText, charMap } = buildCharMap(runs);
+  const fullText = getParagraphText(para as unknown as globalThis.Element);
   const matchStart = normalizeQuotes(fullText).indexOf(searchText);
   if (matchStart === -1) return;
-  replaceAtPosition(runs, charMap, matchStart, searchText.length, value, replacementColor);
+
+  try {
+    replaceParagraphTextRange(
+      para as unknown as globalThis.Element,
+      matchStart,
+      matchStart + searchText.length,
+      replacementColor
+        ? [{ text: value, addRunProps: { color: replacementColor } }]
+        : value,
+    );
+  } catch (e) {
+    if (e instanceof SafeDocxError && (e.code === 'UNSAFE_CONTAINER_BOUNDARY' || e.code === 'UNSUPPORTED_EDIT')) {
+      const runs = getRunElements(para);
+      const { fullText: legacyText, charMap } = buildCharMap(runs);
+      const legacyPos = normalizeQuotes(legacyText).indexOf(searchText);
+      if (legacyPos === -1) return;
+      replaceAtPositionLegacy(runs, charMap, legacyPos, searchText.length, value, replacementColor);
+    } else {
+      throw e;
+    }
+  }
 }
 
 /**
  * Replace the first occurrence of searchText that appears AFTER contextText
  * in the same paragraph. Each call is self-contained — no chaining or order dependency.
+ * Uses docx-core's replaceParagraphTextRange with legacy charMap fallback.
  */
 function replaceFirstAfterContext(
   para: Element,
@@ -469,15 +473,36 @@ function replaceFirstAfterContext(
   value: string,
   replacementColor?: string,
 ): void {
-  const runs = getRunElements(para);
-  if (runs.length === 0) return;
-  const { fullText, charMap } = buildCharMap(runs);
+  const fullText = getParagraphText(para as unknown as globalThis.Element);
   const normalizedFull = normalizeQuotes(fullText);
   const ctxPos = normalizedFull.indexOf(contextText);
   if (ctxPos === -1) return;
   const matchStart = normalizedFull.indexOf(searchText, ctxPos + contextText.length);
   if (matchStart === -1) return;
-  replaceAtPosition(runs, charMap, matchStart, searchText.length, value, replacementColor);
+
+  try {
+    replaceParagraphTextRange(
+      para as unknown as globalThis.Element,
+      matchStart,
+      matchStart + searchText.length,
+      replacementColor
+        ? [{ text: value, addRunProps: { color: replacementColor } }]
+        : value,
+    );
+  } catch (e) {
+    if (e instanceof SafeDocxError && (e.code === 'UNSAFE_CONTAINER_BOUNDARY' || e.code === 'UNSUPPORTED_EDIT')) {
+      const runs = getRunElements(para);
+      const { fullText: legacyText, charMap } = buildCharMap(runs);
+      const normalizedLegacy = normalizeQuotes(legacyText);
+      const legacyCtxPos = normalizedLegacy.indexOf(contextText);
+      if (legacyCtxPos === -1) return;
+      const legacyPos = normalizedLegacy.indexOf(searchText, legacyCtxPos + contextText.length);
+      if (legacyPos === -1) return;
+      replaceAtPositionLegacy(runs, charMap, legacyPos, searchText.length, value, replacementColor);
+    } else {
+      throw e;
+    }
+  }
 }
 
 function replaceInParagraph(
@@ -486,17 +511,17 @@ function replaceInParagraph(
   sortedKeys: string[],
   replacementColor?: string,
 ): void {
-  const runs = getRunElements(para);
-  if (runs.length === 0) return;
-
-  const { fullText } = buildCharMap(runs);
-  const normalizedFull = normalizeQuotes(fullText);
-  if (!sortedKeys.some((key) => normalizedFull.includes(key))) return;
+  // Quick check: skip if no keys match
+  const initialText = getParagraphText(para as unknown as globalThis.Element);
+  if (!initialText) return;
+  const normalizedInitial = normalizeQuotes(initialText);
+  if (!sortedKeys.some((key) => normalizedInitial.includes(key))) return;
 
   for (const key of sortedKeys) {
-    let rebuilt = buildCharMap(runs);
     let iterations = 0;
-    while (normalizeQuotes(rebuilt.fullText).includes(key)) {
+    let paraText = getParagraphText(para as unknown as globalThis.Element);
+
+    while (normalizeQuotes(paraText).includes(key)) {
       iterations++;
       if (iterations > MAX_REPLACEMENTS_PER_KEY) {
         throw new Error(
@@ -506,58 +531,37 @@ function replaceInParagraph(
         );
       }
 
-      const prevText = rebuilt.fullText;
-      const matchStart = normalizeQuotes(rebuilt.fullText).indexOf(key);
+      const prevText = paraText;
+      const matchStart = normalizeQuotes(paraText).indexOf(key);
       const replacement = replacements[key];
 
-      // Surgical replacement: compute common prefix/suffix between key and value
-      // so we only modify the differing middle, preserving formatting on context text.
-      const cpLen = commonPrefixLen(key, replacement);
-      const csLen = commonSuffixLen(key, replacement, cpLen);
-
-      let start: number;
-      let end: number;
-      let replText: string;
-
-      if (cpLen + csLen >= key.length || cpLen + csLen >= replacement.length) {
-        // No useful common prefix/suffix — full replacement (current behavior)
-        start = matchStart;
-        end = matchStart + key.length;
-        replText = replacement;
-      } else {
-        // Surgical: only replace the differing middle
-        start = matchStart + cpLen;
-        end = matchStart + key.length - csLen;
-        replText = replacement.slice(cpLen, replacement.length - csLen);
-      }
-
-      const firstEntry = rebuilt.charMap[start];
-      const lastEntry = rebuilt.charMap[end - 1];
-
-      if (firstEntry.runIndex === lastEntry.runIndex) {
-        const runText = getRunText(runs[firstEntry.runIndex]);
-        setRunText(
-          runs[firstEntry.runIndex],
-          runText.slice(0, firstEntry.charOffset) + replText + runText.slice(lastEntry.charOffset + 1)
+      try {
+        replaceParagraphTextRange(
+          para as unknown as globalThis.Element,
+          matchStart,
+          matchStart + key.length,
+          replacementColor
+            ? [{ text: replacement, addRunProps: { color: replacementColor } }]
+            : replacement,
         );
-      } else {
-        const firstRunText = getRunText(runs[firstEntry.runIndex]);
-        setRunText(runs[firstEntry.runIndex], firstRunText.slice(0, firstEntry.charOffset) + replText);
-        const lastRunText = getRunText(runs[lastEntry.runIndex]);
-        setRunText(runs[lastEntry.runIndex], lastRunText.slice(lastEntry.charOffset + 1));
-        for (let mid = firstEntry.runIndex + 1; mid < lastEntry.runIndex; mid++) {
-          setRunText(runs[mid], '');
+      } catch (e) {
+        if (e instanceof SafeDocxError && (e.code === 'UNSAFE_CONTAINER_BOUNDARY' || e.code === 'UNSUPPORTED_EDIT')) {
+          // Fallback: use legacy charMap splice for this specific match
+          const runs = getRunElements(para);
+          const { fullText: legacyText, charMap } = buildCharMap(runs);
+          const legacyPos = normalizeQuotes(legacyText).indexOf(key);
+          if (legacyPos === -1) break;
+          replaceAtPositionLegacy(runs, charMap, legacyPos, key.length, replacement, replacementColor);
+        } else {
+          throw e;
         }
       }
 
-      if (replacementColor) {
-        setRunColor(runs[firstEntry.runIndex], replacementColor);
-      }
-
-      rebuilt = buildCharMap(runs);
+      // Re-read paragraph text after DOM modification
+      paraText = getParagraphText(para as unknown as globalThis.Element);
 
       // Progress guard: if text didn't change, we're stuck
-      if (rebuilt.fullText === prevText) {
+      if (paraText === prevText) {
         throw new Error(
           `Patcher: no progress replacing key "${key}" — replacement value may contain the search key.`
         );
@@ -566,9 +570,10 @@ function replaceInParagraph(
   }
 
   // Sweep: remove empty runs that are safe to remove (no drawings, fields, etc.)
-  for (let i = runs.length - 1; i >= 0; i--) {
-    if (getRunText(runs[i]) === '' && isRunSafeToRemove(runs[i])) {
-      runs[i].parentNode?.removeChild(runs[i]);
+  const finalRuns = getRunElements(para);
+  for (let i = finalRuns.length - 1; i >= 0; i--) {
+    if (getRunText(finalRuns[i]) === '' && isRunSafeToRemove(finalRuns[i])) {
+      finalRuns[i].parentNode?.removeChild(finalRuns[i]);
     }
   }
 }

--- a/src/core/recipe/verifier.ts
+++ b/src/core/recipe/verifier.ts
@@ -39,7 +39,8 @@ export async function verifyOutput(
   outputPath: string,
   values: Record<string, unknown>,
   replacements: Record<string, string>,
-  cleanConfig?: CleanConfig
+  cleanConfig?: CleanConfig,
+  cleanedSourcePath?: string,
 ): Promise<VerifyResult> {
   const checks: VerifyCheck[] = [];
   const rawFullText = extractAllText(outputPath);
@@ -132,13 +133,18 @@ export async function verifyOutput(
 
   // Check 8: No single-character underlined runs adjacent to non-underlined runs
   // This is a hallmark of quota-based text redistribution corrupting formatting.
-  const formattingAnomalyCount = countFormattingAnomalies(outputPath);
+  // When cleanedSourcePath is provided, only flag NEW anomalies introduced by fill/patch.
+  const outputAnomalyCount = countFormattingAnomalies(outputPath);
+  const baselineAnomalyCount = cleanedSourcePath ? countFormattingAnomalies(cleanedSourcePath) : 0;
+  const newAnomalyCount = Math.max(0, outputAnomalyCount - baselineAnomalyCount);
   checks.push({
     name: 'No formatting anomalies',
-    passed: formattingAnomalyCount === 0,
-    details: formattingAnomalyCount > 0
-      ? `Found ${formattingAnomalyCount} single-char underlined run(s) adjacent to non-underlined runs`
-      : undefined,
+    passed: newAnomalyCount === 0,
+    details: newAnomalyCount > 0
+      ? `Found ${newAnomalyCount} new single-char underlined run(s) adjacent to non-underlined runs (${outputAnomalyCount} total, ${baselineAnomalyCount} in source)`
+      : baselineAnomalyCount > 0
+        ? `${baselineAnomalyCount} pre-existing anomaly(ies) in source (baselined)`
+        : undefined,
   });
 
   return {
@@ -152,7 +158,7 @@ export async function verifyOutput(
  * non-underlined runs. This pattern is the hallmark of quota-based text
  * redistribution corrupting run-level formatting.
  */
-function countFormattingAnomalies(docxPath: string): number {
+export function countFormattingAnomalies(docxPath: string): number {
   const zip = new AdmZip(docxPath);
   const parser = new DOMParser();
   const parts = enumerateTextParts(zip);


### PR DESCRIPTION
## Summary

- **Patcher rewrite**: Replace the charMap-based `replaceAtPosition` with docx-core's `replaceParagraphTextRange`. Removes the surgical `commonPrefixLen`/`commonSuffixLen` optimization that caused mid-word formatting splits (e.g. "clause" bold + "(s)" plain). Adds container-boundary and field-result fallback to legacy charMap splice when docx-core throws `UNSAFE_CONTAINER_BOUNDARY` or `UNSUPPORTED_EDIT`. Uses `getParagraphText()` for position-finding instead of building charMaps for reads.
- **NVCA hardening batch**: Adds field coverage, replacement keys, and integration test fixtures (defaults, partial, series-c) for certificate-of-incorporation, investors-rights-agreement, voting-agreement, and management-rights-letter. Improves verifier formatting anomaly detection with word-boundary-aware underline split heuristic. Allows empty-string default for boolean fields in metadata schema. Adds overnight hardening automation script.

## Test plan

- [x] All 24 patcher unit tests pass (including 4 new regression tests)
- [ ] Integration tests for the 4 NVCA recipes pass with new fixtures
- [ ] Verify no mid-word formatting splits in filled DOCX output
- [ ] Verify container-boundary fallback works for cross-hyperlink replacements