### PR TITLE
feat(mcp): add redline generation + fix Series A replacement keys

### DIFF
--- a/api/_shared.ts
+++ b/api/_shared.ts
@@ -4,7 +4,7 @@
  */
 
 import { randomUUID, createHmac, timingSafeEqual } from 'node:crypto';
-import { readFileSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -41,7 +41,7 @@ import {
   findRecipeDir,
   listRecipeEntries,
 } from '../dist/utils/paths.js';
-import { runRecipe } from '../dist/core/recipe/index.js';
+import { runRecipe, ensureSourceDocx } from '../dist/core/recipe/index.js';
 import {
   listTemplateItems,
   categoryFromId,
@@ -202,6 +202,72 @@ export async function handleFill(
 }
 
 // ---------------------------------------------------------------------------
+// Redline generation — compare source vs filled for recipe templates
+// ---------------------------------------------------------------------------
+
+export interface RedlineResult {
+  base64: string;
+  stats: { insertions: number; deletions: number; modifications: number };
+}
+
+/**
+ * Generate a redline (track-changes) DOCX comparing a base document
+ * against the filled output. Returns null for non-recipe templates.
+ *
+ * @param redlineBase 'source' = cleaned form (text boxes/commentary stripped, shows
+ *                               replacement pattern + field substitution changes)
+ *                    'clean'  = patched intermediate (shows only field substitutions)
+ * @param values      Re-runs recipe with keepIntermediate to access stage files
+ */
+export async function generateRedlineFromFill(
+  template: string,
+  filledBase64: string,
+  redlineBase: 'source' | 'clean' = 'source',
+  values?: Record<string, unknown>,
+): Promise<RedlineResult | null> {
+  const recipeDir = findRecipeDir(template);
+  if (!recipeDir) return null;
+
+  // Use relative path for Vercel serverless tracing (workspace package
+  // may not be in node_modules inside the function bundle).
+  const { compareDocuments } = await import('../packages/docx-core/dist/index.js');
+
+  // Run recipe with keepIntermediate to get stage files for comparison base
+  const tmpOutput = join('/tmp', `${template}-redline-tmp-${randomUUID()}.docx`);
+  const recipeResult = await runRecipe({
+    recipeId: template,
+    outputPath: tmpOutput,
+    values: (values ?? {}) as Record<string, string | boolean>,
+    keepIntermediate: true,
+  });
+
+  // 'source' → cleaned stage: text boxes and commentary removed, but replacement
+  //            patterns and field placeholders still intact. Shows all legal text
+  //            changes. (Raw source can't be used because compareDocuments doesn't
+  //            diff text box/shape elements — they pass through untouched.)
+  // 'clean'  → patched stage: replacement patterns applied ({field_name} tokens),
+  //            shows only field value substitutions.
+  const basePath = redlineBase === 'clean'
+    ? recipeResult.stages.patch
+    : recipeResult.stages.clean;
+  const baseBuffer = readFileSync(basePath);
+
+  const filledBuffer = Buffer.from(filledBase64, 'base64');
+  const compareResult = await compareDocuments(baseBuffer, filledBuffer, {
+    author: 'Open Agreements',
+  });
+
+  return {
+    base64: compareResult.document.toString('base64'),
+    stats: {
+      insertions: compareResult.stats.insertions,
+      deletions: compareResult.stats.deletions,
+      modifications: compareResult.stats.modifications,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Create checklist handler — protocol-agnostic
 // ---------------------------------------------------------------------------
 
@@ -350,6 +416,8 @@ export interface DownloadArtifact {
   values: Record<string, unknown>;
   created_at_ms: number;
   expires_at_ms: number;
+  variant?: 'filled' | 'redline';
+  redline_base?: 'source' | 'clean';
 }
 
 function isDownloadArtifact(value: unknown): value is DownloadArtifact {
@@ -486,7 +554,7 @@ export interface CreatedDownloadArtifact {
 export async function createDownloadArtifact(
   template: string,
   values: Record<string, unknown>,
-  opts?: { ttl_ms?: number; now_ms?: number },
+  opts?: { ttl_ms?: number; now_ms?: number; variant?: 'filled' | 'redline'; redline_base?: 'source' | 'clean' },
 ): Promise<CreatedDownloadArtifact> {
   const nowMs = opts?.now_ms ?? Date.now();
   const ttlMs = opts?.ttl_ms ?? DOWNLOAD_TTL_MS;
@@ -498,6 +566,8 @@ export async function createDownloadArtifact(
     values,
     created_at_ms: nowMs,
     expires_at_ms: expiresAtMs,
+    ...(opts?.variant && { variant: opts.variant }),
+    ...(opts?.redline_base && { redline_base: opts.redline_base }),
   };
 
   await getDownloadArtifactStore().set(rawId, artifact);

--- a/api/download.ts
+++ b/api/download.ts
@@ -5,7 +5,7 @@
  */
 
 import type { HttpRequest, HttpResponse } from './_http-types.js';
-import { resolveDownloadArtifact, handleFill, DOCX_MIME } from './_shared.js';
+import { resolveDownloadArtifact, handleFill, generateRedlineFromFill, DOCX_MIME } from './_shared.js';
 
 type DownloadHttpErrorCode =
   | 'DOWNLOAD_ID_MISSING'
@@ -185,8 +185,25 @@ export default async function handler(req: HttpRequest, res: HttpResponse) {
     return sendDownloadError(req, res, 500, 'DOWNLOAD_RENDER_FAILED', outcome.error);
   }
 
-  const filename = `${resolved.artifact.template}.docx`;
-  const docxBuffer = Buffer.from(outcome.base64, 'base64');
+  let docxBuffer: Buffer;
+  let filename: string;
+
+  if (resolved.artifact.variant === 'redline') {
+    const redline = await generateRedlineFromFill(
+      resolved.artifact.template,
+      outcome.base64,
+      resolved.artifact.redline_base ?? 'source',
+      resolved.artifact.values,
+    );
+    if (!redline) {
+      return sendDownloadError(req, res, 500, 'DOWNLOAD_RENDER_FAILED', 'Redline generation not available for this template.');
+    }
+    docxBuffer = Buffer.from(redline.base64, 'base64');
+    filename = `${resolved.artifact.template}-redline.docx`;
+  } else {
+    docxBuffer = Buffer.from(outcome.base64, 'base64');
+    filename = `${resolved.artifact.template}.docx`;
+  }
 
   res.setHeader('Content-Type', DOCX_MIME);
   res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -15,6 +15,7 @@ import {
   handleListTemplates,
   DOCX_MIME,
   createDownloadArtifact,
+  generateRedlineFromFill,
 } from './_shared.js';
 import { ErrorCode, makeToolError, wrapError, wrapSuccess } from './_envelope.js';
 
@@ -37,6 +38,8 @@ const FillTemplateArgsSchema = z.object({
   template_id: z.string().min(1).optional(),
   values: z.record(z.string(), z.unknown()).optional().default({}),
   return_mode: z.enum(['url', 'mcp_resource']).optional().default('url'),
+  include_redline: z.boolean().optional().default(true),
+  redline_base: z.enum(['source', 'clean']).optional().default('source'),
 }).transform((v) => ({ ...v, template: v.template ?? v.template_id ?? '' }))
   .refine((v) => v.template.length > 0, { message: 'template or template_id is required' });
 
@@ -87,7 +90,9 @@ const TOOLS = [
     name: TOOL_FILL_TEMPLATE,
     description:
       'Fill a legal agreement template with field values and return a document ' +
-      'via URL or MCP resource preview metadata.',
+      'via URL or MCP resource preview metadata. ' +
+      'For recipe templates (e.g. NVCA), also generates a redline (track-changes) ' +
+      'document comparing the filled output against the standard form.',
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -104,6 +109,15 @@ const TOOLS = [
           type: 'string',
           enum: ['url', 'mcp_resource'],
           description: 'Artifact return mode. Defaults to "url".',
+        },
+        include_redline: {
+          type: 'boolean',
+          description: 'Generate a redline (track-changes) document. Defaults to true for recipes.',
+        },
+        redline_base: {
+          type: 'string',
+          enum: ['source', 'clean'],
+          description: 'Base document for redline comparison. "source" = raw standard form (default), "clean" = cleaned intermediate.',
         },
       },
       required: ['template'],
@@ -486,7 +500,7 @@ async function handleToolsCall(id: unknown, params: Record<string, unknown>) {
       );
     }
 
-    const { template, values, return_mode } = parsed.data;
+    const { template, values, return_mode, include_redline, redline_base } = parsed.data;
 
     const outcome = await handleFill(template, values);
 
@@ -501,6 +515,29 @@ async function handleToolsCall(id: unknown, params: Record<string, unknown>) {
     const downloadUrl = `${_baseUrl}/api/download?id=${encodeURIComponent(artifact.download_id)}`;
     const expiresAt = artifact.expires_at;
 
+    // Generate redline (track-changes) for recipe templates
+    let redlineData: Record<string, unknown> = {};
+    if (include_redline) {
+      try {
+        const redline = await generateRedlineFromFill(template, outcome.base64, redline_base, values);
+        if (redline) {
+          const redlineArtifact = await createDownloadArtifact(template, values, {
+            variant: 'redline',
+            redline_base,
+          });
+          const redlineUrl = `${_baseUrl}/api/download?id=${encodeURIComponent(redlineArtifact.download_id)}`;
+          redlineData = {
+            redline_download_url: redlineUrl,
+            redline_download_id: redlineArtifact.download_id,
+            redline_expires_at: redlineArtifact.expires_at,
+            redline_stats: redline.stats,
+          };
+        }
+      } catch {
+        // Redline generation is best-effort; don't fail the fill
+      }
+    }
+
     if (return_mode === 'mcp_resource') {
       return toolSuccessResult(id, TOOL_FILL_TEMPLATE, {
         content_type: DOCX_MIME,
@@ -510,6 +547,7 @@ async function handleToolsCall(id: unknown, params: Record<string, unknown>) {
         download_id: artifact.download_id,
         resource_uri: `oa://filled/${artifact.download_id}`,
         return_mode,
+        ...redlineData,
       });
     }
 
@@ -519,6 +557,7 @@ async function handleToolsCall(id: unknown, params: Record<string, unknown>) {
       expires_at: expiresAt,
       metadata: outcome.metadata,
       return_mode,
+      ...redlineData,
     });
   }
 

--- a/content/recipes/nvca-certificate-of-incorporation/replacements.json
+++ b/content/recipes/nvca-certificate-of-incorporation/replacements.json
@@ -48,5 +48,10 @@
   "[or officer]": "{or_officer_clause}",
   "[the greater of]": "{dividend_formula_prefix} ",
   "[the sum of]": "{dividend_formula_alt}",
-  "[and Section 6.1]": "{redemption_cross_ref_clause}"
+  "[and Section 6.1]": "{redemption_cross_ref_clause}",
+
+  "References to \u201cPreferred Stock\u201d mean the Series A Preferred Stock": "References to \u201cPreferred Stock\u201d mean the Series {series_designation} Preferred Stock",
+  "with respect to the Series A Preferred Stock": "with respect to the Series {series_designation} Preferred Stock",
+  "per share of Series A Preferred Stock": "per share of Series {series_designation} Preferred Stock",
+  "first share of Series A Preferred Stock": "first share of Series {series_designation} Preferred Stock"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -25,11 +25,11 @@
     },
     "api/mcp.ts": {
       "maxDuration": 30,
-      "includeFiles": "{content/templates,content/external,content/recipes,dist}/**"
+      "includeFiles": "{content/templates,content/external,content/recipes,dist,packages/docx-core/dist}/**"
     },
     "api/download.ts": {
       "maxDuration": 30,
-      "includeFiles": "{content/templates,content/external,content/recipes,dist}/**"
+      "includeFiles": "{content/templates,content/external,content/recipes,dist,packages/docx-core/dist}/**"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Fix 6 remaining "Series A" references in NVCA COI by adding 4 replacement keys (verified: 0 "Series A" remain, 8 "Series C" when filled with `series_designation=C`)
- Add automatic redline (track-changes) DOCX generation comparing the cleaned NVCA standard form against the filled output — critical for lawyer review
- New `include_redline` (default true, opt-out) and `redline_base` (`source`|`clean`) parameters on `fill_template` MCP tool
- Download handler supports redline variant artifacts

## Changes
| File | Change |
|------|--------|
| `content/recipes/nvca-certificate-of-incorporation/replacements.json` | +4 Series A replacement keys |
| `api/_shared.ts` | `generateRedlineFromFill()`, extended `DownloadArtifact` |
| `api/mcp.ts` | Schema params + redline response fields |
| `api/download.ts` | Redline variant download support |
| `vercel.json` | `packages/docx-core/dist` in includeFiles |

## Test plan
- [x] Local fill: 0 "Series A", all 39 fields filled
- [x] Source redline: 209 insertions, 351 deletions (text box artifact fixed)
- [x] Clean redline: 433 insertions, 68 deletions (field substitutions only)
- [x] `npm test`: 1,988 tests pass
- [ ] Remote MCP fill via curl after deploy
- [ ] Both download URLs return valid DOCX