### PR TITLE
fix(canary): use trimStart so trailing-space anchors survive drift check

### DIFF
--- a/src/core/recipe/source-drift.ts
+++ b/src/core/recipe/source-drift.ts
@@ -49,7 +49,7 @@ function extractDocumentParagraphs(docxPath: string): string[] {
     while ((tMatch = tRegex.exec(paraXml)) !== null) {
       parts.push(tMatch[1]);
     }
-    const text = parts.join('').trim();
+    const text = parts.join('').trimStart();
     if (text.length > 0) {
       paragraphs.push(text);
     }


### PR DESCRIPTION
## Summary
- `extractDocumentParagraphs` used `.trim()`, which stripped trailing spaces from paragraph text
- The ROFR replacement key `"Email:   "` relies on those trailing spaces as an anchor
- Canary reported "missing replacement anchor groups: 1" and failed CI on every main push since #101 (Mar 15) — 6 consecutive failures
- Fix: `.trim()` → `.trimStart()` preserves trailing whitespace while still filtering empty paragraphs

## Test plan
- [x] `node scripts/source_drift_canary.mjs --download` — all 7 templates PASS locally
- [x] `npm test` — 1,988 tests pass
- [ ] CI green on this PR