### PR TITLE
chore(release): bump to 0.5.0 — MCP registry metadata and tool annotations

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "open-agreements",
   "displayName": "OpenAgreements",
   "description": "Open-source legal template automation for DOCX with MCP tooling.",
-  "version": "0.6.0",
+  "version": "0.5.0",
   "author": {
     "name": "Open Agreements",
     "email": "steven@usejunior.com"

--- a/README.md
+++ b/README.md
@@ -397,6 +397,13 @@ MIT
 
 Template content is licensed by their respective authors — CC BY 4.0 (Common Paper, Bonterms), CC BY-ND 4.0 (Y Combinator), or proprietary (NVCA, downloaded at runtime). See each template's `metadata.yaml` for details.
 
+## Privacy
+
+- **Local mode** (`npx`, global install, stdio MCP): all processing happens on your machine. No document content is sent externally.
+- **Hosted mode** (`https://openagreements.ai/api/mcp`): template filling runs server-side. No filled documents are stored after the response is returned.
+
+See our [Privacy Policy](https://usejunior.com/privacy_policy) for details.
+
 ## Disclaimer
 
 This tool generates documents from standard templates. It does not provide legal advice. No affiliation with or endorsement by Common Paper, Bonterms, Y Combinator, NVCA, or any template source is implied. Consult an attorney for legal guidance.

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -70,6 +70,7 @@ const TOOLS = [
         },
       },
     },
+    annotations: { readOnlyHint: true, destructiveHint: false },
   },
   {
     name: TOOL_GET_TEMPLATE,
@@ -85,6 +86,7 @@ const TOOLS = [
       },
       required: ['template_id'],
     },
+    annotations: { readOnlyHint: true, destructiveHint: false },
   },
   {
     name: TOOL_FILL_TEMPLATE,
@@ -122,6 +124,7 @@ const TOOLS = [
       },
       required: ['template'],
     },
+    annotations: { readOnlyHint: false, destructiveHint: false },
   },
 ];
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "open-agreements",
-  "version": "0.6.0",
+  "version": "0.5.0",
   "description": "Local MCP extension for OpenAgreements workspace organization and contract template drafting.",
   "contextFileName": "GEMINI.md",
   "entrypoint": "GEMINI.md",

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["stevenobiajulu"]
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-agreements",
-  "version": "0.6.0",
+  "version": "0.5.0",
   "workspaces": [
     "packages/allure-test-factory",
     "packages/contract-templates-mcp",
@@ -36,7 +36,8 @@
     "content/",
     "skills/",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "server.json"
   ],
   "bundleDependencies": [
     "@usejunior/docx-core"

--- a/packages/checklist-mcp/package.json
+++ b/packages/checklist-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agreements/checklist-mcp",
-  "version": "0.6.0",
+  "version": "0.5.0",
   "description": "Local stdio MCP server for OpenAgreements checklist memory operations",
   "type": "module",
   "bin": {

--- a/packages/checklist-mcp/src/core/tools.ts
+++ b/packages/checklist-mcp/src/core/tools.ts
@@ -18,6 +18,7 @@ interface ToolDefinition {
   name: string;
   description: string;
   inputSchema: JsonSchema;
+  annotations?: { readOnlyHint?: boolean; destructiveHint?: boolean };
   invoke: (args: unknown) => Promise<ToolCallResult>;
 }
 
@@ -171,6 +172,7 @@ const tools: ToolDefinition[] = [
       required: ['deal_name'],
       additionalProperties: false,
     },
+    annotations: { readOnlyHint: false, destructiveHint: false },
     invoke: async (args) => {
       const input = ChecklistCreateSchema.parse(args ?? {});
       const mod = await requireModules();
@@ -186,6 +188,7 @@ const tools: ToolDefinition[] = [
       properties: {},
       additionalProperties: false,
     },
+    annotations: { readOnlyHint: true, destructiveHint: false },
     invoke: async () => {
       const mod = await requireModules();
       const result = mod.listChecklists();
@@ -203,6 +206,7 @@ const tools: ToolDefinition[] = [
       required: ['checklist_id'],
       additionalProperties: false,
     },
+    annotations: { readOnlyHint: true, destructiveHint: false },
     invoke: async (args) => {
       const input = ChecklistReadSchema.parse(args ?? {});
       const mod = await requireModules();
@@ -223,6 +227,7 @@ const tools: ToolDefinition[] = [
       required: ['checklist_id', 'patch'],
       additionalProperties: false,
     },
+    annotations: { readOnlyHint: true, destructiveHint: false },
     invoke: async (args) => {
       const input = ChecklistPatchValidateSchema.parse(args ?? {});
       const mod = await requireModules();
@@ -246,6 +251,7 @@ const tools: ToolDefinition[] = [
       required: ['checklist_id', 'validation_id', 'patch'],
       additionalProperties: false,
     },
+    annotations: { readOnlyHint: false, destructiveHint: true },
     invoke: async (args) => {
       const input = ChecklistPatchApplySchema.parse(args ?? {});
       const mod = await requireModules();
@@ -274,6 +280,7 @@ const tools: ToolDefinition[] = [
       required: ['checklist_id'],
       additionalProperties: false,
     },
+    annotations: { readOnlyHint: false, destructiveHint: false },
     invoke: async (args) => {
       const input = ChecklistRenderDocxSchema.parse(args ?? {});
       const mod = await requireModules();
@@ -329,6 +336,7 @@ const tools: ToolDefinition[] = [
       required: ['checklist_id'],
       additionalProperties: false,
     },
+    annotations: { readOnlyHint: true, destructiveHint: false },
     invoke: async (args) => {
       const input = ChecklistImportDocxSchema.parse(args ?? {});
       const mod = await requireModules();
@@ -369,11 +377,12 @@ const tools: ToolDefinition[] = [
 // Tool dispatch
 // ---------------------------------------------------------------------------
 
-export function listToolDescriptors(): Array<{ name: string; description: string; inputSchema: JsonSchema }> {
+export function listToolDescriptors(): Array<{ name: string; description: string; inputSchema: JsonSchema; annotations?: { readOnlyHint?: boolean; destructiveHint?: boolean } }> {
   return tools.map((tool) => ({
     name: tool.name,
     description: tool.description,
     inputSchema: tool.inputSchema,
+    ...(tool.annotations ? { annotations: tool.annotations } : {}),
   }));
 }
 

--- a/packages/contract-templates-mcp/package.json
+++ b/packages/contract-templates-mcp/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@open-agreements/contract-templates-mcp",
-  "version": "0.6.0",
+  "version": "0.5.0",
+  "mcpName": "io.github.open-agreements/open-agreements",
   "description": "Local stdio MCP server for OpenAgreements template discovery and filling",
   "type": "module",
   "bin": {

--- a/packages/contract-templates-mcp/src/core/tools.ts
+++ b/packages/contract-templates-mcp/src/core/tools.ts
@@ -57,6 +57,7 @@ interface ToolDefinition {
   name: string;
   description: string;
   inputSchema: JsonSchema;
+  annotations?: { readOnlyHint?: boolean; destructiveHint?: boolean };
   invoke: (args: unknown) => Promise<ToolCallResult>;
 }
 
@@ -159,6 +160,7 @@ const tools: ToolDefinition[] = [
       },
       additionalProperties: false,
     },
+    annotations: { readOnlyHint: true, destructiveHint: false },
     invoke: async (args) => {
       const input = ListTemplatesArgsSchema.parse(args ?? {});
       const items = await loadTemplates();
@@ -189,6 +191,7 @@ const tools: ToolDefinition[] = [
       required: ['template_id'],
       additionalProperties: false,
     },
+    annotations: { readOnlyHint: true, destructiveHint: false },
     invoke: async (args) => {
       const input = GetTemplateArgsSchema.parse(args ?? {});
       const mod = await importRepoModules();
@@ -254,6 +257,7 @@ const tools: ToolDefinition[] = [
       required: ['template'],
       additionalProperties: false,
     },
+    annotations: { readOnlyHint: false, destructiveHint: false },
     invoke: async (args) => {
       const input = FillTemplateArgsSchema.parse(args ?? {});
       const workingDir = mkdtempSync(join(tmpdir(), 'oa-templates-mcp-'));
@@ -306,11 +310,12 @@ const tools: ToolDefinition[] = [
   },
 ];
 
-export function listToolDescriptors(): Array<{ name: string; description: string; inputSchema: JsonSchema }> {
+export function listToolDescriptors(): Array<{ name: string; description: string; inputSchema: JsonSchema; annotations?: { readOnlyHint?: boolean; destructiveHint?: boolean } }> {
   return tools.map((tool) => ({
     name: tool.name,
     description: tool.description,
     inputSchema: tool.inputSchema,
+    ...(tool.annotations ? { annotations: tool.annotations } : {}),
   }));
 }
 

--- a/packages/contracts-workspace-mcp/package.json
+++ b/packages/contracts-workspace-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agreements/contracts-workspace-mcp",
-  "version": "0.6.0",
+  "version": "0.5.0",
   "description": "Local stdio MCP server for contracts workspace operations",
   "type": "module",
   "bin": {

--- a/packages/contracts-workspace-mcp/src/core/tools.ts
+++ b/packages/contracts-workspace-mcp/src/core/tools.ts
@@ -18,6 +18,7 @@ interface ToolDefinition {
   name: string;
   description: string;
   inputSchema: JsonSchema;
+  annotations?: { readOnlyHint?: boolean; destructiveHint?: boolean };
   invoke: (args: unknown) => Promise<ToolCallResult>;
 }
 
@@ -68,6 +69,7 @@ const tools: ToolDefinition[] = [
       },
       additionalProperties: false,
     },
+    annotations: { readOnlyHint: true, destructiveHint: false },
     invoke: async (args) => {
       const input = WorkspaceInitSchema.parse(args ?? {});
       const rootDir = resolveRootDir(input.root_dir);
@@ -105,6 +107,7 @@ const tools: ToolDefinition[] = [
       },
       additionalProperties: false,
     },
+    annotations: { readOnlyHint: true, destructiveHint: false },
     invoke: async (args) => {
       const input = CatalogValidateSchema.parse(args ?? {});
       const rootDir = resolveRootDir(input.root_dir);
@@ -143,6 +146,7 @@ const tools: ToolDefinition[] = [
       },
       additionalProperties: false,
     },
+    annotations: { readOnlyHint: false, destructiveHint: false },
     invoke: async (args) => {
       const input = CatalogFetchSchema.parse(args ?? {});
       const rootDir = resolveRootDir(input.root_dir);
@@ -177,6 +181,7 @@ const tools: ToolDefinition[] = [
       },
       additionalProperties: false,
     },
+    annotations: { readOnlyHint: false, destructiveHint: false },
     invoke: async (args) => {
       const input = StatusGenerateSchema.parse(args ?? {});
       const rootDir = resolveRootDir(input.root_dir);
@@ -212,6 +217,7 @@ const tools: ToolDefinition[] = [
       },
       additionalProperties: false,
     },
+    annotations: { readOnlyHint: true, destructiveHint: false },
     invoke: async (args) => {
       const input = StatusLintSchema.parse(args ?? {});
       const rootDir = resolveRootDir(input.root_dir);
@@ -226,11 +232,12 @@ const tools: ToolDefinition[] = [
   },
 ];
 
-export function listToolDescriptors(): Array<{ name: string; description: string; inputSchema: JsonSchema }> {
+export function listToolDescriptors(): Array<{ name: string; description: string; inputSchema: JsonSchema; annotations?: { readOnlyHint?: boolean; destructiveHint?: boolean } }> {
   return tools.map((tool) => ({
     name: tool.name,
     description: tool.description,
     inputSchema: tool.inputSchema,
+    ...(tool.annotations ? { annotations: tool.annotations } : {}),
   }));
 }
 

--- a/server.json
+++ b/server.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.open-agreements/open-agreements",
+  "title": "Open Agreements",
+  "description": "Fill standard legal agreement templates (NDAs, SAFEs, NVCA docs, employment) as DOCX files.",
+  "version": "0.5.0",
+  "websiteUrl": "https://openagreements.ai",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@open-agreements/contract-templates-mcp",
+      "version": "0.5.0",
+      "transport": { "type": "stdio" },
+      "runtimeHint": "npx",
+      "environmentVariables": []
+    }
+  ],
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://openagreements.ai/api/mcp"
+    }
+  ],
+  "repository": {
+    "url": "https://github.com/open-agreements/open-agreements",
+    "source": "github",
+    "id": "open-agreements/open-agreements"
+  },
+  "license": "MIT",
+  "tags": ["legal", "contracts", "templates", "docx", "nda", "safe", "nvca", "employment"]
+}


### PR DESCRIPTION
## Summary
- Bump all package versions to 0.5.0 (0.6.0 was never published, corrected to avoid gap)
- Add `server.json` for official MCP Registry publish (packages + remotes)
- Add `mcpName` to `@open-agreements/contract-templates-mcp` package.json
- Add tool annotations (`readOnlyHint`/`destructiveHint`) to all 18 tools across 4 files
- Add `glama.json` for Glama maintainer ownership
- Add Privacy section to README

## After merge
1. `git tag v0.5.0 && git push origin v0.5.0` — triggers CI npm publish
2. `mcp-publisher login github && mcp-publisher publish` — publishes to MCP registry