### PR TITLE
fix(mcp): switch stdio output to newline-delimited JSON

### DIFF
--- a/packages/checklist-mcp/src/core/server.ts
+++ b/packages/checklist-mcp/src/core/server.ts
@@ -146,10 +146,7 @@ function pickProtocolVersion(params: unknown): string {
 }
 
 function sendResponse(response: JsonRpcResponse): void {
-  const body = JSON.stringify(response);
-  const bytes = Buffer.byteLength(body, 'utf8');
-  const framed = `Content-Length: ${bytes}\r\nContent-Type: application/json\r\n\r\n${body}`;
-  process.stdout.write(framed);
+  process.stdout.write(JSON.stringify(response) + '\n');
 }
 
 function sendError(id: JsonRpcId, code: number, message: string, data?: unknown): void {

--- a/packages/contract-templates-mcp/src/core/server.ts
+++ b/packages/contract-templates-mcp/src/core/server.ts
@@ -146,10 +146,7 @@ function pickProtocolVersion(params: unknown): string {
 }
 
 function sendResponse(response: JsonRpcResponse): void {
-  const body = JSON.stringify(response);
-  const bytes = Buffer.byteLength(body, 'utf8');
-  const framed = `Content-Length: ${bytes}\r\nContent-Type: application/json\r\n\r\n${body}`;
-  process.stdout.write(framed);
+  process.stdout.write(JSON.stringify(response) + '\n');
 }
 
 function sendError(id: JsonRpcId, code: number, message: string, data?: unknown): void {

--- a/packages/contracts-workspace-mcp/src/core/server.ts
+++ b/packages/contracts-workspace-mcp/src/core/server.ts
@@ -146,10 +146,7 @@ function pickProtocolVersion(params: unknown): string {
 }
 
 function sendResponse(response: JsonRpcResponse): void {
-  const body = JSON.stringify(response);
-  const bytes = Buffer.byteLength(body, 'utf8');
-  const framed = `Content-Length: ${bytes}\r\nContent-Type: application/json\r\n\r\n${body}`;
-  process.stdout.write(framed);
+  process.stdout.write(JSON.stringify(response) + '\n');
 }
 
 function sendError(id: JsonRpcId, code: number, message: string, data?: unknown): void {


### PR DESCRIPTION
## Summary

- Switch `sendResponse` in all three MCP sub-packages from Content-Length framing (LSP-style) to newline-delimited JSON
- Aligns with the official `@modelcontextprotocol/sdk` `StdioServerTransport` convention
- Fixes compatibility with `mcp-proxy` (used by Glama for server releases)

## Affected packages

- `contract-templates-mcp`
- `contracts-workspace-mcp`
- `checklist-mcp`

## What changed

```typescript
// Before (Content-Length framing):
function sendResponse(response: JsonRpcResponse): void {
  const body = JSON.stringify(response);
  const bytes = Buffer.byteLength(body, 'utf8');
  const framed = `Content-Length: ${bytes}\r\nContent-Type: application/json\r\n\r\n${body}`;
  process.stdout.write(framed);
}

// After (newline-delimited JSON):
function sendResponse(response: JsonRpcResponse): void {
  process.stdout.write(JSON.stringify(response) + '\n');
}
```

## Backwards compatible

The `StdioMessageParser` (input side) already accepts both Content-Length and newline-delimited formats, so no client-side changes are needed.

## Test plan

- [x] All 2003 tests pass
- [x] Manual test: contract-templates-mcp responds with clean JSON over stdio
- [x] Verified mcp-proxy can initialize and enumerate tools