### PR TITLE
chore(release): bump to 0.6.2 + add bump_version.mjs

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "open-agreements",
   "displayName": "OpenAgreements",
   "description": "Open-source legal template automation for DOCX with MCP tooling.",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "author": {
     "name": "Open Agreements",
     "email": "steven@usejunior.com"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "open-agreements",
   "displayName": "OpenAgreements",
   "description": "Open-source legal template automation for DOCX with MCP tooling.",
-  "version": "0.5.0",
+  "version": "0.6.1",
   "author": {
     "name": "Open Agreements",
     "email": "steven@usejunior.com"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "open-agreements",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Local MCP extension for OpenAgreements workspace organization and contract template drafting.",
   "contextFileName": "GEMINI.md",
   "entrypoint": "GEMINI.md",

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "open-agreements",
-  "version": "0.5.0",
+  "version": "0.6.1",
   "description": "Local MCP extension for OpenAgreements workspace organization and contract template drafting.",
   "contextFileName": "GEMINI.md",
   "entrypoint": "GEMINI.md",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-agreements",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "workspaces": [
     "packages/allure-test-factory",
     "packages/contract-templates-mcp",

--- a/packages/checklist-mcp/package.json
+++ b/packages/checklist-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agreements/checklist-mcp",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Local stdio MCP server for OpenAgreements checklist memory operations",
   "type": "module",
   "bin": {

--- a/packages/contract-templates-mcp/package.json
+++ b/packages/contract-templates-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agreements/contract-templates-mcp",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "mcpName": "io.github.open-agreements/open-agreements",
   "description": "Local stdio MCP server for OpenAgreements template discovery and filling",
   "type": "module",

--- a/packages/contracts-workspace-mcp/package.json
+++ b/packages/contracts-workspace-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agreements/contracts-workspace-mcp",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Local stdio MCP server for contracts workspace operations",
   "type": "module",
   "bin": {

--- a/scripts/bump_version.mjs
+++ b/scripts/bump_version.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+
+/**
+ * Bump version across all manifests that the release preflight checks.
+ *
+ * Usage:  node scripts/bump_version.mjs <new-version>
+ * Example: node scripts/bump_version.mjs 0.7.0
+ *
+ * Updates:
+ *   - package.json
+ *   - packages/contracts-workspace-mcp/package.json
+ *   - packages/contract-templates-mcp/package.json
+ *   - packages/checklist-mcp/package.json
+ *   - gemini-extension.json
+ *   - .cursor-plugin/plugin.json
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const VERSION_FILES = [
+  "package.json",
+  "packages/contracts-workspace-mcp/package.json",
+  "packages/contract-templates-mcp/package.json",
+  "packages/checklist-mcp/package.json",
+  "gemini-extension.json",
+  ".cursor-plugin/plugin.json",
+];
+
+const newVersion = process.argv[2];
+if (!newVersion) {
+  console.error("Usage: node scripts/bump_version.mjs <new-version>");
+  console.error("Example: node scripts/bump_version.mjs 0.7.0");
+  process.exit(1);
+}
+
+if (!/^\d+\.\d+\.\d+$/.test(newVersion)) {
+  console.error(`Invalid semver: ${newVersion}`);
+  process.exit(1);
+}
+
+const root = resolve(import.meta.dirname, "..");
+
+for (const relPath of VERSION_FILES) {
+  const absPath = resolve(root, relPath);
+  const raw = readFileSync(absPath, "utf8");
+  const oldVersion = JSON.parse(raw).version;
+  // Replace only the first "version" value to preserve all other formatting
+  const updated = raw.replace(
+    /("version"\s*:\s*")([^"]+)(")/,
+    `$1${newVersion}$3`,
+  );
+  if (updated === raw && oldVersion !== newVersion) {
+    console.error(`  ${relPath}: FAILED to locate version field`);
+    process.exit(1);
+  }
+  writeFileSync(absPath, updated);
+  console.log(`  ${relPath}: ${oldVersion} -> ${newVersion}`);
+}
+
+console.log(`\nDone. All ${VERSION_FILES.length} manifests set to ${newVersion}.`);


### PR DESCRIPTION
## Summary
- Bump all 6 release manifests to 0.6.2 (via new bump_version.mjs)
- Add scripts/bump_version.mjs — single command to update all version sources the release preflight checks
- Fix gemini-extension.json and .cursor-plugin/plugin.json stuck at 0.5.0

## Why 0.6.2 not 0.6.1
v0.6.1 tag was briefly pushed then deleted. Skip to 0.6.2 rather than reassign.

## After merge
Tag the merge commit v0.6.2 to trigger trusted publisher release.