### PR TITLE
docs: advertise openagreements.org as primary endpoint

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Agent Skill](https://img.shields.io/badge/agent--skill-open--agreements-purple)](https://skills.sh)
 [![CI](https://github.com/open-agreements/open-agreements/actions/workflows/ci.yml/badge.svg)](https://github.com/open-agreements/open-agreements/actions/workflows/ci.yml)
-[![MCP Server Status](https://img.shields.io/endpoint?url=https%3A%2F%2Fopenagreements.ai%2Fapi%2Fstatus%3Fformat%3Dshields)](https://openagreements.openstatus.dev/)
+[![MCP Server Status](https://img.shields.io/endpoint?url=https%3A%2F%2Fopenagreements.org%2Fapi%2Fstatus%3Fformat%3Dshields)](https://openagreements.openstatus.dev/)
 [![codecov](https://img.shields.io/codecov/c/github/open-agreements/open-agreements/main)](https://app.codecov.io/gh/open-agreements/open-agreements)
 [![GitHub stargazers](https://img.shields.io/github/stars/open-agreements/open-agreements?style=social)](https://github.com/open-agreements/open-agreements/stargazers)
 [![Tests: Vitest](https://img.shields.io/badge/tests-vitest-6E9F18)](https://vitest.dev/)
@@ -51,7 +51,7 @@ Fülle standardisierte juristische Vertragsvorlagen aus und erzeuge signierbare 
 
 OpenAgreements unterstützt zwei Ausführungsmodi mit unterschiedlichen Vertrauensgrenzen:
 
-- Gehosteter Remote-MCP-Connector (`https://openagreements.ai/api/mcp`) für schnelles Setup in Claude.
+- Gehosteter Remote-MCP-Connector (`https://openagreements.org/api/mcp`) für schnelles Setup in Claude.
 - Vollständig lokale Paketausführung (`npx`, globale Installation oder lokales stdio-MCP-Paket) für machine-lokale Workflows.
 
 Es gibt keine globale Empfehlung für einen Standardmodus. Wähle je nach Dokument-Sensibilität, interner Policy und gewünschter Workflow-Geschwindigkeit. Siehe `docs/trust-checklist.md` für eine 60-Sekunden-Datenflussübersicht.
@@ -127,7 +127,7 @@ Dieses Repository enthält ein Cursor-Plugin-Manifest mit MCP-Verdrahtung:
 
 Das Standard-MCP-Setup in `mcp.json` enthält:
 
-- Gehosteten OpenAgreements-MCP-Connector (`https://openagreements.ai/api/mcp`)
+- Gehosteten OpenAgreements-MCP-Connector (`https://openagreements.org/api/mcp`)
 - Lokalen Workspace-MCP-Server (`npx -y @open-agreements/contracts-workspace-mcp`)
 - Lokalen Template-Drafting-MCP-Server (`npx -y @open-agreements/contract-templates-mcp`)
 

--- a/README.es.md
+++ b/README.es.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Agent Skill](https://img.shields.io/badge/agent--skill-open--agreements-purple)](https://skills.sh)
 [![CI](https://github.com/open-agreements/open-agreements/actions/workflows/ci.yml/badge.svg)](https://github.com/open-agreements/open-agreements/actions/workflows/ci.yml)
-[![MCP Server Status](https://img.shields.io/endpoint?url=https%3A%2F%2Fopenagreements.ai%2Fapi%2Fstatus%3Fformat%3Dshields)](https://openagreements.openstatus.dev/)
+[![MCP Server Status](https://img.shields.io/endpoint?url=https%3A%2F%2Fopenagreements.org%2Fapi%2Fstatus%3Fformat%3Dshields)](https://openagreements.openstatus.dev/)
 [![codecov](https://img.shields.io/codecov/c/github/open-agreements/open-agreements/main)](https://app.codecov.io/gh/open-agreements/open-agreements)
 [![GitHub stargazers](https://img.shields.io/github/stars/open-agreements/open-agreements?style=social)](https://github.com/open-agreements/open-agreements/stargazers)
 [![Tests: Vitest](https://img.shields.io/badge/tests-vitest-6E9F18)](https://vitest.dev/)
@@ -51,7 +51,7 @@ Completa plantillas estándar de acuerdos legales y genera archivos DOCX listos 
 
 OpenAgreements admite dos modos de ejecución con límites de confianza diferentes:
 
-- Conector MCP remoto alojado (`https://openagreements.ai/api/mcp`) para configuración rápida en Claude.
+- Conector MCP remoto alojado (`https://openagreements.org/api/mcp`) para configuración rápida en Claude.
 - Ejecución totalmente local del paquete (`npx`, instalación global o paquete MCP local por stdio) para flujos de trabajo locales en tu máquina.
 
 No existe una recomendación de modo global por defecto. Elige según sensibilidad del documento, políticas internas y necesidades de velocidad del flujo de trabajo. Consulta `docs/trust-checklist.md` para un resumen de flujo de datos en 60 segundos.
@@ -127,7 +127,7 @@ Este repositorio incluye un manifiesto de plugin de Cursor con integración MCP:
 
 La configuración MCP por defecto en `mcp.json` incluye:
 
-- Conector MCP OpenAgreements alojado (`https://openagreements.ai/api/mcp`)
+- Conector MCP OpenAgreements alojado (`https://openagreements.org/api/mcp`)
 - Servidor MCP local de workspace (`npx -y @open-agreements/contracts-workspace-mcp`)
 - Servidor MCP local para redacción de plantillas (`npx -y @open-agreements/contract-templates-mcp`)
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Agent Skill](https://img.shields.io/badge/agent--skill-open--agreements-purple)](https://skills.sh)
 [![CI](https://github.com/open-agreements/open-agreements/actions/workflows/ci.yml/badge.svg)](https://github.com/open-agreements/open-agreements/actions/workflows/ci.yml)
-[![MCP Server Status](https://img.shields.io/endpoint?url=https%3A%2F%2Fopenagreements.ai%2Fapi%2Fstatus%3Fformat%3Dshields)](https://openagreements.openstatus.dev/)
+[![MCP Server Status](https://img.shields.io/endpoint?url=https%3A%2F%2Fopenagreements.org%2Fapi%2Fstatus%3Fformat%3Dshields)](https://openagreements.openstatus.dev/)
 [![codecov](https://img.shields.io/codecov/c/github/open-agreements/open-agreements/main)](https://app.codecov.io/gh/open-agreements/open-agreements)
 [![GitHub stargazers](https://img.shields.io/github/stars/open-agreements/open-agreements?style=social)](https://github.com/open-agreements/open-agreements/stargazers)
 [![Tests: Vitest](https://img.shields.io/badge/tests-vitest-6E9F18)](https://vitest.dev/)
@@ -49,7 +49,7 @@ Fill standard legal agreement templates and produce signable DOCX files. Templat
 
 OpenAgreements supports two execution modes with different trust boundaries:
 
-- Hosted remote MCP connector (`https://openagreements.ai/api/mcp`) for fast setup in Claude.
+- Hosted remote MCP connector (`https://openagreements.org/api/mcp`) for fast setup in Claude.
 - Fully local package execution (`npx`, global install, or local stdio MCP package) for machine-local workflows.
 
 There is no global default mode recommendation. Choose based on document sensitivity, internal policy, and workflow speed needs. See `docs/trust-checklist.md` for a 60-second data-flow summary.
@@ -125,7 +125,7 @@ This repository includes a Cursor plugin manifest with MCP wiring:
 
 The default MCP setup in `mcp.json` includes:
 
-- Hosted OpenAgreements MCP connector (`https://openagreements.ai/api/mcp`)
+- Hosted OpenAgreements MCP connector (`https://openagreements.org/api/mcp`)
 - Local workspace MCP server (`npx -y @open-agreements/contracts-workspace-mcp`)
 - Local template drafting MCP server (`npx -y @open-agreements/contract-templates-mcp`)
 
@@ -402,7 +402,7 @@ Template content is licensed by their respective authors — CC BY 4.0 (Common P
 ## Privacy
 
 - **Local mode** (`npx`, global install, stdio MCP): all processing happens on your machine. No document content is sent externally.
-- **Hosted mode** (`https://openagreements.ai/api/mcp`): template filling runs server-side. No filled documents are stored after the response is returned.
+- **Hosted mode** (`https://openagreements.org/api/mcp`): template filling runs server-side. No filled documents are stored after the response is returned.
 
 See our [Privacy Policy](https://usejunior.com/privacy_policy) for details.
 

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Agent Skill](https://img.shields.io/badge/agent--skill-open--agreements-purple)](https://skills.sh)
 [![CI](https://github.com/open-agreements/open-agreements/actions/workflows/ci.yml/badge.svg)](https://github.com/open-agreements/open-agreements/actions/workflows/ci.yml)
-[![MCP Server Status](https://img.shields.io/endpoint?url=https%3A%2F%2Fopenagreements.ai%2Fapi%2Fstatus%3Fformat%3Dshields)](https://openagreements.openstatus.dev/)
+[![MCP Server Status](https://img.shields.io/endpoint?url=https%3A%2F%2Fopenagreements.org%2Fapi%2Fstatus%3Fformat%3Dshields)](https://openagreements.openstatus.dev/)
 [![codecov](https://img.shields.io/codecov/c/github/open-agreements/open-agreements/main)](https://app.codecov.io/gh/open-agreements/open-agreements)
 [![GitHub stargazers](https://img.shields.io/github/stars/open-agreements/open-agreements?style=social)](https://github.com/open-agreements/open-agreements/stargazers)
 [![Tests: Vitest](https://img.shields.io/badge/tests-vitest-6E9F18)](https://vitest.dev/)
@@ -51,7 +51,7 @@ Preencha modelos padrão de acordos legais e gere arquivos DOCX prontos para ass
 
 O OpenAgreements oferece dois modos de execução com limites de confiança diferentes:
 
-- Conector MCP remoto hospedado (`https://openagreements.ai/api/mcp`) para setup rápido no Claude.
+- Conector MCP remoto hospedado (`https://openagreements.org/api/mcp`) para setup rápido no Claude.
 - Execução totalmente local do pacote (`npx`, instalação global ou pacote MCP local por stdio) para fluxos de trabalho na própria máquina.
 
 Não há recomendação global de modo padrão. Escolha com base na sensibilidade do documento, política interna e velocidade desejada no fluxo de trabalho. Veja `docs/trust-checklist.md` para um resumo de fluxo de dados em 60 segundos.
@@ -127,7 +127,7 @@ Este repositório inclui um manifesto de plugin do Cursor com integração MCP:
 
 A configuração MCP padrão em `mcp.json` inclui:
 
-- Conector MCP OpenAgreements hospedado (`https://openagreements.ai/api/mcp`)
+- Conector MCP OpenAgreements hospedado (`https://openagreements.org/api/mcp`)
 - Servidor MCP local de workspace (`npx -y @open-agreements/contracts-workspace-mcp`)
 - Servidor MCP local para drafting de modelos (`npx -y @open-agreements/contract-templates-mcp`)
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Agent Skill](https://img.shields.io/badge/agent--skill-open--agreements-purple)](https://skills.sh)
 [![CI](https://github.com/open-agreements/open-agreements/actions/workflows/ci.yml/badge.svg)](https://github.com/open-agreements/open-agreements/actions/workflows/ci.yml)
-[![MCP Server Status](https://img.shields.io/endpoint?url=https%3A%2F%2Fopenagreements.ai%2Fapi%2Fstatus%3Fformat%3Dshields)](https://openagreements.openstatus.dev/)
+[![MCP Server Status](https://img.shields.io/endpoint?url=https%3A%2F%2Fopenagreements.org%2Fapi%2Fstatus%3Fformat%3Dshields)](https://openagreements.openstatus.dev/)
 [![codecov](https://img.shields.io/codecov/c/github/open-agreements/open-agreements/main)](https://app.codecov.io/gh/open-agreements/open-agreements)
 [![GitHub stargazers](https://img.shields.io/github/stars/open-agreements/open-agreements?style=social)](https://github.com/open-agreements/open-agreements/stargazers)
 [![Tests: Vitest](https://img.shields.io/badge/tests-vitest-6E9F18)](https://vitest.dev/)
@@ -51,7 +51,7 @@
 
 OpenAgreements 支持两种执行模式，信任边界不同：
 
-- 托管远程 MCP 连接器（`https://openagreements.ai/api/mcp`），便于在 Claude 中快速配置。
+- 托管远程 MCP 连接器（`https://openagreements.org/api/mcp`），便于在 Claude 中快速配置。
 - 完全本地包执行（`npx`、全局安装或本地 stdio MCP 包），用于本机本地工作流。
 
 没有全局默认模式推荐。请根据文档敏感度、内部策略和工作流速度需求进行选择。参见 `docs/trust-checklist.md` 获取 60 秒数据流概览。
@@ -127,7 +127,7 @@ open-agreements fill common-paper-mutual-nda -d values.json -o my-nda.docx
 
 `mcp.json` 中的默认 MCP 配置包含：
 
-- 托管 OpenAgreements MCP 连接器（`https://openagreements.ai/api/mcp`）
+- 托管 OpenAgreements MCP 连接器（`https://openagreements.org/api/mcp`）
 - 本地 workspace MCP 服务器（`npx -y @open-agreements/contracts-workspace-mcp`）
 - 本地模板起草 MCP 服务器（`npx -y @open-agreements/contract-templates-mcp`）
 

--- a/mcp.json
+++ b/mcp.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "open-agreements": {
-      "url": "https://openagreements.ai/api/mcp"
+      "url": "https://openagreements.org/api/mcp"
     },
     "contracts-workspace-mcp": {
       "type": "stdio",

--- a/server.json
+++ b/server.json
@@ -4,7 +4,7 @@
   "title": "Open Agreements",
   "description": "Fill standard legal agreement templates (NDAs, SAFEs, NVCA docs, employment) as DOCX files.",
   "version": "0.5.0",
-  "websiteUrl": "https://openagreements.ai",
+  "websiteUrl": "https://openagreements.org",
   "packages": [
     {
       "registryType": "npm",
@@ -18,7 +18,7 @@
   "remotes": [
     {
       "type": "streamable-http",
-      "url": "https://openagreements.ai/api/mcp"
+      "url": "https://openagreements.org/api/mcp"
     }
   ],
   "repository": {


### PR DESCRIPTION
## Summary
- Replace `openagreements.ai` with `openagreements.org` across all user-facing surfaces
- Updates READMEs (en, es, zh, pt-br, de), `mcp.json`, and `server.json`
- Both domains resolve identically; `.org` looks more open-source-native

## Context
The `.org` domain is now live with Vercel nameserver delegation. No functional change — both `.ai` and `.org` serve the same project.

## Test plan
- [ ] Verify `https://openagreements.org/api/mcp` returns valid MCP initialize response
- [ ] Verify shields.io badge still renders from `.org` status endpoint