### PR TITLE
fix(test): exclude .claude/worktrees from vitest discovery

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     exclude: [
       ...configDefaults.exclude,
       '**/.worktrees/**',
+      '.claude/worktrees/**',
     ],
     reporters: [
       'default',


### PR DESCRIPTION
## Summary
- Add `.claude/worktrees/**` to vitest exclude list
- Stale worktree copies under `.claude/worktrees/` were picked up by vitest, causing 19 spurious failures and 5x test duplication (383 files → 78, 3,406 tests → 704, 197s → 27s)
- Existing `**/.worktrees/**` pattern didn't match because the directory is `.claude/worktrees` (no leading dot on `worktrees`)

## Test plan
- [x] `npx vitest run` — 78 files, 704 tests, all passing