### PR TITLE
fix(signing): secure OAuth flow and improve callback UX

### DIFF
--- a/api/auth/docusign/callback.ts
+++ b/api/auth/docusign/callback.ts
@@ -6,14 +6,19 @@
  * Exchanges the authorization code for tokens using PKCE,
  * resolves the user's accountId and baseUri via /userinfo,
  * and stores the encrypted connection record in Firestore.
+ *
+ * Returns a user-friendly HTML page (not JSON) since this is
+ * visited in the user's browser after DocuSign redirects back.
  */
 
 import type { HttpRequest, HttpResponse } from '../../_http-types.js';
 
-const DOCUSIGN_AUTH_BASE = 'https://account-d.docusign.com'; // sandbox
-const INTEGRATION_KEY = process.env.OA_DOCUSIGN_INTEGRATION_KEY || '';
-const SECRET_KEY = process.env.OA_DOCUSIGN_SECRET_KEY || '';
-const REDIRECT_URI = process.env.OA_DOCUSIGN_REDIRECT_URI || 'https://openagreements.ai/api/auth/docusign/callback';
+const DOCUSIGN_AUTH_BASE = (process.env.OA_DOCUSIGN_SANDBOX?.trim() === 'false')
+  ? 'https://account.docusign.com'
+  : 'https://account-d.docusign.com';
+const INTEGRATION_KEY = process.env.OA_DOCUSIGN_INTEGRATION_KEY?.trim() || '';
+const SECRET_KEY = process.env.OA_DOCUSIGN_SECRET_KEY?.trim() || '';
+const REDIRECT_URI = process.env.OA_DOCUSIGN_REDIRECT_URI?.trim() || 'https://openagreements.ai/api/auth/docusign/callback';
 
 function getQuery(req: HttpRequest, key: string): string | undefined {
   const val = req.query[key];
@@ -27,7 +32,67 @@ function getCookie(req: HttpRequest, name: string): string | undefined {
   return match?.[1];
 }
 
+function htmlPage(title: string, heading: string, body: string, isError = false): string {
+  const color = isError ? '#be4b2f' : '#1a7a4c';
+  const icon = isError ? '&#10005;' : '&#10003;';
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${title} — OpenAgreements</title>
+  <style>
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: #f5f0e8;
+      color: #142023;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+    }
+    .card {
+      background: #fff;
+      border: 1px solid #d2c2ae;
+      border-radius: 8px;
+      padding: 40px;
+      max-width: 480px;
+      text-align: center;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+    }
+    .icon {
+      width: 56px;
+      height: 56px;
+      border-radius: 50%;
+      background: ${color};
+      color: #fff;
+      font-size: 28px;
+      line-height: 56px;
+      margin: 0 auto 20px;
+    }
+    h1 { font-size: 1.3rem; margin: 0 0 12px; }
+    p { color: #334348; line-height: 1.5; margin: 0 0 8px; }
+    .subtle { font-size: 0.85rem; color: #667; margin-top: 16px; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="icon">${icon}</div>
+    <h1>${heading}</h1>
+    ${body}
+  </div>
+</body>
+</html>`;
+}
+
 export default async function handler(req: HttpRequest, res: HttpResponse): Promise<void> {
+  // Clear OAuth cookies on every callback (success or failure)
+  const clearCookies = [
+    'oa_pkce_verifier=; Path=/api/auth/docusign; HttpOnly; Secure; SameSite=Lax; Max-Age=0',
+    'oa_oauth_state=; Path=/api/auth/docusign; HttpOnly; Secure; SameSite=Lax; Max-Age=0',
+  ];
+
   if (req.method !== 'GET') {
     res.status(405).json({ error: 'Method not allowed' });
     return;
@@ -38,12 +103,27 @@ export default async function handler(req: HttpRequest, res: HttpResponse): Prom
   const error = getQuery(req, 'error');
 
   if (error) {
-    res.status(400).json({ error: `DocuSign authorization denied: ${error}` });
+    res.setHeader('Set-Cookie', clearCookies);
+    res.setHeader('Content-Type', 'text/html; charset=utf-8');
+    res.status(400).send(htmlPage(
+      'Authorization Denied',
+      'Authorization Denied',
+      `<p>DocuSign did not grant access. You can close this window and try again.</p>
+       <p class="subtle">Error: ${error}</p>`,
+      true,
+    ));
     return;
   }
 
   if (!code || !state) {
-    res.status(400).json({ error: 'Missing code or state parameter' });
+    res.setHeader('Set-Cookie', clearCookies);
+    res.setHeader('Content-Type', 'text/html; charset=utf-8');
+    res.status(400).send(htmlPage(
+      'Invalid Request',
+      'Something went wrong',
+      '<p>Missing authorization parameters. Please try connecting again from your conversation.</p>',
+      true,
+    ));
     return;
   }
 
@@ -52,14 +132,28 @@ export default async function handler(req: HttpRequest, res: HttpResponse): Prom
   const [csrfFromState, apiKey] = state.split(':');
 
   if (!storedCsrf || storedCsrf !== csrfFromState) {
-    res.status(403).json({ error: 'CSRF state mismatch — possible attack or expired session' });
+    res.setHeader('Set-Cookie', clearCookies);
+    res.setHeader('Content-Type', 'text/html; charset=utf-8');
+    res.status(403).send(htmlPage(
+      'Session Expired',
+      'Session Expired',
+      '<p>Your authorization session has expired or is invalid. Please try connecting again from your conversation.</p>',
+      true,
+    ));
     return;
   }
 
   // Get PKCE code verifier from cookie
   const codeVerifier = getCookie(req, 'oa_pkce_verifier');
   if (!codeVerifier) {
-    res.status(400).json({ error: 'PKCE verifier cookie expired — please try connecting again' });
+    res.setHeader('Set-Cookie', clearCookies);
+    res.setHeader('Content-Type', 'text/html; charset=utf-8');
+    res.status(400).send(htmlPage(
+      'Session Expired',
+      'Session Expired',
+      '<p>Your PKCE session has expired. Please try connecting again from your conversation.</p>',
+      true,
+    ));
     return;
   }
 
@@ -82,8 +176,14 @@ export default async function handler(req: HttpRequest, res: HttpResponse): Prom
     });
 
     if (!tokenResponse.ok) {
-      const err = await tokenResponse.text();
-      res.status(502).json({ error: `DocuSign token exchange failed: ${tokenResponse.status}`, details: err });
+      res.setHeader('Set-Cookie', clearCookies);
+      res.setHeader('Content-Type', 'text/html; charset=utf-8');
+      res.status(502).send(htmlPage(
+        'Connection Failed',
+        'Connection Failed',
+        '<p>Could not exchange authorization with DocuSign. Please try again.</p>',
+        true,
+      ));
       return;
     }
 
@@ -99,39 +199,57 @@ export default async function handler(req: HttpRequest, res: HttpResponse): Prom
     });
 
     if (!userInfoResponse.ok) {
-      res.status(502).json({ error: `DocuSign userinfo failed: ${userInfoResponse.status}` });
+      res.setHeader('Set-Cookie', clearCookies);
+      res.setHeader('Content-Type', 'text/html; charset=utf-8');
+      res.status(502).send(htmlPage(
+        'Connection Failed',
+        'Connection Failed',
+        '<p>Could not retrieve your DocuSign account info. Please try again.</p>',
+        true,
+      ));
       return;
     }
 
     const userInfo = await userInfoResponse.json() as {
-      accounts: Array<{ account_id: string; base_uri: string; is_default: boolean }>;
+      accounts: Array<{ account_id: string; account_name: string; base_uri: string; is_default: boolean }>;
     };
 
     const account = userInfo.accounts.find(a => a.is_default) || userInfo.accounts[0];
     if (!account) {
-      res.status(400).json({ error: 'No DocuSign accounts found for this user' });
+      res.setHeader('Set-Cookie', clearCookies);
+      res.setHeader('Content-Type', 'text/html; charset=utf-8');
+      res.status(400).send(htmlPage(
+        'No Account Found',
+        'No DocuSign Account Found',
+        '<p>No DocuSign accounts were found for this user. Please check your DocuSign setup.</p>',
+        true,
+      ));
       return;
     }
 
-    // TODO: Encrypt tokens and store in Firestore
-    // For now, return success with connection info (tokens NOT exposed)
+    // TODO: Encrypt tokens and store in Firestore via SigningContext
+    // For now, return success (tokens are NOT exposed to the browser)
 
     // Clear OAuth cookies
-    res.setHeader('Set-Cookie', [
-      'oa_pkce_verifier=; Path=/api/auth/docusign; HttpOnly; Secure; SameSite=Lax; Max-Age=0',
-      'oa_oauth_state=; Path=/api/auth/docusign; HttpOnly; Secure; SameSite=Lax; Max-Age=0',
-    ]);
-
-    // Return success page
-    res.status(200).json({
-      status: 'connected',
-      provider: 'docusign',
-      account_id: account.account_id,
-      connection_id: `docusign-${account.account_id}`,
-      message: 'DocuSign account connected successfully. You can now send agreements for signature.',
-    });
+    res.setHeader('Set-Cookie', clearCookies);
+    res.setHeader('Content-Type', 'text/html; charset=utf-8');
+    res.status(200).send(htmlPage(
+      'Connected',
+      'DocuSign Connected',
+      `<p>Your DocuSign account <strong>${account.account_name || account.account_id}</strong> has been connected.</p>
+       <p>You can close this window and return to your conversation to send agreements for signature.</p>
+       <p class="subtle">Connection ID: docusign-${account.account_id}</p>`,
+    ));
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    res.status(500).json({ error: 'OAuth callback failed', details: message });
+    res.setHeader('Set-Cookie', clearCookies);
+    res.setHeader('Content-Type', 'text/html; charset=utf-8');
+    res.status(500).send(htmlPage(
+      'Error',
+      'Something Went Wrong',
+      `<p>An unexpected error occurred. Please try connecting again.</p>
+       <p class="subtle">${message}</p>`,
+      true,
+    ));
   }
 }

--- a/api/auth/docusign/connect.ts
+++ b/api/auth/docusign/connect.ts
@@ -10,9 +10,11 @@
 import type { HttpRequest, HttpResponse } from '../../_http-types.js';
 import { randomBytes, createHash } from 'node:crypto';
 
-const DOCUSIGN_AUTH_BASE = 'https://account-d.docusign.com'; // sandbox
-const INTEGRATION_KEY = process.env.OA_DOCUSIGN_INTEGRATION_KEY || '';
-const REDIRECT_URI = process.env.OA_DOCUSIGN_REDIRECT_URI || 'https://openagreements.ai/api/auth/docusign/callback';
+const DOCUSIGN_AUTH_BASE = (process.env.OA_DOCUSIGN_SANDBOX?.trim() === 'false')
+  ? 'https://account.docusign.com'
+  : 'https://account-d.docusign.com';
+const INTEGRATION_KEY = process.env.OA_DOCUSIGN_INTEGRATION_KEY?.trim() || '';
+const REDIRECT_URI = process.env.OA_DOCUSIGN_REDIRECT_URI?.trim() || 'https://openagreements.ai/api/auth/docusign/callback';
 
 function getQuery(req: HttpRequest, key: string): string | undefined {
   const val = req.query[key];

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -149,13 +149,14 @@ const SIGNING_TOOLS = [
     name: TOOL_CONNECT_SIGNING,
     description:
       'Connect your DocuSign account for sending agreements for signature. ' +
-      'Returns an OAuth authorization URL to open in your browser.',
+      'Returns a secure OAuth URL to open in your browser.',
     inputSchema: {
       type: 'object' as const,
       properties: {
         provider: { type: 'string', enum: ['docusign'], description: 'Signing provider.' },
-        redirect_uri: { type: 'string', description: 'OAuth redirect URI.' },
+        api_key: { type: 'string', description: 'Your open_agreements_api_key.' },
       },
+      required: ['api_key'] as const,
       additionalProperties: false,
     },
     annotations: { readOnlyHint: false, destructiveHint: false },

--- a/packages/contract-templates-mcp/src/core/signing-tools.ts
+++ b/packages/contract-templates-mcp/src/core/signing-tools.ts
@@ -16,7 +16,7 @@ import type { ToolCallResult } from './tools.js';
 type JsonSchema = Record<string, unknown>;
 type SigningContext = {
   provider: {
-    getAuthUrl(redirectUri: string, state: string): string;
+    getAuthUrl(redirectUri: string, state: string): { url: string; codeVerifier: string };
     createDraft(documentRef: unknown, metadata: unknown, connection?: unknown, accessToken?: string): Promise<unknown>;
     send(draftId: string, connection?: unknown, accessToken?: string): Promise<unknown>;
     getStatus(envelopeId: string, connection?: unknown, accessToken?: string): Promise<unknown>;
@@ -59,7 +59,7 @@ function requireContext(): SigningContext {
 
 const ConnectSchema = z.object({
   provider: z.enum(['docusign']).default('docusign'),
-  redirect_uri: z.string().url().optional(),
+  api_key: z.string().min(1),
 });
 
 const DisconnectSchema = z.object({
@@ -113,29 +113,28 @@ function validateDocxFile(filePath: string): string | null {
 export const signingTools: ToolDefinition[] = [
   {
     name: 'connect_signing_provider',
-    description: 'Connect your DocuSign account for sending agreements for signature. Returns an OAuth authorization URL to open in your browser.',
+    description: 'Connect your DocuSign account for sending agreements for signature. Returns a secure OAuth URL to open in your browser.',
     inputSchema: {
       type: 'object',
       properties: {
         provider: { type: 'string', enum: ['docusign'], description: 'Signing provider.' },
-        redirect_uri: { type: 'string', description: 'OAuth redirect URI.' },
+        api_key: { type: 'string', description: 'Your open_agreements_api_key.' },
       },
+      required: ['api_key'],
       additionalProperties: false,
     },
     annotations: { readOnlyHint: false, destructiveHint: false },
     invoke: async (args) => {
       const input = ConnectSchema.parse(args ?? {});
       try {
-        const ctx = requireContext();
-        const url = ctx.provider.getAuthUrl(
-          input.redirect_uri
-            || process.env.OA_DOCUSIGN_REDIRECT_URI?.trim()
-            || 'https://openagreements.ai/api/auth/docusign/callback',
-          `mcp-${Date.now()}`,
-        );
+        requireContext(); // Verify signing is configured
+        // Return the secure connect URL — PKCE verifier is stored in HttpOnly cookies,
+        // never exposed in the URL. The connect handler generates its own PKCE challenge.
+        const baseUrl = process.env.OA_BASE_URL?.trim() || 'https://openagreements.ai';
+        const connectUrl = `${baseUrl}/api/auth/docusign/connect?key=${encodeURIComponent(input.api_key)}`;
         return ok('connect_signing_provider', {
           message: 'Open this URL in your browser to connect DocuSign:',
-          auth_url: url,
+          auth_url: connectUrl,
           provider: input.provider,
         });
       } catch (e) {

--- a/packages/signing/src/docusign.ts
+++ b/packages/signing/src/docusign.ts
@@ -74,9 +74,11 @@ export class DocuSignProvider implements SigningProvider {
 
   /**
    * Generate OAuth authorization URL with PKCE.
-   * Returns { url, codeVerifier } — caller must store codeVerifier for handleCallback.
+   * Returns { url, codeVerifier } — caller must store codeVerifier securely
+   * (e.g., in an HttpOnly cookie) for use in handleCallback.
+   * The code verifier is NEVER included in the URL.
    */
-  getAuthUrl(redirectUri: string, state: string): string {
+  getAuthUrl(redirectUri: string, state: string): { url: string; codeVerifier: string } {
     const codeVerifier = generateCodeVerifier();
     const codeChallenge = computeCodeChallenge(codeVerifier);
     const base = authBaseUrl(this.sandbox);
@@ -91,8 +93,10 @@ export class DocuSignProvider implements SigningProvider {
       code_challenge_method: 'S256',
     });
 
-    // Append code_verifier as a hint for the caller to extract and store
-    return `${base}/oauth/auth?${params.toString()}&_code_verifier=${codeVerifier}`;
+    return {
+      url: `${base}/oauth/auth?${params.toString()}`,
+      codeVerifier,
+    };
   }
 
   async handleCallback(

--- a/packages/signing/tests/docusign.test.ts
+++ b/packages/signing/tests/docusign.test.ts
@@ -26,9 +26,9 @@ const testConfig: DocuSignConfig = {
 // ── OA-SIG-007: OAuth URL generation ────────────────────────────────────────
 
 describe('DocuSign OAuth', () => {
-  it.openspec('OA-SIG-007')('getAuthUrl generates valid URL with PKCE params', () => {
+  it.openspec('OA-SIG-007')('getAuthUrl returns URL with PKCE params and separate codeVerifier', () => {
     const provider = new DocuSignProvider(testConfig);
-    const url = provider.getAuthUrl(testConfig.redirectUri, 'test-state-123');
+    const { url, codeVerifier } = provider.getAuthUrl(testConfig.redirectUri, 'test-state-123');
 
     expect(url).toContain('https://account-d.docusign.com/oauth/auth');
     expect(url).toContain('response_type=code');
@@ -37,17 +37,21 @@ describe('DocuSign OAuth', () => {
     expect(url).toContain('state=test-state-123');
     expect(url).toContain('code_challenge_method=S256');
     expect(url).toContain(encodeURIComponent(testConfig.redirectUri));
+    // Code verifier must NOT be in the URL
+    expect(url).not.toContain('code_verifier');
+    expect(url).not.toContain(codeVerifier);
+    expect(codeVerifier.length).toBeGreaterThan(0);
   });
 
   it.openspec('OA-SIG-007')('uses demo auth URL for sandbox', () => {
     const provider = new DocuSignProvider({ ...testConfig, sandbox: true });
-    const url = provider.getAuthUrl(testConfig.redirectUri, 'state');
+    const { url } = provider.getAuthUrl(testConfig.redirectUri, 'state');
     expect(url).toContain('account-d.docusign.com');
   });
 
   it.openspec('OA-SIG-007')('uses production auth URL when not sandbox', () => {
     const provider = new DocuSignProvider({ ...testConfig, sandbox: false });
-    const url = provider.getAuthUrl(testConfig.redirectUri, 'state');
+    const { url } = provider.getAuthUrl(testConfig.redirectUri, 'state');
     expect(url).toContain('account.docusign.com');
     expect(url).not.toContain('account-d.docusign.com');
   });

--- a/packages/signing/tests/manual-e2e.test.ts
+++ b/packages/signing/tests/manual-e2e.test.ts
@@ -112,7 +112,7 @@ describe('Manual E2E: signing config → fill → anchor verification', () => {
       auditLog: async () => {},
     });
 
-    const url = provider.getAuthUrl(
+    const { url, codeVerifier } = provider.getAuthUrl(
       'http://localhost:3000/api/auth/docusign/callback',
       'manual-test-state',
     );
@@ -121,6 +121,8 @@ describe('Manual E2E: signing config → fill → anchor verification', () => {
     expect(url).toContain('d2b5e34b'); // real integration key
     expect(url).toContain('code_challenge_method=S256'); // PKCE
     expect(url).toContain('signature'); // scope
+    expect(url).not.toContain('code_verifier'); // never in URL
+    expect(codeVerifier.length).toBeGreaterThan(0);
   });
 
   it.openspec('OA-SIG-014')('webhook HMAC accepts valid signature and rejects invalid', () => {


### PR DESCRIPTION
## Summary
- PKCE code_verifier removed from OAuth URL (was exposed as query param)
- MCP tool returns /api/auth/docusign/connect instead of raw DocuSign URL
- OAuth callback returns user-friendly HTML instead of raw JSON
- Env vars trimmed in all OAuth handlers

## Test plan
- [x] 86 tests pass
- [x] getAuthUrl tests verify codeVerifier is NOT in the URL
- [x] connect_signing_provider returns connect URL, not raw DocuSign URL