### PR TITLE
chore: release v0.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-agreements",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-agreements",
-      "version": "0.6.2",
+      "version": "0.7.0",
       "bundleDependencies": [
         "@usejunior/docx-core"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-agreements",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "workspaces": [
     "packages/allure-test-factory",
     "packages/contract-templates-mcp",


### PR DESCRIPTION
## v0.7.0 — Agreement Signing Integration

### Features
- **End-to-end agreement signing** via DocuSign (#131)
  - 4 MCP tools: connect_signing_provider, disconnect_signing_provider, send_for_signature, check_signature_status
  - OAuth 2.0 with PKCE, AES-256-GCM token encryption, webhook status tracking
  - Provider-neutral SigningProvider interface (DocuSign first)
- Wyoming restrictive covenant template (#129)
- Accord Project Concerto models for all 40 templates (#127)

### Security
- PKCE code_verifier removed from OAuth URL (#135)
- OAuth callback returns user-friendly HTML instead of raw JSON (#135)
- All signing env vars trimmed at read time (#133, #134)

### DX
- Spec-coverage validator: .skip('reason') warns instead of failing (#130)
- Both validators accept .ts import paths (#130)

### Breaking
- `DocuSignProvider.getAuthUrl()` now returns `{ url, codeVerifier }` instead of a string
- Signing tools consolidated from 6 to 4 (upload merged into send, get_signed merged into check_status)