### PR TITLE
chore: release v0.7.2

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "open-agreements",
   "displayName": "OpenAgreements",
   "description": "Open-source legal template automation for DOCX with MCP tooling.",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "author": {
     "name": "Open Agreements",
     "email": "steven@usejunior.com"

--- a/content/external/yc-safe-discount/metadata.yaml
+++ b/content/external/yc-safe-discount/metadata.yaml
@@ -1,4 +1,5 @@
 name: YC Post-Money SAFE — Discount
+category: safes
 description: Y Combinator's Post-Money SAFE (Simple Agreement for Future Equity) with a discount rate and no valuation cap.
 source_url: https://www.ycombinator.com/documents
 version: '2024.12'

--- a/content/external/yc-safe-mfn/metadata.yaml
+++ b/content/external/yc-safe-mfn/metadata.yaml
@@ -1,4 +1,5 @@
 name: YC Post-Money SAFE — MFN
+category: safes
 description: >-
   Y Combinator's Post-Money SAFE (Simple Agreement for Future Equity) with a most favored nation (MFN) provision, no
   valuation cap, and no discount.

--- a/content/external/yc-safe-pro-rata-side-letter/metadata.yaml
+++ b/content/external/yc-safe-pro-rata-side-letter/metadata.yaml
@@ -1,4 +1,5 @@
 name: YC Pro Rata Side Letter
+category: safes
 description: >-
   Y Combinator's Pro Rata Side Letter, granting the investor pro rata rights in connection with a Post-Money SAFE
   investment.

--- a/content/external/yc-safe-valuation-cap/metadata.yaml
+++ b/content/external/yc-safe-valuation-cap/metadata.yaml
@@ -1,4 +1,5 @@
 name: YC Post-Money SAFE — Valuation Cap
+category: safes
 description: >-
   Y Combinator's Post-Money SAFE (Simple Agreement for Future Equity) with a valuation cap and no discount. The most
   common early-stage investment instrument.

--- a/content/recipes/nvca-certificate-of-incorporation/metadata.yaml
+++ b/content/recipes/nvca-certificate-of-incorporation/metadata.yaml
@@ -1,4 +1,5 @@
 name: NVCA Model Certificate of Incorporation
+category: venture-financing
 description: >-
   Amended and restated certificate of incorporation for venture-backed Delaware corporations, defining preferred stock
   rights, preferences, and privileges.

--- a/content/recipes/nvca-indemnification-agreement/metadata.yaml
+++ b/content/recipes/nvca-indemnification-agreement/metadata.yaml
@@ -1,4 +1,5 @@
 name: NVCA Model Indemnification Agreement
+category: venture-financing
 description: >-
   Director and officer indemnification agreement for venture-backed companies, providing indemnification and advancement
   of expenses.

--- a/content/recipes/nvca-investors-rights-agreement/metadata.yaml
+++ b/content/recipes/nvca-investors-rights-agreement/metadata.yaml
@@ -1,4 +1,5 @@
 name: NVCA Model Investors' Rights Agreement
+category: venture-financing
 description: >-
   Investors' rights agreement for venture financings, covering registration rights, information rights, board observer
   rights, and protective provisions.

--- a/content/recipes/nvca-management-rights-letter/metadata.yaml
+++ b/content/recipes/nvca-management-rights-letter/metadata.yaml
@@ -1,4 +1,5 @@
 name: NVCA Model Management Rights Letter
+category: venture-financing
 description: Management rights letter granting ERISA-qualifying management rights to venture capital fund investors.
 source_url: https://nvca.org/wp-content/uploads/2025/12/NVCA-2020-Management-Rights-Letter-1-1.docx
 source_version: '2020'

--- a/content/recipes/nvca-rofr-co-sale-agreement/metadata.yaml
+++ b/content/recipes/nvca-rofr-co-sale-agreement/metadata.yaml
@@ -1,4 +1,5 @@
 name: NVCA Model Right of First Refusal and Co-Sale Agreement
+category: venture-financing
 description: >-
   Right of first refusal and co-sale agreement for venture financings, restricting transfer of founder shares and
   providing investor co-sale rights.

--- a/content/recipes/nvca-stock-purchase-agreement/metadata.yaml
+++ b/content/recipes/nvca-stock-purchase-agreement/metadata.yaml
@@ -1,4 +1,5 @@
 name: NVCA Model Stock Purchase Agreement
+category: venture-financing
 description: >-
   Series preferred stock purchase agreement for venture capital financings, covering purchase terms, representations,
   and closing conditions.

--- a/content/recipes/nvca-voting-agreement/metadata.yaml
+++ b/content/recipes/nvca-voting-agreement/metadata.yaml
@@ -1,4 +1,5 @@
 name: NVCA Model Voting Agreement
+category: venture-financing
 description: >-
   Standard-form voting agreement for venture capital financings, covering board composition, drag-along rights, and
   stockholder voting obligations.

--- a/content/templates/bonterms-mutual-nda/metadata.yaml
+++ b/content/templates/bonterms-mutual-nda/metadata.yaml
@@ -1,4 +1,5 @@
 name: Bonterms Mutual NDA
+category: confidentiality
 description: >-
   Cover page for the Bonterms Mutual NDA (Version 1.0). The standard terms are incorporated by reference from
   bonterms.com.

--- a/content/templates/bonterms-professional-services-agreement/metadata.yaml
+++ b/content/templates/bonterms-professional-services-agreement/metadata.yaml
@@ -1,4 +1,5 @@
 name: Bonterms Professional Services Agreement
+category: professional-services
 description: >-
   Cover page for the Bonterms Professional Services Agreement (Version 1.2). The standard terms are incorporated by
   reference from bonterms.com.

--- a/content/templates/closing-checklist/metadata.yaml
+++ b/content/templates/closing-checklist/metadata.yaml
@@ -1,4 +1,5 @@
 name: Closing Checklist
+category: other
 description: >-
   A stage-first, document-first closing checklist that tracks canonical
   documents, checklist entries, signatories, action items, and issues.

--- a/content/templates/common-paper-ai-addendum-in-app/metadata.yaml
+++ b/content/templates/common-paper-ai-addendum-in-app/metadata.yaml
@@ -1,4 +1,5 @@
 name: Common Paper AI Addendum In-App
+category: data-compliance
 description: >-
   An in-app AI addendum based on Common Paper's standard form. A streamlined version of the AI addendum designed to be
   accepted electronically within an application.

--- a/content/templates/common-paper-ai-addendum/metadata.yaml
+++ b/content/templates/common-paper-ai-addendum/metadata.yaml
@@ -1,4 +1,5 @@
 name: Common Paper AI Addendum
+category: data-compliance
 description: >-
   An AI addendum cover page and standard terms, based on Common Paper's standard form. Adds AI-specific provisions to an
   existing agreement, covering model training, input/output rights, and AI usage policies.

--- a/content/templates/common-paper-amendment/metadata.yaml
+++ b/content/templates/common-paper-amendment/metadata.yaml
@@ -1,4 +1,5 @@
 name: Common Paper Amendment
+category: deals-partnerships
 description: >-
   An amendment template for modifying existing agreements, based on Common Paper's standard form. References the
   original agreement and details the specific changes being made.

--- a/content/templates/common-paper-business-associate-agreement/metadata.yaml
+++ b/content/templates/common-paper-business-associate-agreement/metadata.yaml
@@ -1,4 +1,5 @@
 name: Common Paper Business Associate Agreement
+category: data-compliance
 description: >-
   A HIPAA business associate agreement cover page and standard terms, based on Common Paper's standard form. Covers the
   use and protection of protected health information (PHI) between a covered entity and a business associate.

--- a/content/templates/common-paper-cloud-service-agreement/metadata.yaml
+++ b/content/templates/common-paper-cloud-service-agreement/metadata.yaml
@@ -1,4 +1,5 @@
 name: Common Paper Cloud Service Agreement
+category: sales-licensing
 description: >-
   A cloud service agreement with order form and framework terms, based on Common Paper's standard terms. Covers SaaS
   subscriptions, payment, SLAs, liability, and data processing. Includes full Standard Terms v2.1.

--- a/content/templates/common-paper-csa-click-through/metadata.yaml
+++ b/content/templates/common-paper-csa-click-through/metadata.yaml
@@ -1,4 +1,5 @@
 name: Common Paper CSA Click-Through
+category: sales-licensing
 description: >-
   A click-through cloud service agreement based on Common Paper's standard terms. Designed for self-serve SaaS products
   where the customer accepts terms online rather than negotiating a paper agreement.

--- a/content/templates/common-paper-csa-with-ai/metadata.yaml
+++ b/content/templates/common-paper-csa-with-ai/metadata.yaml
@@ -1,4 +1,5 @@
 name: Common Paper CSA With AI
+category: sales-licensing
 description: >-
   A cloud service agreement with AI provisions, key terms, and standard terms, based on Common Paper's standard form.
   Extends the standard CSA with AI-specific terms covering model training, input/output rights, and AI usage policies.

--- a/content/templates/common-paper-csa-with-sla/metadata.yaml
+++ b/content/templates/common-paper-csa-with-sla/metadata.yaml
@@ -1,4 +1,5 @@
 name: Common Paper CSA With SLA
+category: sales-licensing
 description: >-
   A cloud service agreement with SLA provisions, key terms, and standard terms, based on Common Paper's standard form.
   Includes uptime targets, response times, and support schedules alongside full CSA terms.

--- a/content/templates/common-paper-csa-without-sla/metadata.yaml
+++ b/content/templates/common-paper-csa-without-sla/metadata.yaml
@@ -1,4 +1,5 @@
 name: Common Paper CSA Without SLA
+category: sales-licensing
 description: >-
   A cloud service agreement with key terms and standard terms, based on Common Paper's standard form. Covers SaaS
   subscriptions, payment, liability, and data processing.

--- a/content/templates/common-paper-data-processing-agreement/metadata.yaml
+++ b/content/templates/common-paper-data-processing-agreement/metadata.yaml
@@ -1,4 +1,5 @@
 name: Common Paper Data Processing Agreement
+category: data-compliance
 description: >-
   A data processing agreement cover page and standard terms, based on Common Paper's standard form. Covers GDPR and data
   protection compliance, including processor/controller roles, data transfers, subprocessors, and security measures.

--- a/content/templates/common-paper-design-partner-agreement/metadata.yaml
+++ b/content/templates/common-paper-design-partner-agreement/metadata.yaml
@@ -1,4 +1,5 @@
 name: Common Paper Design Partner Agreement
+category: deals-partnerships
 description: >-
   A design partner agreement cover page and standard terms, based on Common Paper's standard form. Covers partnerships
   where a company provides early access to a product in development in exchange for feedback and collaboration.

--- a/content/templates/common-paper-independent-contractor-agreement/metadata.yaml
+++ b/content/templates/common-paper-independent-contractor-agreement/metadata.yaml
@@ -1,4 +1,5 @@
 name: Common Paper Independent Contractor Agreement
+category: professional-services
 description: >-
   An independent contractor agreement based on Common Paper's standard form. Covers the engagement of an independent
   contractor, including scope of services, rates, payment, timeline, and governing law.

--- a/content/templates/common-paper-letter-of-intent/metadata.yaml
+++ b/content/templates/common-paper-letter-of-intent/metadata.yaml
@@ -1,4 +1,5 @@
 name: Common Paper Letter of Intent
+category: deals-partnerships
 description: >-
   A letter of intent template for SaaS and technology deals, based on Common Paper's standard form. Outlines product,
   timeline, fees, and references an existing NDA.

--- a/content/templates/common-paper-mutual-nda/metadata.yaml
+++ b/content/templates/common-paper-mutual-nda/metadata.yaml
@@ -1,4 +1,5 @@
 name: Common Paper Mutual NDA
+category: confidentiality
 description: >-
   A mutual non-disclosure agreement cover page based on Common Paper's standard terms. The cover page references the
   Standard Terms posted at commonpaper.com.

--- a/content/templates/common-paper-one-way-nda/metadata.yaml
+++ b/content/templates/common-paper-one-way-nda/metadata.yaml
@@ -1,4 +1,5 @@
 name: Common Paper One-Way NDA
+category: confidentiality
 description: >-
   A one-way (unilateral) non-disclosure agreement cover page based on Common Paper's standard terms. The Discloser
   shares confidential information with the Receiver, but not vice versa. References the Standard Terms posted at

--- a/content/templates/common-paper-order-form-with-sla/metadata.yaml
+++ b/content/templates/common-paper-order-form-with-sla/metadata.yaml
@@ -1,4 +1,5 @@
 name: Common Paper Order Form with SLA
+category: sales-licensing
 description: >-
   An order form template with service level agreement (SLA) provisions, based on Common Paper's standard form. Extends
   the standard order form with uptime targets, response times, and support schedules.

--- a/content/templates/common-paper-order-form/metadata.yaml
+++ b/content/templates/common-paper-order-form/metadata.yaml
@@ -1,4 +1,5 @@
 name: Common Paper Order Form
+category: sales-licensing
 description: >-
   An order form template for cloud service agreements, based on Common Paper's standard form. References existing Key
   Terms and covers subscription details, fees, pilot period, payment, and professional services.

--- a/content/templates/common-paper-partnership-agreement/metadata.yaml
+++ b/content/templates/common-paper-partnership-agreement/metadata.yaml
@@ -1,4 +1,5 @@
 name: Common Paper Partnership Agreement
+category: deals-partnerships
 description: >-
   A partnership agreement cover page and standard terms, based on Common Paper's standard form. Covers business
   partnerships including obligations, fees, territory, liability, and data processing.

--- a/content/templates/common-paper-pilot-agreement/metadata.yaml
+++ b/content/templates/common-paper-pilot-agreement/metadata.yaml
@@ -1,4 +1,5 @@
 name: Common Paper Pilot Agreement
+category: deals-partnerships
 description: >-
   A pilot agreement cover page and standard terms, based on Common Paper's standard form. Covers trial or pilot periods
   for cloud services, including fees, support, and liability provisions.

--- a/content/templates/common-paper-professional-services-agreement/metadata.yaml
+++ b/content/templates/common-paper-professional-services-agreement/metadata.yaml
@@ -1,4 +1,5 @@
 name: Common Paper Professional Services Agreement
+category: professional-services
 description: >-
   A professional services agreement with key terms, statement of work, and standard terms, based on Common Paper's
   standard form. Covers consulting and professional services engagements including deliverables, IP ownership, fees, and

--- a/content/templates/common-paper-software-license-agreement/metadata.yaml
+++ b/content/templates/common-paper-software-license-agreement/metadata.yaml
@@ -1,4 +1,5 @@
 name: Common Paper Software License Agreement
+category: sales-licensing
 description: >-
   Standard terms for a software license agreement, based on Common Paper's standard form. Provides the framework terms
   for on-premise software licensing, to be used with a separate cover page and order form.

--- a/content/templates/common-paper-statement-of-work/metadata.yaml
+++ b/content/templates/common-paper-statement-of-work/metadata.yaml
@@ -1,4 +1,5 @@
 name: Common Paper Statement of Work
+category: professional-services
 description: >-
   A statement of work template for professional services engagements, based on Common Paper's standard form. References
   a PSA or CSA Key Terms and covers scope, deliverables, timeline, fees, and expenses.

--- a/content/templates/common-paper-term-sheet/metadata.yaml
+++ b/content/templates/common-paper-term-sheet/metadata.yaml
@@ -1,4 +1,5 @@
 name: Common Paper Term Sheet
+category: deals-partnerships
 description: >-
   A term sheet template for outlining key business terms, based on Common Paper's standard form. A simple
   topic-and-details format for early-stage deal discussions.

--- a/content/templates/openagreements-employee-ip-inventions-assignment/metadata.yaml
+++ b/content/templates/openagreements-employee-ip-inventions-assignment/metadata.yaml
@@ -1,4 +1,5 @@
 name: OpenAgreements Employee IP and Inventions Assignment
+category: employment
 description: >-
   Employee proprietary information and inventions assignment agreement with
   explicit prior-inventions and personal-project carveout language placeholders.

--- a/content/templates/openagreements-employment-confidentiality-acknowledgement/metadata.yaml
+++ b/content/templates/openagreements-employment-confidentiality-acknowledgement/metadata.yaml
@@ -1,4 +1,5 @@
 name: OpenAgreements Employment Confidentiality Acknowledgement
+category: employment
 description: >-
   Employee confidentiality and acceptable-use acknowledgement companion for
   onboarding packets, including reporting and post-employment handling.

--- a/content/templates/openagreements-employment-offer-letter/metadata.yaml
+++ b/content/templates/openagreements-employment-offer-letter/metadata.yaml
@@ -1,4 +1,5 @@
 name: OpenAgreements Employment Offer Letter
+category: employment
 description: >-
   A startup-focused employment offer letter template for full-time or part-time
   hiring with compensation, equity summary, and at-will framing.

--- a/content/templates/openagreements-restrictive-covenant-wyoming/metadata.yaml
+++ b/content/templates/openagreements-restrictive-covenant-wyoming/metadata.yaml
@@ -1,4 +1,5 @@
 name: OpenAgreements Employee Restrictive Covenant (Wyoming)
+category: employment
 description: >-
   Wyoming-specific employee restrictive covenant agreement with modular
   covenant structure (non-compete, non-solicitation, non-dealing, non-investment,

--- a/content/templates/working-group-list/metadata.yaml
+++ b/content/templates/working-group-list/metadata.yaml
@@ -1,4 +1,5 @@
 name: Working Group List
+category: other
 description: >-
   Standalone working group roster for a transaction. Tracks staffed deal team
   members and contact details outside the closing checklist document.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "open-agreements",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Local MCP extension for OpenAgreements workspace organization and contract template drafting.",
   "contextFileName": "GEMINI.md",
   "entrypoint": "GEMINI.md",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-agreements",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-agreements",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "bundleDependencies": [
         "@usejunior/docx-core"
       ],
@@ -7770,7 +7770,7 @@
     },
     "packages/checklist-mcp": {
       "name": "@open-agreements/checklist-mcp",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "dependencies": {
         "open-agreements": ">=0.3.1",
@@ -7785,7 +7785,7 @@
     },
     "packages/contract-templates-mcp": {
       "name": "@open-agreements/contract-templates-mcp",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "dependencies": {
         "open-agreements": ">=0.3.1",
@@ -7816,7 +7816,7 @@
     },
     "packages/contracts-workspace-mcp": {
       "name": "@open-agreements/contracts-workspace-mcp",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-agreements",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "workspaces": [
     "packages/allure-test-factory",
     "packages/contract-templates-mcp",

--- a/packages/checklist-mcp/package.json
+++ b/packages/checklist-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agreements/checklist-mcp",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Local stdio MCP server for OpenAgreements checklist memory operations",
   "type": "module",
   "bin": {

--- a/packages/contract-templates-mcp/package.json
+++ b/packages/contract-templates-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agreements/contract-templates-mcp",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "mcpName": "io.github.open-agreements/open-agreements",
   "description": "Local stdio MCP server for OpenAgreements template discovery and filling",
   "type": "module",

--- a/packages/contracts-workspace-mcp/package.json
+++ b/packages/contracts-workspace-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agreements/contracts-workspace-mcp",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Local stdio MCP server for contracts workspace operations",
   "type": "module",
   "bin": {

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -39,7 +39,8 @@ function runListJson(opts: ListOptions): void {
       const meta = loadMetadata(dir);
       results.push({
         name: id,
-        category: categoryFromId(id),
+        display_name: meta.name,
+        category: meta.category ?? categoryFromId(id),
         description: meta.description ?? meta.name,
         license: meta.license,
         source_url: meta.source_url,
@@ -61,7 +62,8 @@ function runListJson(opts: ListOptions): void {
         const meta = loadExternalMetadata(dir);
         results.push({
           name: id,
-          category: categoryFromId(id),
+          display_name: meta.name,
+          category: (meta as Record<string, unknown>).category as string ?? categoryFromId(id),
           description: meta.description ?? meta.name,
           license: meta.license,
           source_url: meta.source_url,
@@ -82,7 +84,8 @@ function runListJson(opts: ListOptions): void {
         const meta = loadRecipeMetadata(dir);
         const item: ListItem = {
           name: id,
-          category: categoryFromId(id),
+          display_name: meta.name,
+          category: (meta as Record<string, unknown>).category as string ?? categoryFromId(id),
           description: meta.description ?? meta.name,
           license_note: meta.license_note,
           source_url: meta.source_url,

--- a/src/core/metadata.ts
+++ b/src/core/metadata.ts
@@ -59,6 +59,7 @@ function validatePriorityFields(
 const TemplateMetadataBaseSchema = z.object({
   name: z.string(),
   description: z.string().optional(),
+  category: z.string().optional(),
   source_url: z.string().url(),
   version: z.string(),
   license: LicenseEnum,

--- a/src/core/template-listing.ts
+++ b/src/core/template-listing.ts
@@ -26,6 +26,7 @@ export interface TemplateListField {
 
 export interface TemplateListItem {
   name: string;
+  display_name: string;
   category: string;
   description: string;
   license?: string;
@@ -106,7 +107,8 @@ export function listTemplateItems(opts?: { templatesOnly?: boolean }): TemplateL
       const meta = loadMetadata(entry.dir);
       items.push({
         name: entry.id,
-        category: categoryFromId(entry.id),
+        display_name: meta.name,
+        category: meta.category ?? categoryFromId(entry.id),
         description: meta.description ?? meta.name,
         license: meta.license,
         source_url: meta.source_url,


### PR DESCRIPTION
Bump all package versions to 0.7.2. Same content as v0.7.0/v0.7.1 — prior tags pointed to wrong commits.