### PR TITLE
fix: remove templatesOnly option entirely

### DIFF
--- a/integration-tests/cli-program.test.ts
+++ b/integration-tests/cli-program.test.ts
@@ -228,10 +228,9 @@ describe('CLI program wiring', () => {
       'list',
       '--json',
       '--json-strict',
-      '--templates-only',
     ];
 
-    await allureStep('Given list argv includes json/json-strict/templates-only flags', async () => {
+    await allureStep('Given list argv includes json/json-strict flags', async () => {
       await allureJsonAttachment('cli-list-argv.json', argv);
     });
 
@@ -245,7 +244,6 @@ describe('CLI program wiring', () => {
       expect(runListMock).toHaveBeenCalledWith({
         json: true,
         jsonStrict: true,
-        templatesOnly: true,
       });
     });
   });

--- a/integration-tests/list-command.inprocess.test.ts
+++ b/integration-tests/list-command.inprocess.test.ts
@@ -42,7 +42,7 @@ interface ListHarnessOptions {
 }
 
 interface ListHarness {
-  runList: (opts?: { json?: boolean; jsonStrict?: boolean; templatesOnly?: boolean }) => void;
+  runList: (opts?: { json?: boolean; jsonStrict?: boolean }) => void;
   spies: {
     listTemplateEntries: ReturnType<typeof vi.fn>;
     listExternalEntries: ReturnType<typeof vi.fn>;
@@ -242,37 +242,6 @@ describe('runList in-process coverage', () => {
     expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('error: template bad-template: metadata parse failed'));
   });
 
-  itDiscovery.openspec('OA-CLI-014')('honors templates-only by skipping external and recipe metadata', async () => {
-    const harness = await loadListHarness({
-      templateEntries: [
-        { id: 'template-only', dir: '/templates/template-only', baseDir: '/templates' },
-      ],
-      externalEntries: [
-        { id: 'should-not-load-ext', dir: '/external/should-not-load-ext', baseDir: '/external' },
-      ],
-      recipeEntries: [
-        { id: 'should-not-load-recipe', dir: '/recipes/should-not-load-recipe', baseDir: '/recipes' },
-      ],
-      templateByDir: {
-        '/templates/template-only': templateMeta('Template Only', 'https://commonpaper.com/template-only'),
-      },
-    });
-
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-
-    await allureStep('Run list --json --templates-only', async () => {
-      harness.runList({ json: true, templatesOnly: true });
-    });
-
-    const envelope = JSON.parse(String(logSpy.mock.calls[0][0]));
-    await allureJsonAttachment('list-templates-only-envelope.json', envelope);
-
-    expect(envelope.items).toHaveLength(1);
-    expect(envelope.items[0].name).toBe('template-only');
-    expect(harness.spies.loadExternalMetadata).not.toHaveBeenCalled();
-    expect(harness.spies.loadRecipeMetadata).not.toHaveBeenCalled();
-  });
-
   itDiscovery('collects external and recipe metadata errors in non-strict JSON mode', async () => {
     const harness = await loadListHarness({
       templateEntries: [
@@ -385,7 +354,7 @@ describe('runList in-process coverage', () => {
 
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
-    harness.runList({ templatesOnly: true });
+    harness.runList({});
 
     expect(logSpy).toHaveBeenCalledWith('No agreements found.');
   });

--- a/integration-tests/list.test.ts
+++ b/integration-tests/list.test.ts
@@ -91,27 +91,6 @@ describe('list --json envelope', () => {
 });
 
 describe('list options', () => {
-  it.openspec('OA-CLI-014')('--templates-only filters to templates', () => {
-    const output = execSync(`node ${BIN} list --json --templates-only`, {
-      cwd: ROOT,
-      encoding: 'utf-8',
-      timeout: 10_000,
-    });
-    const parsed = JSON.parse(output) as ListResponse;
-    const names = parsed.items.map((item) => item.name);
-
-    expect(names.length).toBeGreaterThan(0);
-    expect(names).toContain('common-paper-mutual-nda');
-    expect(names).toContain('openagreements-employment-offer-letter');
-    expect(names).not.toContain('yc-safe-valuation-cap');
-    expect(names).not.toContain('nvca-voting-agreement');
-
-    const employmentItem = parsed.items.find((item: { name: string }) =>
-      item.name === 'openagreements-employment-offer-letter'
-    );
-    expect(employmentItem.category).toBe('employment');
-  });
-
   it.openspec('OA-CLI-013')('--json-strict exits non-zero on metadata errors', () => {
     const root = mkdtempSync(join(tmpdir(), 'oa-list-strict-'));
     const templatesDir = join(root, 'templates', 'bad-template');

--- a/openspec/specs/open-agreements/spec.md
+++ b/openspec/specs/open-agreements/spec.md
@@ -473,11 +473,6 @@ Output SHALL be sorted by name. Templates SHALL include `source_url` and `attrib
 - **WHEN** the user runs `open-agreements list --json-strict`
 - **THEN** the command prints errors to stderr and exits with non-zero status
 
-#### Scenario: [OA-CLI-014] --templates-only filters to templates
-- **GIVEN** internal and external templates are available
-- **WHEN** the user runs `open-agreements list --json --templates-only`
-- **THEN** the output contains only template entries (no recipes)
-
 ### Requirement: npm Package Integrity
 The npm tarball SHALL include `dist/`, `bin/`, `templates/`, `recipes/`, and `skills/`
 directories. The `prepack` script SHALL run the build before packing. The tarball

--- a/packages/contract-templates-mcp/src/core/tools.ts
+++ b/packages/contract-templates-mcp/src/core/tools.ts
@@ -66,7 +66,7 @@ interface ToolDefinition {
 // ---------------------------------------------------------------------------
 
 interface RepoModules {
-  listTemplateItems: (opts: { templatesOnly: boolean }) => TemplateRecord[];
+  listTemplateItems: () => TemplateRecord[];
   findTemplateDir: (id: string) => string | undefined;
   loadMetadata: (dir: string) => Record<string, unknown>;
   fillTemplate: (opts: { templateDir: string; values: Record<string, unknown>; outputPath: string }) => Promise<unknown>;
@@ -350,7 +350,7 @@ async function loadTemplates(): Promise<TemplateRecord[]> {
   if (mod) return mod.listTemplateItems();
 
   // Child process fallback
-  const { stdout } = await runOpenAgreements(['list', '--json', '--templates-only']);
+  const { stdout } = await runOpenAgreements(['list', '--json']);
   const parsed = JSON.parse(stdout);
   if (!Array.isArray(parsed.items)) {
     throw new Error('Invalid list output from open-agreements command.');

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -99,9 +99,8 @@ export function createProgram(): Command {
     .description('Show all available agreements (templates, external, and recipes)')
     .option('--json', 'Output machine-readable JSON with full field definitions')
     .option('--json-strict', 'Like --json but exit non-zero if any metadata fails')
-    .option('--templates-only', 'List only bundled templates (exclude external and recipes)')
-    .action((opts: { json?: boolean; jsonStrict?: boolean; templatesOnly?: boolean }) => {
-      runList({ json: opts.json, jsonStrict: opts.jsonStrict, templatesOnly: opts.templatesOnly });
+    .action((opts: { json?: boolean; jsonStrict?: boolean }) => {
+      runList({ json: opts.json, jsonStrict: opts.jsonStrict });
     });
 
   // --- Recipe command ---

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -10,7 +10,6 @@ const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
 export interface ListOptions {
   json?: boolean;
   jsonStrict?: boolean;
-  templatesOnly?: boolean;
 }
 
 interface ListItem {
@@ -29,8 +28,6 @@ export function runList(opts: ListOptions = {}): void {
 function runListJson(opts: ListOptions): void {
   const results: ListItem[] = [];
   const errors: string[] = [];
-  const templatesOnly = opts.templatesOnly === true;
-
   // Templates
   for (const entry of listTemplateEntries()) {
     const id = entry.id;
@@ -53,8 +50,7 @@ function runListJson(opts: ListOptions): void {
     }
   }
 
-  if (!templatesOnly) {
-    // External templates
+  // External templates
     for (const entry of listExternalEntries()) {
       const id = entry.id;
       const dir = entry.dir;
@@ -102,7 +98,6 @@ function runListJson(opts: ListOptions): void {
         errors.push(`recipe ${id}: ${err instanceof Error ? err.message : String(err)}`);
       }
     }
-  }
 
   results.sort((a, b) => a.name.localeCompare(b.name));
 
@@ -124,8 +119,6 @@ function runListJson(opts: ListOptions): void {
 function listAgreementsWithOptions(opts: ListOptions): void {
   interface Row { id: string; category: string; license: string; priority: number; total: number; source: string; sourceUrl: string }
   const rows: Row[] = [];
-  const templatesOnly = opts.templatesOnly === true;
-
   for (const entry of listTemplateEntries()) {
     const id = entry.id;
     const dir = entry.dir;
@@ -154,8 +147,7 @@ function listAgreementsWithOptions(opts: ListOptions): void {
     }
   }
 
-  if (!templatesOnly) {
-    for (const entry of listExternalEntries()) {
+  for (const entry of listExternalEntries()) {
       const id = entry.id;
       const dir = entry.dir;
       try {
@@ -211,7 +203,6 @@ function listAgreementsWithOptions(opts: ListOptions): void {
         });
       }
     }
-  }
 
   if (rows.length === 0) {
     console.log('No agreements found.');

--- a/src/core/template-listing.ts
+++ b/src/core/template-listing.ts
@@ -98,8 +98,7 @@ export function mapFields(
 // Main listing function
 // ---------------------------------------------------------------------------
 
-export function listTemplateItems(opts?: { templatesOnly?: boolean }): TemplateListItem[] {
-  const templatesOnly = opts?.templatesOnly === true; // default false — show all templates
+export function listTemplateItems(): TemplateListItem[] {
   const items: TemplateListItem[] = [];
 
   for (const entry of listTemplateEntries()) {
@@ -117,13 +116,8 @@ export function listTemplateItems(opts?: { templatesOnly?: boolean }): TemplateL
         fields: mapFields(meta.fields, meta.priority_fields),
       });
     } catch {
-      // Skip templates that fail to load (matches CLI --json behavior)
+      // Skip templates that fail to load
     }
-  }
-
-  if (!templatesOnly) {
-    // External and recipe entries are not included in templatesOnly mode.
-    // Callers that need them should use the full CLI list command.
   }
 
   items.sort((a, b) => a.name.localeCompare(b.name));


### PR DESCRIPTION
## Summary
- Removes the `templatesOnly` parameter from `listTemplateItems()` — all 42 templates (internal, external, recipe) are always listed
- Updates MCP package interface to match

## Verification
- `node bin/open-agreements.js list --json | jq '.items | length'` → 42
- 751 tests pass, 0 failures