### PR TITLE
docs: add Built With OpenAgreements section

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ Fill standard legal agreement templates and produce signable DOCX files. Templat
 - LibreOffice-powered DOCX visual rendering uses a pinned build config on macOS (`config/libreoffice-headless.json`); run `npm run check:libreoffice` before visual Allure evidence tests.
 - Maintainer: [Steven Obiajulu](https://www.linkedin.com/in/steven-obiajulu/) (MIT-trained mechanical engineer; Harvard Law trained lawyer).
 
+## Built With OpenAgreements
+
+- [Safe Clause](https://safeclause.deltaxy.ai) — AI-powered contract platform for startups. [#1 on vibecode.law, March 2026](https://vibecode.law/showcase/safe-clause-317416).
+
+*Building on OpenAgreements? Open a PR to add your project.*
+
 ## How It Works
 
 1. Step 1: Choose a template (36 standard agreements)


### PR DESCRIPTION
## Summary
- Adds a "Built With OpenAgreements" section to the README
- Lists Safe Clause (safeclause.deltaxy.ai) — #1 on vibecode.law for March 2026 — as the first project built on OpenAgreements templates
- Includes an invitation for other builders to add their projects via PR

## Context
Safe Clause uses OpenAgreements templates (visible as `openagreements-*` slugs with CC-BY-4.0 badges on their templates page). This section provides social proof and establishes the process for community contributions to the list.

## Test plan
- [ ] README renders correctly on GitHub
- [ ] Links to safeclause.deltaxy.ai and vibecode.law resolve
- [ ] Section appears between "Quality and Trust Signals" and "How It Works"