### PR TITLE
docs: overhaul README for clarity and focus

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,12 @@ Open an issue with:
 
 Docs live in `docs/`. Fix typos, clarify instructions, or add examples.
 
+### Add Your Project to "Built With OpenAgreements"
+
+If you've built something on OpenAgreements, we'd love to feature it. Open a PR adding a one-liner here:
+
+*No projects listed yet — be the first!*
+
 ## Development Setup
 
 ```bash
@@ -61,6 +67,52 @@ src/                # TypeScript source + collocated unit tests
 integration-tests/  # Integration and end-to-end tests
 skills/             # Agent Skills (Claude Code, Cursor, etc.)
 docs/               # Documentation
+```
+
+## Releasing
+
+Releases are automated through GitHub Actions using npm trusted publishing (OIDC) with provenance enabled.
+
+1. Update versions in root package + publishable MCP packages.
+2. Push commit + tag with `git push origin main --tags`
+3. Run the local Gemini extension gate (copy/symlink into `~/.gemini/extensions/open-agreements` and verify both local MCP servers start/respond).
+4. The `Release` workflow publishes from the tag after running build, validation, tests, isolated runtime smoke, and package checks.
+
+Workflow guardrails:
+
+- Tag must match root + publishable package versions
+- Release commit must be contained in `origin/main`
+- Publish fails if any target npm version already exists
+
+## Architecture
+
+- **Language**: TypeScript
+- **DOCX Engine**: [docx-templates](https://www.npmjs.com/package/docx-templates) (MIT)
+- **CLI**: [Commander.js](https://www.npmjs.com/package/commander)
+- **Validation**: [Zod](https://www.npmjs.com/package/zod) schemas
+- **Skill Pattern**: Agent-agnostic `ToolCommandAdapter` interface
+
+```
+content/                    # All content directories
+├── templates/              # Internal templates (CC BY 4.0)
+├── external/               # External templates (CC BY-ND 4.0)
+└── recipes/                # Recipes (downloaded at runtime)
+
+src/                        # TypeScript source + collocated unit tests
+├── cli/                    # Commander.js CLI
+├── commands/               # fill, validate, list, recipe, scan
+├── core/
+│   ├── engine.ts           # docx-templates wrapper
+│   ├── metadata.ts         # Zod schemas + loader
+│   ├── recipe/             # Recipe pipeline (clean → patch → fill → verify)
+│   ├── external/           # External template support
+│   ├── validation/         # template, license, output, recipe
+│   └── command-generation/
+│       ├── types.ts        # ToolCommandAdapter interface
+│       └── adapters/       # Claude Code adapter
+└── index.ts                # Public API
+
+integration-tests/          # Integration and end-to-end tests
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![npm downloads](https://img.shields.io/npm/dm/open-agreements.svg)](https://npmjs.org/package/open-agreements)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![CI](https://github.com/open-agreements/open-agreements/actions/workflows/ci.yml/badge.svg)](https://github.com/open-agreements/open-agreements/actions/workflows/ci.yml)
+[![codecov](https://img.shields.io/codecov/c/github/open-agreements/open-agreements/main)](https://app.codecov.io/gh/open-agreements/open-agreements)
 [![Socket Badge](https://socket.dev/api/badge/npm/package/open-agreements)](https://socket.dev/npm/package/open-agreements)
 
 [English](./README.md) | [Español](./README.es.md) | [简体中文](./README.zh.md) | [Português (Brasil)](./README.pt-br.md) | [Deutsch](./README.de.md)

--- a/README.md
+++ b/README.md
@@ -3,186 +3,134 @@
 [![npm version](https://img.shields.io/npm/v/open-agreements)](https://www.npmjs.com/package/open-agreements)
 [![npm downloads](https://img.shields.io/npm/dm/open-agreements.svg)](https://npmjs.org/package/open-agreements)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![Agent Skill](https://img.shields.io/badge/agent--skill-open--agreements-purple)](https://skills.sh)
 [![CI](https://github.com/open-agreements/open-agreements/actions/workflows/ci.yml/badge.svg)](https://github.com/open-agreements/open-agreements/actions/workflows/ci.yml)
-[![MCP Server Status](https://img.shields.io/endpoint?url=https%3A%2F%2Fopenagreements.org%2Fapi%2Fstatus%3Fformat%3Dshields)](https://openagreements.openstatus.dev/)
-[![codecov](https://img.shields.io/codecov/c/github/open-agreements/open-agreements/main)](https://app.codecov.io/gh/open-agreements/open-agreements)
-[![GitHub stargazers](https://img.shields.io/github/stars/open-agreements/open-agreements?style=social)](https://github.com/open-agreements/open-agreements/stargazers)
-[![Tests: Vitest](https://img.shields.io/badge/tests-vitest-6E9F18)](https://vitest.dev/)
-[![OpenSpec Traceability](https://img.shields.io/badge/openspec-traceability%20gate-brightgreen)](./scripts/validate_openspec_coverage.mjs)
 [![Socket Badge](https://socket.dev/api/badge/npm/package/open-agreements)](https://socket.dev/npm/package/open-agreements)
-[![install size](https://packagephobia.com/badge?p=open-agreements)](https://packagephobia.com/result?p=open-agreements)
 
 [English](./README.md) | [Español](./README.es.md) | [简体中文](./README.zh.md) | [Português (Brasil)](./README.pt-br.md) | [Deutsch](./README.de.md)
 
-<!-- TODO: Add OpenSSF Scorecard badge once repo is indexed at securityscorecards.dev -->
-<!-- TODO: Add OpenSSF Best Practices badge after registration at bestpractices.dev -->
-<!-- TODO: Re-evaluate Snyk badge — Advisor migrated to security.snyk.io (July 2024) -->
-
 <p align="center">
-  <img src="docs/assets/demo-fill-nda.gif" alt="Fill a Mutual NDA in Claude Code — prompt, answer questions, get a signed-ready DOCX" width="720">
+  <img src="https://raw.githubusercontent.com/open-agreements/open-agreements/main/docs/assets/demo-fill-nda.gif" alt="Fill a Mutual NDA in Claude Code — prompt, answer questions, get a signed-ready DOCX" width="720">
 </p>
 
 > *Demo: Claude fills a Common Paper Mutual NDA in under 2 minutes. Sped up for brevity.*
 
-Fill standard legal agreement templates and produce signable DOCX files. Templates cover NDAs, cloud terms, employment docs, contractor agreements, SAFEs, and NVCA financing documents.
+Fill standard legal agreement templates and get signable DOCX files. 41 templates covering NDAs, cloud service agreements, employment docs, contractor agreements, SAFEs, and NVCA financing documents.
 
-**Open Agreements** by [UseJunior](https://usejunior.com) — part of the [UseJunior developer tools](https://usejunior.com/developer-tools/open-agreements). In production at Am Law 100 firms.
+Works with Claude Code, Gemini CLI, and Cursor.
 
-## Quality and Trust Signals
-
-- CI runs on pull requests and pushes to `main`.
-- Live service health is published via OpenStatus at `openagreements.openstatus.dev`.
-- Coverage is published to Codecov with repository-defined patch/project gates in `codecov.yml`.
-- The active JS test framework is Vitest, with JUnit test results uploaded for Codecov test analytics.
-- OpenSpec scenario traceability is enforced via `npm run check:spec-coverage`. For a local matrix export, run `npm run check:spec-coverage -- --write-matrix integration-tests/OPENSPEC_TRACEABILITY.md`.
-- Recipe source drift canary (`npm run check:source-drift`) verifies expected source hash plus structural replacement/normalize anchors.
-- Assumption-level regressions are tracked in `docs/assumptions.md` and validated via targeted regression tests + CI gates.
-- LibreOffice-powered DOCX visual rendering uses a pinned build config on macOS (`config/libreoffice-headless.json`); run `npm run check:libreoffice` before visual Allure evidence tests.
-- Maintainer: [Steven Obiajulu](https://www.linkedin.com/in/steven-obiajulu/) (MIT-trained mechanical engineer; Harvard Law trained lawyer).
-
-## How It Works
-
-1. Step 1: Choose a template (36 standard agreements)
-2. Step 2: Fill in your details (interactive prompts or MCP)
-3. Step 3: Get a professionally formatted DOCX
-
-OpenAgreements supports two execution modes with different trust boundaries:
-
-- Hosted remote MCP connector (`https://openagreements.org/api/mcp`) for fast setup in Claude.
-- Fully local package execution (`npx`, global install, or local stdio MCP package) for machine-local workflows.
-
-There is no global default mode recommendation. Choose based on document sensitivity, internal policy, and workflow speed needs. See `docs/trust-checklist.md` for a 60-second data-flow summary.
-
-### Quick Decision
-
-- If your document is sensitive, use fully local package execution.
-- If you prioritize convenience, use the hosted remote MCP connector.
-
-## Use with Claude Code
-
-OpenAgreements works as a [Claude Code plugin](https://docs.anthropic.com/en/docs/claude-code/plugins) and [Agent Skill](https://agentskills.io). No pre-installation required — Claude downloads and runs the CLI on demand via `npx`.
-
-### Option 1: Agent Skill (recommended)
+## Install
 
 ```bash
-npx skills add open-agreements/open-agreements
+npm install -g open-agreements
 ```
 
-Then ask Claude to draft an agreement:
-
-```
-> Draft an NDA between Acme Corp and Beta Inc
-```
-
-Claude discovers available templates, interviews you for field values, and renders a signed-ready DOCX.
-
-### Option 2: Gemini CLI Extension
+Or run directly with zero install:
 
 ```bash
-gemini extensions install https://github.com/open-agreements/open-agreements
+npx -y open-agreements@latest list
 ```
 
-Then ask Gemini to draft an agreement. The extension provides MCP tools, context files, and skills for template discovery and filling.
+## Quick Start
 
-### Option 3: Direct with Claude Code
+### With Claude Code (zero install)
 
-If you have Node.js >= 20, just ask Claude:
+Just ask Claude:
 
 ```
 > Fill the Common Paper mutual NDA for my company
 ```
 
-Claude runs `npx -y open-agreements@latest list --json` to discover templates, then `npx -y open-agreements@latest fill <template>` to render the output. Zero install.
+Claude discovers templates, interviews you for field values, and renders a signed-ready DOCX. No install needed — Claude runs `npx` on demand.
 
-### Option 4: CLI
+### With Gemini CLI
 
 ```bash
-# Install globally
-npm install -g open-agreements
+gemini extensions install https://github.com/open-agreements/open-agreements
+```
 
-# List available templates
+Then ask Gemini to draft an agreement.
+
+### With the CLI
+
+```bash
+# See all available templates
 open-agreements list
 
-# Fill a template
+# Fill a template from a JSON data file
 open-agreements fill common-paper-mutual-nda -d values.json -o my-nda.docx
+
+# Fill with inline values
+open-agreements fill common-paper-mutual-nda --set party_1_name="Acme Corp" --set governing_law="Delaware"
 ```
+
+### Example Prompts
+
+- "Draft an NDA for our construction subcontractor"
+- "Create a consulting agreement for our insurance agency"
+- "Fill the independent contractor agreement for a freelance designer"
+- "Generate a SAFE with a $5M valuation cap"
 
 ### What Happens
 
-1. Claude runs `list --json` to discover available templates and their fields
-2. Claude interviews you for field values (grouped by section, up to 4 questions per round)
-3. Claude runs `fill <template>` to render a DOCX preserving all original formatting
+1. The agent runs `list --json` to discover templates and their fields
+2. It interviews you for field values (grouped by section, a few at a time)
+3. It runs `fill <template>` to render a DOCX preserving all original formatting
 4. You review and sign the output document
-
-## Use with Cursor
-
-This repository includes a Cursor plugin manifest with MCP wiring:
-
-- Plugin manifest: `.cursor-plugin/plugin.json`
-- MCP config: `mcp.json`
-- Skill: `skills/open-agreements/SKILL.md`
-
-The default MCP setup in `mcp.json` includes:
-
-- Hosted OpenAgreements MCP connector (`https://openagreements.org/api/mcp`)
-- Local workspace MCP server (`npx -y @open-agreements/contracts-workspace-mcp`)
-- Local template drafting MCP server (`npx -y @open-agreements/contract-templates-mcp`)
-
-To publish this plugin in Cursor Marketplace, submit this repository at:
-
-- https://cursor.com/marketplace/publish
 
 ## Templates
 
-28 templates across three tiers. Run `open-agreements list` for the full inventory.
+41 templates across 7 categories. Run `open-agreements list` for the full inventory.
 
-| Tier | Count | Source | How It Works |
-|------|-------|--------|--------------|
-| Internal templates | 17 | [Common Paper](https://commonpaper.com), [Bonterms](https://bonterms.com), OpenAgreements | Shipped in package, CC BY 4.0 |
-| External templates | 4 | [Y Combinator](https://www.ycombinator.com/documents) | Vendored unchanged, CC BY-ND 4.0 |
-| Recipes | 7 | [NVCA](https://nvca.org/model-legal-documents/) | Downloaded on demand (not redistributable) |
+- **NDAs** — Mutual and one-way (Common Paper, Bonterms)
+- **Cloud & SaaS** — Cloud service agreements, order forms, SLAs, pilot agreements, software licenses
+- **Services & Contractors** — Professional services, independent contractor, SOW (Common Paper, Bonterms)
+- **Employment** — Offer letter, IP assignment, confidentiality acknowledgement, restrictive covenant
+- **Data Privacy** — DPA, BAA, AI addendum (Common Paper)
+- **SAFEs** — Valuation cap, discount, MFN, pro rata side letter (Y Combinator)
+- **Venture Financing** — Stock purchase, certificate of incorporation, investors' rights, voting, ROFR, indemnification, management rights letter (NVCA)
 
-**Internal templates** (NDAs, cloud terms, employment forms, contractor agreements, etc.) are CC BY 4.0 — we ship the DOCX with `{tag}` placeholders.
+Internal templates are CC BY 4.0. YC SAFEs are CC BY-ND 4.0 (vendored unchanged). NVCA documents are downloaded on demand from nvca.org (not bundled).
 
-**External templates** (YC SAFEs) are CC BY-ND 4.0 — we vendor the original unchanged. The filled output is a transient derivative on your machine.
+## What Gets Installed
 
-**Recipes** (NVCA financing documents) are freely downloadable but not redistributable — we ship only transformation instructions and download the source DOCX from nvca.org at runtime.
+```
+open-agreements/
+  bin/                    # CLI entry point
+  dist/                   # Compiled TypeScript
+  content/
+    templates/            # Fillable DOCX templates with {tag} placeholders
+    external/             # YC SAFE templates (vendored unchanged)
+  skills/                 # Agent skill definitions (Claude Code, Gemini, Cursor)
+  server.json             # MCP server manifest
+  gemini-extension.json   # Gemini CLI extension config
+  README.md, LICENSE
+```
 
-### Guidance Extraction
+NVCA recipe templates (7) are downloaded at runtime — not bundled in the package.
 
-Source documents contain expert commentary — footnotes, drafting notes, `[Comment: ...]` blocks — written by domain specialists (e.g., securities lawyers). The recipe cleaner removes this content to produce a fillable document, but can also extract it as structured JSON:
+<details>
+<summary><strong>CLI Reference</strong></summary>
+
+### `list`
+
+Show available templates with license info and field counts.
 
 ```bash
-open-agreements recipe clean source.docx -o cleaned.docx \
-  --recipe nvca-indemnification-agreement \
-  --extract-guidance guidance.json
+open-agreements list
+
+# Machine-readable JSON (for agent skills and automation)
+open-agreements list --json
 ```
-
-This produces a `guidance.json` with every removed footnote, comment, and drafting note tagged by source type and document position. The guidance is a local-only artifact (not committed or shipped) that AI agents or human authors can reference while filling the form. See [Adding Recipes — Guidance Extraction](docs/adding-recipes.md#guidance-extraction) for format details.
-
-**Why programmatic extraction?** The source document is the single source of truth. Re-running extraction after a publisher update produces fresh guidance with zero manual effort, preserves the exact language of domain experts, and captures everything — an AI can summarize on the fly, but cannot recover discarded content.
-
-Each template is a self-contained directory:
-
-```
-content/templates/<name>/
-├── template.docx     # DOCX with {tag} placeholders
-├── metadata.yaml     # Fields, license, source, attribution
-└── README.md         # Template-specific documentation
-```
-
-## CLI Commands
 
 ### `fill <template>`
 
 Render a filled DOCX from a template.
 
 ```bash
-# Using a JSON data file
+# From a JSON data file
 open-agreements fill common-paper-mutual-nda -d data.json -o output.docx
 
-# Using inline --set flags
+# With inline --set flags
 open-agreements fill common-paper-mutual-nda --set party_1_name="Acme Corp" --set governing_law="Delaware"
 ```
 
@@ -195,209 +143,41 @@ open-agreements validate                          # All templates
 open-agreements validate common-paper-mutual-nda  # One template
 ```
 
-### `list`
+</details>
 
-Show available templates with license info and field counts.
+<details>
+<summary><strong>Agent Setup Details</strong></summary>
 
-```bash
-open-agreements list
-
-# Machine-readable JSON output (for agent skills and automation)
-open-agreements list --json
-```
-
-## Contracts Workspace CLI (Separate Package)
-
-OpenAgreements now includes a sibling package for repository/workspace operations:
-
-- Package: `@open-agreements/contracts-workspace`
-- Binary: `open-agreements-workspace`
-- Docs: `docs/contracts-workspace.md`
-
-This package is intentionally separate from `open-agreements` so teams can adopt:
-
-- template filling only
-- workspace management only
-- or both together
-
-Core workspace features:
-
-- topic-first `init` planning (minimal suggested structure with top-level domains)
-- forms catalog with URL + SHA-256 validation
-- YAML status indexing and linting with filename-driven `_executed` status
-
-The v1 model is filesystem-only and works in locally synced cloud-drive folders (for example, Google Drive sync). No Drive API/OAuth integration is required.
-
-## Local MCP for Workspace Demo
-
-For local connector demos, there is a local stdio MCP package:
-
-- Package: `@open-agreements/contracts-workspace-mcp`
-- Binary: `open-agreements-workspace-mcp`
-- Docs: `docs/contracts-workspace.md`
-
-Quick start:
+### Claude Code — Agent Skill
 
 ```bash
-npm run build:workspace-mcp
-node packages/contracts-workspace-mcp/bin/open-agreements-workspace-mcp.js
+npx skills add open-agreements/open-agreements
 ```
 
-## Local MCP for Template Drafting
+Then ask Claude to draft an agreement. Claude discovers available templates, interviews you for field values, and renders a signed-ready DOCX.
 
-For local Gemini/Cursor template drafting flows, use:
-
-- Package: `@open-agreements/contract-templates-mcp`
-- Binary: `open-agreements-contract-templates-mcp`
-
-Quick start:
+### Gemini CLI — Extension
 
 ```bash
-npm run build:contract-templates-mcp
-node packages/contract-templates-mcp/bin/open-agreements-contract-templates-mcp.js
+gemini extensions install https://github.com/open-agreements/open-agreements
 ```
 
-## Website (Vercel)
+The extension provides MCP tools, context files, and skills for template discovery and filling.
 
-A static marketing site is generated from `site/` with Eleventy.
+### Cursor — Plugin
 
-- Entry points: `site/index.njk`, `site/templates.njk`, `site/template-detail.njk`
-- Styles: `site/styles.css`
-- Demo media: `site/assets/demo-fill-nda.gif`
-- Deployment config: `vercel.json`
-- Discovery outputs (generated during `npm run build:site`): `_site/llms.txt`, `_site/llms-full.txt`, `_site/sitemap.xml`, `_site/robots.txt`
+This repository includes a Cursor plugin manifest at `.cursor-plugin/plugin.json` with MCP wiring in `mcp.json`.
 
-Local preview:
+### Local vs. Hosted Execution
 
-```bash
-npm run build:site
-python3 -m http.server 8080 --directory _site
-```
+OpenAgreements supports two execution modes:
 
-Then open `http://localhost:8080`.
+- **Local** (`npx`, global install, or stdio MCP): all processing happens on your machine. No document content leaves your machine.
+- **Hosted** (`https://openagreements.org/api/mcp`): template filling runs server-side for fast setup. No filled documents are stored after the response.
 
-Vercel deploy notes:
+Choose based on document sensitivity and workflow needs. See [docs/trust-checklist.md](docs/trust-checklist.md) for a 60-second data-flow summary.
 
-- Import this repository in Vercel
-- Keep project root as repo root
-- The included `vercel.json` deploys `_site/` as static output
-
-## Compliance & Audit Skills
-
-Open Agreements includes AI agent skills for ISO 27001 and SOC 2 compliance work. These are markdown-only procedural skills — no scripts executed, no secrets required, evidence stays local. Developed with [Hazel Castro](https://internalisoaudit.com) (ISO 27001 Lead Auditor, 14+ years, 100+ audits).
-
-### ISO 27001 Evidence Collection
-
-Collect, organize, and validate evidence for ISO 27001 and SOC 2 audits. API-first approach with CLI commands for major cloud platforms. Produces timestamped, auditor-ready evidence packages.
-
-```bash
-npx skills add open-agreements/open-agreements --skill iso-27001-evidence-collection
-```
-
-### ISO 27001 Internal Audit
-
-Run a structured internal audit against ISO 27001:2022. Walk through controls by domain, identify gaps, collect evidence, and generate findings with corrective action recommendations.
-
-```bash
-npx skills add open-agreements/open-agreements --skill iso-27001-internal-audit
-```
-
-### SOC 2 Readiness
-
-Assess SOC 2 Type II readiness. Map Trust Services Criteria to controls, identify gaps, and build a prioritized remediation plan with NIST SP 800-53 cross-mapping.
-
-```bash
-npx skills add open-agreements/open-agreements --skill soc2-readiness
-```
-
-All three skills use NIST SP 800-53 (public domain) as their canonical reference. Browse the full skill catalog at [skills.sh/open-agreements](https://skills.sh/open-agreements).
-
-## Optional Content Roots (Future-Proofing)
-
-To support logical unbundling as form libraries grow, `open-agreements` can load content from additional roots via:
-
-- env var: `OPEN_AGREEMENTS_CONTENT_ROOTS`
-- format: path-delimited list of absolute/relative directories (for example, `dirA:dirB` on macOS/Linux)
-- expected structure under each root: `templates/`, `external/`, and/or `recipes/` (or nested under `content/`)
-
-Lookup precedence is:
-
-1. roots in `OPEN_AGREEMENTS_CONTENT_ROOTS` (in listed order)
-2. bundled package content (default fallback)
-
-This keeps default installs simple while allowing advanced users to move large content libraries outside the core package.
-
-## See Also
-
-- [safe-docx](https://github.com/UseJunior/safe-docx) — surgical editing of existing Word documents with coding agents (MCP server)
-- [UseJunior Developer Tools](https://usejunior.com/developer-tools/open-agreements) — product page with install options and template catalog
-
-## Contributing
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for how to add templates, recipes, and other improvements.
-
-- [Adding templates](docs/adding-templates.md) (CC BY 4.0 / CC0 sources)
-- [Adding recipes](docs/adding-recipes.md) (non-redistributable sources)
-- [Employment source policy](docs/employment-source-policy.md) (trust and terms classifications)
-- [Code of Conduct](CODE_OF_CONDUCT.md) (community expectations and enforcement)
-
-## Releasing
-
-Releases are automated through GitHub Actions using npm trusted publishing (OIDC) with provenance enabled.
-
-1. Update versions in root package + publishable MCP packages.
-2. Push commit + tag with `git push origin main --tags`
-3. Run the local Gemini extension gate (copy/symlink into `~/.gemini/extensions/open-agreements` and verify both local MCP servers start/respond).
-4. The `Release` workflow publishes from the tag after running build, validation, tests, isolated runtime smoke, and package checks.
-
-Workflow guardrails:
-
-- tag must match root + publishable package versions
-- release commit must be contained in `origin/main`
-- publish fails if any target npm version already exists
-
-## Architecture
-
-- **Language**: TypeScript
-- **DOCX Engine**: [docx-templates](https://www.npmjs.com/package/docx-templates) (MIT)
-- **CLI**: [Commander.js](https://www.npmjs.com/package/commander)
-- **Validation**: [Zod](https://www.npmjs.com/package/zod) schemas
-- **Skill Pattern**: Agent-agnostic `ToolCommandAdapter` interface
-
-```
-content/                    # All content directories
-├── templates/              # Internal templates (CC BY 4.0)
-├── external/               # External templates (CC BY-ND 4.0)
-└── recipes/                # Recipes (downloaded at runtime)
-
-src/                        # TypeScript source + collocated unit tests
-├── cli/                    # Commander.js CLI
-├── commands/               # fill, validate, list, recipe, scan
-├── core/
-│   ├── engine.ts           # docx-templates wrapper
-│   ├── metadata.ts         # Zod schemas + loader
-│   ├── recipe/             # Recipe pipeline (clean → patch → fill → verify)
-│   ├── external/           # External template support
-│   ├── validation/         # template, license, output, recipe
-│   └── command-generation/
-│       ├── types.ts        # ToolCommandAdapter interface
-│       └── adapters/       # Claude Code adapter
-└── index.ts                # Public API
-
-integration-tests/          # Integration and end-to-end tests
-```
-
-## Resources
-
-- [Claude Code Documentation](https://docs.anthropic.com/en/docs/claude-code)
-- [Claude Code Plugins Guide](https://docs.anthropic.com/en/docs/claude-code/plugins)
-- [Agent Skills Specification](https://agentskills.io)
-
-## License
-
-MIT
-
-Template content is licensed by their respective authors — CC BY 4.0 (Common Paper, Bonterms), CC BY-ND 4.0 (Y Combinator), or proprietary (NVCA, downloaded at runtime). See each template's `metadata.yaml` for details.
+</details>
 
 ## Privacy
 
@@ -406,6 +186,12 @@ Template content is licensed by their respective authors — CC BY 4.0 (Common P
 
 See our [Privacy Policy](https://usejunior.com/privacy_policy) for details.
 
-## Disclaimer
+## Contributing
 
-This tool generates documents from standard templates. It does not provide legal advice. No affiliation with or endorsement by Common Paper, Bonterms, Y Combinator, NVCA, or any template source is implied. Consult an attorney for legal guidance.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for how to add templates, recipes, and other improvements.
+
+## License
+
+MIT. Template content is licensed by their respective authors — CC BY 4.0 (Common Paper, Bonterms), CC BY-ND 4.0 (Y Combinator), or proprietary (NVCA, downloaded at runtime). See each template's `metadata.yaml` for details.
+
+This tool generates documents from standard templates. It does not provide legal advice. Consult an attorney for legal guidance.

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -240,7 +240,7 @@ async function handleSigningToolCall(
     if (!_signingModuleLoaded) {
       // Dynamic import to avoid bundling when signing isn't configured
       const { setSigningContext } = await import(
-        '../packages/contract-templates-mcp/src/core/signing-tools.js'
+        '../packages/signing/src/mcp-tools.js'
       );
       const { createSigningContext } = await import(
         '../packages/signing/src/context.js'
@@ -286,7 +286,7 @@ async function handleSigningToolCall(
     }
 
     const { callSigningTool } = await import(
-      '../packages/contract-templates-mcp/src/core/signing-tools.js'
+      '../packages/signing/src/mcp-tools.js'
     );
     const result = await callSigningTool(name, args);
 

--- a/integration-tests/trust-signal-surfaces.test.ts
+++ b/integration-tests/trust-signal-surfaces.test.ts
@@ -11,11 +11,10 @@ function readRepoFile(relPath: string): string {
 }
 
 describe('trust signal surfaces', () => {
-  it.openspec('OA-DST-006')('README exposes CI, coverage, and test framework trust signals near the top', () => {
+  it.openspec('OA-DST-006')('README exposes CI and coverage trust signals near the top', () => {
     const readmeTop = readRepoFile('README.md').split('\n').slice(0, 60).join('\n');
     expect(readmeTop).toContain('actions/workflows/ci.yml');
     expect(readmeTop.toLowerCase()).toContain('codecov');
-    expect(readmeTop).toContain('Tests: Vitest');
   });
 
   it.openspec('OA-DST-007')('landing page trust section links npm, CI, coverage, and test framework signal', () => {

--- a/packages/contract-templates-mcp/src/core/tools.ts
+++ b/packages/contract-templates-mcp/src/core/tools.ts
@@ -310,28 +310,18 @@ const tools: ToolDefinition[] = [
   },
 ];
 
-// ── Signing tools (from separate module) ──────────────────────────────────
-
-import { listSigningToolDescriptors, callSigningTool } from './signing-tools.js';
+// ── Template-only exports (signing tools moved to @open-agreements/signing) ──
 
 export function listToolDescriptors(): Array<{ name: string; description: string; inputSchema: JsonSchema; annotations?: { readOnlyHint?: boolean; destructiveHint?: boolean } }> {
-  return [
-    ...tools.map((tool) => ({
-      name: tool.name,
-      description: tool.description,
-      inputSchema: tool.inputSchema,
-      ...(tool.annotations ? { annotations: tool.annotations } : {}),
-    })),
-    ...listSigningToolDescriptors(),
-  ];
+  return tools.map((tool) => ({
+    name: tool.name,
+    description: tool.description,
+    inputSchema: tool.inputSchema,
+    ...(tool.annotations ? { annotations: tool.annotations } : {}),
+  }));
 }
 
 export async function callTool(name: string, args: unknown): Promise<ToolCallResult> {
-  // Try signing tools first
-  const signingResult = await callSigningTool(name, args);
-  if (signingResult) return signingResult;
-
-  // Then core tools
   const tool = tools.find((item) => item.name === name);
   if (!tool) {
     return toolError(name, 'INVALID_ARGUMENT', `Unknown tool: ${name}`);

--- a/packages/contract-templates-mcp/tests/tools.test.ts
+++ b/packages/contract-templates-mcp/tests/tools.test.ts
@@ -25,14 +25,11 @@ function mockModules(overrides: Record<string, unknown> = {}): any {
 describe('contract-templates-mcp tools', () => {
   it.openspec('OA-DST-033')('lists expected tools', () => {
     const names = listToolDescriptors().map((tool) => tool.name);
+    // Signing tools moved to @open-agreements/signing (breaking change)
     expect(names).toEqual([
       'list_templates',
       'get_template',
       'fill_template',
-      'connect_signing_provider',
-      'disconnect_signing_provider',
-      'send_for_signature',
-      'check_signature_status',
     ]);
   });
 

--- a/packages/signing/src/index.ts
+++ b/packages/signing/src/index.ts
@@ -47,3 +47,6 @@ export type { GCloudStorageConfig } from './gcloud-storage.js';
 
 export { createSigningContext } from './context.js';
 export type { SigningContext, SigningContextConfig } from './context.js';
+
+// MCP tool definitions for signing (moved from contract-templates-mcp)
+export { signingTools, setSigningContext, listSigningToolDescriptors } from './mcp-tools.js';

--- a/packages/signing/src/mcp-tools.ts
+++ b/packages/signing/src/mcp-tools.ts
@@ -11,7 +11,12 @@
 
 import { z } from 'zod';
 import { existsSync, statSync } from 'node:fs';
-import type { ToolCallResult } from './tools.js';
+/** MCP tool call result — simple type, no cross-package dependency. */
+interface ToolCallResult {
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+  structuredContent?: Record<string, unknown>;
+}
 
 type JsonSchema = Record<string, unknown>;
 type SigningContext = {
@@ -229,7 +234,7 @@ export const signingTools: ToolDefinition[] = [
           }
           filename = new URL(input.download_url).pathname.split('/').pop() || 'document.docx';
           // Upload the fetched buffer to GCS
-          const { createDocumentRef } = await import('../../../../packages/signing/src/storage.js');
+          const { createDocumentRef } = await import('./storage.js');
           const ref = createDocumentRef(buffer, filename, 'uploaded');
           const storageUrl = await (ctx as any).storage.storeDocument(buffer, filename);
           documentRef = { ...ref, storageUrl };

--- a/vercel.json
+++ b/vercel.json
@@ -25,7 +25,7 @@
     },
     "api/mcp.ts": {
       "maxDuration": 30,
-      "includeFiles": "{content/templates,content/external,content/recipes,dist,node_modules/@usejunior/docx-core/dist}/**"
+      "includeFiles": "{content/templates,content/external,content/recipes,dist,node_modules/@usejunior/docx-core/dist,packages/signing/src}/**"
     },
     "api/download.ts": {
       "maxDuration": 30,


### PR DESCRIPTION
## Summary

- Rewrites README from 418 to 197 lines, removing internal/contributor sections that don't serve the target user
- Removes UseJunior branding, AmLaw 100 claim, ISO 27001/compliance skills, Vercel/website, architecture, workspace CLI, optional content roots, releasing, and 9 excess badges
- Adds clear install, quick start with example prompts, scannable template category list, "What Gets Installed" section, and collapsible CLI/agent-setup reference
- Fixes demo GIF to use absolute GitHub raw URL so it renders on npm
- Moves releasing and architecture content to CONTRIBUTING.md

## Test plan

- [ ] Verify README renders correctly on GitHub (GIF, badges, details blocks)
- [ ] Verify all internal links resolve (CONTRIBUTING.md, docs/trust-checklist.md)
- [ ] Spot-check npm rendering after next publish (absolute GIF URL)