### PR TITLE
chore(release): bump to 0.7.4

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "open-agreements",
   "displayName": "OpenAgreements",
   "description": "Open-source legal template automation for DOCX with MCP tooling.",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "author": {
     "name": "Open Agreements",
     "email": "steven@usejunior.com"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "open-agreements",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Local MCP extension for OpenAgreements workspace organization and contract template drafting.",
   "contextFileName": "GEMINI.md",
   "entrypoint": "GEMINI.md",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-agreements",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "workspaces": [
     "packages/allure-test-factory",
     "packages/contract-templates-mcp",

--- a/packages/checklist-mcp/package.json
+++ b/packages/checklist-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agreements/checklist-mcp",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Local stdio MCP server for OpenAgreements checklist memory operations",
   "type": "module",
   "bin": {

--- a/packages/contract-templates-mcp/package.json
+++ b/packages/contract-templates-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agreements/contract-templates-mcp",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "mcpName": "io.github.open-agreements/open-agreements",
   "description": "Local stdio MCP server for OpenAgreements template discovery and filling",
   "type": "module",

--- a/packages/contracts-workspace-mcp/package.json
+++ b/packages/contracts-workspace-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agreements/contracts-workspace-mcp",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Local stdio MCP server for contracts workspace operations",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- Bump version to 0.7.4 across all 6 manifests

### Changes since v0.7.3

- Signing MCP tools refactored from `contract-templates-mcp` to `packages/signing`
- Import paths updated in `api/mcp.ts` and `vercel.json`
- README overhauled for clarity (#153)
- README badges and See Also restored (#154)
- `CONTRIBUTING.md` added

## Test plan

- [ ] CI passes (tests, validate, spec-coverage, source-drift-canary)
- [ ] `npm pack --dry-run` shows correct version
- [ ] Tag v0.7.4 from main HEAD after merge