### PR TITLE
docs: add Built With OpenAgreements section

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,12 @@ Choose based on document sensitivity and workflow needs. See [docs/trust-checkli
 
 See our [Privacy Policy](https://usejunior.com/privacy_policy) for details.
 
+## Built With OpenAgreements
+
+- [Safe Clause](https://safeclause.deltaxy.ai) — AI-powered contract platform for startups. [#1 on vibecode.law, March 2026](https://vibecode.law/showcase/safe-clause-317416).
+
+*Building on OpenAgreements? Open a PR to add your project.*
+
 ## See Also
 
 - [safe-docx](https://github.com/UseJunior/safe-docx) — surgical editing of existing Word documents with coding agents (MCP server)


### PR DESCRIPTION
## Summary
- Adds a "Built With OpenAgreements" section featuring Safe Clause (#1 on vibecode.law, March 2026)
- Includes an open invitation for other builders to add their projects via PR

Replaces #150 which had merge conflicts after the README restructuring. Content unchanged — reviewed and approved by SafeClause maintainer @navisrohan in #150.

Closes #150