### PR TITLE
Vendor shared workflow into skill directories for Smithery publish

### DIFF
--- a/skills/cloud-service-agreement/SKILL.md
+++ b/skills/cloud-service-agreement/SKILL.md
@@ -41,7 +41,7 @@ Use this skill when the user wants to:
 
 ## Execution
 
-Follow the [standard template-filling workflow](../shared/template-filling-execution.md) with these skill-specific details:
+Follow the [standard template-filling workflow](./template-filling-execution.md) with these skill-specific details:
 
 ### Template options
 

--- a/skills/cloud-service-agreement/template-filling-execution.md
+++ b/skills/cloud-service-agreement/template-filling-execution.md
@@ -1,0 +1,1 @@
+../shared/template-filling-execution.md

--- a/skills/nda/SKILL.md
+++ b/skills/nda/SKILL.md
@@ -36,7 +36,7 @@ Use this skill when the user wants to:
 
 ## Execution
 
-Follow the [standard template-filling workflow](../shared/template-filling-execution.md) with these skill-specific details:
+Follow the [standard template-filling workflow](./template-filling-execution.md) with these skill-specific details:
 
 ### Template options
 

--- a/skills/nda/template-filling-execution.md
+++ b/skills/nda/template-filling-execution.md
@@ -1,0 +1,1 @@
+../shared/template-filling-execution.md

--- a/skills/open-agreements/SKILL.md
+++ b/skills/open-agreements/SKILL.md
@@ -51,7 +51,7 @@ For more targeted workflows, see the category-specific skills:
 
 ## Execution
 
-Follow the [standard template-filling workflow](../shared/template-filling-execution.md) with these skill-specific details:
+Follow the [standard template-filling workflow](./template-filling-execution.md) with these skill-specific details:
 
 ### Template options
 

--- a/skills/open-agreements/template-filling-execution.md
+++ b/skills/open-agreements/template-filling-execution.md
@@ -1,0 +1,1 @@
+../shared/template-filling-execution.md

--- a/skills/safe/SKILL.md
+++ b/skills/safe/SKILL.md
@@ -39,7 +39,7 @@ Use this skill when the user wants to:
 
 ## Execution
 
-Follow the [standard template-filling workflow](../shared/template-filling-execution.md) with these skill-specific details:
+Follow the [standard template-filling workflow](./template-filling-execution.md) with these skill-specific details:
 
 ### Template options
 

--- a/skills/safe/template-filling-execution.md
+++ b/skills/safe/template-filling-execution.md
@@ -1,0 +1,1 @@
+../shared/template-filling-execution.md


### PR DESCRIPTION
## Summary

- `smithery skill publish <dir>` uploads only the target skill directory, so relative `../shared/template-filling-execution.md` links in SKILL.md files break on Smithery because the shared file is outside the upload boundary.
- Created symlinks in each of the 4 affected skill directories (`open-agreements`, `nda`, `safe`, `cloud-service-agreement`) pointing back to `../shared/template-filling-execution.md`.
- Updated the SKILL.md references from `../shared/template-filling-execution.md` to `./template-filling-execution.md` so the link resolves within the published directory.

## Test plan

- [ ] Verify each symlink resolves: `cat skills/nda/template-filling-execution.md` should show the shared file content
- [ ] Run `smithery skill publish skills/nda` (dry run if available) and confirm the shared workflow is included
- [ ] Confirm the remaining 4 skills that were NOT changed (`venture-financing`, `employment-contract`, `data-privacy-agreement`, `services-agreement`) still work via the original `../shared/` path