### PR TITLE
fix: show correct document filename in DocuSign signing flow

### DIFF
--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -271,13 +271,14 @@ const SIGNING_TOOLS = [
   {
     name: TOOL_SEND_FOR_SIGNATURE,
     description:
-      'Upload a DOCX file and send it for electronic signature via DocuSign. ' +
-      'Authentication is handled automatically via OAuth — no API key needed. ' +
-      'Returns an envelope ID to track signing progress.',
+      'Upload a DOCX file and create a draft signing envelope via DocuSign. ' +
+      'Returns a review URL — the user must review and send from DocuSign. Never auto-sends. ' +
+      'Authentication is handled automatically via OAuth — no API key needed.',
     inputSchema: {
       type: 'object' as const,
       properties: {
         download_url: { type: 'string', description: 'URL to download the DOCX file. Use the download_url from fill_template.' },
+        document_name: { type: 'string', description: "Filename for the document (e.g. 'Bonterms Mutual NDA.docx'). Auto-detected from download URL if not provided." },
         signers: {
           type: 'array',
           items: {

--- a/packages/signing/src/context.ts
+++ b/packages/signing/src/context.ts
@@ -10,6 +10,7 @@ import { createGCloudStorageCallbacks, type GCloudStorageConfig } from './gcloud
 import type { ConnectionRecord, DocumentRef, EnvelopeStatus } from './provider.js';
 import { createDocumentRef } from './storage.js';
 import { readFileSync } from 'node:fs';
+import { basename } from 'node:path';
 import { createHash } from 'node:crypto';
 
 export interface SigningContextConfig {
@@ -72,7 +73,7 @@ export function createSigningContext(config: SigningContextConfig): SigningConte
 
     async uploadLocalDocument(filePath: string): Promise<DocumentRef> {
       const buffer = readFileSync(filePath);
-      const filename = filePath.split('/').pop() || 'document.docx';
+      const filename = basename(filePath) || 'document.docx';
       const ref = createDocumentRef(buffer, filename, 'uploaded');
       const storageUrl = await storage.storeDocument(buffer, filename);
       return { ...ref, storageUrl };

--- a/packages/signing/src/mcp-tools.ts
+++ b/packages/signing/src/mcp-tools.ts
@@ -10,6 +10,7 @@
  */
 
 import { z } from 'zod';
+import { basename } from 'node:path';
 import { existsSync, statSync } from 'node:fs';
 /** MCP tool call result — simple type, no cross-package dependency. */
 interface ToolCallResult {
@@ -76,6 +77,7 @@ const MAX_FILE_SIZE_BYTES = 25 * 1024 * 1024; // 25 MB (DocuSign limit)
 const SendSchema = z.object({
   file_path: z.string().min(1).optional(),
   download_url: z.string().url().optional(),
+  document_name: z.string().min(1).optional(),
   signers: z.array(z.object({
     name: z.string().min(1),
     email: z.string().email(),
@@ -184,6 +186,7 @@ export const signingTools: ToolDefinition[] = [
       properties: {
         file_path: { type: 'string', description: 'Local path to the DOCX file (for stdio MCP server).' },
         download_url: { type: 'string', description: 'URL to download the DOCX file (for remote MCP server). Use the download_url from fill_template.' },
+        document_name: { type: 'string', description: "Filename for the document (e.g. 'Bonterms Mutual NDA.docx'). Auto-detected from download URL if not provided." },
         signers: {
           type: 'array',
           items: {
@@ -236,7 +239,9 @@ export const signingTools: ToolDefinition[] = [
             return err('send_for_signature', 'INVALID_DOCUMENT',
               `Downloaded file too large (${(buffer.length / 1024 / 1024).toFixed(1)} MB). Maximum is 25 MB.`);
           }
-          filename = new URL(input.download_url).pathname.split('/').pop() || 'document.docx';
+          const disposition = response.headers.get('content-disposition') || '';
+          const cdMatch = disposition.match(/filename="?([^";\n]+)"?/);
+          filename = cdMatch?.[1] || input.document_name || 'document.docx';
           // Upload the fetched buffer to GCS
           const { createDocumentRef } = await import('./storage.js');
           const ref = createDocumentRef(buffer, filename, 'uploaded');
@@ -249,7 +254,7 @@ export const signingTools: ToolDefinition[] = [
             return err('send_for_signature', 'INVALID_DOCUMENT', fileError);
           }
           documentRef = await ctx.uploadLocalDocument(input.file_path);
-          filename = input.file_path.split('/').pop() || 'document.docx';
+          filename = input.document_name || basename(input.file_path) || 'document.docx';
         } else {
           return err('send_for_signature', 'INVALID_DOCUMENT',
             'Either file_path or download_url is required.');


### PR DESCRIPTION
## Summary
- Read `Content-Disposition` header from download response for filename (fixes "download" showing instead of "Bonterms Mutual NDA.docx")
- Add optional `document_name` param to `send_for_signature` as fallback
- Replace `split('/').pop()` with `path.basename()` for local file paths
- Fix `send_for_signature` description to accurately say it creates a draft envelope

## Test plan
- [ ] Fill template → verify download response has `Content-Disposition` header with proper filename
- [ ] Send for signature via download URL → DocuSign shows template name, not "download"
- [ ] Send with explicit `document_name` param → that name appears in DocuSign
- [ ] Send via `file_path` (stdio) → basename extracted correctly
- [ ] Existing tests pass: `npx vitest run packages/contract-templates-mcp/tests/tools.test.ts` (17/17)
- [ ] Integration tests pass: `npx vitest run integration-tests/api-endpoints.test.ts` (33/33)