### PR TITLE
Add variable signer support to DOCX fill pipeline

### DIFF
--- a/docs/adding-templates.md
+++ b/docs/adding-templates.md
@@ -67,6 +67,7 @@ priority_fields:
 | `number` | Numeric value |
 | `boolean` | true/false |
 | `enum` | One of a fixed set of options (use `options` array) |
+| `array` | Repeating list of objects or values (use nested `items` definitions when you need object fields) |
 
 #### License values
 
@@ -74,6 +75,61 @@ priority_fields:
 |-------|-------------|
 | `CC-BY-4.0` | Creative Commons Attribution 4.0 |
 | `CC0-1.0` | Creative Commons Zero (public domain) |
+
+#### Variable signer blocks
+
+Preferred pattern: array field plus `{FOR}` loop.
+
+```yaml
+fields:
+  - name: signers
+    type: array
+    description: Signers on the document
+    items:
+      - name: name
+        type: string
+        description: Printed signer name
+      - name: title
+        type: string
+        description: Printed signer title
+```
+
+```text
+{FOR signer IN signers}
+_________________________________
+{$signer.name}
+{$signer.title}
+Date: {effective_date}
+{END-FOR signer}
+```
+
+Use this whenever the document can have a variable number of parties, directors, investors, or signers. The fill pipeline already passes arrays through to `docx-templates`, and this pattern keeps the template honest for 1, 3, 7, or more entries without manual cleanup.
+
+Legacy-compatible pattern: fixed extra slots wrapped in `{IF}` blocks.
+
+```yaml
+fields:
+  - name: signer_1_name
+    type: string
+    description: Primary signer name
+  - name: signer_2_name
+    type: string
+    description: Optional second signer name
+    default: ""
+  - name: signer_2_date
+    type: date
+    description: Optional second signer date
+```
+
+```text
+{IF signer_2_name}
+_________________________________
+{signer_2_name}
+Date: {signer_2_date}
+{END-IF}
+```
+
+Use this only when you are preserving a legacy fixed-slot template and do not want to rewrite it around a loop yet. The `default: ""` on the optional slot anchor is required. Without it, the template-path blank placeholder (`_______`) is truthy and the extra block will not prune.
 
 ### 4. Create README.md
 

--- a/integration-tests/fill-pipeline.test.ts
+++ b/integration-tests/fill-pipeline.test.ts
@@ -301,6 +301,19 @@ describe('prepareFillData', () => {
     expect(result.amount).toBe('N/A');
   });
 
+  it('preserves an explicit empty-string default even when blank placeholders are enabled', () => {
+    const fieldsWithEmptyDefault = [
+      ...fields.slice(0, 1),
+      { name: 'amount', type: 'string' as const, description: 'Amount', default: '' },
+    ];
+    const result = prepareFillData({
+      values: { company: 'Acme' },
+      fields: fieldsWithEmptyDefault,
+      useBlankPlaceholder: true,
+    });
+    expect(result.amount).toBe('');
+  });
+
   it.openspec('OA-FIL-009')('coerces boolean fields when coerceBooleans is true', () => {
     const result = prepareFillData({
       values: { company: 'Acme', is_free: 'true' },

--- a/integration-tests/list-command.inprocess.test.ts
+++ b/integration-tests/list-command.inprocess.test.ts
@@ -17,7 +17,14 @@ interface TemplateMeta {
   license: string;
   source_url: string;
   attribution_text: string;
-  fields: Array<{ name: string; type: string; description: string; section?: string; default?: string }>;
+  fields: Array<{
+    name: string;
+    type: string;
+    description: string;
+    section?: string;
+    default?: string;
+    items?: Array<{ name: string; type: string; description: string; section?: string; default?: string }>;
+  }>;
   priority_fields: string[];
 }
 
@@ -240,6 +247,68 @@ describe('runList in-process coverage', () => {
 
     expect(exitSpy).toHaveBeenCalledWith(1);
     expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('error: template bad-template: metadata parse failed'));
+  });
+
+  itDiscovery.openspec('OA-CLI-024')('preserves nested array item schemas in JSON output', async () => {
+    const harness = await loadListHarness({
+      templateEntries: [
+        { id: 'array-template', dir: '/templates/array-template', baseDir: '/templates' },
+      ],
+      templateByDir: {
+        '/templates/array-template': {
+          ...templateMeta('Array Template', 'https://example.com/array-template'),
+          fields: [
+            {
+              name: 'signers',
+              type: 'array',
+              description: 'Signers on the document',
+              items: [
+                { name: 'name', type: 'string', description: 'Printed signer name' },
+                { name: 'title', type: 'string', description: 'Printed signer title', default: '' },
+              ],
+            },
+          ],
+          priority_fields: [],
+        },
+      },
+    });
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await allureStep('Run list in JSON mode for array item schema', async () => {
+      harness.runList({ json: true });
+    });
+
+    const envelope = JSON.parse(String(logSpy.mock.calls[0][0]));
+    await allureJsonAttachment('list-json-array-item-schema.json', envelope);
+
+    const template = envelope.items.find((item: { name: string }) => item.name === 'array-template');
+    expect(template.fields).toHaveLength(1);
+    expect(template.fields[0]).toMatchObject({
+      name: 'signers',
+      type: 'array',
+      required: false,
+    });
+    expect(template.fields[0].items).toEqual([
+      {
+        name: 'name',
+        type: 'string',
+        required: false,
+        section: null,
+        description: 'Printed signer name',
+        default: null,
+        default_value_rationale: null,
+      },
+      {
+        name: 'title',
+        type: 'string',
+        required: false,
+        section: null,
+        description: 'Printed signer title',
+        default: '',
+        default_value_rationale: null,
+      },
+    ]);
   });
 
   itDiscovery('collects external and recipe metadata errors in non-strict JSON mode', async () => {

--- a/integration-tests/variable-signer-rendering.test.ts
+++ b/integration-tests/variable-signer-rendering.test.ts
@@ -1,0 +1,217 @@
+import { afterEach, describe, expect, it as vitestIt } from 'vitest';
+import { itAllure } from './helpers/allure-test.js';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import AdmZip from 'adm-zip';
+import yaml from 'js-yaml';
+import { fillTemplate } from '../src/core/engine.js';
+
+const it = itAllure.epic('Filling & Rendering');
+const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const tempDirs: string[] = [];
+
+const CONTENT_TYPES_XML =
+  '<?xml version="1.0" encoding="UTF-8"?>' +
+  '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">' +
+  '<Default Extension="xml" ContentType="application/xml"/>' +
+  '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+  '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+  '</Types>';
+
+const RELS_XML =
+  '<?xml version="1.0" encoding="UTF-8"?>' +
+  '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+  '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>' +
+  '</Relationships>';
+
+const WORD_RELS_XML =
+  '<?xml version="1.0" encoding="UTF-8"?>' +
+  '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"/>';
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function buildDocxBuffer(paragraphTexts: string[]): Buffer {
+  const paragraphs = paragraphTexts
+    .map((text) => `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`)
+    .join('');
+  const xml =
+    '<?xml version="1.0" encoding="UTF-8"?>' +
+    `<w:document xmlns:w="${W_NS}"><w:body>${paragraphs}</w:body></w:document>`;
+
+  const zip = new AdmZip();
+  zip.addFile('[Content_Types].xml', Buffer.from(CONTENT_TYPES_XML, 'utf-8'));
+  zip.addFile('_rels/.rels', Buffer.from(RELS_XML, 'utf-8'));
+  zip.addFile('word/_rels/document.xml.rels', Buffer.from(WORD_RELS_XML, 'utf-8'));
+  zip.addFile('word/document.xml', Buffer.from(xml, 'utf-8'));
+  return zip.toBuffer();
+}
+
+function extractParagraphTexts(docxPath: string): string[] {
+  const zip = new AdmZip(docxPath);
+  const xml = zip.getEntry('word/document.xml')?.getData().toString('utf-8') ?? '';
+  const paragraphs = [...xml.matchAll(/<w:p[\s>][\s\S]*?<\/w:p>/g)].map((match) => match[0]);
+  return paragraphs
+    .map((paragraph) => [...paragraph.matchAll(/<w:t[^>]*>(.*?)<\/w:t>/g)].map((match) => match[1]).join('').trim())
+    .filter(Boolean);
+}
+
+function createTemplateFixture(
+  fields: unknown[],
+  paragraphTexts: string[],
+  priorityFieldNames: string[] = ['signer_1_name'],
+): string {
+  const dir = mkdtempSync(join(tmpdir(), 'oa-variable-signers-'));
+  tempDirs.push(dir);
+
+  const metadata = {
+    name: 'Variable Signer Fixture',
+    source_url: 'https://example.com/template.docx',
+    version: '1.0',
+    license: 'CC0-1.0',
+    allow_derivatives: true,
+    attribution_text: 'Fixture template for variable signer rendering tests.',
+    fields,
+    priority_fields: priorityFieldNames,
+  };
+
+  writeFileSync(join(dir, 'metadata.yaml'), yaml.dump(metadata), 'utf-8');
+  writeFileSync(join(dir, 'template.docx'), buildDocxBuffer(paragraphTexts));
+  return dir;
+}
+
+describe('variable signer rendering', () => {
+  vitestIt('reproduces the current dangling fixed-slot signature-block behavior', async () => {
+    const templateDir = createTemplateFixture(
+      [
+        { name: 'signer_1_name', type: 'string', description: 'Signer 1 name' },
+        { name: 'signer_1_date', type: 'date', description: 'Signer 1 date' },
+        { name: 'signer_2_name', type: 'string', description: 'Signer 2 name' },
+        { name: 'signer_2_date', type: 'date', description: 'Signer 2 date' },
+        { name: 'signer_3_name', type: 'string', description: 'Signer 3 name' },
+        { name: 'signer_3_date', type: 'date', description: 'Signer 3 date' },
+      ],
+      [
+        '_______',
+        '{signer_1_name}',
+        'Date: {signer_1_date}',
+        '_______',
+        '{signer_2_name}',
+        'Date: {signer_2_date}',
+        '_______',
+        '{signer_3_name}',
+        'Date: {signer_3_date}',
+      ],
+      ['signer_1_name'],
+    );
+
+    const outputPath = join(templateDir, 'output.docx');
+    await fillTemplate({
+      templateDir,
+      outputPath,
+      values: {
+        signer_1_name: 'Alice Johnson',
+        signer_1_date: '2026-04-14',
+      },
+    });
+
+    const paragraphs = extractParagraphTexts(outputPath);
+    expect(paragraphs).toContain('Date: _______');
+    expect(paragraphs.filter((paragraph) => paragraph === '_______').length).toBeGreaterThan(1);
+  });
+
+  it.openspec('OA-FIL-016')('prunes optional fixed signer slots wrapped in IF blocks', async () => {
+    const templateDir = createTemplateFixture(
+      [
+        { name: 'signer_1_name', type: 'string', description: 'Signer 1 name' },
+        { name: 'signer_1_date', type: 'date', description: 'Signer 1 date' },
+        { name: 'signer_2_name', type: 'string', description: 'Signer 2 name', default: '' },
+        { name: 'signer_2_date', type: 'date', description: 'Signer 2 date' },
+        { name: 'signer_3_name', type: 'string', description: 'Signer 3 name', default: '' },
+        { name: 'signer_3_date', type: 'date', description: 'Signer 3 date' },
+      ],
+      [
+        '_______',
+        '{signer_1_name}',
+        'Date: {signer_1_date}',
+        '{IF signer_2_name}',
+        '_______',
+        '{signer_2_name}',
+        'Date: {signer_2_date}',
+        '{END-IF}',
+        '{IF signer_3_name}',
+        '_______',
+        '{signer_3_name}',
+        'Date: {signer_3_date}',
+        '{END-IF}',
+      ],
+      ['signer_1_name'],
+    );
+
+    const outputPath = join(templateDir, 'pruned-output.docx');
+    await fillTemplate({
+      templateDir,
+      outputPath,
+      values: {
+        signer_1_name: 'Alice Johnson',
+        signer_1_date: '2026-04-14',
+      },
+    });
+
+    const paragraphs = extractParagraphTexts(outputPath);
+    expect(paragraphs).toEqual([
+      '_______',
+      'Alice Johnson',
+      'Date: 2026-04-14',
+    ]);
+    expect(paragraphs).not.toContain('Date: _______');
+  });
+
+  it.openspec('OA-FIL-017')('renders exact signer-block counts from a signers array loop', async () => {
+    const templateDir = createTemplateFixture(
+      [
+        {
+          name: 'signers',
+          type: 'array',
+          description: 'Signers on the document',
+          items: [
+            { name: 'name', type: 'string', description: 'Printed signer name' },
+          ],
+        },
+      ],
+      [
+        '{FOR signer IN signers}',
+        '_______',
+        '{$signer.name}',
+        'Date: 2026-04-14',
+        '{END-FOR signer}',
+      ],
+      [],
+    );
+
+    for (const signerCount of [1, 3, 7]) {
+      const outputPath = join(templateDir, `loop-${signerCount}.docx`);
+      await fillTemplate({
+        templateDir,
+        outputPath,
+        values: {
+          signers: Array.from({ length: signerCount }, (_value, index) => ({
+            name: `Signer ${index + 1}`,
+          })),
+        },
+      });
+
+      const paragraphs = extractParagraphTexts(outputPath);
+      expect(paragraphs.filter((paragraph) => paragraph === '_______')).toHaveLength(signerCount);
+      expect(paragraphs.filter((paragraph) => paragraph === 'Date: 2026-04-14')).toHaveLength(signerCount);
+      expect(paragraphs).not.toContain('Date: _______');
+      expect(paragraphs.join('\n')).not.toContain('{FOR');
+      expect(paragraphs.join('\n')).not.toContain('{END-FOR');
+      expect(paragraphs.join('\n')).not.toContain('{$signer.name}');
+    }
+  });
+});

--- a/openspec/changes/add-variable-signer-blocks/design.md
+++ b/openspec/changes/add-variable-signer-blocks/design.md
@@ -1,0 +1,61 @@
+## Context
+The runtime already uses `docx-templates` directly for fill rendering. Upstream supports `{IF}` / `{END-IF}` and `{FOR}` / `{END-FOR}` for paragraph and table repetition. This repo also already passes array values straight through to `createReport()`, and `working-group-list` proves array loops render successfully today.
+
+The two missing pieces are:
+- A reliable, documented pattern for pruning extra fixed signer slots without changing global blank-placeholder behavior
+- Machine-readable array item schemas so clients know the object shape to pass into repeating arrays
+
+## Goals
+- Preserve current blank-placeholder behavior for ordinary optional fields
+- Avoid introducing new template syntax when existing `docx-templates` control tags already work
+- Expose array item schemas in a form that both CLI and MCP clients can consume directly
+
+## Non-Goals
+- Changing the global defaulting behavior for all optional string/date fields
+- Adding bespoke OOXML marker syntax for signature blocks
+- Migrating held Cooley consent templates in this change
+
+## Decisions
+
+### 1. Feature B uses existing `{IF}` blocks, not a new signature-block marker
+Optional extra signer slots will be authored as:
+
+```text
+{IF signer_2_name}
+_______
+{signer_2_name}
+Date: {signer_2_date}
+{END-IF}
+```
+
+The anchor field (`signer_2_name` in this example) must declare `default: ""` in `metadata.yaml`. That keeps the field falsey during template-path fills, so `docx-templates` removes the whole block. This is already compatible with the current renderer and avoids inventing a second pruning mechanism.
+
+### 2. Global blank-placeholder behavior remains unchanged
+`prepareFillData()` currently defaults omitted template-path fields to `BLANK_PLACEHOLDER`. Existing templates depend on that visible behavior, and the current OpenSpec spec explicitly documents it. We will not special-case all optional signer fields in the engine. Instead, template authors opt into pruning with an explicit field default of `""`.
+
+### 3. Array item schemas use nested `items` field definitions
+Array fields in `metadata.yaml` gain an optional `items` property:
+
+```yaml
+- name: signers
+  type: array
+  description: Signers on the document
+  items:
+    - name: name
+      type: string
+      description: Printed signer name
+    - name: title
+      type: string
+      description: Printed signer title
+```
+
+This stays close to JSON Schema naming while reusing the existing field-definition shape. Nested item definitions are recursive, so arrays of objects can describe their object fields without inventing a second schema language.
+
+### 4. Feature C is primarily schema/discovery/documentation work
+No loop-specific engine change is required for the current scope. The runtime already renders `{FOR signer IN signers}` with `{$signer.name}`. The change is to formalize this pattern with tests, expose the expected input shape through discovery surfaces, and document it as the preferred template-authoring approach for variable signers.
+
+## Risks and mitigations
+- Risk: authors forget `default: ""` on optional fixed-slot anchor fields.
+  Mitigation: add a targeted regression test and a worked docs example that calls out the requirement explicitly.
+- Risk: nested array item schemas break existing listing consumers.
+  Mitigation: add new optional `items` properties only; existing flat field metadata remains unchanged.

--- a/openspec/changes/add-variable-signer-blocks/proposal.md
+++ b/openspec/changes/add-variable-signer-blocks/proposal.md
@@ -1,0 +1,16 @@
+# Change: Add variable signer blocks
+
+## Why
+Fixed-count signer fields (`party_1_name`, `board_member_2_name`, etc.) do not scale to templates that require a variable number of signers. They also leave dangling signature blocks when extra signer slots are omitted, which forces manual cleanup and blocks held consent-template work.
+
+## What Changes
+- Document and test conditional signature-block pruning using existing `docx-templates` `{IF}` / `{END-IF}` blocks plus explicit empty-string defaults for optional signer-slot anchor fields
+- Add first-class array item schemas to template metadata so templates can declare repeatable object arrays such as `signers` or `board_members`
+- Surface nested array item schemas through template listing and MCP `get_template`
+- Add end-to-end DOCX fixture tests for fixed-slot pruning and `{FOR}`-based repeating signer blocks
+- Update template-authoring docs with the preferred `{FOR}` pattern and the legacy-compatible pruning pattern
+
+## Impact
+- Affected specs: `open-agreements`
+- Affected code: `src/core/metadata.ts`, `src/core/template-listing.ts`, `packages/contract-templates-mcp/src/core/tools.ts`, metadata/listing tests, fill-pipeline rendering tests, `docs/adding-templates.md`
+- Non-goals: migrating held Cooley consent templates in this change

--- a/openspec/changes/add-variable-signer-blocks/specs/open-agreements/spec.md
+++ b/openspec/changes/add-variable-signer-blocks/specs/open-agreements/spec.md
@@ -1,0 +1,49 @@
+## MODIFIED Requirements
+
+### Requirement: Template Metadata Schema
+Each template directory SHALL contain a `metadata.yaml` validated by Zod schema with fields: `name`, `source_url`, `version`, `license` (enum: CC-BY-4.0, CC0-1.0), `allow_derivatives` (boolean), `attribution_text`, and `fields` (array of field definitions with `name`, `type`, `description`, and optional field metadata such as defaults, sections, enum options, and nested `items` definitions for array fields).
+
+#### Scenario: [OA-TMP-022] Array field item schemas pass validation
+- **GIVEN** a template metadata file with an array field that declares nested `items` field definitions
+- **WHEN** the metadata is validated
+- **THEN** validation accepts the array field schema
+- **AND** nested item field definitions use the same field-definition rules as top-level fields
+
+### Requirement: Machine-Readable Template Discovery
+The `list` command SHALL support a `--json` flag that outputs template metadata including all field definitions, enabling programmatic field discovery by agent skills. Output SHALL be sorted by name. Templates SHALL include `source_url` and `attribution_text`. Array fields with nested item schemas SHALL include those nested item definitions in discovery output.
+
+#### Scenario: [OA-CLI-024] JSON output preserves array item schemas
+- **GIVEN** a template with an array field that declares nested `items`
+- **WHEN** the user runs `open-agreements list --json`
+- **THEN** the matching template entry includes the array field
+- **AND** the array field includes its nested item schema in the JSON output
+
+### Requirement: Fill Data Preparation
+The `prepareFillData` function MUST apply default values for optional fields, coerce boolean string values when configured, and warn on missing required fields. The `computeDisplayFields` callback MUST be invoked when provided. Explicit field-level defaults MUST override the template-path blank placeholder behavior.
+
+#### Scenario: [OA-FIL-016] Explicit empty-string defaults support conditional block pruning
+- **WHEN** an optional signer-slot anchor field declares `default: ""`
+- **AND** the template wraps that signer block in `{IF field}` / `{END-IF}`
+- **AND** the field is omitted from fill values
+- **THEN** `prepareFillData` preserves the explicit empty-string default
+- **AND** the signer block is removed cleanly during DOCX rendering
+
+## ADDED Requirements
+
+### Requirement: Loop-Based Array Rendering
+The template fill path SHALL support `docx-templates` `{FOR}` loops over array fields, including arrays of objects described by template metadata item schemas.
+
+#### Scenario: [OA-FIL-017] Array-driven signer blocks render exact counts
+- **GIVEN** a template with a `signers` array field and a `{FOR signer IN signers}` signature-block loop
+- **WHEN** the template is filled with 1, 3, or 7 signer objects
+- **THEN** the rendered DOCX contains exactly 1, 3, or 7 signature blocks respectively
+- **AND** no loop markers remain in the output
+- **AND** no dangling blank placeholders appear outside the rendered signer blocks
+
+### Requirement: MCP Template Discovery Preserves Array Item Schemas
+The MCP `get_template` tool SHALL surface nested array item schemas so clients can construct valid object-array payloads for `{FOR}`-based templates.
+
+#### Scenario: [OA-DST-034] get_template returns array item schemas
+- **GIVEN** a template with an array field that declares nested `items`
+- **WHEN** a client calls `get_template`
+- **THEN** the returned field metadata includes the nested array item schema unchanged

--- a/openspec/changes/add-variable-signer-blocks/tasks.md
+++ b/openspec/changes/add-variable-signer-blocks/tasks.md
@@ -1,0 +1,19 @@
+## 1. Spec and regression coverage
+- [x] 1.1 Add spec deltas for conditional signer-block pruning and array item schema discovery
+- [x] 1.2 Add a failing regression test that reproduces dangling fixed-slot signature blocks with omitted signer values
+
+## 2. Metadata and discovery
+- [x] 2.1 Extend template metadata to allow nested item schemas on array fields
+- [x] 2.2 Surface nested array item schemas through template listing and MCP `get_template`
+- [x] 2.3 Add metadata/listing/MCP tests for nested array item schemas
+
+## 3. Rendering and docs
+- [x] 3.1 Add fill-path tests for conditional signature-block pruning with explicit empty-string defaults
+- [x] 3.2 Add end-to-end fixture-template tests for `{FOR}`-based signer arrays with 1, 3, and 7 signers
+- [x] 3.3 Update `docs/adding-templates.md` with the preferred loop pattern and the legacy-compatible pruning pattern
+
+## 4. Verification
+- [x] 4.1 Run `npm run preflight:ci` before the change and record the result
+- [x] 4.2 Run targeted tests during implementation
+- [x] 4.3 Run `openspec validate add-variable-signer-blocks --strict`
+- [x] 4.4 Run `npm run preflight:ci` after the change

--- a/packages/contract-templates-mcp/src/core/tools.ts
+++ b/packages/contract-templates-mcp/src/core/tools.ts
@@ -34,6 +34,8 @@ interface TemplateField {
   section: string | null;
   description: string;
   default: string | null;
+  default_value_rationale?: string | null;
+  items?: TemplateField[];
 }
 
 interface TemplateRecord {

--- a/packages/contract-templates-mcp/tests/tools.test.ts
+++ b/packages/contract-templates-mcp/tests/tools.test.ts
@@ -188,6 +188,45 @@ describe('contract-templates-mcp tools', () => {
       expect(error.code).toBe('TEMPLATE_NOT_FOUND');
     });
 
+    it.openspec('OA-DST-034')('get_template preserves nested array item schemas', async () => {
+      _setModuleOverride(mockModules({
+        loadMetadata: () => ({
+          name: 'Array Template',
+          source_url: 'https://example.com/template.docx',
+          fields: [
+            {
+              name: 'signers',
+              type: 'array',
+              description: 'Signers on the document',
+              items: [
+                { name: 'name', type: 'string', description: 'Printed signer name' },
+                { name: 'title', type: 'string', description: 'Printed signer title', default: '' },
+              ],
+            },
+          ],
+          priority_fields: [],
+        }),
+        mapFields: (fields: unknown[]) => fields,
+      }));
+
+      const result = await callTool('get_template', { template_id: 'array-template' });
+      const payload = getPayload(result);
+
+      expect(result.isError).toBeUndefined();
+      expect(payload.ok).toBe(true);
+      const data = payload.data as Record<string, unknown>;
+      const template = data.template as Record<string, unknown>;
+      const fields = template.fields as Array<Record<string, unknown>>;
+      expect(fields[0]).toMatchObject({
+        name: 'signers',
+        type: 'array',
+      });
+      expect(fields[0].items).toEqual([
+        { name: 'name', type: 'string', description: 'Printed signer name' },
+        { name: 'title', type: 'string', description: 'Printed signer title', default: '' },
+      ]);
+    });
+
     it.openspec('OA-DST-032')('fill_template returns FILL_FAILED on engine error', async () => {
       _setModuleOverride(mockModules({
         fillTemplate: async () => { throw new Error('engine failure'); },

--- a/src/core/metadata.test.ts
+++ b/src/core/metadata.test.ts
@@ -49,6 +49,32 @@ describe('FieldDefinitionSchema', () => {
     );
   });
 
+  it.openspec('OA-TMP-022')('accepts an array field with nested item schema', async () => {
+    await expectSafeParseOutcome(
+      'FieldDefinitionSchema',
+      FieldDefinitionSchema,
+      {
+        name: 'signers',
+        type: 'array',
+        description: 'Signers on the document',
+        items: [
+          {
+            name: 'name',
+            type: 'string',
+            description: 'Printed signer name',
+          },
+          {
+            name: 'title',
+            type: 'string',
+            description: 'Printed signer title',
+            default: '',
+          },
+        ],
+      },
+      true
+    );
+  });
+
   it.openspec('OA-TMP-003')('rejects enum field without options', async () => {
     await expectSafeParseOutcome(
       'FieldDefinitionSchema',
@@ -127,6 +153,26 @@ describe('FieldDefinitionSchema', () => {
         type: 'boolean',
         description: 'Active',
         default: 'yes',
+      },
+      false
+    );
+  });
+
+  it('rejects nested items on non-array fields', async () => {
+    await expectSafeParseOutcome(
+      'FieldDefinitionSchema',
+      FieldDefinitionSchema,
+      {
+        name: 'company_name',
+        type: 'string',
+        description: 'Company name',
+        items: [
+          {
+            name: 'nested',
+            type: 'string',
+            description: 'Should not be allowed',
+          },
+        ],
       },
       false
     );

--- a/src/core/metadata.ts
+++ b/src/core/metadata.ts
@@ -6,27 +6,66 @@ import yaml from 'js-yaml';
 export const LicenseEnum = z.enum(['CC-BY-4.0', 'CC0-1.0', 'CC-BY-ND-4.0']);
 export type License = z.infer<typeof LicenseEnum>;
 
-export const FieldDefinitionSchema = z.object({
-  name: z.string(),
-  type: z.enum(['string', 'date', 'number', 'boolean', 'enum', 'array']),
-  description: z.string(),
-  default: z.string().optional(),
-  default_value_rationale: z.string().optional(),
-  options: z.array(z.string()).optional(),
-  section: z.string().optional(),
-}).refine(
-  (f) => f.type !== 'enum' || (f.options !== undefined && f.options.length > 0),
-  { message: 'Fields with type "enum" must have a non-empty options array' }
-).refine(
-  (f) => {
-    if (f.default === undefined) return true;
-    if (f.type === 'number') return !isNaN(Number(f.default));
-    if (f.type === 'boolean') return f.default === 'true' || f.default === 'false';
-    return true;
-  },
-  { message: 'Default value must be valid for the declared field type' }
+const FieldTypeEnum = z.enum(['string', 'date', 'number', 'boolean', 'enum', 'array']);
+export type FieldType = z.infer<typeof FieldTypeEnum>;
+
+export interface FieldDefinition {
+  name: string;
+  type: FieldType;
+  description: string;
+  default?: string;
+  default_value_rationale?: string;
+  options?: string[];
+  section?: string;
+  items?: FieldDefinition[];
+}
+
+export const FieldDefinitionSchema: z.ZodType<FieldDefinition> = z.lazy(() =>
+  z.object({
+    name: z.string(),
+    type: FieldTypeEnum,
+    description: z.string(),
+    default: z.string().optional(),
+    default_value_rationale: z.string().optional(),
+    options: z.array(z.string()).optional(),
+    section: z.string().optional(),
+    items: z.array(FieldDefinitionSchema).nonempty().optional(),
+  }).superRefine((field, ctx) => {
+    if (field.type === 'enum' && (field.options === undefined || field.options.length === 0)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['options'],
+        message: 'Fields with type "enum" must have a non-empty options array',
+      });
+    }
+
+    if (field.items !== undefined && field.type !== 'array') {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['items'],
+        message: 'Only fields with type "array" may define nested items',
+      });
+    }
+
+    if (field.default !== undefined) {
+      if (field.type === 'number' && isNaN(Number(field.default))) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['default'],
+          message: 'Default value must be valid for the declared field type',
+        });
+      }
+
+      if (field.type === 'boolean' && field.default !== 'true' && field.default !== 'false') {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['default'],
+          message: 'Default value must be valid for the declared field type',
+        });
+      }
+    }
+  })
 );
-export type FieldDefinition = z.infer<typeof FieldDefinitionSchema>;
 
 function validatePriorityFields(
   fields: FieldDefinition[],

--- a/src/core/template-listing.ts
+++ b/src/core/template-listing.ts
@@ -7,7 +7,7 @@
  * - MCP `tools.ts` (via dynamic import or npm dependency)
  */
 
-import { loadMetadata } from './metadata.js';
+import { loadMetadata, type FieldDefinition } from './metadata.js';
 import { listTemplateEntries } from '../utils/paths.js';
 
 // ---------------------------------------------------------------------------
@@ -22,6 +22,7 @@ export interface TemplateListField {
   description: string;
   default: string | null;
   default_value_rationale: string | null;
+  items?: TemplateListField[];
 }
 
 export interface TemplateListItem {
@@ -79,7 +80,7 @@ export function sourceName(url: string): string | null {
 }
 
 export function mapFields(
-  fields: { name: string; type: string; section?: string; description: string; default?: string; default_value_rationale?: string }[],
+  fields: FieldDefinition[],
   priorityFields: string[],
 ): TemplateListField[] {
   const required = new Set(priorityFields);
@@ -91,6 +92,7 @@ export function mapFields(
     description: f.description,
     default: f.default ?? null,
     default_value_rationale: f.default_value_rationale ?? null,
+    ...(f.items ? { items: mapFields(f.items, []) } : {}),
   }));
 }
 


### PR DESCRIPTION
## Summary
This PR adds the signer-pipeline infrastructure needed for variable signer counts in DOCX templates.

It ships two related capabilities:
- Feature B: clean pruning for optional fixed signature blocks using existing `{IF}` / `{END-IF}` blocks plus explicit `default: ""` anchor fields
- Feature C: first-class array item schemas so templates can declare fields like `signers` and render them with `{FOR signer IN signers}` loops

## Why
Multi-party templates currently rely on hardcoded signer slots. That breaks two important cases:
- unanimous written consents that must support any board size
- fixed-slot templates rendered with fewer signers, which currently leave dangling signature lines that counsel has to delete by hand

## What changed
- added recursive `items` support for `array` fields in template metadata
- preserved nested array item schemas through template listing and the MCP `get_template` response
- documented the preferred `{FOR}` loop pattern and the legacy-compatible pruning pattern
- added end-to-end coverage for 1 / 3 / 7 signer loop rendering and for fixed-slot pruning
- captured the current broken fixed-slot behavior in a reproduction test
- added the corresponding OpenSpec change package

## Impact
Templates can now model signer lists as structured arrays and emit one signature block per entry without dangling placeholders. Legacy templates can also prune extra fixed slots safely without introducing new template syntax.

## Validation
- `openspec validate add-variable-signer-blocks --strict`
- `npm run build`
- `npm run check:spec-coverage`
- `npx vitest run integration-tests/variable-signer-rendering.test.ts integration-tests/list-command.inprocess.test.ts packages/contract-templates-mcp/tests/tools.test.ts src/core/metadata.test.ts`
- sample DOCX renders reviewed in LibreOffice for 1 / 3 / 7 signers

## Preflight note
`npm run preflight:ci` fails before and after this PR on the same unrelated existing suites:
- `integration-tests/agent-skill-behavior.test.ts`
- `packages/signing/tests/gcloud-storage.test.ts`

No changes were made to `content/templates/cooley-*-consent-safe/`.