### PR TITLE
docs: sync README template catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,8 @@ Website links open a dedicated template page when one exists, or a preselected i
 | Template | Website | Repo |
 |----------|---------|------|
 | Closing Checklist | [Website](https://usejunior.com/templates/closing-checklist/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/closing-checklist) |
+| Cooley Board Consent SAFE | [Website](https://usejunior.com/?template=cooley-board-consent-safe#start) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/cooley-board-consent-safe) |
+| Cooley Stockholder Consent SAFE | [Website](https://usejunior.com/?template=cooley-stockholder-consent-safe#start) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/cooley-stockholder-consent-safe) |
 | Working Group List | [Website](https://usejunior.com/templates/working-group-list/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/working-group-list) |
 
 ## Packages


### PR DESCRIPTION
Follow-up to #172.

This PR syncs the generated README with the current template catalog so the README matches `npm run generate:readme` on `main`.

Specifically, it adds the missing Cooley SAFE consent template rows under the `Other` section.