### PR TITLE
Add structured template author metadata

### DIFF
--- a/content/templates/openagreements-board-consent-safe/metadata.yaml
+++ b/content/templates/openagreements-board-consent-safe/metadata.yaml
@@ -8,6 +8,11 @@ source_url: https://github.com/open-agreements/open-agreements/tree/main/content
 version: '1.0'
 license: CC-BY-4.0
 allow_derivatives: true
+authors:
+  - name: Joey Tsang
+    slug: joey-tsang
+    role: primary_author
+    profile_url: https://www.linkedin.com/in/joey-t-b90912b1/
 attribution_text: >-
   Authored by OpenAgreements contributors. Drafting structure informed by
   publicly available Series Seed SAFE board consent materials. Licensed under

--- a/content/templates/openagreements-employee-ip-inventions-assignment/metadata.yaml
+++ b/content/templates/openagreements-employee-ip-inventions-assignment/metadata.yaml
@@ -7,6 +7,10 @@ source_url: https://github.com/open-agreements/open-agreements/tree/main/templat
 version: '1.1'
 license: CC-BY-4.0
 allow_derivatives: true
+authors:
+  - name: Steven Obiajulu
+    slug: steven-obiajulu
+    role: primary_author
 attribution_text: >-
   Authored by OpenAgreements contributors. Baseline structure inspired by
   permissive public references including the Balanced Employee IP Agreement

--- a/content/templates/openagreements-employment-confidentiality-acknowledgement/metadata.yaml
+++ b/content/templates/openagreements-employment-confidentiality-acknowledgement/metadata.yaml
@@ -7,6 +7,10 @@ source_url: https://github.com/open-agreements/open-agreements/tree/main/templat
 version: '1.1'
 license: CC-BY-4.0
 allow_derivatives: true
+authors:
+  - name: Steven Obiajulu
+    slug: steven-obiajulu
+    role: primary_author
 attribution_text: >-
   Authored by OpenAgreements contributors using permissive public reference
   patterns from Papertrail legal-docs (CC0) and open policy frameworks.

--- a/content/templates/openagreements-employment-offer-letter/metadata.yaml
+++ b/content/templates/openagreements-employment-offer-letter/metadata.yaml
@@ -7,6 +7,10 @@ source_url: https://github.com/open-agreements/open-agreements/tree/main/templat
 version: '1.1'
 license: CC-BY-4.0
 allow_derivatives: true
+authors:
+  - name: Steven Obiajulu
+    slug: steven-obiajulu
+    role: primary_author
 attribution_text: >-
   Authored by OpenAgreements contributors. Drafting structure informed by
   publicly available permissive sources including the DocuSign template library

--- a/content/templates/openagreements-restrictive-covenant-wyoming/metadata.yaml
+++ b/content/templates/openagreements-restrictive-covenant-wyoming/metadata.yaml
@@ -10,8 +10,13 @@ source_url: https://github.com/open-agreements/open-agreements/tree/main/templat
 version: '2.0'
 license: CC-BY-4.0
 allow_derivatives: true
+authors:
+  - name: Joey Tsang
+    slug: joey-tsang
+    role: primary_author
+    profile_url: https://www.linkedin.com/in/joey-t-b90912b1/
 attribution_text: >-
-  Authored by OpenAgreements contributors. Wyoming-specific analysis informed
+  Drafted by Joey Tsang for OpenAgreements. Wyoming-specific analysis informed
   by publicly available commentary from Am Law firms including Ogletree Deakins,
   Fisher Phillips, Littler Mendelson, Foley & Lardner, Faegre Drinker, and
   Vinson & Elkins. See practice note for sources. Licensed under CC BY 4.0.

--- a/content/templates/openagreements-restrictive-covenant-wyoming/metadata.yaml
+++ b/content/templates/openagreements-restrictive-covenant-wyoming/metadata.yaml
@@ -11,12 +11,11 @@ version: '2.0'
 license: CC-BY-4.0
 allow_derivatives: true
 authors:
-  - name: Joey Tsang
-    slug: joey-tsang
+  - name: Steven Obiajulu
+    slug: steven-obiajulu
     role: primary_author
-    profile_url: https://www.linkedin.com/in/joey-t-b90912b1/
 attribution_text: >-
-  Drafted by Joey Tsang for OpenAgreements. Wyoming-specific analysis informed
+  Authored by OpenAgreements contributors. Wyoming-specific analysis informed
   by publicly available commentary from Am Law firms including Ogletree Deakins,
   Fisher Phillips, Littler Mendelson, Foley & Lardner, Faegre Drinker, and
   Vinson & Elkins. See practice note for sources. Licensed under CC BY 4.0.

--- a/content/templates/stockholder-consent-safe/metadata.yaml
+++ b/content/templates/stockholder-consent-safe/metadata.yaml
@@ -9,6 +9,11 @@ source_url: https://github.com/cooleyLLP/seriesseed
 version: '1.0'
 license: CC0-1.0
 allow_derivatives: true
+authors:
+  - name: Joey Tsang
+    slug: joey-tsang
+    role: primary_author
+    profile_url: https://www.linkedin.com/in/joey-t-b90912b1/
 attribution_text: >-
   Adapted from publicly available Series Seed stockholder consent materials at
   https://github.com/cooleyLLP/seriesseed. Made available under CC0 1.0

--- a/data/templates-snapshot.json
+++ b/data/templates-snapshot.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "cli_version": "0.7.2",
+  "cli_version": "0.7.5",
   "items": [
     {
       "name": "bonterms-mutual-nda",
@@ -82,6 +82,168 @@
           "section": "Legal",
           "description": "Courts with jurisdiction over disputes",
           "default": "courts located in San Francisco, California",
+          "default_value_rationale": null
+        },
+        {
+          "name": "party_1_signatory_type",
+          "type": "enum",
+          "required": false,
+          "section": "Signatures",
+          "description": "Whether Party 1 signatory is an entity or individual",
+          "default": "entity",
+          "default_value_rationale": null
+        },
+        {
+          "name": "party_1_signatory_name",
+          "type": "string",
+          "required": false,
+          "section": "Signatures",
+          "description": "Full name of the person signing for Party 1",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "party_1_signatory_title",
+          "type": "string",
+          "required": false,
+          "section": "Signatures",
+          "description": "Title of the person signing for Party 1",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "party_1_signatory_company",
+          "type": "string",
+          "required": false,
+          "section": "Signatures",
+          "description": "Company of the signatory for Party 1 (defaults to party_1_name)",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "party_1_email",
+          "type": "string",
+          "required": false,
+          "section": "Signatures",
+          "description": "Notice email address for Party 1",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "party_1_address",
+          "type": "string",
+          "required": false,
+          "section": "Signatures",
+          "description": "Notice postal address for Party 1",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "party_2_signatory_type",
+          "type": "enum",
+          "required": false,
+          "section": "Signatures",
+          "description": "Whether Party 2 signatory is an entity or individual",
+          "default": "entity",
+          "default_value_rationale": null
+        },
+        {
+          "name": "party_2_signatory_name",
+          "type": "string",
+          "required": false,
+          "section": "Signatures",
+          "description": "Full name of the person signing for Party 2",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "party_2_signatory_title",
+          "type": "string",
+          "required": false,
+          "section": "Signatures",
+          "description": "Title of the person signing for Party 2",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "party_2_signatory_company",
+          "type": "string",
+          "required": false,
+          "section": "Signatures",
+          "description": "Company of the signatory for Party 2 (defaults to party_2_name)",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "party_2_email",
+          "type": "string",
+          "required": false,
+          "section": "Signatures",
+          "description": "Notice email address for Party 2",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "party_2_address",
+          "type": "string",
+          "required": false,
+          "section": "Signatures",
+          "description": "Notice postal address for Party 2",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "party_1_signatory_name_and_title",
+          "type": "string",
+          "required": false,
+          "section": "Signatures",
+          "description": "Computed display field (Name, Title)",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "party_2_signatory_name_and_title",
+          "type": "string",
+          "required": false,
+          "section": "Signatures",
+          "description": "Computed display field (Name, Title)",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "party_1_notice_email_check",
+          "type": "string",
+          "required": false,
+          "section": "Signatures",
+          "description": "Computed checkbox glyph for email notice",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "party_1_notice_postal_check",
+          "type": "string",
+          "required": false,
+          "section": "Signatures",
+          "description": "Computed checkbox glyph for postal notice",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "party_2_notice_email_check",
+          "type": "string",
+          "required": false,
+          "section": "Signatures",
+          "description": "Computed checkbox glyph for email notice",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "party_2_notice_postal_check",
+          "type": "string",
+          "required": false,
+          "section": "Signatures",
+          "description": "Computed checkbox glyph for postal notice",
+          "default": null,
           "default_value_rationale": null
         }
       ]
@@ -10088,9 +10250,141 @@
       ]
     },
     {
+      "name": "cooley-board-consent-safe",
+      "display_name": "Board Consent for SAFE Financing",
+      "category": "corporate-governance",
+      "description": "Action by unanimous written consent of the board of directors of a Delaware corporation approving the issuance of one or more Simple Agreements for Future Equity (SAFEs). Derived from the Cooley Series Seed board consent, adapted for SAFE financing.",
+      "license": "CC0-1.0",
+      "source_url": "https://github.com/cooleyLLP/seriesseed",
+      "source": "github.com",
+      "attribution_text": "Derived from the Cooley Series Seed Board Consent, available at https://github.com/cooleyLLP/seriesseed. Made available under CC0 1.0 Universal Public Domain Dedication.",
+      "fields": [
+        {
+          "name": "company_name",
+          "type": "string",
+          "required": true,
+          "section": "Parties",
+          "description": "Full legal name of the company",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "effective_date",
+          "type": "date",
+          "required": true,
+          "section": "Terms",
+          "description": "Date the consent is effective",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "purchase_amount",
+          "type": "string",
+          "required": true,
+          "section": "Deal Terms",
+          "description": "Aggregate SAFE purchase amount (e.g., \"500,000\")",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "board_member_1_name",
+          "type": "string",
+          "required": true,
+          "section": "Signatures",
+          "description": "Full name of the first board member",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "board_member_2_name",
+          "type": "string",
+          "required": true,
+          "section": "Signatures",
+          "description": "Full name of the second board member",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "board_member_3_name",
+          "type": "string",
+          "required": true,
+          "section": "Signatures",
+          "description": "Full name of the third board member",
+          "default": null,
+          "default_value_rationale": null
+        }
+      ]
+    },
+    {
+      "name": "cooley-stockholder-consent-safe",
+      "display_name": "Stockholder Consent for SAFE Financing",
+      "category": "corporate-governance",
+      "description": "Action by written consent of the stockholders of a Delaware corporation approving the issuance of one or more Simple Agreements for Future Equity (SAFEs). Derived from the Cooley Series Seed stockholder consent, adapted for SAFE financing.",
+      "license": "CC0-1.0",
+      "source_url": "https://github.com/cooleyLLP/seriesseed",
+      "source": "github.com",
+      "attribution_text": "Derived from the Cooley Series Seed Stockholder Consent, available at https://github.com/cooleyLLP/seriesseed. Made available under CC0 1.0 Universal Public Domain Dedication.",
+      "fields": [
+        {
+          "name": "company_name",
+          "type": "string",
+          "required": true,
+          "section": "Parties",
+          "description": "Full legal name of the company",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "effective_date",
+          "type": "date",
+          "required": true,
+          "section": "Terms",
+          "description": "Date the consent is effective",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "purchase_amount",
+          "type": "string",
+          "required": true,
+          "section": "Deal Terms",
+          "description": "Aggregate SAFE purchase amount (e.g., \"500,000\")",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "stockholder_1_name",
+          "type": "string",
+          "required": true,
+          "section": "Signatures",
+          "description": "Full name of the first stockholder",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "stockholder_2_name",
+          "type": "string",
+          "required": true,
+          "section": "Signatures",
+          "description": "Full name of the second stockholder",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "stockholder_3_name",
+          "type": "string",
+          "required": true,
+          "section": "Signatures",
+          "description": "Full name of the third stockholder",
+          "default": null,
+          "default_value_rationale": null
+        }
+      ]
+    },
+    {
       "name": "nvca-certificate-of-incorporation",
       "display_name": "NVCA Model Certificate of Incorporation",
-      "category": "general",
+      "category": "venture-financing",
       "description": "Amended and restated certificate of incorporation for venture-backed Delaware corporations, defining preferred stock rights, preferences, and privileges.",
       "license_note": "NVCA model documents are freely downloadable but not redistributable. This recipe contains only transformation instructions, not the source document.",
       "source_url": "https://nvca.org/wp-content/uploads/2025/10/NVCA-Model-COI-10-1-2025.docx",
@@ -10504,7 +10798,7 @@
     {
       "name": "nvca-indemnification-agreement",
       "display_name": "NVCA Model Indemnification Agreement",
-      "category": "general",
+      "category": "venture-financing",
       "description": "Director and officer indemnification agreement for venture-backed companies, providing indemnification and advancement of expenses.",
       "license_note": "NVCA model documents are freely downloadable but not redistributable. This recipe contains only transformation instructions, not the source document.",
       "source_url": "https://nvca.org/wp-content/uploads/2021/12/NVCA-2020-Indemnification-Agreement.docx",
@@ -10670,7 +10964,7 @@
     {
       "name": "nvca-investors-rights-agreement",
       "display_name": "NVCA Model Investors' Rights Agreement",
-      "category": "general",
+      "category": "venture-financing",
       "description": "Investors' rights agreement for venture financings, covering registration rights, information rights, board observer rights, and protective provisions.",
       "license_note": "NVCA model documents are freely downloadable but not redistributable. This recipe contains only transformation instructions, not the source document.",
       "source_url": "https://nvca.org/wp-content/uploads/2025/10/NVCA-Model-IRA-10-1-2025-2-1.docx",
@@ -10809,7 +11103,7 @@
     {
       "name": "nvca-management-rights-letter",
       "display_name": "NVCA Model Management Rights Letter",
-      "category": "general",
+      "category": "venture-financing",
       "description": "Management rights letter granting ERISA-qualifying management rights to venture capital fund investors.",
       "license_note": "NVCA model documents are freely downloadable but not redistributable. This recipe contains only transformation instructions, not the source document.",
       "source_url": "https://nvca.org/wp-content/uploads/2025/12/NVCA-2020-Management-Rights-Letter-1-1.docx",
@@ -10903,7 +11197,7 @@
     {
       "name": "nvca-rofr-co-sale-agreement",
       "display_name": "NVCA Model Right of First Refusal and Co-Sale Agreement",
-      "category": "general",
+      "category": "venture-financing",
       "description": "Right of first refusal and co-sale agreement for venture financings, restricting transfer of founder shares and providing investor co-sale rights.",
       "license_note": "NVCA model documents are freely downloadable but not redistributable. This recipe contains only transformation instructions, not the source document.",
       "source_url": "https://nvca.org/wp-content/uploads/2025/10/NVCA-Model-ROFRA-10-1-2025.docx",
@@ -11060,7 +11354,7 @@
     {
       "name": "nvca-stock-purchase-agreement",
       "display_name": "NVCA Model Stock Purchase Agreement",
-      "category": "general",
+      "category": "venture-financing",
       "description": "Series preferred stock purchase agreement for venture capital financings, covering purchase terms, representations, and closing conditions.",
       "license_note": "NVCA model documents are freely downloadable but not redistributable. This recipe contains only transformation instructions, not the source document.",
       "source_url": "https://nvca.org/wp-content/uploads/2025/10/NVCA-Model-SPA-10-28-2025-1.docx",
@@ -11379,7 +11673,7 @@
     {
       "name": "nvca-voting-agreement",
       "display_name": "NVCA Model Voting Agreement",
-      "category": "general",
+      "category": "venture-financing",
       "description": "Standard-form voting agreement for venture capital financings, covering board composition, drag-along rights, and stockholder voting obligations.",
       "license_note": "NVCA model documents are freely downloadable but not redistributable. This recipe contains only transformation instructions, not the source document.",
       "source_url": "https://nvca.org/wp-content/uploads/2024/10/NVCA-Model-VA-10-1-2025.docx",
@@ -11883,7 +12177,15 @@
       "license": "CC-BY-4.0",
       "source_url": "https://github.com/open-agreements/open-agreements/tree/main/templates/openagreements-restrictive-covenant-wyoming",
       "source": "OpenAgreements",
-      "attribution_text": "Authored by OpenAgreements contributors. Wyoming-specific analysis informed by publicly available commentary from Am Law firms including Ogletree Deakins, Fisher Phillips, Littler Mendelson, Foley & Lardner, Faegre Drinker, and Vinson & Elkins. See practice note for sources. Licensed under CC BY 4.0.",
+      "attribution_text": "Drafted by Joey Tsang for OpenAgreements. Wyoming-specific analysis informed by publicly available commentary from Am Law firms including Ogletree Deakins, Fisher Phillips, Littler Mendelson, Foley & Lardner, Faegre Drinker, and Vinson & Elkins. See practice note for sources. Licensed under CC BY 4.0.",
+      "authors": [
+        {
+          "name": "Joey Tsang",
+          "slug": "joey-tsang",
+          "role": "primary_author",
+          "profile_url": "https://www.linkedin.com/in/joey-t-b90912b1/"
+        }
+      ],
       "fields": [
         {
           "name": "employer_name",

--- a/data/templates-snapshot.json
+++ b/data/templates-snapshot.json
@@ -10257,7 +10257,15 @@
       "license": "CC0-1.0",
       "source_url": "https://github.com/cooleyLLP/seriesseed",
       "source": "github.com",
-      "attribution_text": "Derived from the Cooley Series Seed Board Consent, available at https://github.com/cooleyLLP/seriesseed. Made available under CC0 1.0 Universal Public Domain Dedication.",
+      "attribution_text": "Adapted by Joey Tsang for OpenAgreements from the Cooley Series Seed Board Consent, available at https://github.com/cooleyLLP/seriesseed. Made available under CC0 1.0 Universal Public Domain Dedication.",
+      "authors": [
+        {
+          "name": "Joey Tsang",
+          "slug": "joey-tsang",
+          "role": "primary_author",
+          "profile_url": "https://www.linkedin.com/in/joey-t-b90912b1/"
+        }
+      ],
       "fields": [
         {
           "name": "company_name",
@@ -10323,7 +10331,15 @@
       "license": "CC0-1.0",
       "source_url": "https://github.com/cooleyLLP/seriesseed",
       "source": "github.com",
-      "attribution_text": "Derived from the Cooley Series Seed Stockholder Consent, available at https://github.com/cooleyLLP/seriesseed. Made available under CC0 1.0 Universal Public Domain Dedication.",
+      "attribution_text": "Adapted by Joey Tsang for OpenAgreements from the Cooley Series Seed Stockholder Consent, available at https://github.com/cooleyLLP/seriesseed. Made available under CC0 1.0 Universal Public Domain Dedication.",
+      "authors": [
+        {
+          "name": "Joey Tsang",
+          "slug": "joey-tsang",
+          "role": "primary_author",
+          "profile_url": "https://www.linkedin.com/in/joey-t-b90912b1/"
+        }
+      ],
       "fields": [
         {
           "name": "company_name",
@@ -11808,7 +11824,14 @@
       "license": "CC-BY-4.0",
       "source_url": "https://github.com/open-agreements/open-agreements/tree/main/templates/openagreements-employee-ip-inventions-assignment",
       "source": "OpenAgreements",
-      "attribution_text": "Authored by OpenAgreements contributors. Baseline structure inspired by permissive public references including the Balanced Employee IP Agreement (CC0) and Papertrail legal-docs (CC0). Licensed under CC BY 4.0.",
+      "attribution_text": "Drafted by Steven Obiajulu for OpenAgreements. Baseline structure inspired by permissive public references including the Balanced Employee IP Agreement (CC0) and Papertrail legal-docs (CC0). Licensed under CC BY 4.0.",
+      "authors": [
+        {
+          "name": "Steven Obiajulu",
+          "slug": "steven-obiajulu",
+          "role": "primary_author"
+        }
+      ],
       "fields": [
         {
           "name": "company_name",
@@ -11928,7 +11951,14 @@
       "license": "CC-BY-4.0",
       "source_url": "https://github.com/open-agreements/open-agreements/tree/main/templates/openagreements-employment-confidentiality-acknowledgement",
       "source": "OpenAgreements",
-      "attribution_text": "Authored by OpenAgreements contributors using permissive public reference patterns from Papertrail legal-docs (CC0) and open policy frameworks. Licensed under CC BY 4.0.",
+      "attribution_text": "Drafted by Steven Obiajulu for OpenAgreements using permissive public reference patterns from Papertrail legal-docs (CC0) and open policy frameworks. Licensed under CC BY 4.0.",
+      "authors": [
+        {
+          "name": "Steven Obiajulu",
+          "slug": "steven-obiajulu",
+          "role": "primary_author"
+        }
+      ],
       "fields": [
         {
           "name": "company_name",
@@ -12039,7 +12069,14 @@
       "license": "CC-BY-4.0",
       "source_url": "https://github.com/open-agreements/open-agreements/tree/main/templates/openagreements-employment-offer-letter",
       "source": "OpenAgreements",
-      "attribution_text": "Authored by OpenAgreements contributors. Drafting structure informed by publicly available permissive sources including the DocuSign template library (MIT) and Papertrail legal-docs (CC0). Licensed under CC BY 4.0.",
+      "attribution_text": "Drafted by Steven Obiajulu for OpenAgreements. Drafting structure informed by publicly available permissive sources including the DocuSign template library (MIT) and Papertrail legal-docs (CC0). Licensed under CC BY 4.0.",
+      "authors": [
+        {
+          "name": "Steven Obiajulu",
+          "slug": "steven-obiajulu",
+          "role": "primary_author"
+        }
+      ],
       "fields": [
         {
           "name": "employer_name",
@@ -12177,13 +12214,12 @@
       "license": "CC-BY-4.0",
       "source_url": "https://github.com/open-agreements/open-agreements/tree/main/templates/openagreements-restrictive-covenant-wyoming",
       "source": "OpenAgreements",
-      "attribution_text": "Drafted by Joey Tsang for OpenAgreements. Wyoming-specific analysis informed by publicly available commentary from Am Law firms including Ogletree Deakins, Fisher Phillips, Littler Mendelson, Foley & Lardner, Faegre Drinker, and Vinson & Elkins. See practice note for sources. Licensed under CC BY 4.0.",
+      "attribution_text": "Drafted by Steven Obiajulu for OpenAgreements. Wyoming-specific analysis informed by publicly available commentary from Am Law firms including Ogletree Deakins, Fisher Phillips, Littler Mendelson, Foley & Lardner, Faegre Drinker, and Vinson & Elkins. See practice note for sources. Licensed under CC BY 4.0.",
       "authors": [
         {
-          "name": "Joey Tsang",
-          "slug": "joey-tsang",
-          "role": "primary_author",
-          "profile_url": "https://www.linkedin.com/in/joey-t-b90912b1/"
+          "name": "Steven Obiajulu",
+          "slug": "steven-obiajulu",
+          "role": "primary_author"
         }
       ],
       "fields": [

--- a/data/templates-snapshot.json
+++ b/data/templates-snapshot.json
@@ -10250,154 +10250,6 @@
       ]
     },
     {
-      "name": "cooley-board-consent-safe",
-      "display_name": "Board Consent for SAFE Financing",
-      "category": "corporate-governance",
-      "description": "Action by unanimous written consent of the board of directors of a Delaware corporation approving the issuance of one or more Simple Agreements for Future Equity (SAFEs). Derived from the Cooley Series Seed board consent, adapted for SAFE financing.",
-      "license": "CC0-1.0",
-      "source_url": "https://github.com/cooleyLLP/seriesseed",
-      "source": "github.com",
-      "attribution_text": "Adapted by Joey Tsang for OpenAgreements from the Cooley Series Seed Board Consent, available at https://github.com/cooleyLLP/seriesseed. Made available under CC0 1.0 Universal Public Domain Dedication.",
-      "authors": [
-        {
-          "name": "Joey Tsang",
-          "slug": "joey-tsang",
-          "role": "primary_author",
-          "profile_url": "https://www.linkedin.com/in/joey-t-b90912b1/"
-        }
-      ],
-      "fields": [
-        {
-          "name": "company_name",
-          "type": "string",
-          "required": true,
-          "section": "Parties",
-          "description": "Full legal name of the company",
-          "default": null,
-          "default_value_rationale": null
-        },
-        {
-          "name": "effective_date",
-          "type": "date",
-          "required": true,
-          "section": "Terms",
-          "description": "Date the consent is effective",
-          "default": null,
-          "default_value_rationale": null
-        },
-        {
-          "name": "purchase_amount",
-          "type": "string",
-          "required": true,
-          "section": "Deal Terms",
-          "description": "Aggregate SAFE purchase amount (e.g., \"500,000\")",
-          "default": null,
-          "default_value_rationale": null
-        },
-        {
-          "name": "board_member_1_name",
-          "type": "string",
-          "required": true,
-          "section": "Signatures",
-          "description": "Full name of the first board member",
-          "default": null,
-          "default_value_rationale": null
-        },
-        {
-          "name": "board_member_2_name",
-          "type": "string",
-          "required": true,
-          "section": "Signatures",
-          "description": "Full name of the second board member",
-          "default": null,
-          "default_value_rationale": null
-        },
-        {
-          "name": "board_member_3_name",
-          "type": "string",
-          "required": true,
-          "section": "Signatures",
-          "description": "Full name of the third board member",
-          "default": null,
-          "default_value_rationale": null
-        }
-      ]
-    },
-    {
-      "name": "cooley-stockholder-consent-safe",
-      "display_name": "Stockholder Consent for SAFE Financing",
-      "category": "corporate-governance",
-      "description": "Action by written consent of the stockholders of a Delaware corporation approving the issuance of one or more Simple Agreements for Future Equity (SAFEs). Derived from the Cooley Series Seed stockholder consent, adapted for SAFE financing.",
-      "license": "CC0-1.0",
-      "source_url": "https://github.com/cooleyLLP/seriesseed",
-      "source": "github.com",
-      "attribution_text": "Adapted by Joey Tsang for OpenAgreements from the Cooley Series Seed Stockholder Consent, available at https://github.com/cooleyLLP/seriesseed. Made available under CC0 1.0 Universal Public Domain Dedication.",
-      "authors": [
-        {
-          "name": "Joey Tsang",
-          "slug": "joey-tsang",
-          "role": "primary_author",
-          "profile_url": "https://www.linkedin.com/in/joey-t-b90912b1/"
-        }
-      ],
-      "fields": [
-        {
-          "name": "company_name",
-          "type": "string",
-          "required": true,
-          "section": "Parties",
-          "description": "Full legal name of the company",
-          "default": null,
-          "default_value_rationale": null
-        },
-        {
-          "name": "effective_date",
-          "type": "date",
-          "required": true,
-          "section": "Terms",
-          "description": "Date the consent is effective",
-          "default": null,
-          "default_value_rationale": null
-        },
-        {
-          "name": "purchase_amount",
-          "type": "string",
-          "required": true,
-          "section": "Deal Terms",
-          "description": "Aggregate SAFE purchase amount (e.g., \"500,000\")",
-          "default": null,
-          "default_value_rationale": null
-        },
-        {
-          "name": "stockholder_1_name",
-          "type": "string",
-          "required": true,
-          "section": "Signatures",
-          "description": "Full name of the first stockholder",
-          "default": null,
-          "default_value_rationale": null
-        },
-        {
-          "name": "stockholder_2_name",
-          "type": "string",
-          "required": true,
-          "section": "Signatures",
-          "description": "Full name of the second stockholder",
-          "default": null,
-          "default_value_rationale": null
-        },
-        {
-          "name": "stockholder_3_name",
-          "type": "string",
-          "required": true,
-          "section": "Signatures",
-          "description": "Full name of the third stockholder",
-          "default": null,
-          "default_value_rationale": null
-        }
-      ]
-    },
-    {
       "name": "nvca-certificate-of-incorporation",
       "display_name": "NVCA Model Certificate of Incorporation",
       "category": "venture-financing",
@@ -11817,6 +11669,80 @@
       ]
     },
     {
+      "name": "openagreements-board-consent-safe",
+      "display_name": "Board Consent for SAFE Financing",
+      "category": "corporate-governance",
+      "description": "Action by unanimous written consent of the board of directors of a Delaware corporation approving the issuance of one or more Simple Agreements for Future Equity (SAFEs). Canonically authored in Contract IR and rendered to DOCX.",
+      "license": "CC-BY-4.0",
+      "source_url": "https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-board-consent-safe",
+      "source": "OpenAgreements",
+      "attribution_text": "Authored by OpenAgreements contributors. Drafting structure informed by publicly available Series Seed SAFE board consent materials. Licensed under CC BY 4.0.",
+      "authors": [
+        {
+          "name": "Joey Tsang",
+          "slug": "joey-tsang",
+          "role": "primary_author",
+          "profile_url": "https://www.linkedin.com/in/joey-t-b90912b1/"
+        }
+      ],
+      "fields": [
+        {
+          "name": "company_name",
+          "type": "string",
+          "required": true,
+          "section": "Parties",
+          "description": "Full legal name of the company",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "effective_date",
+          "type": "date",
+          "required": true,
+          "section": "Terms",
+          "description": "Date the consent is effective",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "purchase_amount",
+          "type": "string",
+          "required": true,
+          "section": "Deal Terms",
+          "description": "Aggregate SAFE purchase amount (for example, \"500,000\")",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "board_member_1_name",
+          "type": "string",
+          "required": true,
+          "section": "Signatures",
+          "description": "Full name of the first board member",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "board_member_2_name",
+          "type": "string",
+          "required": true,
+          "section": "Signatures",
+          "description": "Full name of the second board member",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "board_member_3_name",
+          "type": "string",
+          "required": true,
+          "section": "Signatures",
+          "description": "Full name of the third board member",
+          "default": null,
+          "default_value_rationale": null
+        }
+      ]
+    },
+    {
       "name": "openagreements-employee-ip-inventions-assignment",
       "display_name": "OpenAgreements Employee IP and Inventions Assignment",
       "category": "employment",
@@ -11824,7 +11750,7 @@
       "license": "CC-BY-4.0",
       "source_url": "https://github.com/open-agreements/open-agreements/tree/main/templates/openagreements-employee-ip-inventions-assignment",
       "source": "OpenAgreements",
-      "attribution_text": "Drafted by Steven Obiajulu for OpenAgreements. Baseline structure inspired by permissive public references including the Balanced Employee IP Agreement (CC0) and Papertrail legal-docs (CC0). Licensed under CC BY 4.0.",
+      "attribution_text": "Authored by OpenAgreements contributors. Baseline structure inspired by permissive public references including the Balanced Employee IP Agreement (CC0) and Papertrail legal-docs (CC0). Licensed under CC BY 4.0.",
       "authors": [
         {
           "name": "Steven Obiajulu",
@@ -11951,7 +11877,7 @@
       "license": "CC-BY-4.0",
       "source_url": "https://github.com/open-agreements/open-agreements/tree/main/templates/openagreements-employment-confidentiality-acknowledgement",
       "source": "OpenAgreements",
-      "attribution_text": "Drafted by Steven Obiajulu for OpenAgreements using permissive public reference patterns from Papertrail legal-docs (CC0) and open policy frameworks. Licensed under CC BY 4.0.",
+      "attribution_text": "Authored by OpenAgreements contributors using permissive public reference patterns from Papertrail legal-docs (CC0) and open policy frameworks. Licensed under CC BY 4.0.",
       "authors": [
         {
           "name": "Steven Obiajulu",
@@ -12069,7 +11995,7 @@
       "license": "CC-BY-4.0",
       "source_url": "https://github.com/open-agreements/open-agreements/tree/main/templates/openagreements-employment-offer-letter",
       "source": "OpenAgreements",
-      "attribution_text": "Drafted by Steven Obiajulu for OpenAgreements. Drafting structure informed by publicly available permissive sources including the DocuSign template library (MIT) and Papertrail legal-docs (CC0). Licensed under CC BY 4.0.",
+      "attribution_text": "Authored by OpenAgreements contributors. Drafting structure informed by publicly available permissive sources including the DocuSign template library (MIT) and Papertrail legal-docs (CC0). Licensed under CC BY 4.0.",
       "authors": [
         {
           "name": "Steven Obiajulu",
@@ -12214,7 +12140,7 @@
       "license": "CC-BY-4.0",
       "source_url": "https://github.com/open-agreements/open-agreements/tree/main/templates/openagreements-restrictive-covenant-wyoming",
       "source": "OpenAgreements",
-      "attribution_text": "Drafted by Steven Obiajulu for OpenAgreements. Wyoming-specific analysis informed by publicly available commentary from Am Law firms including Ogletree Deakins, Fisher Phillips, Littler Mendelson, Foley & Lardner, Faegre Drinker, and Vinson & Elkins. See practice note for sources. Licensed under CC BY 4.0.",
+      "attribution_text": "Authored by OpenAgreements contributors. Wyoming-specific analysis informed by publicly available commentary from Am Law firms including Ogletree Deakins, Fisher Phillips, Littler Mendelson, Foley & Lardner, Faegre Drinker, and Vinson & Elkins. See practice note for sources. Licensed under CC BY 4.0.",
       "authors": [
         {
           "name": "Steven Obiajulu",
@@ -12473,6 +12399,80 @@
           "section": "Document Management",
           "description": "Internal computed footer text for document-system traceability",
           "default": "",
+          "default_value_rationale": null
+        }
+      ]
+    },
+    {
+      "name": "stockholder-consent-safe",
+      "display_name": "Stockholder Consent for SAFE Financing",
+      "category": "corporate-governance",
+      "description": "Action by written consent of the stockholders of a Delaware corporation approving the issuance of one or more Simple Agreements for Future Equity (SAFEs). Adapted for SAFE financing from publicly available Series Seed stockholder consent materials.",
+      "license": "CC0-1.0",
+      "source_url": "https://github.com/cooleyLLP/seriesseed",
+      "source": "github.com",
+      "attribution_text": "Adapted from publicly available Series Seed stockholder consent materials at https://github.com/cooleyLLP/seriesseed. Made available under CC0 1.0 Universal Public Domain Dedication.",
+      "authors": [
+        {
+          "name": "Joey Tsang",
+          "slug": "joey-tsang",
+          "role": "primary_author",
+          "profile_url": "https://www.linkedin.com/in/joey-t-b90912b1/"
+        }
+      ],
+      "fields": [
+        {
+          "name": "company_name",
+          "type": "string",
+          "required": true,
+          "section": "Parties",
+          "description": "Full legal name of the company",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "effective_date",
+          "type": "date",
+          "required": true,
+          "section": "Terms",
+          "description": "Date the consent is effective",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "purchase_amount",
+          "type": "string",
+          "required": true,
+          "section": "Deal Terms",
+          "description": "Aggregate SAFE purchase amount (e.g., \"500,000\")",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "stockholder_1_name",
+          "type": "string",
+          "required": true,
+          "section": "Signatures",
+          "description": "Full name of the first stockholder",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "stockholder_2_name",
+          "type": "string",
+          "required": true,
+          "section": "Signatures",
+          "description": "Full name of the second stockholder",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "stockholder_3_name",
+          "type": "string",
+          "required": true,
+          "section": "Signatures",
+          "description": "Full name of the third stockholder",
+          "default": null,
           "default_value_rationale": null
         }
       ]

--- a/integration-tests/list.test.ts
+++ b/integration-tests/list.test.ts
@@ -95,13 +95,40 @@ describe('list --json envelope', () => {
     }
   });
 
-  it.openspec('OA-CLI-024')('includes structured authors when template metadata provides them', () => {
+  it.openspec('OA-CLI-024')('includes structured authors for authored templates', () => {
     if (!available || !parsed) return;
     const wyomingTemplate = parsed.items.find(
       (item) => item.name === 'openagreements-restrictive-covenant-wyoming'
     );
+    const boardConsentTemplate = parsed.items.find(
+      (item) => item.name === 'openagreements-board-consent-safe'
+    );
+    const stockholderConsentTemplate = parsed.items.find(
+      (item) => item.name === 'stockholder-consent-safe'
+    );
     expect(wyomingTemplate).toBeDefined();
+    expect(boardConsentTemplate).toBeDefined();
+    expect(stockholderConsentTemplate).toBeDefined();
     expect(wyomingTemplate?.authors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'Steven Obiajulu',
+          slug: 'steven-obiajulu',
+          role: 'primary_author',
+        }),
+      ])
+    );
+    expect(boardConsentTemplate?.authors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'Joey Tsang',
+          slug: 'joey-tsang',
+          role: 'primary_author',
+          profile_url: 'https://www.linkedin.com/in/joey-t-b90912b1/',
+        }),
+      ])
+    );
+    expect(stockholderConsentTemplate?.authors).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           name: 'Joey Tsang',

--- a/integration-tests/list.test.ts
+++ b/integration-tests/list.test.ts
@@ -13,6 +13,12 @@ interface ListItem {
   name: string;
   attribution_text?: string;
   category?: string;
+  authors?: Array<{
+    name: string;
+    slug?: string;
+    role?: string;
+    profile_url?: string;
+  }>;
   [key: string]: unknown;
 }
 
@@ -87,6 +93,24 @@ describe('list --json envelope', () => {
         })
       );
     }
+  });
+
+  it.openspec('OA-CLI-024')('includes structured authors when template metadata provides them', () => {
+    if (!available || !parsed) return;
+    const wyomingTemplate = parsed.items.find(
+      (item) => item.name === 'openagreements-restrictive-covenant-wyoming'
+    );
+    expect(wyomingTemplate).toBeDefined();
+    expect(wyomingTemplate?.authors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'Joey Tsang',
+          slug: 'joey-tsang',
+          role: 'primary_author',
+          profile_url: 'https://www.linkedin.com/in/joey-t-b90912b1/',
+        }),
+      ])
+    );
   });
 });
 

--- a/openspec/changes/add-template-author-metadata/proposal.md
+++ b/openspec/changes/add-template-author-metadata/proposal.md
@@ -6,8 +6,8 @@ Template authorship is currently flattened into generic attribution text. That m
 ## What Changes
 - Add optional structured `authors` metadata to internal and external template metadata.
 - Include structured `authors` in `list --json` output when present.
-- Attach Joey Tsang as the primary author of the Wyoming restrictive covenant template.
+- Add structured author metadata to OpenAgreements-authored employment templates and Joey Tsang-authored SAFE consent templates.
 
 ## Impact
 - Affected specs: `open-agreements`
-- Affected code: `src/core/metadata.ts`, `src/commands/list.ts`, `content/templates/openagreements-restrictive-covenant-wyoming/metadata.yaml`, `data/templates-snapshot.json`
+- Affected code: `src/core/metadata.ts`, `src/commands/list.ts`, template `metadata.yaml` files with author metadata, `data/templates-snapshot.json`

--- a/openspec/changes/add-template-author-metadata/proposal.md
+++ b/openspec/changes/add-template-author-metadata/proposal.md
@@ -1,0 +1,13 @@
+# Change: add template author metadata
+
+## Why
+Template authorship is currently flattened into generic attribution text. That makes it hard for downstream consumers to credit specific drafters, render author bios, and attach visible authorship to public template pages.
+
+## What Changes
+- Add optional structured `authors` metadata to internal and external template metadata.
+- Include structured `authors` in `list --json` output when present.
+- Attach Joey Tsang as the primary author of the Wyoming restrictive covenant template.
+
+## Impact
+- Affected specs: `open-agreements`
+- Affected code: `src/core/metadata.ts`, `src/commands/list.ts`, `content/templates/openagreements-restrictive-covenant-wyoming/metadata.yaml`, `data/templates-snapshot.json`

--- a/openspec/changes/add-template-author-metadata/specs/open-agreements/spec.md
+++ b/openspec/changes/add-template-author-metadata/specs/open-agreements/spec.md
@@ -1,0 +1,28 @@
+## MODIFIED Requirements
+### Requirement: Template Metadata Schema
+Each template directory SHALL contain a `metadata.yaml` validated by Zod schema with fields: `name`, `source_url`, `version`, `license` (enum: CC-BY-4.0, CC0-1.0), `allow_derivatives` (boolean), `attribution_text`, `fields` (array of field definitions with name, type, description, required). Template metadata MAY also include an `authors` array of structured author records with `name` and optional `slug`, `role`, and `profile_url`.
+
+#### Scenario: [OA-TMP-009] Valid metadata passes validation
+- **GIVEN** a template directory with a `metadata.yaml` containing all required fields with valid values
+- **WHEN** the system validates the metadata
+- **THEN** validation passes with no errors
+
+#### Scenario: [OA-TMP-024] Structured authors pass validation
+- **GIVEN** a template directory with `metadata.yaml` containing an `authors` array with author names and optional author metadata
+- **WHEN** the system validates the metadata
+- **THEN** validation passes
+- **AND** each author record preserves `name`, `slug`, `role`, and `profile_url` when provided
+
+### Requirement: Machine-Readable Template Discovery
+The `list` command SHALL support a `--json` flag that outputs template metadata including all field definitions, enabling programmatic field discovery by agent skills. Output SHALL be sorted by name. Templates SHALL include `source_url` and `attribution_text`. Templates with structured author metadata SHALL include an `authors` array in the JSON output.
+
+#### Scenario: [OA-CLI-012] JSON output includes full metadata sorted by name
+- **GIVEN** templates are available
+- **WHEN** the user runs `open-agreements list --json`
+- **THEN** the output is a valid JSON envelope with `schema_version`, `cli_version`, and `items` array sorted by name, where each item includes `name`, `description`, `license`, `source_url`, `source`, `attribution_text`, and `fields`
+
+#### Scenario: [OA-CLI-024] JSON output includes template authors when present
+- **GIVEN** a template metadata file provides structured author metadata
+- **WHEN** the user runs `open-agreements list --json`
+- **THEN** the corresponding item includes an `authors` array
+- **AND** each author preserves `name`, `slug`, `role`, and `profile_url` when provided

--- a/openspec/changes/add-template-author-metadata/tasks.md
+++ b/openspec/changes/add-template-author-metadata/tasks.md
@@ -1,0 +1,9 @@
+## 1. Implementation
+- [x] 1.1 Extend template metadata validation to accept optional structured authors.
+- [x] 1.2 Include structured authors in `list --json` output when metadata provides them.
+- [x] 1.3 Add Joey Tsang as the Wyoming template's primary author and regenerate the template snapshot.
+- [x] 1.4 Add metadata and integration test coverage for structured authors.
+
+## 2. Validation
+- [x] 2.1 Run targeted tests for metadata parsing and list JSON output.
+- [x] 2.2 Run `openspec validate add-template-author-metadata --strict`.

--- a/openspec/changes/add-template-author-metadata/tasks.md
+++ b/openspec/changes/add-template-author-metadata/tasks.md
@@ -1,7 +1,7 @@
 ## 1. Implementation
 - [x] 1.1 Extend template metadata validation to accept optional structured authors.
 - [x] 1.2 Include structured authors in `list --json` output when metadata provides them.
-- [x] 1.3 Add Joey Tsang as the Wyoming template's primary author and regenerate the template snapshot.
+- [x] 1.3 Add structured author metadata to authored templates and regenerate the template snapshot.
 - [x] 1.4 Add metadata and integration test coverage for structured authors.
 
 ## 2. Validation

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -43,6 +43,7 @@ function runListJson(opts: ListOptions): void {
         source_url: meta.source_url,
         source: sourceName(meta.source_url),
         attribution_text: meta.attribution_text,
+        ...(meta.authors ? { authors: meta.authors } : {}),
         fields: mapFields(meta.fields, meta.priority_fields),
       });
     } catch (err) {
@@ -65,6 +66,7 @@ function runListJson(opts: ListOptions): void {
           source_url: meta.source_url,
           source: sourceName(meta.source_url),
           attribution_text: meta.attribution_text,
+          ...(meta.authors ? { authors: meta.authors } : {}),
           fields: mapFields(meta.fields, meta.priority_fields),
         });
       } catch (err) {

--- a/src/core/metadata.test.ts
+++ b/src/core/metadata.test.ts
@@ -219,6 +219,31 @@ describe('TemplateMetadataSchema', () => {
       false
     );
   });
+
+  it.openspec('OA-TMP-024')('accepts optional structured authors metadata', async () => {
+    await expectSafeParseOutcome(
+      'TemplateMetadataSchema',
+      TemplateMetadataSchema,
+      {
+        name: 'Test NDA',
+        source_url: 'https://example.com/nda',
+        version: '1.0',
+        license: 'CC-BY-4.0',
+        allow_derivatives: true,
+        attribution_text: 'Based on Example NDA',
+        authors: [
+          {
+            name: 'Joey Tsang',
+            slug: 'joey-tsang',
+            role: 'primary_author',
+            profile_url: 'https://www.linkedin.com/in/joey-t-b90912b1/',
+          },
+        ],
+        fields: [],
+      },
+      true
+    );
+  });
 });
 
 describe('RecipeMetadataSchema', () => {

--- a/src/core/metadata.ts
+++ b/src/core/metadata.ts
@@ -6,6 +6,14 @@ import yaml from 'js-yaml';
 export const LicenseEnum = z.enum(['CC-BY-4.0', 'CC0-1.0', 'CC-BY-ND-4.0']);
 export type License = z.infer<typeof LicenseEnum>;
 
+export const TemplateAuthorSchema = z.object({
+  name: z.string(),
+  slug: z.string().regex(/^[a-z0-9-]+$/).optional(),
+  role: z.string().optional(),
+  profile_url: z.string().url().optional(),
+});
+export type TemplateAuthor = z.infer<typeof TemplateAuthorSchema>;
+
 export const FieldDefinitionSchema = z.object({
   name: z.string(),
   type: z.enum(['string', 'date', 'number', 'boolean', 'enum', 'array']),
@@ -65,6 +73,7 @@ const TemplateMetadataBaseSchema = z.object({
   license: LicenseEnum,
   allow_derivatives: z.boolean(),
   attribution_text: z.string(),
+  authors: z.array(TemplateAuthorSchema).optional(),
   fields: z.array(FieldDefinitionSchema),
   priority_fields: z.array(z.string()).default([]),
 });


### PR DESCRIPTION
## Summary
- add optional structured `authors` metadata to template validation and `list --json`
- attach author records to authored OpenAgreements employment templates and Joey Tsang-authored SAFE consent templates
- refresh `data/templates-snapshot.json` and list integration coverage for author output

## Validation
- `npm run build`
- `node scripts/export-templates-snapshot.mjs`
- `npx vitest run integration-tests/list.test.ts`
- `openspec validate add-template-author-metadata --strict`
