### PR TITLE
chore(skills): add version to unit-test-philosophy for directory publishing

### DIFF
--- a/skills/unit-test-philosophy/SKILL.md
+++ b/skills/unit-test-philosophy/SKILL.md
@@ -8,6 +8,7 @@ description: >-
   src, integration-tests, and workspace packages.
 metadata:
   short-description: Open Agreements testing philosophy
+  version: "0.1.0"
 catalog_group: Developer Workflows
 catalog_order: 20
 ---


### PR DESCRIPTION
## Summary
- Adds `metadata.version: "0.1.0"` to `unit-test-philosophy` SKILL.md. ClawHub requires a version in frontmatter to publish.
- Prerequisite for publishing this skill to Smithery + ClawHub via the `Publish Skills Directories` workflow.

## Test plan
- [x] Frontmatter parses correctly
- [ ] After merge, dispatch publish workflow with this skill included