### PR TITLE
feat(discovery): MCP Server Card at /.well-known/mcp-server-card

### DIFF
--- a/site/.well-known/mcp-server-card
+++ b/site/.well-known/mcp-server-card
@@ -7,8 +7,7 @@
   "websiteUrl": "https://openagreements.org",
   "repository": {
     "url": "https://github.com/open-agreements/open-agreements",
-    "source": "github",
-    "id": "open-agreements/open-agreements"
+    "source": "github"
   },
   "remotes": [
     {

--- a/site/.well-known/mcp-server-card
+++ b/site/.well-known/mcp-server-card
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/v1/server-card.schema.json",
+  "name": "io.github.open-agreements/open-agreements",
+  "title": "Open Agreements",
+  "description": "MCP server to fill standard legal agreement templates (NDAs, SAFEs, NVCA docs, employment) and return signed-ready DOCX files.",
+  "version": "0.5.0",
+  "websiteUrl": "https://openagreements.org",
+  "repository": {
+    "url": "https://github.com/open-agreements/open-agreements",
+    "source": "github",
+    "id": "open-agreements/open-agreements"
+  },
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://openagreements.org/api/mcp"
+    }
+  ],
+  "license": "MIT",
+  "tags": ["legal", "contracts", "templates", "docx", "nda", "safe", "nvca", "employment"]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -10,6 +10,16 @@
     { "source": "/.well-known/oauth-protected-resource", "destination": "/api/auth/well-known-protected-resource" },
     { "source": "/.well-known/oauth-authorization-server", "destination": "/api/auth/well-known-oauth-as" }
   ],
+  "headers": [
+    {
+      "source": "/.well-known/mcp-server-card",
+      "headers": [
+        { "key": "Content-Type", "value": "application/json" },
+        { "key": "Cache-Control", "value": "public, max-age=3600" },
+        { "key": "Access-Control-Allow-Origin", "value": "*" }
+      ]
+    }
+  ],
   "redirects": [
     { "source": "/", "destination": "https://usejunior.com/developer-tools/open-agreements", "statusCode": 301 },
     { "source": "/templates", "destination": "https://usejunior.com/developer-tools/open-agreements/templates", "statusCode": 301 },

--- a/vercel.json
+++ b/vercel.json
@@ -16,7 +16,9 @@
       "headers": [
         { "key": "Content-Type", "value": "application/json" },
         { "key": "Cache-Control", "value": "public, max-age=3600" },
-        { "key": "Access-Control-Allow-Origin", "value": "*" }
+        { "key": "Access-Control-Allow-Origin", "value": "*" },
+        { "key": "Access-Control-Allow-Methods", "value": "GET" },
+        { "key": "Access-Control-Allow-Headers", "value": "Content-Type" }
       ]
     }
   ],


### PR DESCRIPTION
## Summary

Advertises the live HTTP-transport MCP server at `https://openagreements.org/api/mcp` via the [SEP-2127 Server Card](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127) discovery mechanism, so agents crawling `openagreements.org` can find the MCP endpoint without prior knowledge.

- New static file at `site/.well-known/mcp-server-card` (no extension, per SEP-2127 §"Discovery / .well-known URI").
- Flat top-level shape aligned with `server.json` (server.json is a strict superset per the SEP): `name`, `title`, `description`, `version`, `websiteUrl`, `repository`, `remotes[{type: streamable-http, url: ...}]`, `license`, `tags`.
- `vercel.json` `headers` entry overrides `Content-Type` to `application/json` for the extensionless path and adds CORS + short cache.

## Why now

- `api/mcp.ts` is already deployed and serves a valid MCP `initialize` handshake at `/api/mcp` (protocol `2025-03-26`, server name `OpenAgreements`, tools capability).
- `server.json` already exists at repo root with the right shape — this PR is a small mechanical step to also expose the discovery card at the well-known URL.
- The `agent-card.json` (A2A / Google Agent Card) is already served at `/.well-known/agent-card.json`; this adds the MCP equivalent.

## Caveats

- **SEP-2127 is a draft PR, not merged.** Fields align with the current head. If the spec changes shape/path before merge, this card will need a mechanical update. The schema URI (`schemas/v1/server-card.schema.json`) currently 404s; we publish the forward-pointing URI anyway so validators know what to target once the schema lands.
- The card intentionally omits `packages` (stdio/npm info). The registry-submission `server.json` at repo root is the place for that.

## Test plan

- [x] `node -e \"JSON.parse(require('fs').readFileSync('site/.well-known/mcp-server-card'))\"` passes.
- [x] `REDIRECT_MODE=1 npm run build:site:vercel` succeeds; `_site/.well-known/mcp-server-card` is present and valid JSON.
- [ ] On Vercel preview: `curl -sI <preview>/.well-known/mcp-server-card` returns `200` with `Content-Type: application/json` and CORS header.
- [ ] On Vercel preview: `curl -s <preview>/.well-known/mcp-server-card | jq .` parses; `remotes[0].url` resolves to the MCP endpoint.

## Related

- Sibling PR on `usejunior.com`: [UseJunior/dev-website#70](https://github.com/UseJunior/dev-website/pull/70) (agent-skills index + Content-Signal + Link header).
- Tracking issue that flagged this: [UseJunior/dev-website#69](https://github.com/UseJunior/dev-website/issues/69) — which proposed the card belongs here (at openagreements.org), not at usejunior.com. This PR closes that direction.