### PR TITLE
feat(discovery): API catalog (RFC 9727) at /.well-known/api-catalog

### DIFF
--- a/site/.well-known/api-catalog
+++ b/site/.well-known/api-catalog
@@ -1,0 +1,22 @@
+{
+  "linkset": [
+    {
+      "anchor": "https://openagreements.org/api/mcp",
+      "service-desc": [
+        {
+          "href": "https://openagreements.org/.well-known/mcp-server-card",
+          "type": "application/json"
+        }
+      ]
+    },
+    {
+      "anchor": "https://openagreements.org/api/a2a",
+      "service-desc": [
+        {
+          "href": "https://openagreements.org/.well-known/agent-card.json",
+          "type": "application/json"
+        }
+      ]
+    }
+  ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -20,6 +20,16 @@
         { "key": "Access-Control-Allow-Methods", "value": "GET" },
         { "key": "Access-Control-Allow-Headers", "value": "Content-Type" }
       ]
+    },
+    {
+      "source": "/.well-known/api-catalog",
+      "headers": [
+        { "key": "Content-Type", "value": "application/linkset+json; profile=\"https://www.rfc-editor.org/info/rfc9727\"" },
+        { "key": "Cache-Control", "value": "public, max-age=3600" },
+        { "key": "Access-Control-Allow-Origin", "value": "*" },
+        { "key": "Access-Control-Allow-Methods", "value": "GET" },
+        { "key": "Access-Control-Allow-Headers", "value": "Content-Type" }
+      ]
     }
   ],
   "redirects": [


### PR DESCRIPTION
## Summary

Publishes `/.well-known/api-catalog` per RFC 9727 so agents can programmatically discover openagreements.org's HTTP APIs. Pattern mirrors the merged MCP Server Card PR (#189).

Closes #190. Originally surfaced in `UseJunior/dev-website#68`, which closed as N/A since usejunior.com has no public APIs to catalog.

## Content

- `site/.well-known/api-catalog` (no extension, passthrough-copied to `_site/.well-known/`).
- Linkset with two entries: `/api/mcp` → mcp-server-card, `/api/a2a` → agent-card.json.
- `vercel.json` `headers` entry for the new path: `Content-Type: application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"`, full CORS triplet, 1-hour cache.

## Intentionally omitted

- `/api/download` — no machine-readable spec.
- OAuth `.well-known/*` endpoints — discovery metadata, not APIs.
- `service-doc` (human docs) — optional per RFC 9727; no stable URL to link right now.
- Link header on the homepage — openagreements.org root is a 301 redirect, so it wouldn't attach.

## Test plan

- [x] `REDIRECT_MODE=1 npm run build:site:vercel` succeeds; `_site/.well-known/api-catalog` is present and valid JSON.
- [ ] On Vercel preview: `curl -sI <preview>/.well-known/api-catalog` returns `200` with `Content-Type: application/linkset+json; profile="..."`.
- [ ] On Vercel preview: `jq` parses the body; `linkset[].anchor` values match the live API paths.
- [ ] CORS headers (`Allow-Origin *`, `Allow-Methods GET`, `Allow-Headers Content-Type`) all present.
- [ ] Post-merge: `curl -s https://openagreements.org/.well-known/api-catalog | jq .` works anonymously.