### PR TITLE
fix(ci): raise vitest timeouts so coverage job stops flaking

### DIFF
--- a/integration-tests/fill-pipeline.test.ts
+++ b/integration-tests/fill-pipeline.test.ts
@@ -1036,7 +1036,7 @@ describe('Parametric smoke test — signatory fields across all templates', () =
     } finally {
       spy.mockRestore();
     }
-  }, 60_000);
+  }, 180_000);
 
   it.openspec('OA-NDA-008')('all templates fill cleanly in individual mode', async () => {
     const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -1065,5 +1065,5 @@ describe('Parametric smoke test — signatory fields across all templates', () =
     } finally {
       spy.mockRestore();
     }
-  }, 60_000);
+  }, 180_000);
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,14 @@ import { configDefaults, defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
+    // Vitest's default 5000ms is too tight under --coverage: v8 instrumentation
+    // adds ~2x overhead locally and 3-5x on CI runners, which causes tests that
+    // comfortably pass at ~500ms to time out on the coverage job. Raise the
+    // default to give headroom for coverage + Allure wrapper overhead without
+    // hiding genuinely-hung tests. Tests that need more can still pass an
+    // explicit timeout as the third arg to it()/test().
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
     setupFiles: ['allure-vitest/setup'],
     exclude: [
       ...configDefaults.exclude,


### PR DESCRIPTION
## Summary

11 tests were timing out on the coverage CI job ([run 24693662002](https://github.com/open-agreements/open-agreements/actions/runs/24693662002) and earlier) with identical `Test timed out in 5000ms` errors traced back to the Allure-vitest wrapper in `packages/allure-test-factory/src/index.js:953`. Logic is fine — v8 coverage instrumentation + Allure wrapping + CI runner pressure pushes test wall-clock over the default 5s and even past the 60s the two parametric smokes had set.

Local repro (same commits, with `--coverage`):
- Without `--coverage`: 47 fill-pipeline tests in 14.85s, parametric smokes at 6127ms / 5957ms.
- With `--coverage`: same tests in 34.48s, parametric smokes at 12739ms / 16826ms (≈2× slowdown).
- CI adds another 3–5× on top of that.

## Fix

- `vitest.config.ts`: set `testTimeout: 30_000` and `hookTimeout: 30_000`. The old 5000ms default is unrealistic for anything doing real file-system / DOCX work once v8 coverage is in the picture. Tests that genuinely hang will still fail — just at 30s instead of 5s.
- `integration-tests/fill-pipeline.test.ts`: two parametric smokes bumped `60_000 → 180_000`. Locally under coverage they complete in ~12s; CI budget is now ~3 min of headroom.

## Verification

```
$ npx vitest run --coverage \
    src/core/checklist/patch-apply.test.ts \
    integration-tests/checklist-docx-roundtrip.test.ts \
    integration-tests/closing-checklist-rendering.test.ts \
    integration-tests/fill-pipeline.test.ts

Test Files  4 passed (4)
      Tests  99 passed (99)
   Duration  27.04s
```

All 4 previously-failing files are green. 99/99 tests pass.

## Why not fix the Allure wrapper or switch coverage providers

- Switching `v8 → istanbul` would change coverage numbers and require a separate perf + accuracy review.
- The Allure `no vitest context is detected` stderr warnings are a separate issue (allure-vitest 3.7 vs vitest 3.2 — context detection broke) that doesn't cause the timeout failures. Worth filing separately.

Scoped to just the two timeout knobs. Unblocks unrelated PRs (including #192) that inherit the same CI failure from `main`.