### PR TITLE
fix(ci): scale packaging.test.ts subprocess timeouts under coverage

### DIFF
--- a/integration-tests/packaging.test.ts
+++ b/integration-tests/packaging.test.ts
@@ -28,7 +28,7 @@ describe('npm packaging', () => {
         execSync('npm pack --dry-run --json --ignore-scripts 2>/dev/null', {
           cwd: new URL('..', import.meta.url).pathname,
           encoding: 'utf-8',
-          timeout: 30_000,
+          timeout: seconds(30),
         })
       );
       files = packResult[0].files.map((f) => f.path);
@@ -102,23 +102,23 @@ describe('npm packaging', () => {
       tarball = execSync('npm pack --ignore-scripts', {
         cwd: repoRoot,
         encoding: 'utf-8',
-        timeout: 30_000,
+        timeout: seconds(30),
       })
         .trim()
         .split('\n')
         .at(-1) ?? '';
 
-      execSync('npm init -y', { cwd: sandbox, encoding: 'utf-8', timeout: 10_000 });
+      execSync('npm init -y', { cwd: sandbox, encoding: 'utf-8', timeout: seconds(10) });
       execSync(`npm install --ignore-scripts "${join(repoRoot, tarball)}"`, {
         cwd: sandbox,
         encoding: 'utf-8',
-        timeout: 60_000,
+        timeout: seconds(60),
       });
 
       const output = execSync('npx open-agreements list --json', {
         cwd: sandbox,
         encoding: 'utf-8',
-        timeout: 30_000,
+        timeout: seconds(30),
       });
       const parsed = JSON.parse(output);
       expect(parsed.schema_version).toBe(1);


### PR DESCRIPTION
## Summary

Small follow-up to #194. That PR scaled the outer Vitest hook/test timeouts in `packaging.test.ts` via `seconds(45)` / `seconds(30)`, but left the nested `execSync` subprocess timeouts at hard-coded `30_000` / `10_000` / `60_000` / `30_000`.

Peer review (Codex and Gemini) independently flagged this as an inconsistency: under coverage-induced runner contention, the inner subprocess SIGKILL can fire before the scaled outer Vitest timeout has a chance to grant its headroom. Result: a spurious "Command failed" error rather than a clean timeout, with the outer budget wasted.

This PR wraps all four subprocess timeouts in `seconds()` so the full packaging flow scales uniformly:

| Subprocess | Before | Non-coverage | Under coverage |
|---|---|---|---|
| `npm pack --dry-run` (beforeAll) | 30s | 30s | 90s |
| `npm pack` (install test) | 30s | 30s | 90s |
| `npm init -y` | 10s | 10s | 30s |
| `npm install` | 60s | 60s | 180s |
| `npx open-agreements list` | 30s | 30s | 90s |

`seconds()` returns a raw millisecond number which is directly compatible with `child_process.execSync`'s `timeout` option — no wrapper changes needed.

## Test plan
- [x] `VITEST_COVERAGE=1 vitest run --coverage integration-tests/packaging.test.ts` → 7 passed
- [x] `tsc --noEmit` clean
- [ ] CI green