### PR TITLE
fix(mcp): normalize runtime exceptions to envelope shape (#197)

### DIFF
--- a/api/_envelope.ts
+++ b/api/_envelope.ts
@@ -15,6 +15,7 @@ export const ErrorCode = {
   DOWNLOAD_LINK_INVALID: 'DOWNLOAD_LINK_INVALID',
   DOWNLOAD_LINK_EXPIRED: 'DOWNLOAD_LINK_EXPIRED',
   DOWNLOAD_LINK_NOT_FOUND: 'DOWNLOAD_LINK_NOT_FOUND',
+  INTERNAL_ERROR: 'INTERNAL_ERROR',
 } as const;
 
 export type ErrorCodeValue = (typeof ErrorCode)[keyof typeof ErrorCode];

--- a/api/download.ts
+++ b/api/download.ts
@@ -180,7 +180,13 @@ export default async function handler(req: HttpRequest, res: HttpResponse) {
     return sendDownloadError(req, res, mapped.status, mapped.code, mapped.message);
   }
 
-  const outcome = await handleFill(resolved.artifact.template, resolved.artifact.values);
+  let outcome: Awaited<ReturnType<typeof handleFill>>;
+  try {
+    outcome = await handleFill(resolved.artifact.template, resolved.artifact.values);
+  } catch (err) {
+    console.error({ endpoint: 'download', phase: 'fill', id, err });
+    return sendDownloadError(req, res, 500, 'DOWNLOAD_RENDER_FAILED', 'Template render failed.');
+  }
   if (!outcome.ok) {
     return sendDownloadError(req, res, 500, 'DOWNLOAD_RENDER_FAILED', outcome.error);
   }
@@ -189,12 +195,18 @@ export default async function handler(req: HttpRequest, res: HttpResponse) {
   let filename: string;
 
   if (resolved.artifact.variant === 'redline') {
-    const redline = await generateRedlineFromFill(
-      resolved.artifact.template,
-      outcome.base64,
-      resolved.artifact.redline_base ?? 'source',
-      resolved.artifact.values,
-    );
+    let redline: Awaited<ReturnType<typeof generateRedlineFromFill>>;
+    try {
+      redline = await generateRedlineFromFill(
+        resolved.artifact.template,
+        outcome.base64,
+        resolved.artifact.redline_base ?? 'source',
+        resolved.artifact.values,
+      );
+    } catch (err) {
+      console.error({ endpoint: 'download', phase: 'redline', id, err });
+      return sendDownloadError(req, res, 500, 'DOWNLOAD_RENDER_FAILED', 'Redline generation failed.');
+    }
     if (!redline) {
       return sendDownloadError(req, res, 500, 'DOWNLOAD_RENDER_FAILED', 'Redline generation not available for this template.');
     }

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -812,7 +812,20 @@ async function handleToolsCall(id: unknown, params: Record<string, unknown>) {
 
     const { template, values, return_mode, include_redline, redline_base } = parsed.data;
 
-    const outcome = await handleFill(template, values);
+    let outcome: Awaited<ReturnType<typeof handleFill>>;
+    try {
+      outcome = await handleFill(template, values);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error({ tool: TOOL_FILL_TEMPLATE, phase: 'fill', id, err });
+      return toolErrorResult(
+        id,
+        TOOL_FILL_TEMPLATE,
+        ErrorCode.INTERNAL_ERROR,
+        `Fill failed: ${message}`,
+        { retriable: false },
+      );
+    }
 
     if (!outcome.ok) {
       const errorCode = isUnknownTemplateError(outcome.error)
@@ -821,7 +834,20 @@ async function handleToolsCall(id: unknown, params: Record<string, unknown>) {
       return toolErrorResult(id, TOOL_FILL_TEMPLATE, errorCode, outcome.error);
     }
 
-    const artifact = await createDownloadArtifact(template, values);
+    let artifact: Awaited<ReturnType<typeof createDownloadArtifact>>;
+    try {
+      artifact = await createDownloadArtifact(template, values);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error({ tool: TOOL_FILL_TEMPLATE, phase: 'artifact', id, err });
+      return toolErrorResult(
+        id,
+        TOOL_FILL_TEMPLATE,
+        ErrorCode.INTERNAL_ERROR,
+        `Download artifact creation failed: ${message}`,
+        { retriable: false },
+      );
+    }
     const downloadUrl = `${_baseUrl}/api/download?id=${encodeURIComponent(artifact.download_id)}`;
     const expiresAt = artifact.expires_at;
 
@@ -843,8 +869,9 @@ async function handleToolsCall(id: unknown, params: Record<string, unknown>) {
             redline_stats: redline.stats,
           };
         }
-      } catch {
-        // Redline generation is best-effort; don't fail the fill
+      } catch (err) {
+        // Redline generation is best-effort; log but don't fail the fill
+        console.error({ tool: TOOL_FILL_TEMPLATE, phase: 'redline', id, err });
       }
     }
 
@@ -926,6 +953,14 @@ export default async function handler(req: HttpRequest, res: HttpResponse) {
 
   const params = (body.params ?? {}) as Record<string, unknown>;
 
+  // Capture tool name up front so the outer catch can envelope-wrap unexpected
+  // throws during tools/call handling. (auth injection at the tools/call case
+  // only mutates params.arguments, not params.name.)
+  const requestedToolName =
+    body.method === 'tools/call'
+      ? ((params as { name?: unknown }).name as string | undefined)
+      : undefined;
+
   try {
     switch (body.method) {
       case 'initialize':
@@ -961,6 +996,20 @@ export default async function handler(req: HttpRequest, res: HttpResponse) {
     }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
+    console.error({ phase: 'outer', method: body.method, tool: requestedToolName, err });
+    // For tools/call, preserve the documented envelope contract even on
+    // unexpected throws. Other methods keep the JSON-RPC protocol error.
+    if (body.method === 'tools/call') {
+      return res.status(200).json(
+        toolErrorResult(
+          body.id,
+          requestedToolName ?? 'tools/call',
+          ErrorCode.INTERNAL_ERROR,
+          `Internal error: ${message}`,
+          { retriable: false },
+        ),
+      );
+    }
     return res.status(200).json(jsonRpcError(body.id, -32603, `Internal error: ${message}`));
   }
 }

--- a/docs/mcp-migration-v2.md
+++ b/docs/mcp-migration-v2.md
@@ -66,6 +66,7 @@ curl -L "$DOWNLOAD_URL" -o filled.docx
 | `DOWNLOAD_LINK_INVALID` | Malformed or signature-invalid download ID | `false` |
 | `DOWNLOAD_LINK_EXPIRED` | Download link expired | `false` |
 | `DOWNLOAD_LINK_NOT_FOUND` | Download ID not found in TTL store | `false` |
+| `INTERNAL_ERROR` | Unexpected server error during tool execution | `false` |
 
 ## `/api/download` Contract
 
@@ -86,6 +87,7 @@ curl -L "$DOWNLOAD_URL" -o filled.docx
 - Success envelopes include placeholder rate metadata fields (`limit`, `remaining`, `reset_at`) as `null` until rate limiting is wired.
 - Auth and rate-limit error codes are defined for forward compatibility.
 - Clients should branch on error `code` and `retriable` instead of string matching.
+- Current carve-out: auth failures on protected `tools/call` requests are still returned at the HTTP boundary as `401`/`403` with a JSON-RPC `-32001` body, not as an `AUTH_REQUIRED` envelope. Migrating this boundary to the envelope is tracked as a follow-up.
 
 ## Browser GET Behavior
 

--- a/integration-tests/api-endpoints.test.ts
+++ b/integration-tests/api-endpoints.test.ts
@@ -56,6 +56,7 @@ const createDownloadArtifactMock = vi.fn(() => ({
   expires_at_ms: Date.now() + 3600000,
 }));
 const resolveDownloadArtifactMock = vi.fn();
+const generateRedlineFromFillMock = vi.fn();
 
 vi.mock('../api/_shared.js', () => ({
   handleFill: handleFillMock,
@@ -63,6 +64,7 @@ vi.mock('../api/_shared.js', () => ({
   handleGetTemplate: handleGetTemplateMock,
   createDownloadArtifact: createDownloadArtifactMock,
   resolveDownloadArtifact: resolveDownloadArtifactMock,
+  generateRedlineFromFill: generateRedlineFromFillMock,
   DOCX_MIME: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
   PROJECT_ROOT: '/mock',
 }));
@@ -707,5 +709,56 @@ describe('Download endpoint — api/download.ts', () => {
     await downloadHandler(req, res);
 
     expect(res.statusCode).toBe(204);
+  });
+
+  // Regression coverage for issue #197: unhandled throws in the download
+  // render path must return DOWNLOAD_RENDER_FAILED with a generic message
+  // (no err.message leak into the browser-visible body).
+  it.openspec('OA-DST-025')('returns DOWNLOAD_RENDER_FAILED (generic message) when generateRedlineFromFill throws', async () => {
+    resolveDownloadArtifactMock.mockReturnValue({
+      ok: true,
+      artifact: {
+        template: 'common-paper-mutual-nda',
+        values: { company_name: 'Acme Corp' },
+        variant: 'redline',
+        redline_base: 'source',
+        expires_at_ms: Date.now() + 3600000,
+        created_at_ms: Date.now(),
+      },
+    });
+    handleFillMock.mockResolvedValue(MOCK_FILL_SUCCESS);
+    generateRedlineFromFillMock.mockRejectedValueOnce(new Error('sensitive internal details'));
+
+    const req = createMockReq({ method: 'GET', query: { id: 'valid-id.valid-sig' } });
+    const res = createMockRes();
+    await downloadHandler(req, res);
+
+    expect(res.statusCode).toBe(500);
+    expect(getErrorObject(res).code).toBe('DOWNLOAD_RENDER_FAILED');
+    expect(getErrorObject(res).message).toBe('Redline generation failed.');
+    // err.message must not leak into the response body
+    expect(JSON.stringify(res.body)).not.toContain('sensitive internal details');
+  });
+
+  it.openspec('OA-DST-025')('returns DOWNLOAD_RENDER_FAILED (generic message) when handleFill throws', async () => {
+    resolveDownloadArtifactMock.mockReturnValue({
+      ok: true,
+      artifact: {
+        template: 'common-paper-mutual-nda',
+        values: { company_name: 'Acme Corp' },
+        expires_at_ms: Date.now() + 3600000,
+        created_at_ms: Date.now(),
+      },
+    });
+    handleFillMock.mockRejectedValueOnce(new Error('sensitive fill trace'));
+
+    const req = createMockReq({ method: 'GET', query: { id: 'valid-id.valid-sig' } });
+    const res = createMockRes();
+    await downloadHandler(req, res);
+
+    expect(res.statusCode).toBe(500);
+    expect(getErrorObject(res).code).toBe('DOWNLOAD_RENDER_FAILED');
+    expect(getErrorObject(res).message).toBe('Template render failed.');
+    expect(JSON.stringify(res.body)).not.toContain('sensitive fill trace');
   });
 });

--- a/integration-tests/mcp-contract.test.ts
+++ b/integration-tests/mcp-contract.test.ts
@@ -428,4 +428,103 @@ describe('MCP contract envelope behaviors', () => {
     expect(envelope.ok).toBe(true);
     expect(envelope.data.templates[0].display_name).toBe('Common Paper Mutual NDA');
   });
+
+  // Regression coverage for issue #197: unhandled runtime exceptions in
+  // fill/download paths must still produce the v2 envelope, not a raw
+  // JSON-RPC -32603.
+  it.openspec('OA-DST-032')('returns INTERNAL_ERROR envelope when handleFill throws', async () => {
+    handleFillMock.mockRejectedValueOnce(new Error('render engine crashed'));
+
+    const req = createMockReq({
+      body: {
+        jsonrpc: '2.0',
+        id: 30,
+        method: 'tools/call',
+        params: {
+          name: 'fill_template',
+          arguments: {
+            template: 'common-paper-mutual-nda',
+            values: { company_name: 'Acme Corp' },
+          },
+        },
+      },
+    });
+    const res = createMockRes();
+    await mcpHandler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(getResultObject(res).isError).toBe(true);
+    const envelope = parseEnvelope(res.body);
+    expect(envelope.ok).toBe(false);
+    expect(envelope.tool).toBe('fill_template');
+    expect(envelope.schema_version).toBe('2026-02-19');
+    expect(envelope.error.code).toBe('INTERNAL_ERROR');
+    expect(envelope.error.retriable).toBe(false);
+    expect(envelope.error.message).toContain('Fill failed');
+    expect(envelope.error.message).toContain('render engine crashed');
+  });
+
+  it.openspec('OA-DST-032')('returns INTERNAL_ERROR envelope when createDownloadArtifact throws', async () => {
+    createDownloadArtifactMock.mockImplementationOnce(() => {
+      throw new Error('download store unavailable');
+    });
+
+    const req = createMockReq({
+      body: {
+        jsonrpc: '2.0',
+        id: 31,
+        method: 'tools/call',
+        params: {
+          name: 'fill_template',
+          arguments: {
+            template: 'common-paper-mutual-nda',
+            values: { company_name: 'Acme Corp' },
+          },
+        },
+      },
+    });
+    const res = createMockRes();
+    await mcpHandler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(getResultObject(res).isError).toBe(true);
+    const envelope = parseEnvelope(res.body);
+    expect(envelope.ok).toBe(false);
+    expect(envelope.tool).toBe('fill_template');
+    expect(envelope.error.code).toBe('INTERNAL_ERROR');
+    expect(envelope.error.retriable).toBe(false);
+    expect(envelope.error.message).toContain('Download artifact creation failed');
+    expect(envelope.error.message).toContain('download store unavailable');
+  });
+
+  it.openspec('OA-DST-032')('outer safety-net: returns INTERNAL_ERROR envelope when a non-fill tool handler throws', async () => {
+    handleGetTemplateMock.mockImplementationOnce(() => {
+      throw new Error('catalog corruption');
+    });
+
+    const req = createMockReq({
+      body: {
+        jsonrpc: '2.0',
+        id: 32,
+        method: 'tools/call',
+        params: {
+          name: 'get_template',
+          arguments: { template_id: 'common-paper-mutual-nda' },
+        },
+      },
+    });
+    const res = createMockRes();
+    await mcpHandler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    // Outer catch routes through toolErrorResult, which sets isError on the result.
+    expect(getResultObject(res).isError).toBe(true);
+    const envelope = parseEnvelope(res.body);
+    expect(envelope.ok).toBe(false);
+    expect(envelope.tool).toBe('get_template');
+    expect(envelope.schema_version).toBe('2026-02-19');
+    expect(envelope.error.code).toBe('INTERNAL_ERROR');
+    expect(envelope.error.retriable).toBe(false);
+    expect(envelope.error.message).toContain('catalog corruption');
+  });
 });


### PR DESCRIPTION
## Summary

Closes #197.

Unhandled throws in the `fill_template` handler and `/api/download` path were falling through to raw JSON-RPC `-32603` / default 500 responses instead of the v2 envelope contract documented in `docs/mcp-migration-v2.md`. Clients that branch on `envelope.ok` / `envelope.error.code` broke at the moment error handling matters.

## Changes

- **`api/_envelope.ts`** — add `INTERNAL_ERROR` code (`retriable: false`).
- **`api/mcp.ts`** — wrap `handleFill`, `createDownloadArtifact`, and the best-effort redline path with phase-specific try/catch (logs `{tool, phase, id, err}` server-side, returns envelope error). Add outer-catch safety net so unexpected throws in any tool handler still envelope-wrap on `tools/call`; preserve `jsonRpcError(-32603)` frame for non-tool methods (`initialize`, `tools/list`, `ping`). Capture `requestedToolName` up front (auth injection only mutates `params.arguments`).
- **`api/download.ts`** — wrap `handleFill` and `generateRedlineFromFill` in try/catch; return generic client-safe messages (`"Template render failed."` / `"Redline generation failed."`). `err.message` stays in server logs only — not in the browser-visible body, since `sendDownloadError` renders into both JSON and HTML.
- **`docs/mcp-migration-v2.md`** — document `INTERNAL_ERROR`; carve out the existing auth boundary (still HTTP `401`/`403` + `-32001`) as a tracked follow-up.
- **Tests** — 5 regression tests across `mcp-contract.test.ts` and `api-endpoints.test.ts` covering all four uncaught branches plus the outer-catch safety net.

## Reviewer feedback baked in

Plan was peer-reviewed by Gemini CLI and Codex CLI. Material revisions from review:

- `retriable: false` (was `true`) — these throws are deterministic bugs, not transient infra; `retriable: true` would invite retry storms.
- Mock target is `'../api/_shared.js'` (where `createDownloadArtifact` / `resolveDownloadArtifact` actually come from) — `_download-artifacts` is not the import surface.
- Download regression test placed in `api-endpoints.test.ts` (the handler-level mock fixture), not `api-download-tokens.test.ts` (token-helper-only).
- Generic messages in `/api/download` to avoid leaking `err.message` into HTML/JSON browser responses.
- MCP spec (2025-11-25, 2025-06-18) confirms tool errors belong inside `result` with `isError: true`, not as protocol-level JSON-RPC errors — the envelope approach is spec-aligned.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run integration-tests/mcp-contract.test.ts integration-tests/api-endpoints.test.ts` — 48/48 pass (3 new envelope tests, 2 new download tests, plus existing happy-path regressions)
- [x] Full `npm test` — 803 pass; only pre-existing `packages/signing/tests/gcloud-storage.test.ts` failures remain (live-GCS-credential dependent, unrelated)
- [ ] Manual MCP probe: `tools/call fill_template` with mocked throw → verify envelope `{ok:false, tool:'fill_template', error:{code:'INTERNAL_ERROR', retriable:false}}` and `result.isError:true`
- [ ] Manual download probe: `/api/download?id=<throwing-id>` → HTTP 500 with generic `"Template render failed."`; confirm `err.message` does NOT appear in body

## Out of scope

- Migrating auth failures (`-32001` / `401` / `403`) to envelope `AUTH_REQUIRED` — separate concern, follow-up tracked in updated migration doc.