### PR TITLE
fix(download): close residual throw surfaces + redact bearer-token id in logs

### DIFF
--- a/api/download.ts
+++ b/api/download.ts
@@ -4,8 +4,18 @@
  * the filled template, and serves the DOCX as a browser download.
  */
 
+import { createHash } from 'node:crypto';
 import type { HttpRequest, HttpResponse } from './_http-types.js';
 import { resolveDownloadArtifact, handleFill, generateRedlineFromFill, DOCX_MIME } from './_shared.js';
+
+/**
+ * Hash the download id for log correlation. The raw id is a live signed bearer
+ * token — anyone with log access could replay it until expiry. Log only a
+ * non-reversible fingerprint instead.
+ */
+function idFingerprint(id: string): string {
+  return createHash('sha256').update(id).digest('hex').slice(0, 12);
+}
 
 type DownloadHttpErrorCode =
   | 'DOWNLOAD_ID_MISSING'
@@ -173,8 +183,18 @@ export default async function handler(req: HttpRequest, res: HttpResponse) {
   if (!id || typeof id !== 'string') {
     return sendDownloadError(req, res, 400, 'DOWNLOAD_ID_MISSING', 'Missing "id" query parameter.');
   }
+  const idFp = idFingerprint(id);
 
-  const resolved = await resolveDownloadArtifact(id);
+  let resolved: Awaited<ReturnType<typeof resolveDownloadArtifact>>;
+  try {
+    resolved = await resolveDownloadArtifact(id);
+  } catch (err) {
+    // Throws here typically mean the artifact store (KV/Upstash) is unavailable
+    // or returned a malformed payload. Either way, return the documented
+    // DOWNLOAD_RENDER_FAILED shape rather than a raw platform 500.
+    console.error({ endpoint: 'download', phase: 'resolve', idFp, err });
+    return sendDownloadError(req, res, 500, 'DOWNLOAD_RENDER_FAILED', 'Download lookup failed.');
+  }
   if (!resolved.ok) {
     const mapped = mapResolveErrorToHttp(resolved.code);
     return sendDownloadError(req, res, mapped.status, mapped.code, mapped.message);
@@ -184,45 +204,72 @@ export default async function handler(req: HttpRequest, res: HttpResponse) {
   try {
     outcome = await handleFill(resolved.artifact.template, resolved.artifact.values);
   } catch (err) {
-    console.error({ endpoint: 'download', phase: 'fill', id, err });
+    console.error({
+      endpoint: 'download',
+      phase: 'fill',
+      idFp,
+      template: resolved.artifact.template,
+      variant: resolved.artifact.variant ?? 'source',
+      err,
+    });
     return sendDownloadError(req, res, 500, 'DOWNLOAD_RENDER_FAILED', 'Template render failed.');
   }
   if (!outcome.ok) {
     return sendDownloadError(req, res, 500, 'DOWNLOAD_RENDER_FAILED', outcome.error);
   }
 
-  let docxBuffer: Buffer;
-  let filename: string;
+  try {
+    let docxBuffer: Buffer;
+    let filename: string;
 
-  if (resolved.artifact.variant === 'redline') {
-    let redline: Awaited<ReturnType<typeof generateRedlineFromFill>>;
-    try {
-      redline = await generateRedlineFromFill(
-        resolved.artifact.template,
-        outcome.base64,
-        resolved.artifact.redline_base ?? 'source',
-        resolved.artifact.values,
-      );
-    } catch (err) {
-      console.error({ endpoint: 'download', phase: 'redline', id, err });
-      return sendDownloadError(req, res, 500, 'DOWNLOAD_RENDER_FAILED', 'Redline generation failed.');
+    if (resolved.artifact.variant === 'redline') {
+      let redline: Awaited<ReturnType<typeof generateRedlineFromFill>>;
+      try {
+        redline = await generateRedlineFromFill(
+          resolved.artifact.template,
+          outcome.base64,
+          resolved.artifact.redline_base ?? 'source',
+          resolved.artifact.values,
+        );
+      } catch (err) {
+        console.error({
+          endpoint: 'download',
+          phase: 'redline',
+          idFp,
+          template: resolved.artifact.template,
+          err,
+        });
+        return sendDownloadError(req, res, 500, 'DOWNLOAD_RENDER_FAILED', 'Redline generation failed.');
+      }
+      if (!redline) {
+        return sendDownloadError(req, res, 500, 'DOWNLOAD_RENDER_FAILED', 'Redline generation not available for this template.');
+      }
+      docxBuffer = Buffer.from(redline.base64, 'base64');
+      filename = `${resolved.artifact.template}-redline.docx`;
+    } else {
+      docxBuffer = Buffer.from(outcome.base64, 'base64');
+      filename = `${resolved.artifact.template}.docx`;
     }
-    if (!redline) {
-      return sendDownloadError(req, res, 500, 'DOWNLOAD_RENDER_FAILED', 'Redline generation not available for this template.');
-    }
-    docxBuffer = Buffer.from(redline.base64, 'base64');
-    filename = `${resolved.artifact.template}-redline.docx`;
-  } else {
-    docxBuffer = Buffer.from(outcome.base64, 'base64');
-    filename = `${resolved.artifact.template}.docx`;
-  }
 
-  res.setHeader('Content-Type', DOCX_MIME);
-  res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
-  res.setHeader('Content-Length', docxBuffer.length);
-  res.setHeader('Cache-Control', 'no-store');
-  if (req.method === 'HEAD') {
-    return res.status(200).end();
+    res.setHeader('Content-Type', DOCX_MIME);
+    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+    res.setHeader('Content-Length', docxBuffer.length);
+    res.setHeader('Cache-Control', 'no-store');
+    if (req.method === 'HEAD') {
+      return res.status(200).end();
+    }
+    return res.status(200).send(docxBuffer);
+  } catch (err) {
+    // Catch any throw in Buffer.from / response assembly (malformed base64,
+    // header-write failure, etc.) so we still emit the documented contract.
+    console.error({
+      endpoint: 'download',
+      phase: 'assemble',
+      idFp,
+      template: resolved.artifact.template,
+      variant: resolved.artifact.variant ?? 'source',
+      err,
+    });
+    return sendDownloadError(req, res, 500, 'DOWNLOAD_RENDER_FAILED', 'Download assembly failed.');
   }
-  return res.status(200).send(docxBuffer);
 }

--- a/integration-tests/api-endpoints.test.ts
+++ b/integration-tests/api-endpoints.test.ts
@@ -761,4 +761,72 @@ describe('Download endpoint — api/download.ts', () => {
     expect(getErrorObject(res).message).toBe('Template render failed.');
     expect(JSON.stringify(res.body)).not.toContain('sensitive fill trace');
   });
+
+  // Follow-up to #197 (#206): close the residual uncaught surfaces before
+  // the existing handleFill catch and around buffer/response assembly.
+  it.openspec('OA-DST-025')('returns DOWNLOAD_RENDER_FAILED when resolveDownloadArtifact throws (e.g. KV outage)', async () => {
+    resolveDownloadArtifactMock.mockImplementationOnce(() => {
+      throw new Error('upstash unreachable');
+    });
+
+    const req = createMockReq({ method: 'GET', query: { id: 'valid-id.valid-sig' } });
+    const res = createMockRes();
+    await downloadHandler(req, res);
+
+    expect(res.statusCode).toBe(500);
+    expect(getErrorObject(res).code).toBe('DOWNLOAD_RENDER_FAILED');
+    expect(getErrorObject(res).message).toBe('Download lookup failed.');
+    expect(JSON.stringify(res.body)).not.toContain('upstash unreachable');
+  });
+
+  it.openspec('OA-DST-025')('returns DOWNLOAD_RENDER_FAILED when Buffer assembly throws on malformed base64', async () => {
+    resolveDownloadArtifactMock.mockReturnValue({
+      ok: true,
+      artifact: {
+        template: 'common-paper-mutual-nda',
+        values: { company_name: 'Acme Corp' },
+        expires_at_ms: Date.now() + 3600000,
+        created_at_ms: Date.now(),
+      },
+    });
+    // Force the response-assembly path to throw via a setHeader stub.
+    handleFillMock.mockResolvedValue(MOCK_FILL_SUCCESS);
+
+    const req = createMockReq({ method: 'GET', query: { id: 'valid-id.valid-sig' } });
+    const res = createMockRes();
+    let triggered = false;
+    res.setHeader = ((k: string, v: string) => {
+      if (k === 'Content-Length' && !triggered) {
+        triggered = true;
+        throw new Error('header write failed');
+      }
+      res.headers[k] = v;
+      return res;
+    }) as MockRes['setHeader'];
+    await downloadHandler(req, res);
+
+    expect(res.statusCode).toBe(500);
+    expect(getErrorObject(res).code).toBe('DOWNLOAD_RENDER_FAILED');
+    expect(getErrorObject(res).message).toBe('Download assembly failed.');
+    expect(JSON.stringify(res.body)).not.toContain('header write failed');
+  });
+
+  it.openspec('OA-DST-025')('does not log the raw download id in error paths', async () => {
+    resolveDownloadArtifactMock.mockImplementationOnce(() => {
+      throw new Error('store error');
+    });
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const rawId = 'super-secret-bearer-token-abc123.sig-xyz';
+    const req = createMockReq({ method: 'GET', query: { id: rawId } });
+    const res = createMockRes();
+    await downloadHandler(req, res);
+
+    const logged = JSON.stringify(consoleErrorSpy.mock.calls);
+    expect(logged).not.toContain(rawId);
+    // We do log a fingerprint (idFp), so a 12-hex-char token replaces the raw id.
+    expect(logged).toMatch(/"idFp":"[0-9a-f]{12}"/);
+
+    consoleErrorSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up to #206 (issue #197). Peer review (Codex CLI) surfaced two real gaps the original PR didn't cover:

1. **Two more uncaught throw surfaces in `/api/download`** that bypass the `DOWNLOAD_RENDER_FAILED` contract:
   - `resolveDownloadArtifact(id)` at the top of the handler — throws on KV/Upstash outage or malformed store payload.
   - The response-assembly block — `Buffer.from(base64, 'base64')` and the `setHeader` calls — can throw on malformed base64 or runtime header-write failure.

   Both now wrapped with try/catch and routed through `sendDownloadError(500, 'DOWNLOAD_RENDER_FAILED', ...)` with generic client-safe messages (`"Download lookup failed."`, `"Download assembly failed."`).

2. **Security: bearer-token leak in logs.** The previous PR logged `id` directly in `console.error({endpoint, phase, id, err})`. The download `id` is a live signed bearer token — anyone with log access could replay it until expiry to fetch the document. Replaced with a 12-char SHA-256 fingerprint (`idFp`) plus structured correlation fields (`template`, `variant`) so we keep debuggability without leaking the live token.

## Changes

- `api/download.ts` — add `idFingerprint(id)` helper using `node:crypto.createHash('sha256').slice(0, 12)`. Wrap `resolveDownloadArtifact` (new), the response-assembly block (new), and tighten log fields on the existing `handleFill` / `generateRedlineFromFill` catches. Replace `id` with `idFp` everywhere in `console.error`.
- `integration-tests/api-endpoints.test.ts` — 3 new regression tests:
  - `resolveDownloadArtifact` throws → `DOWNLOAD_RENDER_FAILED` + generic message
  - Response assembly throws (via setHeader stub) → `DOWNLOAD_RENDER_FAILED` + generic message
  - Raw download id never appears in `console.error`; logged value matches `/"idFp":"[0-9a-f]{12}"/`

## Reviewer credit

Codex CLI flagged both items in the post-merge review of #206. Item 1 was called out as the "blocker-ish" follow-up; item 2 is the security concern.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run integration-tests/api-endpoints.test.ts integration-tests/mcp-contract.test.ts` — 51/51 pass (3 new + 48 existing)
- [ ] Manual probe: simulate KV outage (or mock `resolveDownloadArtifact` throw) → 500 with `{error:{code:'DOWNLOAD_RENDER_FAILED', message:'Download lookup failed.'}}`; confirm raw token does not appear in server logs.

## Out of scope (separate follow-ups)

Both reviewers also flagged these as worthwhile but bigger:

- Migrate signing tools (`send_for_signature`, `check_signature_status`) to v2 envelope — they currently use a legacy `{tool, status, ...}` shape.
- Migrate auth failures from JSON-RPC `-32001` / HTTP 401/403 to envelope `AUTH_REQUIRED`.
- Surface a `redline_unavailable_reason` field in the success envelope when the best-effort redline path fails (currently logged-only).
- Narrow `INTERNAL_ERROR.retriable` classifier so storage/network phases can be `retriable: true` while render bugs stay `false`.

Each is its own focused PR.