### PR TITLE
fix(mcp): structured request/error logs with x-vercel-id propagation (#202)

### DIFF
--- a/api/_log.ts
+++ b/api/_log.ts
@@ -1,0 +1,105 @@
+/**
+ * Structured logging helper for HTTP API endpoints (Vercel).
+ *
+ * Emits single-line JSON records to stdout (info) or stderr (error). Vercel
+ * preserves log level by stream, and `vercel logs` plus downstream drains
+ * (Axiom, Datadog) filter on it — collapsing every record onto stderr would
+ * make normal request traces look like failures.
+ *
+ * HTTP-only: this module is never imported by `src/` or `bin/`; the CLI is
+ * unaffected.
+ */
+
+import { createHash } from 'node:crypto';
+import type { HttpRequest } from './_http-types.js';
+
+export type RequestContext = {
+  vercelId?: string;
+  mcpSessionId?: string;
+  userAgent?: string;
+  baseUrl: string;
+};
+
+function firstString(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) return value[0];
+  return value;
+}
+
+/**
+ * Read correlation headers and derive baseUrl. Returns the request-scoped
+ * context that callers thread through their handlers.
+ *
+ * `vercelId` is omitted (not synthesized) when `x-vercel-id` is absent —
+ * fabricating a fallback id muddies log search and creates a false sense of
+ * correlation. Locally and in tests, the field simply isn't there.
+ */
+export function getRequestContext(req: HttpRequest): RequestContext {
+  const proto = firstString(req.headers['x-forwarded-proto']) ?? 'https';
+  const host =
+    firstString(req.headers['x-forwarded-host']) ??
+    firstString(req.headers['host']) ??
+    'openagreements.org';
+  const baseUrl = `${proto}://${host}`;
+
+  const ctx: RequestContext = { baseUrl };
+
+  const vercelId = firstString(req.headers['x-vercel-id']);
+  if (vercelId) ctx.vercelId = vercelId;
+
+  const mcpSessionId = firstString(req.headers['mcp-session-id']);
+  if (mcpSessionId) ctx.mcpSessionId = mcpSessionId;
+
+  const userAgent = firstString(req.headers['user-agent']);
+  if (userAgent) ctx.userAgent = userAgent;
+
+  return ctx;
+}
+
+/**
+ * Fingerprint a Bearer token for log correlation without leaking the secret.
+ * Used only on auth-denied paths — never on successful auth, since
+ * fingerprinting on success expands the redaction surface without
+ * proportional debugging value.
+ *
+ * Returns `null` when the header is missing or not a Bearer token, so the
+ * caller can spread `...redactBearer(...)` safely (a null spread is a no-op,
+ * keeping the log record free of empty fields).
+ */
+export function redactBearer(
+  authHeader: string | string[] | undefined,
+): { tokenFp: string } | null {
+  const header = firstString(authHeader);
+  if (!header) return null;
+  const match = /^Bearer\s+(.+)$/i.exec(header);
+  if (!match) return null;
+  const token = match[1].trim();
+  if (!token) return null;
+  return { tokenFp: createHash('sha256').update(token).digest('hex').slice(0, 12) };
+}
+
+/**
+ * Normalize an unknown thrown value into a JSON-serializable shape.
+ * Raw `Error` instances serialize to `{}` via `JSON.stringify`, which is why
+ * the previous `console.error({ err })` callsites lost their detail on Vercel.
+ */
+export function normalizeError(err: unknown): { name: string; message: string; stack?: string } {
+  if (err instanceof Error) {
+    return { name: err.name, message: err.message, stack: err.stack };
+  }
+  return { name: 'NonError', message: String(err) };
+}
+
+function emit(stream: 'log' | 'error', level: 'info' | 'error', record: Record<string, unknown>): void {
+  const payload = { level, ts: new Date().toISOString(), ...record };
+  // Single-line JSON. Vercel captures stdout/stderr line-by-line.
+  // eslint-disable-next-line no-console
+  console[stream](JSON.stringify(payload));
+}
+
+export function info(record: Record<string, unknown>): void {
+  emit('log', 'info', record);
+}
+
+export function error(record: Record<string, unknown>): void {
+  emit('error', 'error', record);
+}

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -23,6 +23,14 @@ import {
 import { ErrorCode, makeToolError, wrapError, wrapSuccess } from './_envelope.js';
 import { jwtVerify, createRemoteJWKSet } from 'jose';
 import { OA_ORIGIN, MCP_RESOURCE } from './_config.js';
+import {
+  getRequestContext,
+  redactBearer,
+  normalizeError,
+  info as logInfo,
+  error as logError,
+  type RequestContext,
+} from './_log.js';
 
 // ---------------------------------------------------------------------------
 // Zod schemas for MCP tool argument validation
@@ -54,9 +62,6 @@ const SearchTemplatesArgsSchema = z.object({
   source: z.string().optional(),
   max_results: z.number().int().min(1).max(50).optional().default(10),
 });
-
-// Base URL for download links — derived from the incoming request at call time
-let _baseUrl = OA_ORIGIN;
 
 // ---------------------------------------------------------------------------
 // OAuth JWT verification for signing tools
@@ -330,6 +335,7 @@ async function handleSigningToolCall(
   id: unknown,
   name: string,
   args: Record<string, unknown>,
+  ctx: RequestContext,
 ): Promise<ReturnType<typeof jsonRpcResult>> {
   try {
     if (!_signingModuleLoaded) {
@@ -392,6 +398,15 @@ async function handleSigningToolCall(
     return jsonRpcResult(id, result);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
+    logError({
+      event: 'tool_internal_error',
+      endpoint: 'mcp',
+      tool: name,
+      phase: 'signing',
+      jsonrpcId: id,
+      ...normalizeError(err),
+      ...ctx,
+    });
     return toolErrorResult(
       id,
       name,
@@ -708,7 +723,7 @@ function handleToolsList(id: unknown) {
   return jsonRpcResult(id, { tools: ALL_TOOLS });
 }
 
-async function handleToolsCall(id: unknown, params: Record<string, unknown>) {
+async function handleToolsCall(id: unknown, params: Record<string, unknown>, ctx: RequestContext) {
   const name = params.name as string;
   const args = (params.arguments as Record<string, unknown>) ?? {};
 
@@ -718,7 +733,7 @@ async function handleToolsCall(id: unknown, params: Record<string, unknown>) {
     if (args.__auth_sub && !args.api_key) {
       args.api_key = args.__auth_sub;
     }
-    return handleSigningToolCall(id, name, args);
+    return handleSigningToolCall(id, name, args, ctx);
   }
 
   if (name === TOOL_LIST_TEMPLATES) {
@@ -819,7 +834,15 @@ async function handleToolsCall(id: unknown, params: Record<string, unknown>) {
       outcome = await handleFill(template, values);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      console.error({ tool: TOOL_FILL_TEMPLATE, phase: 'fill', id, err });
+      logError({
+        event: 'tool_internal_error',
+        endpoint: 'mcp',
+        tool: TOOL_FILL_TEMPLATE,
+        phase: 'fill',
+        jsonrpcId: id,
+        ...normalizeError(err),
+        ...ctx,
+      });
       return toolErrorResult(
         id,
         TOOL_FILL_TEMPLATE,
@@ -843,7 +866,16 @@ async function handleToolsCall(id: unknown, params: Record<string, unknown>) {
       const message = err instanceof Error ? err.message : String(err);
       if (err instanceof DownloadStoreUnavailableError) {
         const cause = err instanceof DownloadStoreConfigurationError ? 'configuration' : 'runtime';
-        console.error({ tool: TOOL_FILL_TEMPLATE, phase: 'artifact', id, cause, err });
+        logError({
+          event: 'tool_internal_error',
+          endpoint: 'mcp',
+          tool: TOOL_FILL_TEMPLATE,
+          phase: 'artifact',
+          cause,
+          jsonrpcId: id,
+          ...normalizeError(err),
+          ...ctx,
+        });
         return toolErrorResult(
           id,
           TOOL_FILL_TEMPLATE,
@@ -855,7 +887,15 @@ async function handleToolsCall(id: unknown, params: Record<string, unknown>) {
           },
         );
       }
-      console.error({ tool: TOOL_FILL_TEMPLATE, phase: 'artifact', id, err });
+      logError({
+        event: 'tool_internal_error',
+        endpoint: 'mcp',
+        tool: TOOL_FILL_TEMPLATE,
+        phase: 'artifact',
+        jsonrpcId: id,
+        ...normalizeError(err),
+        ...ctx,
+      });
       return toolErrorResult(
         id,
         TOOL_FILL_TEMPLATE,
@@ -864,7 +904,7 @@ async function handleToolsCall(id: unknown, params: Record<string, unknown>) {
         { retriable: false },
       );
     }
-    const downloadUrl = `${_baseUrl}/api/download?id=${encodeURIComponent(artifact.download_id)}`;
+    const downloadUrl = `${ctx.baseUrl}/api/download?id=${encodeURIComponent(artifact.download_id)}`;
     const expiresAt = artifact.expires_at;
 
     // Generate redline (track-changes) for recipe templates
@@ -877,7 +917,7 @@ async function handleToolsCall(id: unknown, params: Record<string, unknown>) {
             variant: 'redline',
             redline_base,
           });
-          const redlineUrl = `${_baseUrl}/api/download?id=${encodeURIComponent(redlineArtifact.download_id)}`;
+          const redlineUrl = `${ctx.baseUrl}/api/download?id=${encodeURIComponent(redlineArtifact.download_id)}`;
           redlineData = {
             redline_download_url: redlineUrl,
             redline_download_id: redlineArtifact.download_id,
@@ -886,8 +926,19 @@ async function handleToolsCall(id: unknown, params: Record<string, unknown>) {
           };
         }
       } catch (err) {
-        // Redline generation is best-effort; log but don't fail the fill
-        console.error({ tool: TOOL_FILL_TEMPLATE, phase: 'redline', id, err });
+        // Redline generation is best-effort; log but don't fail the fill.
+        // parentOk:true so dashboards can distinguish a redline-only blip
+        // from a hard fill failure.
+        logError({
+          event: 'tool_internal_error',
+          endpoint: 'mcp',
+          tool: TOOL_FILL_TEMPLATE,
+          phase: 'redline',
+          parentOk: true,
+          jsonrpcId: id,
+          ...normalizeError(err),
+          ...ctx,
+        });
       }
     }
 
@@ -934,7 +985,34 @@ export default async function handler(req: HttpRequest, res: HttpResponse) {
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Mcp-Session-Id, Authorization');
   res.setHeader('Access-Control-Expose-Headers', 'Mcp-Session-Id, WWW-Authenticate');
 
+  // OPTIONS preflight — no logging, just the platform-required CORS handshake.
   if (req.method === 'OPTIONS') return res.status(204).end();
+
+  const ctx = getRequestContext(req);
+  const startedAt = Date.now();
+
+  // Helper: emit request_complete and return the response. Every non-OPTIONS
+  // terminal path goes through this so we always have a record with status,
+  // ok, durationMs, and ctx for the request.
+  const complete = (
+    status: number,
+    ok: boolean,
+    extra: { jsonrpcMethod?: string; toolName?: string; jsonrpcId?: unknown },
+    payload: unknown,
+    sender: 'json' | 'send' = 'json',
+  ) => {
+    logInfo({
+      event: 'request_complete',
+      endpoint: 'mcp',
+      status,
+      ok,
+      durationMs: Date.now() - startedAt,
+      ...extra,
+      ...ctx,
+    });
+    if (sender === 'send') return res.status(status).send(payload);
+    return res.status(status).json(payload);
+  };
 
   if (req.method === 'GET') {
     const acceptHeader = req.headers['accept'];
@@ -942,28 +1020,59 @@ export default async function handler(req: HttpRequest, res: HttpResponse) {
     if (accept.includes('text/html')) {
       res.setHeader('Content-Type', 'text/html; charset=utf-8');
       res.setHeader('Cache-Control', 'no-store');
-      return res.status(200).send(mcpGetHtmlPage());
+      return complete(200, true, {}, mcpGetHtmlPage(), 'send');
     }
-    return res.status(405).json({ error: 'Only POST requests are accepted for MCP clients' });
+    logInfo({
+      event: 'request_rejected_http_method',
+      endpoint: 'mcp',
+      method: req.method,
+      status: 405,
+      ...ctx,
+    });
+    return complete(405, false, {}, { error: 'Only POST requests are accepted for MCP clients' });
   }
 
   if (req.method !== 'POST') {
-    return res.status(405).json({ error: 'Only POST requests are accepted for MCP clients' });
+    logInfo({
+      event: 'request_rejected_http_method',
+      endpoint: 'mcp',
+      method: req.method,
+      status: 405,
+      ...ctx,
+    });
+    return complete(405, false, {}, { error: 'Only POST requests are accepted for MCP clients' });
   }
-
-  // Capture base URL from request for building download links.
-  const proto = req.headers['x-forwarded-proto'] ?? 'https';
-  const host = req.headers['x-forwarded-host'] ?? req.headers['host'] ?? 'openagreements.org';
-  _baseUrl = `${proto}://${host}`;
 
   const body = req.body as { jsonrpc?: string; id?: unknown; method?: string; params?: unknown };
 
   if (!body || body.jsonrpc !== '2.0' || typeof body.method !== 'string') {
-    return res.status(400).json(jsonRpcError(body?.id, -32600, 'Invalid JSON-RPC 2.0 request'));
+    logError({
+      event: 'request_rejected_invalid_jsonrpc',
+      endpoint: 'mcp',
+      status: 400,
+      jsonrpcId: body?.id,
+      ...ctx,
+    });
+    return complete(400, false, { jsonrpcId: body?.id }, jsonRpcError(body?.id, -32600, 'Invalid JSON-RPC 2.0 request'));
   }
 
   // Notifications (no id) — acknowledge without response body.
   if (body.id === undefined || body.id === null) {
+    logInfo({
+      event: 'notification',
+      endpoint: 'mcp',
+      jsonrpcMethod: body.method,
+      ...ctx,
+    });
+    logInfo({
+      event: 'request_complete',
+      endpoint: 'mcp',
+      status: 202,
+      ok: true,
+      durationMs: Date.now() - startedAt,
+      jsonrpcMethod: body.method,
+      ...ctx,
+    });
     return res.status(202).end();
   }
 
@@ -977,46 +1086,79 @@ export default async function handler(req: HttpRequest, res: HttpResponse) {
       ? ((params as { name?: unknown }).name as string | undefined)
       : undefined;
 
+  logInfo({
+    event: 'request_start',
+    endpoint: 'mcp',
+    jsonrpcMethod: body.method,
+    toolName: requestedToolName,
+    jsonrpcId: body.id,
+    ...ctx,
+  });
+
+  const trace = { jsonrpcMethod: body.method, toolName: requestedToolName, jsonrpcId: body.id };
+
   try {
     switch (body.method) {
       case 'initialize':
-        return res.status(200).json(handleInitialize(body.id, params));
+        return complete(200, true, trace, handleInitialize(body.id, params));
       case 'tools/list':
-        return res.status(200).json(handleToolsList(body.id));
+        return complete(200, true, trace, handleToolsList(body.id));
       case 'tools/call': {
         // Check if this tool requires authentication
         const toolName = (params as { name?: string }).name;
         if (toolName && AUTH_REQUIRED_TOOLS.has(toolName)) {
           const auth = await verifyAuth(req);
           if (!auth.authenticated) {
+            logError({
+              event: 'auth_denied',
+              endpoint: 'mcp',
+              status: auth.status,
+              error: auth.error,
+              toolName,
+              jsonrpcId: body.id,
+              ...redactBearer(req.headers['authorization']),
+              ...ctx,
+            });
             if (auth.status === 401) {
               res.setHeader('WWW-Authenticate',
                 `Bearer resource_metadata="${OA_ORIGIN}/.well-known/oauth-protected-resource"`);
-              return res.status(401).json(
-                jsonRpcError(body.id, -32001, auth.errorDescription));
+              return complete(401, false, trace, jsonRpcError(body.id, -32001, auth.errorDescription));
             }
-            return res.status(403).json(
-              jsonRpcError(body.id, -32001, auth.errorDescription));
+            return complete(403, false, trace, jsonRpcError(body.id, -32001, auth.errorDescription));
           }
           // Pass auth context to handler via arguments (where signing tools read it)
           const toolArgs = ((params as Record<string, unknown>).arguments ?? {}) as Record<string, unknown>;
           toolArgs.__auth_sub = auth.sub;
           (params as Record<string, unknown>).arguments = toolArgs;
         }
-        return res.status(200).json(await handleToolsCall(body.id, params));
+        const toolResult = await handleToolsCall(body.id, params, ctx);
+        const toolOk = !(toolResult as { result?: { error?: unknown } })?.result?.error;
+        return complete(200, toolOk, trace, toolResult);
       }
       case 'ping':
-        return res.status(200).json(jsonRpcResult(body.id, {}));
+        return complete(200, true, trace, jsonRpcResult(body.id, {}));
       default:
-        return res.status(200).json(jsonRpcError(body.id, -32601, `Method not supported: "${body.method}"`));
+        return complete(200, false, trace, jsonRpcError(body.id, -32601, `Method not supported: "${body.method}"`));
     }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    console.error({ phase: 'outer', method: body.method, tool: requestedToolName, err });
+    logError({
+      event: 'unhandled_exception',
+      endpoint: 'mcp',
+      jsonrpcMethod: body.method,
+      toolName: requestedToolName,
+      jsonrpcId: body.id,
+      ...normalizeError(err),
+      durationMs: Date.now() - startedAt,
+      ...ctx,
+    });
     // For tools/call, preserve the documented envelope contract even on
     // unexpected throws. Other methods keep the JSON-RPC protocol error.
     if (body.method === 'tools/call') {
-      return res.status(200).json(
+      return complete(
+        200,
+        false,
+        trace,
         toolErrorResult(
           body.id,
           requestedToolName ?? 'tools/call',
@@ -1026,6 +1168,6 @@ export default async function handler(req: HttpRequest, res: HttpResponse) {
         ),
       );
     }
-    return res.status(200).json(jsonRpcError(body.id, -32603, `Internal error: ${message}`));
+    return complete(200, false, trace, jsonRpcError(body.id, -32603, `Internal error: ${message}`));
   }
 }

--- a/integration-tests/mcp-contract.test.ts
+++ b/integration-tests/mcp-contract.test.ts
@@ -548,3 +548,203 @@ describe('MCP contract envelope behaviors', () => {
     expect(envelope.error.message).toContain('catalog corruption');
   });
 });
+
+describe('MCP structured logging', () => {
+  type LogCall = Record<string, unknown>;
+
+  function captureLogs() {
+    const infoSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const parsed = (spy: ReturnType<typeof vi.spyOn>): LogCall[] =>
+      spy.mock.calls
+        .map((call) => {
+          try {
+            return JSON.parse(String(call[0])) as LogCall;
+          } catch {
+            return null;
+          }
+        })
+        .filter((value): value is LogCall => value !== null);
+    return {
+      infoLogs: () => parsed(infoSpy),
+      errorLogs: () => parsed(errorSpy),
+      allRaw: () => JSON.stringify([...infoSpy.mock.calls, ...errorSpy.mock.calls]),
+      restore: () => {
+        infoSpy.mockRestore();
+        errorSpy.mockRestore();
+      },
+    };
+  }
+
+  it.openspec('OA-DST-038')('propagates x-vercel-id into request_start and request_complete', async () => {
+    const cap = captureLogs();
+    const req = createMockReq({
+      headers: {
+        'content-type': 'application/json',
+        host: 'openagreements.ai',
+        'x-vercel-id': 'fra1::abc123',
+      },
+      body: { jsonrpc: '2.0', id: 7, method: 'tools/list', params: {} },
+    });
+    const res = createMockRes();
+    await mcpHandler(req, res);
+
+    const start = cap.infoLogs().find((l) => l.event === 'request_start');
+    const done = cap.infoLogs().find((l) => l.event === 'request_complete');
+
+    expect(start).toMatchObject({
+      event: 'request_start',
+      endpoint: 'mcp',
+      level: 'info',
+      vercelId: 'fra1::abc123',
+      jsonrpcMethod: 'tools/list',
+      jsonrpcId: 7,
+    });
+    expect(done).toMatchObject({
+      event: 'request_complete',
+      endpoint: 'mcp',
+      vercelId: 'fra1::abc123',
+      ok: true,
+      status: 200,
+    });
+    expect(typeof done?.durationMs).toBe('number');
+    cap.restore();
+  });
+
+  it.openspec('OA-DST-039')('propagates vercelId and normalizes err in tool_internal_error', async () => {
+    handleFillMock.mockImplementationOnce(async () => {
+      throw new Error('synthetic fill failure');
+    });
+    const cap = captureLogs();
+    const req = createMockReq({
+      headers: {
+        'content-type': 'application/json',
+        host: 'openagreements.ai',
+        'x-vercel-id': 'iad1::xyz789',
+      },
+      body: {
+        jsonrpc: '2.0',
+        id: 11,
+        method: 'tools/call',
+        params: {
+          name: 'fill_template',
+          arguments: { template: 'common-paper-mutual-nda', values: { company_name: 'Acme' } },
+        },
+      },
+    });
+    const res = createMockRes();
+    await mcpHandler(req, res);
+
+    const errLog = cap.errorLogs().find((l) => l.event === 'tool_internal_error');
+    expect(errLog).toMatchObject({
+      event: 'tool_internal_error',
+      endpoint: 'mcp',
+      level: 'error',
+      vercelId: 'iad1::xyz789',
+      tool: 'fill_template',
+      phase: 'fill',
+      jsonrpcId: 11,
+      name: 'Error',
+      message: 'synthetic fill failure',
+    });
+    expect(typeof errLog?.stack).toBe('string');
+    cap.restore();
+  });
+
+  it.openspec('OA-DST-040')('redacts bearer token to a fingerprint on auth_denied', async () => {
+    const cap = captureLogs();
+    const rawToken = 'super-secret-bearer-zzz-do-not-leak';
+    const req = createMockReq({
+      headers: {
+        'content-type': 'application/json',
+        host: 'openagreements.ai',
+        authorization: `Bearer ${rawToken}`,
+      },
+      body: {
+        jsonrpc: '2.0',
+        id: 12,
+        method: 'tools/call',
+        params: {
+          name: 'send_for_signature',
+          arguments: {},
+        },
+      },
+    });
+    const res = createMockRes();
+    await mcpHandler(req, res);
+
+    const denied = cap.errorLogs().find((l) => l.event === 'auth_denied');
+    expect(denied).toBeDefined();
+    expect(denied).toMatchObject({
+      event: 'auth_denied',
+      endpoint: 'mcp',
+      toolName: 'send_for_signature',
+    });
+    expect(String(denied?.tokenFp)).toMatch(/^[0-9a-f]{12}$/);
+
+    // Critical: the raw bearer token must never appear in any captured log.
+    expect(cap.allRaw()).not.toContain(rawToken);
+    cap.restore();
+  });
+
+  it.openspec('OA-DST-041')('does not fingerprint bearer tokens on non-auth-required successful paths', async () => {
+    const cap = captureLogs();
+    const req = createMockReq({
+      headers: {
+        'content-type': 'application/json',
+        host: 'openagreements.ai',
+        // list_templates is not in AUTH_REQUIRED_TOOLS — verifyAuth is never called.
+        authorization: 'Bearer harmless-but-should-not-be-logged',
+      },
+      body: { jsonrpc: '2.0', id: 13, method: 'tools/list', params: {} },
+    });
+    const res = createMockRes();
+    await mcpHandler(req, res);
+
+    const all = [...cap.infoLogs(), ...cap.errorLogs()];
+    expect(all.find((l) => l.event === 'request_complete')?.ok).toBe(true);
+    // No log should carry tokenFp on a non-auth-required path.
+    expect(all.some((l) => 'tokenFp' in l)).toBe(false);
+    cap.restore();
+  });
+
+  it.openspec('OA-DST-042')('logs request_rejected_invalid_jsonrpc when envelope is malformed', async () => {
+    const cap = captureLogs();
+    const req = createMockReq({
+      body: { id: 14, method: 'tools/list' /* jsonrpc field missing */ },
+    });
+    const res = createMockRes();
+    await mcpHandler(req, res);
+
+    const rejected = cap.errorLogs().find((l) => l.event === 'request_rejected_invalid_jsonrpc');
+    expect(rejected).toMatchObject({
+      event: 'request_rejected_invalid_jsonrpc',
+      endpoint: 'mcp',
+      level: 'error',
+      status: 400,
+      jsonrpcId: 14,
+    });
+    expect(res.statusCode).toBe(400);
+    cap.restore();
+  });
+
+  it.openspec('OA-DST-043')('omits vercelId entirely when x-vercel-id header is absent', async () => {
+    const cap = captureLogs();
+    const req = createMockReq({
+      // No x-vercel-id header.
+      headers: { 'content-type': 'application/json', host: 'openagreements.ai' },
+      body: { jsonrpc: '2.0', id: 15, method: 'tools/list', params: {} },
+    });
+    const res = createMockRes();
+    await mcpHandler(req, res);
+
+    const start = cap.infoLogs().find((l) => l.event === 'request_start');
+    expect(start).toBeDefined();
+    // The key must be absent — not undefined, not null, not a synthetic id.
+    expect('vercelId' in (start as object)).toBe(false);
+
+    const done = cap.infoLogs().find((l) => l.event === 'request_complete');
+    expect('vercelId' in (done as object)).toBe(false);
+    cap.restore();
+  });
+});

--- a/openspec/changes/add-mcp-structured-logging/proposal.md
+++ b/openspec/changes/add-mcp-structured-logging/proposal.md
@@ -1,0 +1,50 @@
+# Change: Add structured request/error logs to api/mcp.ts with Vercel request-id propagation
+
+## Why
+
+The MCP HTTP handler at `api/mcp.ts` (deployed on Vercel at
+`openagreements.org/api/mcp`) emits only sparse `console.error` calls on a
+handful of error paths. Successful requests, auth failures, and malformed
+envelopes leave no trace in Vercel runtime logs, and **no record correlates
+back to the `x-vercel-id` header that Vercel attaches per request**. When a
+client reports a problem against the remote MCP, support has to reconstruct
+what happened from the platform's per-function log line — slow and often
+impossible (issue #202).
+
+The fix is to emit single-line structured JSON for every lifecycle event of
+every MCP HTTP request, each tagged with the Vercel request id and the
+JSON-RPC method/tool/id. Scope is HTTP-only: the CLI/STDIO path is untouched.
+
+## What Changes
+
+- **New `api/_log.ts`** — small HTTP-only helper exporting `getRequestContext`
+  (reads `x-vercel-id`, derives `baseUrl` from forwarded headers),
+  `redactBearer` (12-char sha256 fingerprint of a Bearer token),
+  `normalizeError` (Error → `{ name, message, stack }` so `JSON.stringify`
+  doesn't drop the detail), and `info`/`error` emitters that route to
+  `console.log` / `console.error` respectively. The helper is endpoint-agnostic
+  (caller passes `endpoint: 'mcp'`) so `api/download.ts` and `api/a2a.ts` can
+  adopt it later without churn.
+- **`api/mcp.ts`** — capture a per-request `ctx` (request id + base URL +
+  session/user agent) and `startedAt` at handler entry. Thread `ctx` into
+  `handleToolsCall` and `handleSigningToolCall` as a third parameter, and
+  delete the previous module-scoped `_baseUrl` (race-prone in serverless).
+  Emit `request_start`, `request_complete` (every non-OPTIONS terminal path,
+  with `status`/`ok`/`durationMs`), `request_rejected_http_method`,
+  `request_rejected_invalid_jsonrpc`, `notification`, `auth_denied` (with
+  `tokenFp`, never the raw token), `tool_internal_error` (preserving
+  `phase: 'fill'|'artifact'|'redline'|'signing'` and `cause` discriminators),
+  and `unhandled_exception`.
+- **`integration-tests/mcp-contract.test.ts`** — six new logging tests bound
+  to `OA-DST-038`…`OA-DST-043` covering vercel-id propagation in success and
+  error paths, bearer-token redaction on `auth_denied`, no fingerprint on
+  non-auth-required successful paths, malformed-envelope logging, and the
+  no-fallback-id rule when `x-vercel-id` is absent.
+
+## Out of scope
+
+- `api/download.ts` and `api/a2a.ts` adopting the helper (separate change).
+- A logging dependency (pino, winston, etc.) — overkill for one helper file.
+- A `/healthz` endpoint — issue #202 explicitly rules this out.
+- CLI/STDIO logging — `src/cli/index.ts` does not import `api/`, so the new
+  helper never reaches it.

--- a/openspec/changes/add-mcp-structured-logging/specs/open-agreements/spec.md
+++ b/openspec/changes/add-mcp-structured-logging/specs/open-agreements/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Structured Lifecycle Logs for MCP HTTP Transport
+The `/api/mcp` HTTP handler SHALL emit single-line structured JSON log records for every request lifecycle event, written to `stdout` for informational events and `stderr` for error events so that `vercel logs` filtering and downstream log drains can categorize them by severity. Every record SHALL include `endpoint:'mcp'`, an ISO-8601 `ts`, and a `level` of `'info'` or `'error'`. Every record from a request whose inbound `x-vercel-id` header is present SHALL include `vercelId` set to that value. When `x-vercel-id` is absent the record SHALL omit the `vercelId` field entirely (no synthetic fallback id).
+
+The handler SHALL emit `request_start` immediately before dispatch and `request_complete` on every non-OPTIONS terminal path (including `initialize`, `tools/list`, `tools/call`, `ping`, JSON-RPC method-not-found, malformed-envelope rejections, HTTP method rejections, and the outer unhandled-exception catch). `request_complete` records SHALL include `status`, `ok`, `durationMs`, `jsonrpcMethod` when known, and `toolName` when the request is `tools/call`.
+
+The handler SHALL emit additional discriminator events as appropriate: `request_rejected_http_method` (status 405), `request_rejected_invalid_jsonrpc` (status 400), `notification` (id-less envelope), `auth_denied`, `tool_internal_error`, and `unhandled_exception`. `tool_internal_error` records SHALL preserve the existing `phase` discriminator (`'fill'`, `'artifact'`, `'redline'`, or `'signing'`) and the `cause` discriminator (`'configuration'` or `'runtime'`) where applicable; the `redline` phase SHALL additionally carry `parentOk:true` so dashboards can distinguish a best-effort redline failure from a hard fill failure.
+
+#### Scenario: [OA-DST-038] x-vercel-id propagates into request_start and request_complete
+- **WHEN** a valid JSON-RPC `tools/list` request reaches `/api/mcp` with header `x-vercel-id: fra1::abc123`
+- **THEN** an info log line is written to `stdout` with `event:'request_start'`, `endpoint:'mcp'`, `level:'info'`, `vercelId:'fra1::abc123'`, `jsonrpcMethod:'tools/list'`, and the inbound `jsonrpcId`
+- **AND** an info log line is written to `stdout` with `event:'request_complete'`, `vercelId:'fra1::abc123'`, `ok:true`, `status:200`, and a numeric `durationMs`
+
+#### Scenario: [OA-DST-039] vercelId propagates into tool_internal_error and err is normalized
+- **WHEN** `fill_template` is invoked with header `x-vercel-id: iad1::xyz789` and the underlying fill throws an `Error('synthetic fill failure')`
+- **THEN** an error log line is written to `stderr` with `event:'tool_internal_error'`, `endpoint:'mcp'`, `level:'error'`, `vercelId:'iad1::xyz789'`, `tool:'fill_template'`, `phase:'fill'`, the inbound `jsonrpcId`, `name:'Error'`, `message:'synthetic fill failure'`, and a non-empty `stack`
+
+#### Scenario: [OA-DST-040] auth_denied logs a token fingerprint, never the raw bearer token
+- **WHEN** `tools/call` invokes a signing tool (e.g. `send_for_signature`) with `Authorization: Bearer <secret>` and the auth handshake fails
+- **THEN** an error log line is written with `event:'auth_denied'`, `endpoint:'mcp'`, `toolName:'send_for_signature'`, and a `tokenFp` field whose value matches the regex `^[0-9a-f]{12}$`
+- **AND** the raw bearer-token string SHALL NOT appear anywhere in any captured log record (regression guard against accidental token leakage)
+
+#### Scenario: [OA-DST-041] Successful non-auth-required paths do not fingerprint bearer tokens
+- **WHEN** a non-auth-required tool such as `tools/list` is invoked with an `Authorization: Bearer <token>` header present (the header is not consumed because the tool is not in the auth-required set)
+- **THEN** no log line emitted by the request SHALL contain a `tokenFp` field
+
+#### Scenario: [OA-DST-042] Malformed JSON-RPC envelopes are logged
+- **WHEN** the request body is missing the `jsonrpc:'2.0'` field
+- **THEN** an error log line is written with `event:'request_rejected_invalid_jsonrpc'`, `endpoint:'mcp'`, `level:'error'`, `status:400`, and the inbound `jsonrpcId` if present
+- **AND** the HTTP response is the existing `400 jsonRpcError(-32600, 'Invalid JSON-RPC 2.0 request')` payload
+
+#### Scenario: [OA-DST-043] vercelId is omitted (not synthesized) when x-vercel-id is absent
+- **WHEN** a valid JSON-RPC request reaches `/api/mcp` with no `x-vercel-id` header
+- **THEN** the `request_start` and `request_complete` records SHALL NOT contain a `vercelId` key (the field is omitted, not set to a generated UUID or any other fallback value)

--- a/openspec/changes/add-mcp-structured-logging/tasks.md
+++ b/openspec/changes/add-mcp-structured-logging/tasks.md
@@ -1,0 +1,35 @@
+# Tasks
+
+## 1. New logging helper
+
+- [x] Add `api/_log.ts` with `getRequestContext`, `redactBearer`, `normalizeError`, `info`, `error`.
+- [x] Omit `vercelId` from records when `x-vercel-id` is absent (no synthetic fallback).
+- [x] Split sinks: `info` → `console.log`, `error` → `console.error`.
+- [x] Endpoint-agnostic — callers stamp `endpoint: 'mcp'`.
+
+## 2. Wire into api/mcp.ts
+
+- [x] Delete module-scoped `_baseUrl`; thread `ctx.baseUrl` through handlers.
+- [x] Add `ctx` as third argument to `handleToolsCall(id, params, ctx)` and `handleSigningToolCall(id, name, args, ctx)`.
+- [x] Emit `request_start` + `request_complete` (every non-OPTIONS terminal path, with `status`/`ok`/`durationMs`).
+- [x] Emit `request_rejected_http_method`, `request_rejected_invalid_jsonrpc`, `notification`.
+- [x] Emit `auth_denied` with `tokenFp` (never the raw bearer token); fingerprint only on denied paths, never on success.
+- [x] Replace 5 existing `console.error` calls with structured `error()` records preserving `phase`/`cause` discriminators; redline catch carries `parentOk: true`.
+- [x] Replace outer catch with `event: 'unhandled_exception'` log including `durationMs`.
+
+## 3. Tests
+
+- [x] Add 6 regression tests in `integration-tests/mcp-contract.test.ts` bound to `OA-DST-038`…`OA-DST-043`.
+- [x] Verify `npx vitest run integration-tests/mcp-contract.test.ts` passes (19/19 with new tests).
+- [x] Spy on both `console.log` and `console.error` since the helper splits sinks.
+
+## 4. Spec deltas
+
+- [x] Author `openspec/changes/add-mcp-structured-logging/specs/open-agreements/spec.md` with `OA-DST-038`…`OA-DST-043`.
+- [x] Verify ID availability: `grep -rhoE "OA-DST-[0-9]+" openspec/ integration-tests/ | sort -u | tail` confirms 037 was the previous ceiling.
+
+## 5. Validation
+
+- [ ] `npx openspec validate add-mcp-structured-logging --strict`
+- [ ] `npm run test -- integration-tests/mcp-contract.test.ts integration-tests/validate-openspec-coverage-script.test.ts`
+- [ ] Local smoke against `vercel dev` to confirm `x-vercel-id` propagation when present and absence otherwise (deferred to PR review).


### PR DESCRIPTION
Closes #202.

## Summary

The MCP HTTP handler at `api/mcp.ts` emitted only sparse `console.error` calls on a few error paths. Successful requests, auth failures, and malformed envelopes left no trace in Vercel runtime logs, and **no record correlated back to `x-vercel-id`** — production debugging required reconstructing failures from sparse platform logs.

This PR adds single-line structured JSON logs for every lifecycle event of every MCP HTTP request, each tagged with the Vercel request id. **Scope is HTTP-only** — `src/cli/index.ts` does not import `api/`, so the CLI/STDIO path is untouched.

- New `api/_log.ts`: tiny endpoint-agnostic helper (`getRequestContext`, `redactBearer`, `normalizeError`, split-sink `info()`/`error()`).
- `api/mcp.ts`: capture per-request `ctx` (`vercelId`, `baseUrl`, …) and thread it into `handleToolsCall` / `handleSigningToolCall`; delete the old module-scoped `_baseUrl` (race-prone in serverless). Emit `request_start`, `request_complete` (every non-OPTIONS terminal path with `status`/`ok`/`durationMs`), `request_rejected_*`, `notification`, `auth_denied`, `tool_internal_error` (preserving `phase` + `cause`), and `unhandled_exception`.
- 6 new regression tests bound to `OA-DST-038`…`OA-DST-043`.
- OpenSpec change `add-mcp-structured-logging` with proposal, tasks, and spec deltas (validates clean under `--strict`).

## Design choices (resolved through parallel codex+gemini peer review of the plan)

- **`vercelId` is omitted, not synthesized**, when `x-vercel-id` is absent — fake correlation ids muddy log search.
- **Bearer-token fingerprinting only on denied paths**, never on success — minimal redaction surface; regression-tested.
- **OpenSpec ID family is `OA-DST-*`** (existing MCP/download tests use it), not a new `OA-MCP-*` prefix.
- **`request_complete` is emitted on every non-OPTIONS terminal path**, not just `tools/call`, so `initialize` / `tools/list` / `ping` / method-not-found also have a `durationMs` row.
- **Inner-catch `phase`/`cause` discriminators are preserved** — flattening to a generic `tool_internal_error` would have been a debugging regression.
- **Split sinks**: `info` → `console.log`, `error` → `console.error`. Vercel's UI and downstream drains treat the streams differently for alerting.

## Test plan

- [x] `npx vitest run integration-tests/mcp-contract.test.ts` — 19/19 passing (13 existing + 6 new).
- [x] `npx vitest run --exclude '**/gcloud-storage.test.ts'` — 827 passed, 4 skipped, 0 failed (the gcloud-storage failures are pre-existing GCP credential flakes unrelated to this change).
- [x] `npx openspec validate add-mcp-structured-logging --strict` — clean.
- [x] `node scripts/validate_openspec_coverage.mjs --capability open-agreements` — passes; the new `OA-DST-038`…`043` IDs are now present in the change spec.
- [x] `npx tsc --noEmit` — clean (handler signature changes propagate through).
- [ ] Smoke against `vercel dev` confirming the JSON lines stream as expected (deferred to PR review — preview deploy gives the same coverage).