### PR TITLE
fix(mcp): align list_templates default + serverInfo.version with package metadata (#203)

### DIFF
--- a/api/_config.ts
+++ b/api/_config.ts
@@ -3,12 +3,24 @@
  * Single source of truth for OA origin, DocuSign settings, and common helpers.
  */
 
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { HttpRequest } from './_http-types.js';
 
 // ── OA Identity ─────────────────────────────────────────────────────────────
 
 export const OA_ORIGIN = process.env.OA_ORIGIN?.trim() || 'https://openagreements.org';
 export const MCP_RESOURCE = `${OA_ORIGIN}/api/mcp`;
+
+const __config_dirname = dirname(fileURLToPath(import.meta.url));
+const PACKAGE_ROOT = join(__config_dirname, '..');
+
+let _pkgVersion = '0.0.0';
+try {
+  _pkgVersion = JSON.parse(readFileSync(join(PACKAGE_ROOT, 'package.json'), 'utf-8')).version;
+} catch { /* fallback */ }
+export const OA_PACKAGE_VERSION = _pkgVersion;
 
 // ── DocuSign ────────────────────────────────────────────────────────────────
 

--- a/api/_shared.ts
+++ b/api/_shared.ts
@@ -7,6 +7,7 @@ import { randomUUID } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { OA_PACKAGE_VERSION } from './_config.js';
 
 // ---------------------------------------------------------------------------
 // Path resolution — must run before any dist/ function calls
@@ -366,10 +367,5 @@ export function handleListTemplates(): ListOutcome {
 
   const items = [...internal, ...external, ...recipes].sort((a, b) => a.name.localeCompare(b.name));
 
-  let cliVersion = '0.0.0';
-  try {
-    cliVersion = JSON.parse(readFileSync(join(PROJECT_ROOT, 'package.json'), 'utf-8')).version;
-  } catch { /* fallback */ }
-
-  return { cliVersion, items };
+  return { cliVersion: OA_PACKAGE_VERSION, items };
 }

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -22,7 +22,7 @@ import {
 } from './_shared.js';
 import { ErrorCode, makeToolError, wrapError, wrapSuccess } from './_envelope.js';
 import { jwtVerify, createRemoteJWKSet } from 'jose';
-import { OA_ORIGIN, MCP_RESOURCE } from './_config.js';
+import { OA_ORIGIN, MCP_RESOURCE, OA_PACKAGE_VERSION } from './_config.js';
 import {
   getRequestContext,
   redactBearer,
@@ -169,7 +169,7 @@ const TOOLS = [
         mode: {
           type: 'string',
           enum: ['compact', 'full'],
-          description: 'Response detail mode. Defaults to "full".',
+          description: 'Response detail mode. Defaults to "compact".',
         },
       },
     },
@@ -771,7 +771,7 @@ function handleInitialize(id: unknown, params: Record<string, unknown>) {
   return jsonRpcResult(id, {
     protocolVersion: clientVersion,
     capabilities: { tools: { listChanged: false } },
-    serverInfo: { name: 'OpenAgreements', version: '1.0.0' },
+    serverInfo: { name: 'OpenAgreements', version: OA_PACKAGE_VERSION },
   });
 }
 

--- a/docs/mcp-migration-v2.md
+++ b/docs/mcp-migration-v2.md
@@ -39,8 +39,8 @@ Error responses now use the same envelope shape with `ok: false` and a structure
 
 ## `list_templates` Modes
 
-- `mode: "full"` (default): full field metadata for each template
-- `mode: "compact"`: minimal index entries (`template_id`, `name`, `field_count`)
+- `mode: "compact"` (default): minimal index entries (`template_id`, `name`, `field_count`)
+- `mode: "full"`: full field metadata for each template
 
 ## `fill_template` Return Modes
 

--- a/integration-tests/api-endpoints.test.ts
+++ b/integration-tests/api-endpoints.test.ts
@@ -3,6 +3,7 @@
  * Mocks the shared business logic so tests exercise only the protocol routing.
  */
 
+import { readFileSync } from 'node:fs';
 import { afterEach, describe, expect, vi } from 'vitest';
 import { itAllure, allureStep, allureJsonAttachment } from './helpers/allure-test.js';
 
@@ -381,6 +382,8 @@ describe('MCP endpoint — api/mcp.ts', () => {
     const result = getResultObject(res);
     expect(result.protocolVersion).toBe('2024-11-05');
     expect(result.serverInfo.name).toBe('OpenAgreements');
+    const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf-8'));
+    expect(result.serverInfo.version).toBe(pkg.version);
     expect(result.capabilities.tools).toBeDefined();
   });
 
@@ -416,6 +419,10 @@ describe('MCP endpoint — api/mcp.ts', () => {
       'search_templates',
       'send_for_signature',
     ]);
+
+    // Descriptor must advertise the same default the Zod schema enforces.
+    const listTemplates = tools.find((t: { name: string }) => t.name === 'list_templates');
+    expect(listTemplates.inputSchema.properties.mode.description).toContain('"compact"');
   });
 
   it.openspec('OA-DST-024')('handles tools/call list_templates with envelope response', async () => {

--- a/integration-tests/api-endpoints.test.ts
+++ b/integration-tests/api-endpoints.test.ts
@@ -422,7 +422,7 @@ describe('MCP endpoint — api/mcp.ts', () => {
 
     // Descriptor must advertise the same default the Zod schema enforces.
     const listTemplates = tools.find((t: { name: string }) => t.name === 'list_templates');
-    expect(listTemplates.inputSchema.properties.mode.description).toContain('"compact"');
+    expect(listTemplates.inputSchema.properties.mode.description).toContain('Defaults to "compact"');
   });
 
   it.openspec('OA-DST-024')('handles tools/call list_templates with envelope response', async () => {


### PR DESCRIPTION
## Summary

Closes #203 — three small contract-drift bugs in the hosted MCP HTTP endpoint at `api/mcp.ts`:

1. **`list_templates` default mode mismatch** — the Zod schema defaulted `mode` to `"compact"` (`api/mcp.ts:30`), but the tool descriptor advertised `"full"` as the default (`api/mcp.ts:157`). Fixed the descriptor (kept the runtime default — example clients in `docs/examples/mcp-client-{node,python}.md` already pass `"compact"` explicitly, smaller payload is friendlier for LLM token budgets, and changing the runtime default would be a behavior change for clients in the wild).
2. **`serverInfo.version` hardcoded** — `handleInitialize` returned `"1.0.0"` while `package.json` ships `0.7.5`. Added a single canonical `OA_PACKAGE_VERSION` constant in `api/_config.ts` that reads `package.json` at module load (with `'0.0.0'` fallback) and used it in `handleInitialize`. Also refactored `api/_shared.ts:handleListTemplates` to use the same constant for A2A `cliVersion` so version sourcing has one path.
3. **`docs/mcp-migration-v2.md:42` repeated the wrong claim** — flipped `(default)` from the `full` bullet to the `compact` bullet to match the runtime.

## Tests

- Extended the `initialize` handshake test in `integration-tests/api-endpoints.test.ts` to assert `result.serverInfo.version === package.json.version`. The test reads `package.json` directly (not via `OA_PACKAGE_VERSION`) so it tests correctness, not plumbing.
- Added a `tools/list` assertion that the `list_templates` descriptor's `mode.description` contains `Defaults to "compact"` (anchored on the literal phrase, not just the word `compact`, so future wording drift is caught).
- Existing assertion at line 417 already covers the runtime default for the no-args path, so no new test needed there.

All 57 tests in `api-endpoints.test.ts` + `mcp-contract.test.ts` pass.

## Production verification

The new constant relies on `package.json` being bundled with the Vercel function. The same `readFileSync(join(PROJECT_ROOT, 'package.json'))` pattern already runs in the deployed `api/_shared.ts` for A2A `cliVersion`. I probed the live A2A endpoint:

\`\`\`bash
curl -s https://openagreements.org/api/a2a -X POST \
  -H 'content-type: application/json' \
  -d '{"jsonrpc":"2.0","id":1,"method":"message/send","params":{"message":{"parts":[{"type":"data","data":{"skill":"list-templates"}}]}}}' \
  | jq '.result.artifacts[0].parts[0].data.cli_version'
# => "0.7.5"
\`\`\`

Vercel's Node File Tracer bundles `package.json` correctly. No `vercel.json` changes needed.

## Out of scope — follow-up suggestions

A repo-wide sweep surfaced sibling drift in other MCP surfaces (same class of bug, different transports/packages). These are intentionally **not** in this PR to keep it scoped to #203, but may be worth a follow-up issue:

- `server.json:6` — `"version": "0.5.0"` (root MCP registry manifest, lags `package.json` 0.7.5)
- `server.json:13` — `packages[0].version: "0.5.0"` (npm package entry, also lags)
- `packages/contract-templates-mcp/src/core/server.ts:25` — hardcoded `version: '0.2.0'`
- `packages/checklist-mcp/src/core/server.ts:25` — hardcoded `version: '0.1.0'`
- `packages/contracts-workspace-mcp/src/core/server.ts:25` — hardcoded `version: '0.2.0'`

## Test plan

- [x] `npm run build` passes
- [x] `npx vitest run integration-tests/api-endpoints.test.ts integration-tests/mcp-contract.test.ts` — 57/57 pass
- [x] Production probe of `cli_version` returns `0.7.5`
- [ ] CI passes