### PR TITLE
refactor: DRY follow-up to PR #232 (canonical-source + layouts + tests)

### DIFF
--- a/integration-tests/canonical-source-sync.test.ts
+++ b/integration-tests/canonical-source-sync.test.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import { describe, expect } from 'vitest';
 import { itAllure } from './helpers/allure-test.js';
 import { compileCanonicalSourceFile } from '../scripts/template_renderer/canonical-source.mjs';
-import { discoverCanonicalTemplates } from '../scripts/template_renderer/canonical-sources.mjs';
+import { discoverTemplateSources } from '../scripts/template_renderer/canonical-sources.mjs';
 import { loadStyleProfile, renderFromValidatedSpec } from '../scripts/template_renderer/index.mjs';
 
 const it = itAllure.epic('Filling & Rendering');
@@ -17,7 +17,7 @@ const stylePath = join(
   'openagreements-default-v1.json'
 );
 
-const canonicalTemplates = discoverCanonicalTemplates(repoRoot);
+const canonicalTemplates = discoverTemplateSources(repoRoot).filter((s) => s.type === 'canonical');
 
 describe('canonical Markdown -> JSON spec sync', () => {
   it.openspec('OA-TMP-035')('discovers at least one canonical template under content/templates', () => {

--- a/integration-tests/employment-template-spacing.test.ts
+++ b/integration-tests/employment-template-spacing.test.ts
@@ -1,141 +1,38 @@
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
-import AdmZip from 'adm-zip';
-import { DOMParser } from '@xmldom/xmldom';
 import { describe, expect } from 'vitest';
 import { itAllure } from './helpers/allure-test.js';
+import {
+  EMPLOYMENT_TEMPLATE_CASES,
+  isClauseHeadingParagraph,
+  isDefinitionItemParagraph,
+  loadDocumentXml,
+  paragraphSpacing,
+  standardTermsParagraphs,
+} from './helpers/standard-terms-docx.js';
 
-const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const it = itAllure.epic('Verification & Drift');
 
-const EMPLOYMENT_SPACING_CASES = [
-  {
-    templatePath: 'content/templates/openagreements-employment-offer-letter/template.docx',
-    endMarker: 'Signatures',
-  },
-  {
-    templatePath: 'content/templates/openagreements-employee-ip-inventions-assignment/template.docx',
-    endMarker: 'Signatures',
-  },
-  {
-    templatePath: 'content/templates/openagreements-employment-confidentiality-acknowledgement/template.docx',
-    endMarker: 'Acknowledgement Signature',
-  },
-] as const;
-
-function loadDocumentXml(templatePath: string): string {
-  const absolutePath = join(import.meta.dirname, '..', templatePath);
-  const zip = new AdmZip(readFileSync(absolutePath));
-  const entry = zip.getEntry('word/document.xml');
-  if (!entry) {
-    throw new Error(`word/document.xml missing in ${templatePath}`);
-  }
-  return entry.getData().toString('utf-8');
-}
-
-function paragraphText(paragraph: Element): string {
-  const textNodes = paragraph.getElementsByTagNameNS(W_NS, 't');
-  let text = '';
-  for (let i = 0; i < textNodes.length; i += 1) {
-    text += textNodes[i].textContent ?? '';
-  }
-  return text.trim();
-}
-
-function isClauseHeadingParagraph(text: string): boolean {
-  return /^\d+\.\s/.test(text);
-}
-
-function isDefinitionItemParagraph(text: string): boolean {
-  return /^\d+\.\d+\s/.test(text);
-}
-
-function paragraphSpacing(paragraph: Element): {
-  after: string | null;
-  before: string | null;
-  line: string | null;
-  afterAutospacing: string | null;
-  beforeAutospacing: string | null;
-  contextualSpacing: string | null;
-} {
-  const pPrNodes = paragraph.getElementsByTagNameNS(W_NS, 'pPr');
-  if (pPrNodes.length === 0) {
-    return {
-      after: null,
-      before: null,
-      line: null,
-      afterAutospacing: null,
-      beforeAutospacing: null,
-      contextualSpacing: null,
-    };
-  }
-  const spacingNodes = pPrNodes[0].getElementsByTagNameNS(W_NS, 'spacing');
-  const contextualNodes = pPrNodes[0].getElementsByTagNameNS(W_NS, 'contextualSpacing');
-  const contextualSpacing = contextualNodes.length > 0
-    ? contextualNodes[0].getAttributeNS(W_NS, 'val')
-    : null;
-  if (spacingNodes.length === 0) {
-    return {
-      after: null,
-      before: null,
-      line: null,
-      afterAutospacing: null,
-      beforeAutospacing: null,
-      contextualSpacing,
-    };
-  }
-  return {
-    before: spacingNodes[0].getAttributeNS(W_NS, 'before'),
-    after: spacingNodes[0].getAttributeNS(W_NS, 'after'),
-    line: spacingNodes[0].getAttributeNS(W_NS, 'line'),
-    afterAutospacing: spacingNodes[0].getAttributeNS(W_NS, 'afterAutospacing'),
-    beforeAutospacing: spacingNodes[0].getAttributeNS(W_NS, 'beforeAutospacing'),
-    contextualSpacing,
-  };
-}
+const repoRoot = new URL('..', import.meta.url).pathname;
 
 describe('employment template standard-terms spacing', () => {
-  for (const testCase of EMPLOYMENT_SPACING_CASES) {
+  for (const testCase of EMPLOYMENT_TEMPLATE_CASES) {
     it.openspec('OA-FIL-020')(`${testCase.templatePath} keeps 6pt spacing in Standard Terms`, () => {
-      const xml = loadDocumentXml(testCase.templatePath);
-      const doc = new DOMParser().parseFromString(xml, 'text/xml');
+      const documentXml = loadDocumentXml(repoRoot, testCase.templatePath);
+      const paragraphs = standardTermsParagraphs(documentXml, testCase.endMarker);
+      expect(paragraphs.length).toBeGreaterThan(0);
 
-      const bodyNodes = doc.getElementsByTagNameNS(W_NS, 'body');
-      expect(bodyNodes.length).toBeGreaterThan(0);
-      const body = bodyNodes[0];
-
-      const paragraphs: Element[] = [];
-      for (let i = 0; i < body.childNodes.length; i += 1) {
-        const node = body.childNodes[i] as Element;
-        if (!node || node.localName !== 'p' || node.namespaceURI !== W_NS) continue;
-        paragraphs.push(node);
-      }
-
-      let inStandardTerms = false;
+      // In OOXML, explicit "false" is semantically equivalent to absent (null)
+      const isSet = (v: string | null) => v !== null && v !== 'false';
       const spacingFailures: string[] = [];
-      let checkedParagraphs = 0;
 
-      for (const paragraph of paragraphs) {
-        const text = paragraphText(paragraph);
-        if (text === 'Standard Terms') {
-          inStandardTerms = true;
-          continue;
-        }
-        if (text === testCase.endMarker) {
-          inStandardTerms = false;
-        }
-        if (!inStandardTerms || text === '') continue;
-
+      for (const { text, paragraph } of paragraphs) {
         const spacing = paragraphSpacing(paragraph);
-        checkedParagraphs += 1;
         const isHeading = isClauseHeadingParagraph(text);
         const isDefinition = isDefinitionItemParagraph(text);
         const expectedAfter = isHeading ? '120' : '280';
-        // In OOXML, explicit "false" is semantically equivalent to absent (null)
-        const isSet = (v: string | null) => v !== null && v !== 'false';
         const beforeOk = isDefinition
           ? spacing.before === '0' || spacing.before === '320'
           : spacing.before === (isHeading ? '320' : '0');
+
         if (
           !beforeOk
           || spacing.after !== expectedAfter
@@ -155,7 +52,6 @@ describe('employment template standard-terms spacing', () => {
         }
       }
 
-      expect(checkedParagraphs).toBeGreaterThan(0);
       expect(spacingFailures).toEqual([]);
     });
   }

--- a/integration-tests/employment-template-style-spacing.test.ts
+++ b/integration-tests/employment-template-style-spacing.test.ts
@@ -1,137 +1,26 @@
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
-import AdmZip from 'adm-zip';
 import { DOMParser } from '@xmldom/xmldom';
 import { describe, expect } from 'vitest';
 import { itAllure } from './helpers/allure-test.js';
+import {
+  EMPLOYMENT_TEMPLATE_CASES,
+  W_NS,
+  isClauseHeadingParagraph,
+  isDefinitionItemParagraph,
+  loadXmlPart,
+  paragraphSpacing,
+  paragraphStyle,
+  standardTermsParagraphs,
+  wordAttr,
+} from './helpers/standard-terms-docx.js';
 
-const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const it = itAllure.epic('Verification & Drift');
 
-const EMPLOYMENT_TEMPLATE_CASES = [
-  {
-    templatePath: 'content/templates/openagreements-employment-offer-letter/template.docx',
-    endMarker: 'Signatures',
-  },
-  {
-    templatePath: 'content/templates/openagreements-employee-ip-inventions-assignment/template.docx',
-    endMarker: 'Signatures',
-  },
-  {
-    templatePath: 'content/templates/openagreements-employment-confidentiality-acknowledgement/template.docx',
-    endMarker: 'Acknowledgement Signature',
-  },
-] as const;
-
-function loadXmlPart(templatePath: string, partPath: string): string {
-  const absolutePath = join(import.meta.dirname, '..', templatePath);
-  const zip = new AdmZip(readFileSync(absolutePath));
-  const entry = zip.getEntry(partPath);
-  if (!entry) {
-    throw new Error(`${partPath} missing in ${templatePath}`);
-  }
-  return entry.getData().toString('utf-8');
-}
-
-function paragraphText(paragraph: Element): string {
-  const textNodes = paragraph.getElementsByTagNameNS(W_NS, 't');
-  let text = '';
-  for (let i = 0; i < textNodes.length; i += 1) {
-    text += textNodes[i].textContent ?? '';
-  }
-  return text.trim();
-}
-
-function isClauseHeadingParagraph(text: string): boolean {
-  return /^\d+\.\s/.test(text);
-}
-
-function isDefinitionItemParagraph(text: string): boolean {
-  return /^\d+\.\d+\s/.test(text);
-}
-
-function directChild(parent: Element, localName: string): Element | null {
-  for (let i = 0; i < parent.childNodes.length; i += 1) {
-    const child = parent.childNodes[i] as Element;
-    if (!child || child.nodeType !== 1 || child.localName !== localName || child.namespaceURI !== W_NS) {
-      continue;
-    }
-    return child;
-  }
-  return null;
-}
-
-function wordAttr(node: Element | null, name: string): string | null {
-  if (!node) return null;
-  return node.getAttributeNS(W_NS, name) ?? node.getAttribute(`w:${name}`) ?? node.getAttribute(name);
-}
-
-function paragraphStyle(paragraph: Element): string | null {
-  const pPr = directChild(paragraph, 'pPr');
-  if (!pPr) return null;
-  const pStyle = directChild(pPr, 'pStyle');
-  return wordAttr(pStyle, 'val');
-}
-
-function paragraphSpacing(paragraph: Element): {
-  before: string | null;
-  after: string | null;
-  line: string | null;
-} {
-  const pPr = directChild(paragraph, 'pPr');
-  if (!pPr) {
-    return { before: null, after: null, line: null };
-  }
-  const spacing = directChild(pPr, 'spacing');
-  if (!spacing) {
-    return { before: null, after: null, line: null };
-  }
-  return {
-    before: wordAttr(spacing, 'before'),
-    after: wordAttr(spacing, 'after'),
-    line: wordAttr(spacing, 'line'),
-  };
-}
-
-function standardTermsParagraphs(documentXml: string, endMarker: string): Array<{ text: string; paragraph: Element }> {
-  const doc = new DOMParser().parseFromString(documentXml, 'text/xml');
-  const bodyNodes = doc.getElementsByTagNameNS(W_NS, 'body');
-  if (bodyNodes.length === 0) {
-    throw new Error('word/body missing');
-  }
-
-  const body = bodyNodes[0];
-  let inStandardTerms = false;
-  const matches: Array<{ text: string; paragraph: Element }> = [];
-
-  for (let i = 0; i < body.childNodes.length; i += 1) {
-    const node = body.childNodes[i] as Element;
-    if (!node || node.nodeType !== 1 || node.localName !== 'p' || node.namespaceURI !== W_NS) {
-      continue;
-    }
-
-    const text = paragraphText(node);
-    if (text === 'Standard Terms') {
-      inStandardTerms = true;
-      continue;
-    }
-    if (text === endMarker) {
-      inStandardTerms = false;
-    }
-    if (!inStandardTerms || text === '') {
-      continue;
-    }
-
-    matches.push({ text, paragraph: node });
-  }
-
-  return matches;
-}
+const repoRoot = new URL('..', import.meta.url).pathname;
 
 describe('employment template style and spacing', () => {
   for (const testCase of EMPLOYMENT_TEMPLATE_CASES) {
     it.openspec('OA-FIL-020')(`${testCase.templatePath} emits Standard Terms paragraph styles`, () => {
-      const stylesXml = loadXmlPart(testCase.templatePath, 'word/styles.xml');
+      const stylesXml = loadXmlPart(repoRoot, testCase.templatePath, 'word/styles.xml');
       const stylesDoc = new DOMParser().parseFromString(stylesXml, 'text/xml');
       const styleNodes = stylesDoc.getElementsByTagNameNS(W_NS, 'style');
       const paragraphStyleIds = new Set<string>();
@@ -147,7 +36,7 @@ describe('employment template style and spacing', () => {
       expect(paragraphStyleIds.has('OAClauseHeading')).toBe(true);
       expect(paragraphStyleIds.has('OAClauseBody')).toBe(true);
 
-      const documentXml = loadXmlPart(testCase.templatePath, 'word/document.xml');
+      const documentXml = loadXmlPart(repoRoot, testCase.templatePath, 'word/document.xml');
       const paragraphs = standardTermsParagraphs(documentXml, testCase.endMarker);
       expect(paragraphs.length).toBeGreaterThan(0);
 
@@ -166,7 +55,7 @@ describe('employment template style and spacing', () => {
     });
 
     it.openspec('OA-FIL-020')(`${testCase.templatePath} keeps Standard Terms spacing values`, () => {
-      const documentXml = loadXmlPart(testCase.templatePath, 'word/document.xml');
+      const documentXml = loadXmlPart(repoRoot, testCase.templatePath, 'word/document.xml');
       const paragraphs = standardTermsParagraphs(documentXml, testCase.endMarker);
       expect(paragraphs.length).toBeGreaterThan(0);
 

--- a/integration-tests/helpers/standard-terms-docx.ts
+++ b/integration-tests/helpers/standard-terms-docx.ts
@@ -1,0 +1,159 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import AdmZip from 'adm-zip';
+import { DOMParser } from '@xmldom/xmldom';
+
+export const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+export const EMPLOYMENT_TEMPLATE_CASES = [
+  {
+    templatePath: 'content/templates/openagreements-employment-offer-letter/template.docx',
+    endMarker: 'Signatures',
+  },
+  {
+    templatePath: 'content/templates/openagreements-employee-ip-inventions-assignment/template.docx',
+    endMarker: 'Signatures',
+  },
+  {
+    templatePath: 'content/templates/openagreements-employment-confidentiality-acknowledgement/template.docx',
+    endMarker: 'Acknowledgement Signature',
+  },
+] as const;
+
+export type EmploymentTemplateCase = typeof EMPLOYMENT_TEMPLATE_CASES[number];
+
+export function loadXmlPart(repoRoot: string, templatePath: string, partPath: string): string {
+  const absolutePath = join(repoRoot, templatePath);
+  const zip = new AdmZip(readFileSync(absolutePath));
+  const entry = zip.getEntry(partPath);
+  if (!entry) {
+    throw new Error(`${partPath} missing in ${templatePath}`);
+  }
+  return entry.getData().toString('utf-8');
+}
+
+export function loadDocumentXml(repoRoot: string, templatePath: string): string {
+  return loadXmlPart(repoRoot, templatePath, 'word/document.xml');
+}
+
+export function directChild(parent: Element, localName: string): Element | null {
+  for (let i = 0; i < parent.childNodes.length; i += 1) {
+    const child = parent.childNodes[i] as Element;
+    if (!child || child.nodeType !== 1 || child.localName !== localName || child.namespaceURI !== W_NS) {
+      continue;
+    }
+    return child;
+  }
+  return null;
+}
+
+export function wordAttr(node: Element | null, name: string): string | null {
+  if (!node) return null;
+  return node.getAttributeNS(W_NS, name) ?? node.getAttribute(`w:${name}`) ?? node.getAttribute(name);
+}
+
+export function paragraphText(paragraph: Element): string {
+  const textNodes = paragraph.getElementsByTagNameNS(W_NS, 't');
+  let text = '';
+  for (let i = 0; i < textNodes.length; i += 1) {
+    text += textNodes[i].textContent ?? '';
+  }
+  return text.trim();
+}
+
+export function isClauseHeadingParagraph(text: string): boolean {
+  return /^\d+\.\s/.test(text);
+}
+
+export function isDefinitionItemParagraph(text: string): boolean {
+  return /^\d+\.\d+\s/.test(text);
+}
+
+export function paragraphStyle(paragraph: Element): string | null {
+  const pPr = directChild(paragraph, 'pPr');
+  if (!pPr) return null;
+  const pStyle = directChild(pPr, 'pStyle');
+  return wordAttr(pStyle, 'val');
+}
+
+export interface ParagraphSpacing {
+  before: string | null;
+  after: string | null;
+  line: string | null;
+  afterAutospacing: string | null;
+  beforeAutospacing: string | null;
+  contextualSpacing: string | null;
+}
+
+export function paragraphSpacing(paragraph: Element): ParagraphSpacing {
+  const pPr = directChild(paragraph, 'pPr');
+  if (!pPr) {
+    return {
+      before: null,
+      after: null,
+      line: null,
+      afterAutospacing: null,
+      beforeAutospacing: null,
+      contextualSpacing: null,
+    };
+  }
+  const contextualNode = directChild(pPr, 'contextualSpacing');
+  const contextualSpacing = wordAttr(contextualNode, 'val');
+  const spacing = directChild(pPr, 'spacing');
+  if (!spacing) {
+    return {
+      before: null,
+      after: null,
+      line: null,
+      afterAutospacing: null,
+      beforeAutospacing: null,
+      contextualSpacing,
+    };
+  }
+  return {
+    before: wordAttr(spacing, 'before'),
+    after: wordAttr(spacing, 'after'),
+    line: wordAttr(spacing, 'line'),
+    afterAutospacing: wordAttr(spacing, 'afterAutospacing'),
+    beforeAutospacing: wordAttr(spacing, 'beforeAutospacing'),
+    contextualSpacing,
+  };
+}
+
+export function standardTermsParagraphs(
+  documentXml: string,
+  endMarker: string
+): Array<{ text: string; paragraph: Element }> {
+  const doc = new DOMParser().parseFromString(documentXml, 'text/xml');
+  const bodyNodes = doc.getElementsByTagNameNS(W_NS, 'body');
+  if (bodyNodes.length === 0) {
+    throw new Error('word/body missing');
+  }
+
+  const body = bodyNodes[0];
+  let inStandardTerms = false;
+  const matches: Array<{ text: string; paragraph: Element }> = [];
+
+  for (let i = 0; i < body.childNodes.length; i += 1) {
+    const node = body.childNodes[i] as Element;
+    if (!node || node.nodeType !== 1 || node.localName !== 'p' || node.namespaceURI !== W_NS) {
+      continue;
+    }
+
+    const text = paragraphText(node);
+    if (text === 'Standard Terms') {
+      inStandardTerms = true;
+      continue;
+    }
+    if (text === endMarker) {
+      inStandardTerms = false;
+    }
+    if (!inStandardTerms || text === '') {
+      continue;
+    }
+
+    matches.push({ text, paragraph: node });
+  }
+
+  return matches;
+}

--- a/scripts/template_renderer/canonical-frontmatter.mjs
+++ b/scripts/template_renderer/canonical-frontmatter.mjs
@@ -1,0 +1,51 @@
+import yaml from 'js-yaml';
+
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/;
+
+export function parseCanonicalFrontmatter(raw, filePath) {
+  const match = raw.match(FRONTMATTER_RE);
+  if (!match) {
+    throw new Error(`Canonical source (${filePath}) must start with YAML frontmatter`);
+  }
+
+  let frontmatter;
+  try {
+    frontmatter = yaml.load(match[1]);
+  } catch (err) {
+    throw new Error(`Canonical source frontmatter (${filePath}) failed to parse: ${err.message}`);
+  }
+
+  if (!frontmatter || typeof frontmatter !== 'object') {
+    throw new Error(`Canonical source frontmatter (${filePath}) must be a YAML object`);
+  }
+
+  return { frontmatter, body: match[2] };
+}
+
+export function tryParseCanonicalFrontmatter(raw) {
+  try {
+    return parseCanonicalFrontmatter(raw, '<probe>');
+  } catch {
+    return null;
+  }
+}
+
+export function hasCanonicalIdentity(frontmatter) {
+  return (
+    typeof frontmatter?.template_id === 'string' &&
+    typeof frontmatter?.layout_id === 'string' &&
+    typeof frontmatter?.style_id === 'string'
+  );
+}
+
+export function assertCanonicalIdentity(frontmatter, filePath) {
+  if (!frontmatter?.template_id) {
+    throw new Error(`Canonical source (${filePath}) is missing template_id`);
+  }
+  if (!frontmatter.layout_id) {
+    throw new Error(`Canonical source (${filePath}) is missing layout_id`);
+  }
+  if (!frontmatter.style_id) {
+    throw new Error(`Canonical source (${filePath}) is missing style_id`);
+  }
+}

--- a/scripts/template_renderer/canonical-source.mjs
+++ b/scripts/template_renderer/canonical-source.mjs
@@ -1,9 +1,11 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import yaml from 'js-yaml';
+import {
+  assertCanonicalIdentity,
+  parseCanonicalFrontmatter,
+} from './canonical-frontmatter.mjs';
 import { validateContractSpec } from './schema.mjs';
 
-const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/;
 const DIRECTIVE_RE = /^<!--\s*oa:([a-z-]+)(?:\s+([\s\S]*?))?\s*-->$/;
 const ATTR_RE = /([a-z_][a-z0-9_-]*)=(?:"([^"]*)"|([^\s]+))/g;
 const TOP_LEVEL_SECTION_RE = /^##\s+(.+)$/;
@@ -18,23 +20,6 @@ function invariant(condition, message) {
   if (!condition) {
     throw new Error(message);
   }
-}
-
-function parseFrontmatter(raw, filePath) {
-  const match = raw.match(FRONTMATTER_RE);
-  if (!match) {
-    throw new Error(`Canonical source (${filePath}) must start with YAML frontmatter`);
-  }
-
-  const frontmatter = yaml.load(match[1]);
-  if (!frontmatter || typeof frontmatter !== 'object') {
-    throw new Error(`Canonical source frontmatter (${filePath}) must be a YAML object`);
-  }
-
-  return {
-    frontmatter,
-    body: match[2],
-  };
 }
 
 function normalizeNumberedHeading(text) {
@@ -119,30 +104,7 @@ function splitTopLevelSections(body, filePath) {
   return byTitle;
 }
 
-function paragraphTextFromLines(lines) {
-  const paragraphs = [];
-  let current = [];
-
-  for (const rawLine of lines) {
-    const line = rawLine.trimEnd();
-    if (line.trim().length === 0) {
-      if (current.length > 0) {
-        paragraphs.push(current.map((part) => part.trim()).join(' '));
-        current = [];
-      }
-      continue;
-    }
-    current.push(line);
-  }
-
-  if (current.length > 0) {
-    paragraphs.push(current.map((part) => part.trim()).join(' '));
-  }
-
-  return paragraphs.join('\n\n');
-}
-
-function splitParagraphs(lines) {
+function paragraphsFromLines(lines) {
   const paragraphs = [];
   let current = [];
 
@@ -163,6 +125,10 @@ function splitParagraphs(lines) {
   }
 
   return paragraphs;
+}
+
+function paragraphTextFromLines(lines) {
+  return paragraphsFromLines(lines).join('\n\n');
 }
 
 function parseMarkdownTable(lines, filePath) {
@@ -321,7 +287,7 @@ function parseDefinitionParagraph(paragraph, filePath, index) {
 function parseDefinitionsClauseBody(lines, filePath) {
   const terms = [];
   const seenTerms = new Set();
-  const paragraphs = splitParagraphs(lines);
+  const paragraphs = paragraphsFromLines(lines);
 
   invariant(paragraphs.length > 0, `Canonical source (${filePath}) definitions clause has no definition paragraphs`);
 
@@ -744,12 +710,10 @@ function projectToContractSpec(normalized, frontmatter, filePath) {
 }
 
 export function compileCanonicalSourceString(raw, filePath = 'canonical source') {
-  const { frontmatter, body } = parseFrontmatter(raw, filePath);
+  const { frontmatter, body } = parseCanonicalFrontmatter(raw, filePath);
   const sectionLines = splitTopLevelSections(body, filePath);
 
-  invariant(frontmatter.template_id, `Canonical source (${filePath}) is missing template_id`);
-  invariant(frontmatter.layout_id, `Canonical source (${filePath}) is missing layout_id`);
-  invariant(frontmatter.style_id, `Canonical source (${filePath}) is missing style_id`);
+  assertCanonicalIdentity(frontmatter, filePath);
   invariant(frontmatter.document, `Canonical source (${filePath}) is missing document frontmatter`);
 
   const normalized = normalizeCanonicalTemplate(frontmatter, {

--- a/scripts/template_renderer/canonical-sources.mjs
+++ b/scripts/template_renderer/canonical-sources.mjs
@@ -1,8 +1,9 @@
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { join, relative } from 'node:path';
-import yaml from 'js-yaml';
-
-const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---/;
+import {
+  hasCanonicalIdentity,
+  tryParseCanonicalFrontmatter,
+} from './canonical-frontmatter.mjs';
 
 const TEMPLATES_DIR = 'content/templates';
 const CANONICAL_TEMPLATE_FILENAME = 'template.md';
@@ -24,20 +25,8 @@ function isCanonicalSource(filePath) {
   } catch {
     return false;
   }
-  const match = raw.match(FRONTMATTER_RE);
-  if (!match) return false;
-  let frontmatter;
-  try {
-    frontmatter = yaml.load(match[1]);
-  } catch {
-    return false;
-  }
-  if (!frontmatter || typeof frontmatter !== 'object') return false;
-  return (
-    typeof frontmatter.template_id === 'string' &&
-    typeof frontmatter.layout_id === 'string' &&
-    typeof frontmatter.style_id === 'string'
-  );
+  const parsed = tryParseCanonicalFrontmatter(raw);
+  return parsed !== null && hasCanonicalIdentity(parsed.frontmatter);
 }
 
 function fileExists(filePath) {
@@ -79,8 +68,4 @@ export function discoverTemplateSources(repoRoot) {
   }
 
   return sources.sort((a, b) => a.slug.localeCompare(b.slug));
-}
-
-export function discoverCanonicalTemplates(repoRoot) {
-  return discoverTemplateSources(repoRoot).filter((s) => s.type === 'canonical');
 }

--- a/scripts/template_renderer/layouts/cover-standard-signature-v1.mjs
+++ b/scripts/template_renderer/layouts/cover-standard-signature-v1.mjs
@@ -548,36 +548,8 @@ function bodyParagraphsFromText(text, style, opts = {}) {
   );
 }
 
-function clauseParagraphs(index, clauseItem, style, opts = {}) {
-  // Definitions clause type
-  if (clauseItem.type === 'definitions') {
-    return [
-      new Paragraph({
-        style: 'OAClauseHeading',
-        contextualSpacing: false,
-        spacing: {
-          before: style.spacing.clause_heading_before,
-          after: style.spacing.clause_heading_after,
-          line: style.spacing.line,
-          beforeAutoSpacing: false,
-          afterAutoSpacing: false,
-        },
-        children: [
-          new TextRun({
-            text: `${index}. ${clauseItem.heading}.`,
-            font: style.fonts.body,
-            size: 22,
-            bold: true,
-            color: style.colors.ink,
-          }),
-        ],
-      }),
-      ...definitionSubParagraphs(index, clauseItem.terms, style),
-    ];
-  }
-
-  // Text clause with optional condition/omitted_body
-  const headingParagraph = new Paragraph({
+function clauseHeadingParagraph(index, heading, style) {
+  return new Paragraph({
     style: 'OAClauseHeading',
     contextualSpacing: false,
     spacing: {
@@ -589,7 +561,7 @@ function clauseParagraphs(index, clauseItem, style, opts = {}) {
     },
     children: [
       new TextRun({
-        text: `${index}. ${clauseItem.heading}.`,
+        text: `${index}. ${heading}.`,
         font: style.fonts.body,
         size: 22,
         bold: true,
@@ -597,7 +569,17 @@ function clauseParagraphs(index, clauseItem, style, opts = {}) {
       }),
     ],
   });
+}
 
+function clauseParagraphs(index, clauseItem, style, opts = {}) {
+  if (clauseItem.type === 'definitions') {
+    return [
+      clauseHeadingParagraph(index, clauseItem.heading, style),
+      ...definitionSubParagraphs(index, clauseItem.terms, style),
+    ];
+  }
+
+  const headingParagraph = clauseHeadingParagraph(index, clauseItem.heading, style);
   const termsOpt = opts.terms;
   const bodyParas = bodyParagraphsFromText(clauseItem.body, style, { size: 22, style: 'OAClauseBody', terms: termsOpt });
 
@@ -727,7 +709,11 @@ function signerFieldMap(signer) {
   return new Map(signer.rows.map((row) => [row.id, row]));
 }
 
-function twoPartySignatureTable(signatureSpec, style, nilBorder, ruleBorder) {
+// Shared shell for the 4-column dual-party signature table used by both
+// `signers`-mode and the legacy `two-party` mode. Callers normalize their
+// inputs into `{ leftHeader, rightHeader, rows }` where each row is
+// `{ label, hint?, leftValue, rightValue, leftLined?, rightLined? }`.
+function dualPartySignatureTable({ leftHeader, rightHeader, rows }, style, nilBorder, ruleBorder) {
   return new Table({
     width: { size: 10075, type: WidthType.DXA },
     layout: TableLayoutType.FIXED,
@@ -744,26 +730,43 @@ function twoPartySignatureTable(signatureSpec, style, nilBorder, ruleBorder) {
       new TableRow({
         children: [
           signatureLabelCell('', '', style, nilBorder),
-          signatureHeaderCell(signatureSpec.party_a.toUpperCase(), style, nilBorder),
+          signatureHeaderCell(leftHeader.toUpperCase(), style, nilBorder),
           signatureSpacerCell(nilBorder),
-          signatureHeaderCell(signatureSpec.party_b.toUpperCase(), style, nilBorder),
+          signatureHeaderCell(rightHeader.toUpperCase(), style, nilBorder),
         ],
       }),
-      ...signatureSpec.rows.map((row) =>
+      ...rows.map((row) =>
         new TableRow({
           height: { value: style.sizes.signature_row_height, rule: HeightRule.ATLEAST },
           children: [
             signatureLabelCell(row.label, row.hint, style, nilBorder),
-            signatureLineCell(row.left ?? '', style, nilBorder, ruleBorder),
+            signatureLineCell(row.leftValue ?? '', style, nilBorder, row.leftLined === false ? nilBorder : ruleBorder),
             signatureSpacerCell(nilBorder),
-            row.left_only
-              ? signatureLineCell('', style, nilBorder, nilBorder)
-              : signatureLineCell(row.right ?? '', style, nilBorder, ruleBorder),
+            signatureLineCell(row.rightValue ?? '', style, nilBorder, row.rightLined === false ? nilBorder : ruleBorder),
           ],
         })
       ),
     ],
   });
+}
+
+function twoPartySignatureTable(signatureSpec, style, nilBorder, ruleBorder) {
+  return dualPartySignatureTable(
+    {
+      leftHeader: signatureSpec.party_a,
+      rightHeader: signatureSpec.party_b,
+      rows: signatureSpec.rows.map((row) => ({
+        label: row.label,
+        hint: row.hint,
+        leftValue: row.left,
+        rightValue: row.left_only ? '' : row.right,
+        rightLined: !row.left_only,
+      })),
+    },
+    style,
+    nilBorder,
+    ruleBorder
+  );
 }
 
 function onePartySignatureTable(signatureSpec, style, nilBorder, ruleBorder) {
@@ -836,45 +839,27 @@ function signerModeSignatureTable(signatureSpec, style, nilBorder, ruleBorder) {
     }
   }
 
-  return new Table({
-    width: { size: 10075, type: WidthType.DXA },
-    layout: TableLayoutType.FIXED,
-    columnWidths: style.table_widths.signature_two_party,
-    borders: {
-      top: nilBorder,
-      left: nilBorder,
-      bottom: nilBorder,
-      right: nilBorder,
-      insideH: nilBorder,
-      insideV: nilBorder,
-    },
-    rows: [
-      new TableRow({
-        children: [
-          signatureLabelCell('', '', style, nilBorder),
-          signatureHeaderCell(leftSigner.label.toUpperCase(), style, nilBorder),
-          signatureSpacerCell(nilBorder),
-          signatureHeaderCell(rightSigner.label.toUpperCase(), style, nilBorder),
-        ],
-      }),
-      ...rowIds.map((rowId) => {
+  return dualPartySignatureTable(
+    {
+      leftHeader: leftSigner.label,
+      rightHeader: rightSigner.label,
+      rows: rowIds.map((rowId) => {
         const leftRow = leftRows.get(rowId);
         const rightRow = rightRows.get(rowId);
-        const label = leftRow?.label ?? rightRow?.label ?? rowId;
-        const hint = leftRow?.hint ?? rightRow?.hint;
-
-        return new TableRow({
-          height: { value: style.sizes.signature_row_height, rule: HeightRule.ATLEAST },
-          children: [
-            signatureLabelCell(label, hint, style, nilBorder),
-            signatureLineCell(leftRow?.value ?? '', style, nilBorder, leftRow ? ruleBorder : nilBorder),
-            signatureSpacerCell(nilBorder),
-            signatureLineCell(rightRow?.value ?? '', style, nilBorder, rightRow ? ruleBorder : nilBorder),
-          ],
-        });
+        return {
+          label: leftRow?.label ?? rightRow?.label ?? rowId,
+          hint: leftRow?.hint ?? rightRow?.hint,
+          leftValue: leftRow?.value,
+          rightValue: rightRow?.value,
+          leftLined: Boolean(leftRow),
+          rightLined: Boolean(rightRow),
+        };
       }),
-    ],
-  });
+    },
+    style,
+    nilBorder,
+    ruleBorder
+  );
 }
 
 function renderMarkdown(spec) {


### PR DESCRIPTION
## Summary

Follow-up to #232 that lands the DRY cuts both Codex and Gemini peer
reviews flagged as load-bearing. Pure refactor: behavior preserved,
existing failure messages preserved, regenerated DOCX is byte-identical
in `word/document.xml` (only `docProps/core.xml` timestamps change), so
the committed `.docx` files are not touched.

Net **−281 lines** across 6 modified files plus two new helper modules.

## What changed

**`scripts/template_renderer/canonical-frontmatter.mjs`** *(new)* — single primitive shared by discovery and the compiler:
- `parseCanonicalFrontmatter` (throws) for the compiler
- `tryParseCanonicalFrontmatter` (silent) for discovery probes
- `hasCanonicalIdentity` (predicate) / `assertCanonicalIdentity` (throws)

Eliminates the duplicated regex + YAML parse + `template_id`/`layout_id`/`style_id` check between `canonical-sources.mjs` and `canonical-source.mjs`.

**`scripts/template_renderer/canonical-source.mjs`** — `paragraphTextFromLines` and `splitParagraphs` were byte-identical except one joined with `\n\n`. Collapsed into a single `paragraphsFromLines` primitive plus a one-line wrapper.

**`scripts/template_renderer/canonical-sources.mjs`** — uses the shared frontmatter primitive; one-caller `discoverCanonicalTemplates()` wrapper inlined at its single call site.

**`scripts/template_renderer/layouts/cover-standard-signature-v1.mjs`** — two refactors:
- `clauseHeadingParagraph(index, heading, style)` extraction (definitions and text clauses were building near-identical `OAClauseHeading` paragraphs)
- `dualPartySignatureTable({ leftHeader, rightHeader, rows }, ...)` shell shared by `twoPartySignatureTable` and `signerModeSignatureTable`. Each caller now owns only its input normalization (and, for signer-mode, the label/hint mismatch validation). `onePartySignatureTable` keeps its own shell — the 1-party 2-column structure is genuinely different.

**`integration-tests/helpers/standard-terms-docx.ts`** *(new)* — shared OOXML helpers (xmldom traversal, namespace handling, paragraph text/style/spacing extraction, Standard Terms body walker, clause/definition heading regexes, employment-template fixture list). The two spacing tests collapse from ~140 lines each to ~50.

## Decisions to NOT extract (Codex's "do-not-over-abstract" guidance)
- Did **not** collapse `twoPartySignatureTable`, `onePartySignatureTable`, and `signerModeSignatureTable` into a single mega-builder. Share the 4-column shell only.
- Did **not** export filename/path constants for tests to consume — the manifest from `discoverTemplateSources` is the right SSOT; tests use `source.templatePath` / `source.jsonPath`.
- Did **not** parametrize `canonical-source-authoring.test.ts` boundary tests with `it.each` — distinct boundaries deserve distinct setup and failure text.
- Did **not** move "exactly 2 signers" into the global schema — it's a layout-specific invariant that belongs at the renderer boundary.

## Validation
- `npm run build` — clean
- `npm run lint` — clean
- `npx vitest run integration-tests packages/contract-templates-mcp/tests` — **527/527 passing across 58 files**
- `npm run generate:templates` — only `docProps/core.xml` timestamp differs vs HEAD; `word/document.xml`, `word/styles.xml`, etc. byte-identical (DOCX files not committed)

## Test plan
- [ ] CI green (build, lint, vitest, spec coverage, source drift, allure labels)
- [ ] Reviewer spot-checks the new `canonical-frontmatter.mjs` primitive against PR #232's failure messages (none changed)
- [ ] Reviewer confirms `dualPartySignatureTable` produces equivalent OOXML for both two-party and signer-mode paths