### PR TITLE
refactor(canonical-frontmatter): preserve YAML cause + split identity helpers

### DIFF
--- a/integration-tests/canonical-frontmatter.test.ts
+++ b/integration-tests/canonical-frontmatter.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertCanonicalIdentity,
+  parseCanonicalFrontmatter,
+  tryParseCanonicalFrontmatter,
+} from '../scripts/template_renderer/canonical-frontmatter.mjs';
+
+describe('parseCanonicalFrontmatter — YAML error contract', () => {
+  it('wraps YAML parse failures with file path and preserves the original via cause', () => {
+    const malformed = '---\ntemplate_id: [unclosed\n---\nbody';
+    let captured: unknown;
+    try {
+      parseCanonicalFrontmatter(malformed, '/fake/path.md');
+    } catch (err) {
+      captured = err;
+    }
+    expect(captured).toBeInstanceOf(Error);
+    const error = captured as Error & { cause?: unknown };
+    expect(error.message).toMatch(/Canonical source frontmatter \(\/fake\/path\.md\) failed to parse:/);
+    expect(error.cause).toBeInstanceOf(Error);
+    expect(error.message).toContain((error.cause as Error).message);
+  });
+
+  it('throws when the frontmatter block is missing', () => {
+    expect(() => parseCanonicalFrontmatter('no frontmatter here', '/fake/path.md'))
+      .toThrowError(/must start with YAML frontmatter/);
+  });
+
+  it('throws when frontmatter is not a YAML object', () => {
+    const scalar = '---\njust-a-string\n---\nbody';
+    expect(() => parseCanonicalFrontmatter(scalar, '/fake/path.md'))
+      .toThrowError(/must be a YAML object/);
+  });
+});
+
+describe('tryParseCanonicalFrontmatter', () => {
+  it('returns null on parse failure', () => {
+    expect(tryParseCanonicalFrontmatter('no frontmatter here')).toBeNull();
+  });
+
+  it('returns frontmatter and body on success', () => {
+    const result = tryParseCanonicalFrontmatter('---\ntemplate_id: foo\n---\nbody');
+    expect(result?.frontmatter).toEqual({ template_id: 'foo' });
+    expect(result?.body).toBe('body');
+  });
+});
+
+describe('assertCanonicalIdentity — non-empty enforcement', () => {
+  it('passes when all three fields are non-empty strings', () => {
+    expect(() =>
+      assertCanonicalIdentity(
+        { template_id: 't', layout_id: 'l', style_id: 's' },
+        '/fake.md',
+      ),
+    ).not.toThrow();
+  });
+
+  it('throws on an empty string with a field-specific message', () => {
+    expect(() =>
+      assertCanonicalIdentity(
+        { template_id: '', layout_id: 'l', style_id: 's' },
+        '/fake.md',
+      ),
+    ).toThrowError(/missing template_id/);
+  });
+
+  it('throws on a missing field', () => {
+    expect(() =>
+      assertCanonicalIdentity(
+        { template_id: 't', layout_id: 'l' },
+        '/fake.md',
+      ),
+    ).toThrowError(/missing style_id/);
+  });
+});

--- a/scripts/template_renderer/canonical-frontmatter.mjs
+++ b/scripts/template_renderer/canonical-frontmatter.mjs
@@ -2,6 +2,10 @@ import yaml from 'js-yaml';
 
 const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/;
 
+function isNonEmptyString(value) {
+  return typeof value === 'string' && value.length > 0;
+}
+
 export function parseCanonicalFrontmatter(raw, filePath) {
   const match = raw.match(FRONTMATTER_RE);
   if (!match) {
@@ -12,7 +16,10 @@ export function parseCanonicalFrontmatter(raw, filePath) {
   try {
     frontmatter = yaml.load(match[1]);
   } catch (err) {
-    throw new Error(`Canonical source frontmatter (${filePath}) failed to parse: ${err.message}`);
+    throw new Error(
+      `Canonical source frontmatter (${filePath}) failed to parse: ${err.message}`,
+      { cause: err },
+    );
   }
 
   if (!frontmatter || typeof frontmatter !== 'object') {
@@ -30,22 +37,14 @@ export function tryParseCanonicalFrontmatter(raw) {
   }
 }
 
-export function hasCanonicalIdentity(frontmatter) {
-  return (
-    typeof frontmatter?.template_id === 'string' &&
-    typeof frontmatter?.layout_id === 'string' &&
-    typeof frontmatter?.style_id === 'string'
-  );
-}
-
 export function assertCanonicalIdentity(frontmatter, filePath) {
-  if (!frontmatter?.template_id) {
+  if (!isNonEmptyString(frontmatter?.template_id)) {
     throw new Error(`Canonical source (${filePath}) is missing template_id`);
   }
-  if (!frontmatter.layout_id) {
+  if (!isNonEmptyString(frontmatter?.layout_id)) {
     throw new Error(`Canonical source (${filePath}) is missing layout_id`);
   }
-  if (!frontmatter.style_id) {
+  if (!isNonEmptyString(frontmatter?.style_id)) {
     throw new Error(`Canonical source (${filePath}) is missing style_id`);
   }
 }

--- a/scripts/template_renderer/canonical-sources.mjs
+++ b/scripts/template_renderer/canonical-sources.mjs
@@ -1,9 +1,6 @@
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { join, relative } from 'node:path';
-import {
-  hasCanonicalIdentity,
-  tryParseCanonicalFrontmatter,
-} from './canonical-frontmatter.mjs';
+import { tryParseCanonicalFrontmatter } from './canonical-frontmatter.mjs';
 
 const TEMPLATES_DIR = 'content/templates';
 const CANONICAL_TEMPLATE_FILENAME = 'template.md';
@@ -18,6 +15,17 @@ function isDirectory(path) {
   }
 }
 
+// Discovery probes shape only (any string in the three identity fields).
+// Strict non-empty validation happens later in compileCanonicalSourceString()
+// via assertCanonicalIdentity().
+function hasCanonicalIdentityShape(frontmatter) {
+  return (
+    typeof frontmatter?.template_id === 'string' &&
+    typeof frontmatter?.layout_id === 'string' &&
+    typeof frontmatter?.style_id === 'string'
+  );
+}
+
 function isCanonicalSource(filePath) {
   let raw;
   try {
@@ -26,7 +34,7 @@ function isCanonicalSource(filePath) {
     return false;
   }
   const parsed = tryParseCanonicalFrontmatter(raw);
-  return parsed !== null && hasCanonicalIdentity(parsed.frontmatter);
+  return parsed !== null && hasCanonicalIdentityShape(parsed.frontmatter);
 }
 
 function fileExists(filePath) {


### PR DESCRIPTION
## Summary

Two surgical follow-ups to #234, surfaced by retrospective Codex + Gemini peer review:

1. **`parseCanonicalFrontmatter` preserves the YAML cause.** `throw new Error(message, { cause: err })` instead of dropping the original `YAMLException`. Wrapped message unchanged. Repo-wide grep confirmed no callers catch `YAMLException`, so this is a pure debuggability improvement.

2. **Identity helpers split by concern.**
   - `assertCanonicalIdentity` (strict, compile-time) now uses a private `isNonEmptyString()` predicate. Behavior unchanged for all current inputs — truthiness already rejected empty strings.
   - `hasCanonicalIdentity` export deleted. Its sole caller (the discovery probe in `canonical-sources.mjs`) gains a local `hasCanonicalIdentityShape()` helper with a comment clarifying that discovery probes shape only and that non-empty validation happens later via `assertCanonicalIdentity()` in `compileCanonicalSourceString()`. Codifies the two-stage "discover broadly, validate strictly" design that was previously accidental.

New `integration-tests/canonical-frontmatter.test.ts` (8 tests) locks the YAML wrap-with-cause contract and the `assertCanonicalIdentity` non-empty behavior.

## Why this PR exists

After PR #234 merged, retrospective peer reviews via Codex + Gemini flagged two non-blocking but worth-fixing items:

- **Codex #1:** PR #234 silently changed the YAML error shape (raw `YAMLException` → wrapped generic `Error`). Adding `{ cause: err }` restores the original for debugging without changing the message contract.
- **Codex #2:** `hasCanonicalIdentity` (typeof check, accepts empty strings) and `assertCanonicalIdentity` (truthiness, rejects empty strings) had inconsistent definitions in the same module. The runtime behavior was actually correct (discover broadly, validate strictly) but the design was accidental. Plan-review round 2 caught that *unifying* the helpers would change discovery behavior — instead this PR splits them by concern.

Out of scope (from the same review, deferred for separate cleanup):
- Cross-cutting `new URL(..).pathname` → `fileURLToPath()` portability cleanup (touches files outside #234 surface).
- Gemini-flagged nits (heading regex constants, `paragraphsFromLines` edge-case tests, JSDoc, dynamic fixture discovery).

Peer-review drafts kept at:
- `drafts/peer-review-pr234-{codex,gemini}-2026-04-29.md`
- `drafts/peer-review-pr234-followup-plan-{codex,gemini}-2026-04-29.md`

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] `npx vitest run integration-tests packages/contract-templates-mcp/tests` — 535/535 pass
- [x] `npm run generate:templates` — byte-identical `word/document.xml` (only `docProps/core.xml` timestamps change)
- [ ] CI green