### PR TITLE
feat(metadata): project display labels and markdown availability

### DIFF
--- a/api/_shared.ts
+++ b/api/_shared.ts
@@ -48,7 +48,7 @@ import {
   categoryFromId,
   sourceName,
   mapFields,
-  type TemplateListItem,
+  hasTemplateMarkdownSource,
 } from '../dist/core/template-listing.js';
 export { searchTemplates } from '../dist/core/template-search.js';
 export {
@@ -108,12 +108,14 @@ export interface TemplateItem {
   source_url: string;
   source: string | null;
   attribution_text?: string;
+  has_template_md: boolean;
   fields: {
     name: string;
     type: string;
     required: boolean;
     section: string | null;
     description: string;
+    display_label: string | null;
     default: string | null;
   }[];
 }
@@ -139,12 +141,13 @@ interface RawTemplateMetadata {
     type: string;
     section?: string;
     description: string;
+    display_label?: string;
     default?: string;
   }[];
   priority_fields: string[];
 }
 
-function toTemplateItem(templateId: string, meta: RawTemplateMetadata): TemplateItem {
+function toTemplateItem(templateId: string, meta: RawTemplateMetadata, hasTemplateMd = false): TemplateItem {
   return {
     name: templateId,
     display_name: meta.name,
@@ -154,6 +157,7 @@ function toTemplateItem(templateId: string, meta: RawTemplateMetadata): Template
     source_url: meta.source_url,
     source: sourceName(meta.source_url),
     attribution_text: meta.attribution_text,
+    has_template_md: hasTemplateMd,
     fields: mapFields(meta.fields, meta.priority_fields),
   };
 }
@@ -168,6 +172,7 @@ function recipeToTemplateItem(recipeId: string, meta: RecipeMetadata): TemplateI
     source_url: meta.source_url,
     source: sourceName(meta.source_url),
     attribution_text: undefined,
+    has_template_md: false,
     fields: mapFields(meta.fields, meta.priority_fields),
   };
 }
@@ -315,7 +320,7 @@ export function handleGetTemplate(templateId: string): TemplateItem | null {
   if (internalDir) {
     try {
       const meta = loadMetadata(internalDir) as RawTemplateMetadata;
-      return toTemplateItem(templateId, meta);
+      return toTemplateItem(templateId, meta, hasTemplateMarkdownSource(internalDir));
     } catch {
       return null;
     }
@@ -325,7 +330,7 @@ export function handleGetTemplate(templateId: string): TemplateItem | null {
   if (externalDir) {
     try {
       const meta = loadExternalMetadata(externalDir) as RawTemplateMetadata;
-      return toTemplateItem(templateId, meta);
+      return toTemplateItem(templateId, meta, false);
     } catch {
       return null;
     }
@@ -353,7 +358,7 @@ export function handleListTemplates(): ListOutcome {
   for (const entry of listExternalEntries()) {
     try {
       const meta = loadExternalMetadata(entry.dir) as RawTemplateMetadata;
-      external.push(toTemplateItem(entry.id, meta));
+      external.push(toTemplateItem(entry.id, meta, false));
     } catch { /* skip */ }
   }
 

--- a/content/templates/openagreements-employee-ip-inventions-assignment/metadata.yaml
+++ b/content/templates/openagreements-employee-ip-inventions-assignment/metadata.yaml
@@ -15,23 +15,28 @@ fields:
   - name: company_name
     type: string
     description: Legal name of employer
+    display_label: Company
     section: Parties
   - name: employee_name
     type: string
     description: Full legal name of employee
+    display_label: Employee
     section: Parties
   - name: effective_date
     type: date
     description: Effective date of this agreement
+    display_label: Effective Date
     section: Timing
   - name: prior_inventions_disclosure
     type: string
     description: List of prior inventions excluded from assignment, or None
+    display_label: Prior Inventions Disclosure
     default: None listed
     section: Inventions
   - name: excluded_inventions_statement
     type: string
     description: Carveout statement for independently developed inventions
+    display_label: Excluded Inventions Statement
     default: >-
       Inventions developed entirely on personal time without use of company
       equipment, supplies, facilities, confidential information, or trade
@@ -40,33 +45,40 @@ fields:
   - name: confidential_information_definition
     type: string
     description: Definition summary for confidential information obligations
+    display_label: Confidential Information Definition
     section: Confidentiality
   - name: return_of_materials_timing
     type: string
     description: Timing for return or deletion of company materials
+    display_label: Return of Materials Timing
     section: Confidentiality
   - name: post_termination_assistance
     type: string
     description: Cooperation obligations after termination
+    display_label: Post-Termination Assistance
     default: reasonable assistance with filings and signatures related to assigned inventions
     section: Inventions
   - name: governing_law
     type: string
     description: Governing law state
+    display_label: Governing Law
     default: California
     section: Legal
   - name: venue
     type: string
     description: Venue for disputes
+    display_label: Venue
     default: state and federal courts in the governing law state
     section: Legal
   - name: cloud_drive_id
     type: string
     description: Optional document-system URI or file ID for execution copy traceability
+    display_label: Cloud Drive ID
     section: Document Management
   - name: cloud_drive_id_footer
     type: string
     description: Internal computed footer text for document-system traceability
+    display_label: Cloud Drive ID Footer
     default: ''
     section: Document Management
 priority_fields: []

--- a/content/templates/openagreements-employment-confidentiality-acknowledgement/metadata.yaml
+++ b/content/templates/openagreements-employment-confidentiality-acknowledgement/metadata.yaml
@@ -15,47 +15,58 @@ fields:
   - name: company_name
     type: string
     description: Legal name of the company
+    display_label: Company
     section: Parties
   - name: employee_name
     type: string
     description: Full legal name of employee
+    display_label: Employee
     section: Parties
   - name: policy_effective_date
     type: date
     description: Effective date for this acknowledgement
+    display_label: Policy Effective Date
     section: Timing
   - name: approved_tools_scope
     type: string
     description: Approved tools/systems scope for company data
+    display_label: Approved Tools Scope
     section: Data Handling
   - name: data_access_scope
     type: string
     description: Permitted access scope and business purpose
+    display_label: Data Access Scope
     section: Data Handling
   - name: security_reporting_contact
     type: string
     description: Contact for reporting incidents or accidental disclosure
+    display_label: Security Reporting Contact
     section: Reporting
   - name: post_employment_obligations
     type: string
     description: Obligations after employment ends
+    display_label: Post-Employment Obligations
     default: no retention, sharing, or use of company confidential information after termination
     section: Post-Employment
   - name: acknowledgement_date
     type: date
     description: Date of employee acknowledgement
+    display_label: Acknowledgement Date
     section: Signature
   - name: signatory_name
     type: string
     description: Printed name used in signature block
+    display_label: Signatory Name
     section: Signature
   - name: cloud_drive_id
     type: string
     description: Optional document-system URI or file ID for execution copy traceability
+    display_label: Cloud Drive ID
     section: Document Management
   - name: cloud_drive_id_footer
     type: string
     description: Internal computed footer text for document-system traceability
+    display_label: Cloud Drive ID Footer
     default: ''
     section: Document Management
 priority_fields: []

--- a/content/templates/openagreements-employment-offer-letter/metadata.yaml
+++ b/content/templates/openagreements-employment-offer-letter/metadata.yaml
@@ -15,18 +15,22 @@ fields:
   - name: employer_name
     type: string
     description: Legal name of the employer
+    display_label: Employer
     section: Parties
   - name: employee_name
     type: string
     description: Full legal name of the employee
+    display_label: Employee
     section: Parties
   - name: position_title
     type: string
     description: Offered role title
+    display_label: Position Title
     section: Role
   - name: employment_type
     type: enum
     description: Employment basis
+    display_label: Employment Type
     options:
       - full-time
       - part-time
@@ -34,43 +38,53 @@ fields:
   - name: start_date
     type: date
     description: Employment start date
+    display_label: Start Date
     section: Timing
   - name: reporting_manager
     type: string
     description: Manager or role this position reports to
+    display_label: Reporting Manager
     section: Role
   - name: base_salary
     type: string
     description: Base salary or hourly amount
+    display_label: Base Salary
     section: Compensation
   - name: bonus_terms
     type: string
     description: Bonus eligibility summary
+    display_label: Bonus Terms
     section: Compensation
   - name: equity_terms
     type: string
     description: Equity grant summary, if any
+    display_label: Equity Terms
     section: Compensation
   - name: work_location
     type: string
     description: Primary work location and/or remote status
+    display_label: Primary Work Location
     section: Work Model
   - name: governing_law
     type: string
     description: Governing law state for the offer letter
+    display_label: Governing Law
     default: California
     section: Legal
   - name: offer_expiration_date
     type: date
     description: Date by which the offer must be accepted
+    display_label: Offer Expiration Date
     section: Timing
   - name: cloud_drive_id
     type: string
     description: Optional document-system URI or file ID for execution copy traceability
+    display_label: Cloud Drive ID
     section: Document Management
   - name: cloud_drive_id_footer
     type: string
     description: Internal computed footer text for document-system traceability
+    display_label: Cloud Drive ID Footer
     default: ''
     section: Document Management
 priority_fields: []

--- a/content/templates/openagreements-restrictive-covenant-wyoming/metadata.yaml
+++ b/content/templates/openagreements-restrictive-covenant-wyoming/metadata.yaml
@@ -20,23 +20,28 @@ fields:
   - name: employer_name
     type: string
     description: Legal name of the employer
+    display_label: Employer
     section: Parties
   - name: employee_name
     type: string
     description: Full legal name of the employee
+    display_label: Employee
     section: Parties
   - name: employee_title
     type: string
     description: Employee job title or position (optional)
+    display_label: Employee Title / Position
     default: ''
     section: Parties
   - name: effective_date
     type: date
     description: Effective date of this agreement
+    display_label: Effective Date
     section: Timing
   - name: governing_law
     type: string
     description: Governing law state
+    display_label: Governing Law
     default: Wyoming
     section: Legal
 
@@ -46,6 +51,7 @@ fields:
     description: >-
       Employee role classification under Wyo. Stat. section 1-23-108.
       AI-only field that drives memo warnings. Not shown in the output document.
+    display_label: Worker Category
     options:
       - Executive
       - Management
@@ -60,6 +66,7 @@ fields:
       AI-only field that drives memo warnings and conditional gating.
       Not shown in the output document. Options: Executive or Management
       Personnel, Trade Secret Protection, None.
+    display_label: Restriction Pathways
     default: None
     section: AI Analysis
 
@@ -67,11 +74,13 @@ fields:
   - name: confidentiality_trade_secret_duration
     type: string
     description: Duration of confidentiality obligations for trade secrets
+    display_label: Confidentiality - Trade Secrets Duration
     default: Perpetual
     section: Confidentiality
   - name: confidentiality_other_duration
     type: string
     description: Duration of confidentiality obligations for non-trade-secret information
+    display_label: Confidentiality - Other Confidential Information Duration
     default: 24 months
     default_value_rationale: >-
       24 months is common for non-trade-secret confidentiality obligations
@@ -82,11 +91,13 @@ fields:
   - name: employee_nonsolicit_included
     type: boolean
     description: Whether the employee non-solicitation covenant is included
+    display_label: Include Employee Non-Solicitation
     default: 'true'
     section: Employee Non-Solicitation
   - name: employee_nonsolicit_duration
     type: string
     description: Duration of employee non-solicitation restriction
+    display_label: Employee Non-Solicitation - Duration
     default: 12 months
     default_value_rationale: >-
       12 months is the most common enforceable duration. Mayer Brown guidance
@@ -97,6 +108,7 @@ fields:
     description: >-
       Lookback period for determining which employees are covered by
       the non-solicitation restriction.
+    display_label: Covered Employees Lookback Period
     default: 12 months
     default_value_rationale: >-
       12 months is the most common lookback period for employee
@@ -107,11 +119,13 @@ fields:
   - name: customer_nonsolicit_included
     type: boolean
     description: Whether the customer/partner non-solicitation covenant is included
+    display_label: Include Customer Non-Solicitation
     default: 'true'
     section: Customer Non-Solicitation
   - name: customer_nonsolicit_duration
     type: string
     description: Duration of customer/partner non-solicitation restriction
+    display_label: Customer Non-Solicitation - Duration
     default: 12 months
     default_value_rationale: >-
       12 months is the most common enforceable duration. Compass Minerals uses
@@ -122,6 +136,7 @@ fields:
     description: >-
       Lookback period for determining which customers are covered by
       the non-solicitation and non-dealing restrictions.
+    display_label: Covered Customers Lookback Period
     default: 12 months
     default_value_rationale: >-
       12 months is the most common lookback period for customer
@@ -134,6 +149,7 @@ fields:
     description: >-
       Whether the non-competition covenant is included. Requires a lawful
       restriction pathway under Wyo. Stat. section 1-23-108.
+    display_label: Include Non-Competition
     default: 'false'
     default_value_rationale: >-
       Wyo. Stat. section 1-23-108 voids most non-compete covenants. The
@@ -143,6 +159,7 @@ fields:
   - name: noncompete_duration
     type: string
     description: Duration of non-competition restriction
+    display_label: Non-Competition - Duration
     default: 12 months
     default_value_rationale: >-
       12 months is the most common enforceable duration. Hassler v. Circle C
@@ -152,6 +169,7 @@ fields:
   - name: territory
     type: string
     description: Geographic scope of the non-competition restriction
+    display_label: Non-Competition - Restricted Territory
     default: the geographic area in which Employee provided services
     default_value_rationale: >-
       Tied to the employee's actual service area. Narrower scope improves
@@ -162,12 +180,14 @@ fields:
     description: >-
       Description of the business activities that constitute competition
       with the employer.
+    display_label: Non-Competition - Competitive Business
     section: Non-Competition
   - name: specified_competitors
     type: string
     description: >-
       Optional named list of specific competitors. Narrowing the restriction
       to named competitors strengthens enforceability.
+    display_label: Non-Competition - Specified Competitors
     default: ''
     section: Non-Competition
 
@@ -177,11 +197,13 @@ fields:
     description: >-
       Whether the no-business-with-covered-customers covenant is included.
       Requires a lawful restriction pathway under Wyo. Stat. section 1-23-108.
+    display_label: Include No Business with Covered Customers
     default: 'false'
     section: No Business with Covered Customers
   - name: nondealing_duration
     type: string
     description: Duration of the no-business-with-covered-customers restriction
+    display_label: No Business with Covered Customers - Duration
     default: 12 months
     section: No Business with Covered Customers
 
@@ -191,6 +213,7 @@ fields:
     description: >-
       Maximum ownership percentage of publicly traded securities permitted
       under the Passive Public Holdings carveout.
+    display_label: Passive Public Holdings Threshold
     default: five percent
     default_value_rationale: >-
       Five percent of any class of publicly traded securities is the standard
@@ -204,11 +227,13 @@ fields:
     description: >-
       Whether the non-investment covenant is included. Requires a lawful
       restriction pathway under Wyo. Stat. section 1-23-108.
+    display_label: Include Non-Investment
     default: 'false'
     section: Non-Investment
   - name: noninvestment_duration
     type: string
     description: Duration of non-investment restriction
+    display_label: Non-Investment - Duration
     default: 12 months
     section: Non-Investment
 
@@ -216,6 +241,7 @@ fields:
   - name: nondisparagement_duration
     type: string
     description: Duration of non-disparagement obligation (measured from termination)
+    display_label: Non-Disparagement - Duration
     default: 24 months
     default_value_rationale: >-
       24 months is common for employment non-disparagement provisions.
@@ -225,10 +251,12 @@ fields:
   - name: cloud_drive_id
     type: string
     description: Optional document-system URI or file ID for execution copy traceability
+    display_label: Cloud Drive ID
     section: Document Management
   - name: cloud_drive_id_footer
     type: string
     description: Internal computed footer text for document-system traceability
+    display_label: Cloud Drive ID Footer
     default: ''
     section: Document Management
 priority_fields:

--- a/data/templates-snapshot.json
+++ b/data/templates-snapshot.json
@@ -22,7 +22,8 @@
           "section": "Parties",
           "description": "Full legal name of the first party",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_2_name",
@@ -31,7 +32,8 @@
           "section": "Parties",
           "description": "Full legal name of the second party",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "effective_date",
@@ -40,7 +42,8 @@
           "section": "Terms",
           "description": "Date the NDA takes effect",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "purpose",
@@ -49,7 +52,8 @@
           "section": "Terms",
           "description": "Permitted purpose for sharing confidential information",
           "default": "Evaluating a potential business relationship",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "nda_term",
@@ -58,7 +62,8 @@
           "section": "Terms",
           "description": "Duration of the NDA agreement and disclosure period",
           "default": "1 year",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "confidentiality_period",
@@ -67,7 +72,8 @@
           "section": "Terms",
           "description": "How long confidential information remains protected after NDA expires",
           "default": "1 year",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "governing_law",
@@ -76,7 +82,8 @@
           "section": "Legal",
           "description": "State or jurisdiction whose laws govern the agreement",
           "default": "California",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "courts",
@@ -85,7 +92,8 @@
           "section": "Legal",
           "description": "Courts with jurisdiction over disputes",
           "default": "courts located in San Francisco, California",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_1_signatory_type",
@@ -94,7 +102,8 @@
           "section": "Signatures",
           "description": "Whether Party 1 signatory is an entity or individual",
           "default": "entity",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_1_signatory_name",
@@ -103,7 +112,8 @@
           "section": "Signatures",
           "description": "Full name of the person signing for Party 1",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_1_signatory_title",
@@ -112,7 +122,8 @@
           "section": "Signatures",
           "description": "Title of the person signing for Party 1",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_1_signatory_company",
@@ -121,7 +132,8 @@
           "section": "Signatures",
           "description": "Company of the signatory for Party 1 (defaults to party_1_name)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_1_email",
@@ -130,7 +142,8 @@
           "section": "Signatures",
           "description": "Notice email address for Party 1",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_1_address",
@@ -139,7 +152,8 @@
           "section": "Signatures",
           "description": "Notice postal address for Party 1",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_2_signatory_type",
@@ -148,7 +162,8 @@
           "section": "Signatures",
           "description": "Whether Party 2 signatory is an entity or individual",
           "default": "entity",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_2_signatory_name",
@@ -157,7 +172,8 @@
           "section": "Signatures",
           "description": "Full name of the person signing for Party 2",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_2_signatory_title",
@@ -166,7 +182,8 @@
           "section": "Signatures",
           "description": "Title of the person signing for Party 2",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_2_signatory_company",
@@ -175,7 +192,8 @@
           "section": "Signatures",
           "description": "Company of the signatory for Party 2 (defaults to party_2_name)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_2_email",
@@ -184,7 +202,8 @@
           "section": "Signatures",
           "description": "Notice email address for Party 2",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_2_address",
@@ -193,7 +212,8 @@
           "section": "Signatures",
           "description": "Notice postal address for Party 2",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_1_signatory_name_and_title",
@@ -202,7 +222,8 @@
           "section": "Signatures",
           "description": "Computed display field (Name, Title)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_2_signatory_name_and_title",
@@ -211,7 +232,8 @@
           "section": "Signatures",
           "description": "Computed display field (Name, Title)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_1_notice_email_check",
@@ -220,7 +242,8 @@
           "section": "Signatures",
           "description": "Computed checkbox glyph for email notice",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_1_notice_postal_check",
@@ -229,7 +252,8 @@
           "section": "Signatures",
           "description": "Computed checkbox glyph for postal notice",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_2_notice_email_check",
@@ -238,7 +262,8 @@
           "section": "Signatures",
           "description": "Computed checkbox glyph for email notice",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_2_notice_postal_check",
@@ -247,9 +272,11 @@
           "section": "Signatures",
           "description": "Computed checkbox glyph for postal notice",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         }
-      ]
+      ],
+      "has_template_md": false
     },
     {
       "name": "bonterms-professional-services-agreement",
@@ -271,7 +298,8 @@
           "section": "Parties",
           "description": "Full legal name of the customer",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_name",
@@ -280,7 +308,8 @@
           "section": "Parties",
           "description": "Full legal name of the provider",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "effective_date",
@@ -289,7 +318,8 @@
           "section": "Terms",
           "description": "Date the agreement takes effect",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "governing_law",
@@ -298,7 +328,8 @@
           "section": "Legal",
           "description": "State or jurisdiction whose laws govern the agreement",
           "default": "California",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "courts",
@@ -307,7 +338,8 @@
           "section": "Legal",
           "description": "Courts with jurisdiction over disputes",
           "default": "courts located in San Francisco, California",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "deliverables_type",
@@ -316,9 +348,11 @@
           "section": "Terms",
           "description": "Type of rights in deliverables: \"licensed\" or \"assigned\"",
           "default": "licensed",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         }
-      ]
+      ],
+      "has_template_md": false
     },
     {
       "name": "closing-checklist",
@@ -340,7 +374,8 @@
           "section": null,
           "description": "Name of the deal or transaction",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "updated_at",
@@ -349,7 +384,8 @@
           "section": null,
           "description": "ISO date when the checklist was last updated",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "documents",
@@ -358,7 +394,8 @@
           "section": null,
           "description": "Checklist entry rows with 4 columns: number, title, status (human-readable), responsible_party. Stage headings and citation/signatory sub-rows are included.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "action_items",
@@ -367,7 +404,8 @@
           "section": null,
           "description": "Unlinked action items (item_id, description, status, assigned_to, due_date)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "open_issues",
@@ -376,9 +414,11 @@
           "section": null,
           "description": "Unlinked issues (issue_id, title, status, summary)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         }
-      ]
+      ],
+      "has_template_md": false
     },
     {
       "name": "common-paper-ai-addendum",
@@ -400,7 +440,8 @@
           "section": "Parties",
           "description": "Official company name",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "agreement_description",
@@ -409,7 +450,8 @@
           "section": "Terms",
           "description": "Description of the underlying agreement",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "ai_policy_reference",
@@ -418,7 +460,8 @@
           "section": "Service",
           "description": "Reference to AI usage policy",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "additional_terms",
@@ -427,7 +470,8 @@
           "section": "Legal",
           "description": "Additional AI-specific terms",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "training_data_none",
@@ -436,7 +480,8 @@
           "section": "AI Training",
           "description": "No Training Data types selected",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "training_data_usage",
@@ -445,7 +490,8 @@
           "section": "AI Training",
           "description": "Usage Data is Training Data",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "training_data_feedback",
@@ -454,7 +500,8 @@
           "section": "AI Training",
           "description": "Feedback is Training Data",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "training_data_input",
@@ -463,7 +510,8 @@
           "section": "AI Training",
           "description": "Input is Training Data",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "training_data_output",
@@ -472,7 +520,8 @@
           "section": "AI Training",
           "description": "Output is Training Data",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "training_data_prompts",
@@ -481,7 +530,8 @@
           "section": "AI Training",
           "description": "User prompts (excluding other Input) are Training Data",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "training_data_customer_content",
@@ -490,7 +540,8 @@
           "section": "AI Training",
           "description": "Customer Content is Training Data",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "training_data_additional",
@@ -499,7 +550,8 @@
           "section": "AI Training",
           "description": "Additional Training Data types apply",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "model_training_none",
@@ -508,7 +560,8 @@
           "section": "AI Training",
           "description": "No model training permitted",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "model_training_customer_only",
@@ -517,7 +570,8 @@
           "section": "AI Training",
           "description": "Model training solely for Customer benefit",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "training_data_aggregated",
@@ -526,7 +580,8 @@
           "section": "AI Training",
           "description": "Training Data must be aggregated",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "training_data_deidentified",
@@ -535,7 +590,8 @@
           "section": "AI Training",
           "description": "Training Data must be de-identified",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "training_data_best_effort_deidentify",
@@ -544,7 +600,8 @@
           "section": "AI Training",
           "description": "Provider will use commercially reasonable efforts to de-identify Training Data",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "training_requirements_additional",
@@ -553,7 +610,8 @@
           "section": "AI Training",
           "description": "Additional Training Data requirements apply",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "no_customer_identification",
@@ -562,7 +620,8 @@
           "section": "AI Output",
           "description": "Neither Input nor Output may identify Customer",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "improvements_for_customer_only",
@@ -571,7 +630,8 @@
           "section": "AI Output",
           "description": "Improvements from Customer data solely for Customer benefit",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "output_restrictions_additional",
@@ -580,7 +640,8 @@
           "section": "AI Output",
           "description": "Additional output restrictions apply",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "ai_provider_covered_claims",
@@ -589,7 +650,8 @@
           "section": "AI Liability",
           "description": "Provider AI-specific Covered Claims apply",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_covered_claims_detail",
@@ -598,7 +660,8 @@
           "section": "AI Liability",
           "description": "Detail of Provider Covered Claims describing Output IP infringement provisions",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_covered_claims_exclusions",
@@ -607,7 +670,8 @@
           "section": "AI Liability",
           "description": "Provider Covered Claims indemnity exclusions (e.g. combined use, Input, breach, modifications)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_covered_claims_detail",
@@ -616,7 +680,8 @@
           "section": "AI Liability",
           "description": "Detail of Customer Covered Claims describing IP infringement and usage violation provisions",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "ai_customer_covered_claims",
@@ -625,7 +690,8 @@
           "section": "AI Liability",
           "description": "Customer AI-specific Covered Claims apply",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_type",
@@ -634,7 +700,8 @@
           "section": "Signature Block",
           "description": "Whether the Provider signatory is an entity or individual",
           "default": "entity",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_name",
@@ -643,7 +710,8 @@
           "section": "Signature Block",
           "description": "Full legal name of the Provider's signatory",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_title",
@@ -652,7 +720,8 @@
           "section": "Signature Block",
           "description": "Title/role of the Provider's signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_company",
@@ -661,7 +730,8 @@
           "section": "Signature Block",
           "description": "Company name for the Provider signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_email",
@@ -670,7 +740,8 @@
           "section": "Signature Block",
           "description": "Notice email address for the Provider",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_type",
@@ -679,7 +750,8 @@
           "section": "Signature Block",
           "description": "Whether the Customer signatory is an entity or individual",
           "default": "entity",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_name",
@@ -688,7 +760,8 @@
           "section": "Signature Block",
           "description": "Full legal name of the Customer's signatory",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_title",
@@ -697,7 +770,8 @@
           "section": "Signature Block",
           "description": "Title/role of the Customer's signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_company",
@@ -706,7 +780,8 @@
           "section": "Signature Block",
           "description": "Company name for the Customer signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_email",
@@ -715,9 +790,11 @@
           "section": "Signature Block",
           "description": "Notice email address for the Customer",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         }
-      ]
+      ],
+      "has_template_md": false
     },
     {
       "name": "common-paper-ai-addendum-in-app",
@@ -739,7 +816,8 @@
           "section": "Service",
           "description": "Reference to AI usage policy",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "additional_terms",
@@ -748,7 +826,8 @@
           "section": "Legal",
           "description": "Additional AI-specific terms",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "training_data_none",
@@ -757,7 +836,8 @@
           "section": "AI Training",
           "description": "No Training Data types selected",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "training_data_usage",
@@ -766,7 +846,8 @@
           "section": "AI Training",
           "description": "Usage Data is Training Data",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "training_data_feedback",
@@ -775,7 +856,8 @@
           "section": "AI Training",
           "description": "Feedback is Training Data",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "training_data_input",
@@ -784,7 +866,8 @@
           "section": "AI Training",
           "description": "Input is Training Data",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "training_data_output",
@@ -793,7 +876,8 @@
           "section": "AI Training",
           "description": "Output is Training Data",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "training_data_prompts",
@@ -802,7 +886,8 @@
           "section": "AI Training",
           "description": "User prompts (excluding other Input) are Training Data",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "training_data_customer_content",
@@ -811,7 +896,8 @@
           "section": "AI Training",
           "description": "Customer Content is Training Data",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "training_data_additional",
@@ -820,7 +906,8 @@
           "section": "AI Training",
           "description": "Additional Training Data types apply",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "model_training_none",
@@ -829,7 +916,8 @@
           "section": "AI Training",
           "description": "No model training permitted",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "model_training_customer_only",
@@ -838,7 +926,8 @@
           "section": "AI Training",
           "description": "Model training solely for Customer benefit",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "training_data_aggregated",
@@ -847,7 +936,8 @@
           "section": "AI Training",
           "description": "Training Data must be aggregated",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "training_data_deidentified",
@@ -856,7 +946,8 @@
           "section": "AI Training",
           "description": "Training Data must be de-identified",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "training_data_best_effort_deidentify",
@@ -865,7 +956,8 @@
           "section": "AI Training",
           "description": "Provider will use commercially reasonable efforts to de-identify Training Data",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "training_requirements_additional",
@@ -874,7 +966,8 @@
           "section": "AI Training",
           "description": "Additional Training Data requirements apply",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "no_customer_identification",
@@ -883,7 +976,8 @@
           "section": "AI Output",
           "description": "Neither Input nor Output may identify Customer",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "improvements_for_customer_only",
@@ -892,7 +986,8 @@
           "section": "AI Output",
           "description": "Improvements from Customer data solely for Customer benefit",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "output_restrictions_additional",
@@ -901,7 +996,8 @@
           "section": "AI Output",
           "description": "Additional output restrictions apply",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "ai_provider_covered_claims",
@@ -910,7 +1006,8 @@
           "section": "AI Liability",
           "description": "Provider AI-specific Covered Claims apply",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_covered_claims_detail",
@@ -919,7 +1016,8 @@
           "section": "AI Liability",
           "description": "Detail of Provider Covered Claims describing Output IP infringement provisions",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_covered_claims_exclusions",
@@ -928,7 +1026,8 @@
           "section": "AI Liability",
           "description": "Provider Covered Claims indemnity exclusions (e.g. combined use, Input, breach, modifications)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_covered_claims_detail",
@@ -937,7 +1036,8 @@
           "section": "AI Liability",
           "description": "Detail of Customer Covered Claims describing IP infringement and usage violation provisions",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "ai_customer_covered_claims",
@@ -946,9 +1046,11 @@
           "section": "AI Liability",
           "description": "Customer AI-specific Covered Claims apply",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         }
-      ]
+      ],
+      "has_template_md": false
     },
     {
       "name": "common-paper-amendment",
@@ -970,7 +1072,8 @@
           "section": "Parties",
           "description": "Company name (shown in header)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_1",
@@ -979,7 +1082,8 @@
           "section": "Parties",
           "description": "Full name of the first party to the original agreement",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_2",
@@ -988,7 +1092,8 @@
           "section": "Parties",
           "description": "Full name of the second party to the original agreement",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "agreement_name",
@@ -997,7 +1102,8 @@
           "section": "Terms",
           "description": "Name of the agreement being amended",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "agreement_date",
@@ -1006,7 +1112,8 @@
           "section": "Terms",
           "description": "Date of the original agreement",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "amendment_effective_date",
@@ -1015,7 +1122,8 @@
           "section": "Terms",
           "description": "Effective date of this amendment",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "amendment_topic",
@@ -1024,7 +1132,8 @@
           "section": "Terms",
           "description": "Topic or variable being changed",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "amendment_details",
@@ -1033,7 +1142,8 @@
           "section": "Terms",
           "description": "Details about what is being changed",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_1_signatory_type",
@@ -1042,7 +1152,8 @@
           "section": "Signature Block",
           "description": "Whether the first party signatory is an entity or individual",
           "default": "entity",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_1_signatory_name",
@@ -1051,7 +1162,8 @@
           "section": "Signature Block",
           "description": "Full legal name of the first party's signatory",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_1_signatory_title",
@@ -1060,7 +1172,8 @@
           "section": "Signature Block",
           "description": "Title/role of the first party's signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_1_signatory_company",
@@ -1069,7 +1182,8 @@
           "section": "Signature Block",
           "description": "Company name for the first party signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_1_signatory_email",
@@ -1078,7 +1192,8 @@
           "section": "Signature Block",
           "description": "Notice email address for the first party",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_2_signatory_type",
@@ -1087,7 +1202,8 @@
           "section": "Signature Block",
           "description": "Whether the second party signatory is an entity or individual",
           "default": "entity",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_2_signatory_name",
@@ -1096,7 +1212,8 @@
           "section": "Signature Block",
           "description": "Full legal name of the second party's signatory",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_2_signatory_title",
@@ -1105,7 +1222,8 @@
           "section": "Signature Block",
           "description": "Title/role of the second party's signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_2_signatory_company",
@@ -1114,7 +1232,8 @@
           "section": "Signature Block",
           "description": "Company name for the second party signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_2_signatory_email",
@@ -1123,9 +1242,11 @@
           "section": "Signature Block",
           "description": "Notice email address for the second party",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         }
-      ]
+      ],
+      "has_template_md": false
     },
     {
       "name": "common-paper-business-associate-agreement",
@@ -1147,7 +1268,8 @@
           "section": "Parties",
           "description": "Official company name",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_role",
@@ -1156,7 +1278,8 @@
           "section": "Parties",
           "description": "Role in the agreement (Business Associate or Covered Entity)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "principal_agreement",
@@ -1165,7 +1288,8 @@
           "section": "Terms",
           "description": "Reference to the principal agreement",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "subcontractor_role",
@@ -1174,7 +1298,8 @@
           "section": "Terms",
           "description": "Role of subcontractors",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "free_text",
@@ -1183,7 +1308,8 @@
           "section": "Terms",
           "description": "Free text entry",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "aggregation_restrictions",
@@ -1192,7 +1318,8 @@
           "section": "Terms",
           "description": "Specific aggregation restrictions",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "offshoring_restrictions",
@@ -1201,7 +1328,8 @@
           "section": "Terms",
           "description": "Specific offshoring rights or restrictions",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "breach_notification_unit",
@@ -1210,7 +1338,8 @@
           "section": "Terms",
           "description": "Unit for breach notification period",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "breach_notification_number",
@@ -1219,7 +1348,8 @@
           "section": "Terms",
           "description": "Numeric value for the breach notification period (e.g. 5)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "other_changes",
@@ -1228,7 +1358,8 @@
           "section": "Terms",
           "description": "Prose describing other changes to BAA Standard Terms",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "custom_effective_date",
@@ -1237,7 +1368,8 @@
           "section": "Terms",
           "description": "Custom effective date (if not date of last signature)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "maintains_designated_record_set",
@@ -1246,7 +1378,8 @@
           "section": "Terms",
           "description": "Whether Provider maintains PHI in a Designated Record Set",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "no_subcontracting",
@@ -1255,7 +1388,8 @@
           "section": "Subcontracting",
           "description": "Provider will not subcontract",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "subcontracting_with_conditions",
@@ -1264,7 +1398,8 @@
           "section": "Subcontracting",
           "description": "Provider will not subcontract unless conditions are met",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "subcontract_notice_required",
@@ -1273,7 +1408,8 @@
           "section": "Subcontracting",
           "description": "Notice must be provided to Company before subcontracting",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "subcontract_permission_required",
@@ -1282,7 +1418,8 @@
           "section": "Subcontracting",
           "description": "Company explicit permission required for subcontracting",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "no_offshoring",
@@ -1291,7 +1428,8 @@
           "section": "Subcontracting",
           "description": "Offshoring of PHI and/or Services is not permitted",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "offshoring_with_conditions",
@@ -1300,7 +1438,8 @@
           "section": "Subcontracting",
           "description": "Offshoring not permitted unless conditions met",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "no_deidentification",
@@ -1309,7 +1448,8 @@
           "section": "De-identification",
           "description": "Provider will not de-identify PHI",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "deidentification_with_conditions",
@@ -1318,7 +1458,8 @@
           "section": "De-identification",
           "description": "Provider will not de-identify PHI unless conditions met",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "deidentification_purpose",
@@ -1327,7 +1468,8 @@
           "section": "De-identification",
           "description": "Specific purpose(s) for which Provider may de-identify PHI (e.g. generating data analytics)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "deidentify_for_purpose",
@@ -1336,7 +1478,8 @@
           "section": "De-identification",
           "description": "De-identification for specific purposes only",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "deidentify_additional_requirements",
@@ -1345,7 +1488,8 @@
           "section": "De-identification",
           "description": "Additional requirements for de-identifying PHI",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "no_aggregation",
@@ -1354,7 +1498,8 @@
           "section": "De-identification",
           "description": "Provider will not aggregate PHI",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "aggregation_with_conditions",
@@ -1363,7 +1508,8 @@
           "section": "De-identification",
           "description": "Provider will not aggregate PHI unless conditions met",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_type",
@@ -1372,7 +1518,8 @@
           "section": "Signature Block",
           "description": "Whether the Provider signatory is an entity or individual",
           "default": "entity",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_name",
@@ -1381,7 +1528,8 @@
           "section": "Signature Block",
           "description": "Full legal name of the Provider's signatory",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_title",
@@ -1390,7 +1538,8 @@
           "section": "Signature Block",
           "description": "Title/role of the Provider's signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_company",
@@ -1399,7 +1548,8 @@
           "section": "Signature Block",
           "description": "Company name for the Provider signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_email",
@@ -1408,7 +1558,8 @@
           "section": "Signature Block",
           "description": "Notice email address for the Provider",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "company_signatory_type",
@@ -1417,7 +1568,8 @@
           "section": "Signature Block",
           "description": "Whether the Company signatory is an entity or individual",
           "default": "entity",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "company_signatory_name",
@@ -1426,7 +1578,8 @@
           "section": "Signature Block",
           "description": "Full legal name of the Company's signatory",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "company_signatory_title",
@@ -1435,7 +1588,8 @@
           "section": "Signature Block",
           "description": "Title/role of the Company's signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "company_signatory_company",
@@ -1444,7 +1598,8 @@
           "section": "Signature Block",
           "description": "Company name for the Company signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "company_signatory_email",
@@ -1453,9 +1608,11 @@
           "section": "Signature Block",
           "description": "Notice email address for the Company",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         }
-      ]
+      ],
+      "has_template_md": false
     },
     {
       "name": "common-paper-cloud-service-agreement",
@@ -1477,7 +1634,8 @@
           "section": "Parties",
           "description": "Name of the cloud service provider",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_name",
@@ -1486,7 +1644,8 @@
           "section": "Parties",
           "description": "Name of the customer",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_legal_name",
@@ -1495,7 +1654,8 @@
           "section": "Parties",
           "description": "Official legal entity name of provider (for signature block)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_legal_name",
@@ -1504,7 +1664,8 @@
           "section": "Parties",
           "description": "Official legal entity name of customer (for signature block)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "effective_date",
@@ -1513,7 +1674,8 @@
           "section": "Terms",
           "description": "Effective Date of Key Terms referenced in Order Form",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cloud_service",
@@ -1522,7 +1684,8 @@
           "section": "Service",
           "description": "Description of the cloud service / product",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "order_date_is_last_signature",
@@ -1531,7 +1694,8 @@
           "section": "Terms",
           "description": "If true, order date is date of last signature; if false, use custom_order_date",
           "default": "true",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "custom_order_date",
@@ -1540,7 +1704,8 @@
           "section": "Terms",
           "description": "Custom start date (only used when order_date_is_last_signature is false)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_pilot",
@@ -1549,7 +1714,8 @@
           "section": "Service",
           "description": "Whether a pilot/trial period is included",
           "default": "false",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "pilot_period",
@@ -1558,7 +1724,8 @@
           "section": "Service",
           "description": "Length of pilot/trial period (e.g. \"3 months\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "pilot_is_free",
@@ -1567,7 +1734,8 @@
           "section": "Service",
           "description": "If true, pilot is a free trial; if false, pilot has a fee",
           "default": "true",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "pilot_fee",
@@ -1576,7 +1744,8 @@
           "section": "Payment",
           "description": "Fee for pilot period (e.g. \"$500\"). Only used when pilot_is_free is false",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "pilot_modifications",
@@ -1585,7 +1754,8 @@
           "section": "Service",
           "description": "Modifications to the Agreement that apply only during the Pilot Period",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "subscription_period",
@@ -1594,7 +1764,8 @@
           "section": "Service",
           "description": "Length of access to the service (e.g. \"12 months\", \"1 year\")",
           "default": "12 months",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_is_per_unit",
@@ -1603,7 +1774,8 @@
           "section": "Payment",
           "description": "Whether fees are per-unit pricing (amount per fee_unit)",
           "default": "true",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fees",
@@ -1612,7 +1784,8 @@
           "section": "Payment",
           "description": "Subscription fee amount (e.g. \"$10,000\"). Used in computed fees_display.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_unit",
@@ -1621,7 +1794,8 @@
           "section": "Payment",
           "description": "Fee billing unit (e.g. \"year\", \"month\", \"User\"). Used in computed fees_display.",
           "default": "year",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_is_other",
@@ -1630,7 +1804,8 @@
           "section": "Payment",
           "description": "Whether an alternative fee structure is used",
           "default": "false",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "other_fee_structure",
@@ -1639,7 +1814,8 @@
           "section": "Payment",
           "description": "Description of alternative fee structure",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_may_increase",
@@ -1648,7 +1824,8 @@
           "section": "Payment",
           "description": "Whether fees may increase up to a cap percentage per renewal",
           "default": "false",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_increase_cap_pct",
@@ -1657,7 +1834,8 @@
           "section": "Payment",
           "description": "Maximum percentage fees may increase per renewal (e.g. \"5\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_will_increase",
@@ -1666,7 +1844,8 @@
           "section": "Payment",
           "description": "Whether fees will increase by a fixed percentage per renewal",
           "default": "false",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_increase_fixed_pct",
@@ -1675,7 +1854,8 @@
           "section": "Payment",
           "description": "Fixed percentage fees will increase per renewal (e.g. \"3\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_inclusive_of_taxes",
@@ -1684,7 +1864,8 @@
           "section": "Payment",
           "description": "Whether fees are inclusive of taxes (modifies Standard Terms Section 4.1)",
           "default": "false",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "payment_by_invoice",
@@ -1693,7 +1874,8 @@
           "section": "Payment",
           "description": "If true, payment by invoice; if false, automatic payment",
           "default": "true",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "payment_frequency",
@@ -1702,7 +1884,8 @@
           "section": "Payment",
           "description": "Billing frequency (e.g. \"monthly\", \"quarterly\", \"annually\")",
           "default": "annually",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "payment_terms_days",
@@ -1711,7 +1894,8 @@
           "section": "Payment",
           "description": "Days to pay after invoice (e.g. \"30\", \"45\"). Only for invoice payment",
           "default": "30",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "payment_due_from",
@@ -1720,7 +1904,8 @@
           "section": "Payment",
           "description": "When payment terms start (e.g. \"Customer's receipt of invoice\")",
           "default": "the invoice date",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "auto_renew",
@@ -1729,7 +1914,8 @@
           "section": "Terms",
           "description": "If true, order auto-renews with non-renewal notice; if false, expires at end",
           "default": "true",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "non_renewal_notice_days",
@@ -1738,7 +1924,8 @@
           "section": "Terms",
           "description": "Days of notice required before non-renewal (e.g. \"30\", \"60\"). Used in computed auto_renewal_display.",
           "default": "30",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_use_limitations",
@@ -1747,7 +1934,8 @@
           "section": "Service",
           "description": "Whether use limitations are specified",
           "default": "false",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "use_limitations",
@@ -1756,7 +1944,8 @@
           "section": "Service",
           "description": "Geographic restrictions, system requirements, or other use limitations",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_technical_support",
@@ -1765,7 +1954,8 @@
           "section": "Service",
           "description": "Whether technical support details are included",
           "default": "false",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "technical_support",
@@ -1774,7 +1964,8 @@
           "section": "Service",
           "description": "Description of included support and how to access it",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_sla",
@@ -1783,7 +1974,8 @@
           "section": "Service",
           "description": "Whether an SLA is included",
           "default": "false",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "sla_description",
@@ -1792,7 +1984,8 @@
           "section": "Service",
           "description": "Service Level Agreement details",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_professional_services",
@@ -1801,7 +1994,8 @@
           "section": "Service",
           "description": "Whether professional services are included",
           "default": "false",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "professional_services_description",
@@ -1810,7 +2004,8 @@
           "section": "Service",
           "description": "Professional services description or SOW reference",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "effective_date_is_last_signature",
@@ -1819,7 +2014,8 @@
           "section": "Legal",
           "description": "If true, effective date is date of last signature; if false, use custom date",
           "default": "true",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "custom_effective_date",
@@ -1828,7 +2024,8 @@
           "section": "Legal",
           "description": "Custom effective date (only used when effective_date_is_last_signature is false)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "governing_law",
@@ -1837,7 +2034,8 @@
           "section": "Legal",
           "description": "State, province, or country whose laws govern the agreement",
           "default": "Delaware",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "jurisdiction",
@@ -1846,7 +2044,8 @@
           "section": "Legal",
           "description": "Courts with jurisdiction over disputes",
           "default": "courts located in New Castle County, Delaware",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_covered_claims",
@@ -1855,7 +2054,8 @@
           "section": "Liability",
           "description": "Whether indemnity covered claims are included",
           "default": "true",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_provider_covered_claims",
@@ -1864,7 +2064,8 @@
           "section": "Liability",
           "description": "Whether provider covered claims (IP indemnity) are included",
           "default": "true",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_customer_covered_claims",
@@ -1873,7 +2074,8 @@
           "section": "Liability",
           "description": "Whether customer covered claims (IP + restrictions indemnity) are included",
           "default": "true",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "general_cap_is_multiplier",
@@ -1882,7 +2084,8 @@
           "section": "Liability",
           "description": "General cap is Nx fees paid in prior 12 months",
           "default": "true",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "general_cap_multiplier",
@@ -1891,7 +2094,8 @@
           "section": "Liability",
           "description": "Multiplier for fee-based general cap (e.g. \"2\")",
           "default": "2",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "general_cap_is_dollar",
@@ -1900,7 +2104,8 @@
           "section": "Liability",
           "description": "General cap is a fixed dollar amount",
           "default": "false",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "general_cap_dollar",
@@ -1909,7 +2114,8 @@
           "section": "Liability",
           "description": "Fixed dollar amount for general cap (e.g. \"100,000\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "general_cap_is_greater_of",
@@ -1918,7 +2124,8 @@
           "section": "Liability",
           "description": "General cap is the greater of a dollar amount or Nx fees",
           "default": "false",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "general_cap_greater_dollar",
@@ -1927,7 +2134,8 @@
           "section": "Liability",
           "description": "Dollar amount for greater-of general cap (e.g. \"100,000\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "general_cap_greater_multiplier",
@@ -1936,7 +2144,8 @@
           "section": "Liability",
           "description": "Multiplier for greater-of general cap (e.g. \"2\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_increased_claims",
@@ -1945,7 +2154,8 @@
           "section": "Liability",
           "description": "Whether increased claims (supercap) provisions are included",
           "default": "false",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_claims_description",
@@ -1954,7 +2164,8 @@
           "section": "Liability",
           "description": "Description of claims covered by the increased cap (supercap)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_cap_description",
@@ -1963,7 +2174,8 @@
           "section": "Liability",
           "description": "Description of the increased cap amount",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_unlimited_claims",
@@ -1972,7 +2184,8 @@
           "section": "Liability",
           "description": "Whether unlimited claims (no liability cap) are included",
           "default": "false",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "unlimited_claims_description",
@@ -1981,7 +2194,8 @@
           "section": "Liability",
           "description": "Description of claims excluded from liability cap",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_additional_warranties",
@@ -1990,7 +2204,8 @@
           "section": "Legal",
           "description": "Whether additional warranties beyond standard terms are included",
           "default": "false",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_warranty_description",
@@ -1999,7 +2214,8 @@
           "section": "Legal",
           "description": "Additional warranties from provider",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_warranty_description",
@@ -2008,7 +2224,8 @@
           "section": "Legal",
           "description": "Additional warranties from customer",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_dpa",
@@ -2017,7 +2234,8 @@
           "section": "Privacy",
           "description": "Whether a Data Processing Agreement is referenced",
           "default": "false",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "dpa_reference",
@@ -2026,7 +2244,8 @@
           "section": "Privacy",
           "description": "Reference to or description of the DPA",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_security_policy",
@@ -2035,7 +2254,8 @@
           "section": "Privacy",
           "description": "Whether a security policy section is included",
           "default": "false",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "security_policy_description",
@@ -2044,7 +2264,8 @@
           "section": "Privacy",
           "description": "Security policy details or certification commitments",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_insurance",
@@ -2053,7 +2274,8 @@
           "section": "Legal",
           "description": "Whether insurance minimum requirements are included",
           "default": "false",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "insurance_description",
@@ -2062,7 +2284,8 @@
           "section": "Legal",
           "description": "Insurance coverage requirements and minimums",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "order_date_display",
@@ -2071,7 +2294,8 @@
           "section": "Terms",
           "description": "[Computed] Order date text, derived from order_date_is_last_signature and custom_order_date",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "pilot_fee_display",
@@ -2080,7 +2304,8 @@
           "section": "Service",
           "description": "[Computed] Pilot fee text, derived from pilot_is_free and pilot_fee",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fees_display",
@@ -2089,7 +2314,8 @@
           "section": "Payment",
           "description": "[Computed] Fee structure text, derived from fee boolean fields and amounts",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "payment_display",
@@ -2098,7 +2324,8 @@
           "section": "Payment",
           "description": "[Computed] Payment process text, derived from payment_by_invoice and related fields",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "auto_renewal_display",
@@ -2107,7 +2334,8 @@
           "section": "Terms",
           "description": "[Computed] Auto-renewal text, derived from auto_renew and non_renewal_notice_days",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "effective_date_display",
@@ -2116,7 +2344,8 @@
           "section": "Legal",
           "description": "[Computed] Effective date text, derived from effective_date_is_last_signature and custom_effective_date",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "covered_claims_display",
@@ -2125,7 +2354,8 @@
           "section": "Liability",
           "description": "[Computed] Covered claims text, derived from provider/customer covered claims booleans",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "general_cap_display",
@@ -2134,7 +2364,8 @@
           "section": "Liability",
           "description": "[Computed] General cap amount text, derived from cap type booleans and amounts",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_type",
@@ -2143,7 +2374,8 @@
           "section": "Signature Block",
           "description": "Whether the Provider signatory is an entity or individual",
           "default": "entity",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_name",
@@ -2152,7 +2384,8 @@
           "section": "Signature Block",
           "description": "Full legal name of the Provider's signatory",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_title",
@@ -2161,7 +2394,8 @@
           "section": "Signature Block",
           "description": "Title/role of the Provider's signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_company",
@@ -2170,7 +2404,8 @@
           "section": "Signature Block",
           "description": "Company name for the Provider signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_email",
@@ -2179,7 +2414,8 @@
           "section": "Signature Block",
           "description": "Notice email address for the Provider",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_type",
@@ -2188,7 +2424,8 @@
           "section": "Signature Block",
           "description": "Whether the Customer signatory is an entity or individual",
           "default": "entity",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_name",
@@ -2197,7 +2434,8 @@
           "section": "Signature Block",
           "description": "Full legal name of the Customer's signatory",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_title",
@@ -2206,7 +2444,8 @@
           "section": "Signature Block",
           "description": "Title/role of the Customer's signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_company",
@@ -2215,7 +2454,8 @@
           "section": "Signature Block",
           "description": "Company name for the Customer signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_email",
@@ -2224,9 +2464,11 @@
           "section": "Signature Block",
           "description": "Notice email address for the Customer",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         }
-      ]
+      ],
+      "has_template_md": false
     },
     {
       "name": "common-paper-csa-click-through",
@@ -2248,7 +2490,8 @@
           "section": "Parties",
           "description": "Name of the cloud service provider",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cloud_service",
@@ -2257,7 +2500,8 @@
           "section": "Service",
           "description": "Description of the cloud service",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "custom_order_date",
@@ -2266,7 +2510,8 @@
           "section": "Terms",
           "description": "Custom order date",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "effective_date",
@@ -2275,7 +2520,8 @@
           "section": "Terms",
           "description": "Effective date of the agreement",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "subscription_period",
@@ -2284,7 +2530,8 @@
           "section": "Terms",
           "description": "Length of access to the service",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "payment_frequency",
@@ -2293,7 +2540,8 @@
           "section": "Payment",
           "description": "Payment frequency",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "payment_terms_days",
@@ -2302,7 +2550,8 @@
           "section": "Payment",
           "description": "Days to pay after invoice",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "non_renewal_notice_date",
@@ -2311,7 +2560,8 @@
           "section": "Terms",
           "description": "Non-renewal notice date requirement",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "order_date",
@@ -2320,7 +2570,8 @@
           "section": "Terms",
           "description": "Order date description",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "governing_law",
@@ -2329,7 +2580,8 @@
           "section": "Legal",
           "description": "Governing law jurisdiction",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "jurisdiction",
@@ -2338,7 +2590,8 @@
           "section": "Legal",
           "description": "Courts with jurisdiction",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_email",
@@ -2347,7 +2600,8 @@
           "section": "Parties",
           "description": "Provider's email for notices",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "unlimited_claims",
@@ -2356,7 +2610,8 @@
           "section": "Liability",
           "description": "Description of unlimited claims",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "pricing_page",
@@ -2365,9 +2620,11 @@
           "section": "Payment",
           "description": "Reference to pricing page",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         }
-      ]
+      ],
+      "has_template_md": false
     },
     {
       "name": "common-paper-csa-with-ai",
@@ -2389,7 +2646,8 @@
           "section": "Parties",
           "description": "Company name (shown in header)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_name",
@@ -2398,7 +2656,8 @@
           "section": "Parties",
           "description": "Name of the Provider",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_name",
@@ -2407,7 +2666,8 @@
           "section": "Parties",
           "description": "Name of the Customer",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "key_terms_effective_date",
@@ -2416,7 +2676,8 @@
           "section": "Terms",
           "description": "Effective Date of the Key Terms",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cloud_service",
@@ -2425,7 +2686,8 @@
           "section": "Service",
           "description": "Description of the cloud service",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "custom_start_date",
@@ -2434,7 +2696,8 @@
           "section": "Terms",
           "description": "Custom start date",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "subscription_period",
@@ -2443,7 +2706,8 @@
           "section": "Service",
           "description": "Length of access to the service",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "pilot_period",
@@ -2452,7 +2716,8 @@
           "section": "Service",
           "description": "Length of pilot/trial period",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fees",
@@ -2461,7 +2726,8 @@
           "section": "Payment",
           "description": "Subscription fee amount",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_unit",
@@ -2470,7 +2736,8 @@
           "section": "Payment",
           "description": "Fee billing unit",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "custom_fee_structure",
@@ -2479,7 +2746,8 @@
           "section": "Payment",
           "description": "Custom fee structure description (used with fee_is_other)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "use_limitations",
@@ -2488,7 +2756,8 @@
           "section": "Service",
           "description": "Description of use limitations or prohibited uses of the Cloud Service",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "professional_services_billing",
@@ -2497,7 +2766,8 @@
           "section": "Payment",
           "description": "How professional services fees will be billed",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_increase_max_percent",
@@ -2506,7 +2776,8 @@
           "section": "Payment",
           "description": "Maximum fee increase percentage per renewal (used with fee_may_increase)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_increase_percent",
@@ -2515,7 +2786,8 @@
           "section": "Payment",
           "description": "Fee increase percentage per renewal (used with fee_will_increase)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "sla_terms",
@@ -2524,7 +2796,8 @@
           "section": "Service",
           "description": "Service level terms describing uptime commitments, remedies for SLA breaches, and refund policies",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_claim_other_detail",
@@ -2533,7 +2806,8 @@
           "section": "Liability",
           "description": "Description of a custom Increased Claim category",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "unlimited_claim_other_detail",
@@ -2542,7 +2816,8 @@
           "section": "Liability",
           "description": "Description of a custom Unlimited Claim category",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "additional_warranty_provider_detail",
@@ -2551,7 +2826,8 @@
           "section": "Terms",
           "description": "Additional warranty text provided by the Provider",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "additional_warranty_customer_detail",
@@ -2560,7 +2836,8 @@
           "section": "Terms",
           "description": "Additional warranty text provided by the Customer",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "other_security_certification",
@@ -2569,7 +2846,8 @@
           "section": "Security",
           "description": "Name of additional security certification (e.g. \"ISO 27701\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "payment_frequency",
@@ -2578,7 +2856,8 @@
           "section": "Payment",
           "description": "Payment frequency",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "payment_terms_days",
@@ -2587,7 +2866,8 @@
           "section": "Payment",
           "description": "Days to pay after invoice",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "payment_due_from",
@@ -2596,7 +2876,8 @@
           "section": "Payment",
           "description": "When payment terms start",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "non_renewal_notice_days",
@@ -2605,7 +2886,8 @@
           "section": "Terms",
           "description": "Non-renewal notice days",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "technical_support",
@@ -2614,7 +2896,8 @@
           "section": "Service",
           "description": "Description of support",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "support_policy_reference",
@@ -2623,7 +2906,8 @@
           "section": "Service",
           "description": "Reference to support policy",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "professional_services_reference",
@@ -2632,7 +2916,8 @@
           "section": "Service",
           "description": "SOW or PSA reference",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "professional_services_description",
@@ -2641,7 +2926,8 @@
           "section": "Service",
           "description": "Professional services description",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "custom_effective_date",
@@ -2650,7 +2936,8 @@
           "section": "Legal",
           "description": "Custom effective date",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "governing_law",
@@ -2659,7 +2946,8 @@
           "section": "Legal",
           "description": "Governing law",
           "default": "Delaware",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "jurisdiction",
@@ -2668,7 +2956,8 @@
           "section": "Legal",
           "description": "Jurisdiction",
           "default": "courts located in New Castle County, Delaware",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "general_cap_amount",
@@ -2677,7 +2966,8 @@
           "section": "Liability",
           "description": "General liability cap amount",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cap_multiplier",
@@ -2686,7 +2976,8 @@
           "section": "Liability",
           "description": "Liability cap multiplier",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_cap_amount",
@@ -2695,7 +2986,8 @@
           "section": "Liability",
           "description": "Increased liability cap amount",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "greater_of_dollar",
@@ -2704,7 +2996,8 @@
           "section": "Liability",
           "description": "Greater-of dollar amount",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "greater_of_multiplier",
@@ -2713,7 +3006,8 @@
           "section": "Liability",
           "description": "Greater-of multiplier",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "dpa_reference",
@@ -2722,7 +3016,8 @@
           "section": "Privacy",
           "description": "DPA reference",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "pilot_has_fee",
@@ -2731,7 +3026,8 @@
           "section": "Payment",
           "description": "Set to true when the Pilot Period has an associated fee (not a free trial).",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "pilot_modifications",
@@ -2740,7 +3036,8 @@
           "section": "Service",
           "description": "Set to true when modifications to the Agreement apply only during the Pilot Period.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_is_per_unit",
@@ -2749,7 +3046,8 @@
           "section": "Payment",
           "description": "Set to true when fees are charged per unit (e.g., per user, per month).",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_is_other",
@@ -2758,7 +3056,8 @@
           "section": "Payment",
           "description": "Set to true when a custom fee structure applies. Describe in custom_fee_structure.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_may_increase",
@@ -2767,7 +3066,8 @@
           "section": "Payment",
           "description": "Set to true when fees may increase up to a specified percentage upon renewal.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_will_increase",
@@ -2776,7 +3076,8 @@
           "section": "Payment",
           "description": "Set to true when fees will automatically increase upon renewal.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_inclusive_of_taxes",
@@ -2785,7 +3086,8 @@
           "section": "Payment",
           "description": "Set to true when fees are inclusive of taxes, modifying Section 4.1 of the Standard Terms.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "payment_by_invoice",
@@ -2794,7 +3096,8 @@
           "section": "Payment",
           "description": "Set to true when payment is by invoice (not automatic payment).",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "no_auto_renew",
@@ -2803,7 +3106,8 @@
           "section": "Terms",
           "description": "Set to true when this Order Form does not automatically renew, modifying Section 5.1 of the Standard Terms.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "professional_services_by_reference",
@@ -2812,7 +3116,8 @@
           "section": "Service",
           "description": "Set to true when professional services are described by reference to an external SOW or PSA.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "professional_services_described",
@@ -2821,7 +3126,8 @@
           "section": "Service",
           "description": "Set to true when professional services are described inline in the Order Form.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "professional_services_payment",
@@ -2830,7 +3136,8 @@
           "section": "Payment",
           "description": "Set to true when a separate payment process applies to professional services.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_provider_covered_claims",
@@ -2839,7 +3146,8 @@
           "section": "Liability",
           "description": "Set to true when Provider Covered Claims (IP indemnification) are included.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_customer_covered_claims",
@@ -2848,7 +3156,8 @@
           "section": "Liability",
           "description": "Set to true when Customer Covered Claims (IP and restrictions indemnification) are included.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "general_cap_type",
@@ -2857,7 +3166,8 @@
           "section": "Liability",
           "description": "How the General Cap Amount (baseline liability limit) is calculated. \"multiplier\" uses a multiple of fees, \"dollar\" uses a fixed amount, \"greater_of\" uses the greater of a dollar amount or a multiple of fees.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_cap_type",
@@ -2866,7 +3176,8 @@
           "section": "Liability",
           "description": "How the Increased Cap Amount (higher liability limit for Increased Claims) is calculated. Same options as general_cap_type.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_claim_breach_privacy",
@@ -2875,7 +3186,8 @@
           "section": "Liability",
           "description": "Set to true when breach of Section 3 (Privacy & Security) should be classified as an Increased Claim with a higher liability cap.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_claim_breach_conf",
@@ -2884,7 +3196,8 @@
           "section": "Liability",
           "description": "Set to true when breach of Section 10 (Confidentiality) should be classified as an Increased Claim (excluding data or security breaches).",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_claim_indemnification",
@@ -2893,7 +3206,8 @@
           "section": "Liability",
           "description": "Set to true when indemnification obligations for Covered Claims should be classified as an Increased Claim.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_claim_breach_privacy_gross",
@@ -2902,7 +3216,8 @@
           "section": "Liability",
           "description": "Set to true when breach of Privacy & Security resulting from gross negligence is an Increased Claim.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_claim_breach_conf_gross",
@@ -2911,7 +3226,8 @@
           "section": "Liability",
           "description": "Set to true when breach of Confidentiality resulting from gross negligence is an Increased Claim.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_claim_other",
@@ -2920,7 +3236,8 @@
           "section": "Liability",
           "description": "Set to true to include a custom Increased Claim category. Specify in increased_claim_other_detail.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "unlimited_claim_indemnification",
@@ -2929,7 +3246,8 @@
           "section": "Liability",
           "description": "Set to true when indemnification for Covered Claims should have no liability cap (Unlimited Claim).",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "unlimited_claim_breach_privacy_gross",
@@ -2938,7 +3256,8 @@
           "section": "Liability",
           "description": "Set to true when breach of Privacy & Security resulting from gross negligence should have no liability cap (Unlimited Claim).",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "unlimited_claim_breach_conf_gross",
@@ -2947,7 +3266,8 @@
           "section": "Liability",
           "description": "Set to true when breach of Confidentiality resulting from gross negligence should have no liability cap (Unlimited Claim).",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "unlimited_claim_breach_privacy",
@@ -2956,7 +3276,8 @@
           "section": "Liability",
           "description": "Set to true when breach of Section 3 (Privacy & Security) should have no liability cap (Unlimited Claim).",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "unlimited_claim_breach_conf",
@@ -2965,7 +3286,8 @@
           "section": "Liability",
           "description": "Set to true when breach of Section 10 (Confidentiality) should have no liability cap (Unlimited Claim).",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "unlimited_claim_other",
@@ -2974,7 +3296,8 @@
           "section": "Liability",
           "description": "Set to true to include a custom Unlimited Claim category. Specify in unlimited_claim_other_detail.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "additional_warranty_by_provider",
@@ -2983,7 +3306,8 @@
           "section": "Legal",
           "description": "Set to true when Provider is providing additional warranties beyond the Standard Terms.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "additional_warranty_by_customer",
@@ -2992,7 +3316,8 @@
           "section": "Legal",
           "description": "Set to true when Customer is providing additional warranties beyond the Standard Terms.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "security_reasonable_efforts",
@@ -3001,7 +3326,8 @@
           "section": "Security",
           "description": "Set to true when Provider will use commercially reasonable efforts to secure the Cloud Service.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_security_policy",
@@ -3010,7 +3336,8 @@
           "section": "Security",
           "description": "Set to true when Provider has a Security Policy available at the specified DPA reference URL.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_security_certifications",
@@ -3019,7 +3346,8 @@
           "section": "Security",
           "description": "Set to true when Provider maintains annually updated security reports or certifications.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cert_iso_27001",
@@ -3028,7 +3356,8 @@
           "section": "Security",
           "description": "Set to true when Provider holds ISO 27001 certification.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cert_penetration_testing",
@@ -3037,7 +3366,8 @@
           "section": "Security",
           "description": "Set to true when Provider performs regular penetration testing.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cert_soc2_type1",
@@ -3046,7 +3376,8 @@
           "section": "Security",
           "description": "Set to true when Provider holds SOC 2 Type I certification.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cert_pci_level1",
@@ -3055,7 +3386,8 @@
           "section": "Security",
           "description": "Set to true when Provider holds PCI Level 1 certification.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cert_soc2_type2",
@@ -3064,7 +3396,8 @@
           "section": "Security",
           "description": "Set to true when Provider holds SOC 2 Type II certification.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cert_pci_level2",
@@ -3073,7 +3406,8 @@
           "section": "Security",
           "description": "Set to true when Provider holds PCI Level 2 certification.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cert_hitrust",
@@ -3082,7 +3416,8 @@
           "section": "Security",
           "description": "Set to true when Provider holds HITRUST certification.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cert_fedramp",
@@ -3091,7 +3426,8 @@
           "section": "Security",
           "description": "Set to true when Provider holds FedRAMP Authorization.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cert_other",
@@ -3100,7 +3436,8 @@
           "section": "Security",
           "description": "Set to true to include an additional security certification. Specify the certification in other_security_certification.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "insurance_commercial_liability",
@@ -3109,7 +3446,8 @@
           "section": "Insurance",
           "description": "Set to true when Provider must carry commercial general liability insurance with a minimum limit.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "insurance_workers_comp",
@@ -3118,7 +3456,8 @@
           "section": "Insurance",
           "description": "Set to true when Provider must carry workers' compensation or employers' liability insurance.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "insurance_errors_omissions",
@@ -3127,7 +3466,8 @@
           "section": "Insurance",
           "description": "Set to true when Provider must carry errors and omissions or professional liability insurance.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "insurance_cyber",
@@ -3136,7 +3476,8 @@
           "section": "Insurance",
           "description": "Set to true when Provider must carry cyber liability insurance with a minimum limit.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "insurance_additional_insured",
@@ -3145,7 +3486,8 @@
           "section": "Insurance",
           "description": "Set to true when Provider's policies will cover Customer as additional insured.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "additional_insured_commercial",
@@ -3154,7 +3496,8 @@
           "section": "Insurance",
           "description": "Set to true when Customer is additional insured on commercial general liability policy.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "additional_insured_eo",
@@ -3163,7 +3506,8 @@
           "section": "Insurance",
           "description": "Set to true when Customer is additional insured on errors and omissions or professional liability policy.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "additional_insured_cyber",
@@ -3172,7 +3516,8 @@
           "section": "Insurance",
           "description": "Set to true when Customer is additional insured on cyber liability policy.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "ai_policy_reference",
@@ -3181,7 +3526,8 @@
           "section": "Service",
           "description": "Reference to AI usage policy (URL or attached)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "ai_additional_terms",
@@ -3190,7 +3536,8 @@
           "section": "Legal",
           "description": "Additional AI-specific terms",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "ai_training_data_none",
@@ -3199,7 +3546,8 @@
           "section": "AI Terms",
           "description": "Set to true when no customer data may be used as AI Training Data.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "ai_training_data_usage",
@@ -3208,7 +3556,8 @@
           "section": "AI Terms",
           "description": "Set to true when Usage Data may be used as AI Training Data.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "ai_training_data_feedback",
@@ -3217,7 +3566,8 @@
           "section": "AI Terms",
           "description": "Set to true when Feedback may be used as AI Training Data.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "ai_training_data_input",
@@ -3226,7 +3576,8 @@
           "section": "AI Terms",
           "description": "Set to true when Input may be used as AI Training Data.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "ai_training_data_output",
@@ -3235,7 +3586,8 @@
           "section": "AI Terms",
           "description": "Set to true when Output may be used as AI Training Data.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "ai_training_data_user_prompts",
@@ -3244,7 +3596,8 @@
           "section": "AI Terms",
           "description": "Set to true when User prompts (excluding other Input components) may be used as AI Training Data.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "ai_training_data_customer_content",
@@ -3253,7 +3606,8 @@
           "section": "AI Terms",
           "description": "Set to true when Customer Content may be used as AI Training Data.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "ai_training_data_other",
@@ -3262,7 +3616,8 @@
           "section": "AI Terms",
           "description": "Set to true to include additional AI Training Data categories. Specify in ai_additional_terms.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "ai_training_data_aggregated",
@@ -3271,7 +3626,8 @@
           "section": "AI Terms",
           "description": "Set to true when Training Data must be aggregated before use.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "ai_training_data_deidentified",
@@ -3280,7 +3636,8 @@
           "section": "AI Terms",
           "description": "Set to true when Training Data must be de-identified before use.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "ai_training_data_deidentify_efforts",
@@ -3289,7 +3646,8 @@
           "section": "AI Terms",
           "description": "Set to true when Provider will use commercially reasonable efforts to de-identify Training Data using industry standard technology.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "ai_training_restrictions_other",
@@ -3298,7 +3656,8 @@
           "section": "AI Terms",
           "description": "Set to true to include additional AI Training Data restrictions. Specify in ai_additional_terms.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "ai_provider_covered_claims",
@@ -3307,7 +3666,8 @@
           "section": "AI Terms",
           "description": "Set to true when AI-specific Provider Covered Claims (Output IP infringement) are included in the AI Addendum.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "ai_customer_covered_claims",
@@ -3316,7 +3676,8 @@
           "section": "AI Terms",
           "description": "Set to true when AI-specific Customer Covered Claims (Input IP infringement and usage violations) are included in the AI Addendum.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "ai_acceptable_use_policy",
@@ -3325,7 +3686,8 @@
           "section": "AI Terms",
           "description": "Set to true when use of AI Services is subject to an Acceptable Use Policy at the specified ai_policy_reference.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_type",
@@ -3334,7 +3696,8 @@
           "section": "Signature Block",
           "description": "Whether the Provider signatory is an entity or individual",
           "default": "entity",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_name",
@@ -3343,7 +3706,8 @@
           "section": "Signature Block",
           "description": "Full legal name of the Provider's signatory",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_title",
@@ -3352,7 +3716,8 @@
           "section": "Signature Block",
           "description": "Title/role of the Provider's signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_company",
@@ -3361,7 +3726,8 @@
           "section": "Signature Block",
           "description": "Company name for the Provider signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_email",
@@ -3370,7 +3736,8 @@
           "section": "Signature Block",
           "description": "Notice email address for the Provider",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_type",
@@ -3379,7 +3746,8 @@
           "section": "Signature Block",
           "description": "Whether the Customer signatory is an entity or individual",
           "default": "entity",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_name",
@@ -3388,7 +3756,8 @@
           "section": "Signature Block",
           "description": "Full legal name of the Customer's signatory",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_title",
@@ -3397,7 +3766,8 @@
           "section": "Signature Block",
           "description": "Title/role of the Customer's signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_company",
@@ -3406,7 +3776,8 @@
           "section": "Signature Block",
           "description": "Company name for the Customer signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_email",
@@ -3415,9 +3786,11 @@
           "section": "Signature Block",
           "description": "Notice email address for the Customer",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         }
-      ]
+      ],
+      "has_template_md": false
     },
     {
       "name": "common-paper-csa-with-sla",
@@ -3439,7 +3812,8 @@
           "section": "Parties",
           "description": "Company name (shown in header)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_name",
@@ -3448,7 +3822,8 @@
           "section": "Parties",
           "description": "Name of the Provider",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_name",
@@ -3457,7 +3832,8 @@
           "section": "Parties",
           "description": "Name of the Customer",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "key_terms_effective_date",
@@ -3466,7 +3842,8 @@
           "section": "Terms",
           "description": "Effective Date of the Key Terms",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cloud_service",
@@ -3475,7 +3852,8 @@
           "section": "Service",
           "description": "Description of the cloud service",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "custom_start_date",
@@ -3484,7 +3862,8 @@
           "section": "Terms",
           "description": "Custom start date",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "subscription_period",
@@ -3493,7 +3872,8 @@
           "section": "Service",
           "description": "Length of access to the service",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "pilot_period",
@@ -3502,7 +3882,8 @@
           "section": "Service",
           "description": "Length of pilot/trial period",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fees",
@@ -3511,7 +3892,8 @@
           "section": "Payment",
           "description": "Subscription fee amount",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_unit",
@@ -3520,7 +3902,8 @@
           "section": "Payment",
           "description": "Fee billing unit",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "custom_fee_structure",
@@ -3529,7 +3912,8 @@
           "section": "Payment",
           "description": "Custom fee structure description (used with fee_is_other)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "use_limitations",
@@ -3538,7 +3922,8 @@
           "section": "Service",
           "description": "Description of use limitations or prohibited uses of the Cloud Service",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "professional_services_billing",
@@ -3547,7 +3932,8 @@
           "section": "Payment",
           "description": "How professional services fees will be billed",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_increase_max_percent",
@@ -3556,7 +3942,8 @@
           "section": "Payment",
           "description": "Maximum fee increase percentage per renewal (used with fee_may_increase)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_increase_percent",
@@ -3565,7 +3952,8 @@
           "section": "Payment",
           "description": "Fee increase percentage per renewal (used with fee_will_increase)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_claim_other_detail",
@@ -3574,7 +3962,8 @@
           "section": "Liability",
           "description": "Description of a custom Increased Claim category",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "unlimited_claim_other_detail",
@@ -3583,7 +3972,8 @@
           "section": "Liability",
           "description": "Description of a custom Unlimited Claim category",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "additional_warranty_provider_detail",
@@ -3592,7 +3982,8 @@
           "section": "Terms",
           "description": "Additional warranty text provided by the Provider",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "additional_warranty_customer_detail",
@@ -3601,7 +3992,8 @@
           "section": "Terms",
           "description": "Additional warranty text provided by the Customer",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "other_security_certification",
@@ -3610,7 +4002,8 @@
           "section": "Security",
           "description": "Name of additional security certification (e.g. \"ISO 27701\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "payment_frequency",
@@ -3619,7 +4012,8 @@
           "section": "Payment",
           "description": "Payment frequency",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "payment_terms_days",
@@ -3628,7 +4022,8 @@
           "section": "Payment",
           "description": "Days to pay after invoice",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "payment_due_from",
@@ -3637,7 +4032,8 @@
           "section": "Payment",
           "description": "When payment terms start",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "non_renewal_notice_days",
@@ -3646,7 +4042,8 @@
           "section": "Terms",
           "description": "Non-renewal notice days",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "technical_support",
@@ -3655,7 +4052,8 @@
           "section": "Service",
           "description": "Description of support",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "support_policy_reference",
@@ -3664,7 +4062,8 @@
           "section": "Service",
           "description": "Reference to support policy",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "professional_services_reference",
@@ -3673,7 +4072,8 @@
           "section": "Service",
           "description": "SOW or PSA reference",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "professional_services_description",
@@ -3682,7 +4082,8 @@
           "section": "Service",
           "description": "Professional services description",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "custom_effective_date",
@@ -3691,7 +4092,8 @@
           "section": "Legal",
           "description": "Custom effective date",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "governing_law",
@@ -3700,7 +4102,8 @@
           "section": "Legal",
           "description": "Governing law",
           "default": "Delaware",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "jurisdiction",
@@ -3709,7 +4112,8 @@
           "section": "Legal",
           "description": "Jurisdiction",
           "default": "courts located in New Castle County, Delaware",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "general_cap_amount",
@@ -3718,7 +4122,8 @@
           "section": "Liability",
           "description": "General liability cap amount",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cap_multiplier",
@@ -3727,7 +4132,8 @@
           "section": "Liability",
           "description": "Liability cap multiplier",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_cap_amount",
@@ -3736,7 +4142,8 @@
           "section": "Liability",
           "description": "Increased liability cap amount",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "greater_of_dollar",
@@ -3745,7 +4152,8 @@
           "section": "Liability",
           "description": "Greater-of dollar amount",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "greater_of_multiplier",
@@ -3754,7 +4162,8 @@
           "section": "Liability",
           "description": "Greater-of multiplier",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "dpa_reference",
@@ -3763,7 +4172,8 @@
           "section": "Privacy",
           "description": "DPA reference",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "pilot_has_fee",
@@ -3772,7 +4182,8 @@
           "section": "Payment",
           "description": "Set to true when the Pilot Period has an associated fee (not a free trial).",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "pilot_modifications",
@@ -3781,7 +4192,8 @@
           "section": "Service",
           "description": "Set to true when modifications to the Agreement apply only during the Pilot Period.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_is_per_unit",
@@ -3790,7 +4202,8 @@
           "section": "Payment",
           "description": "Set to true when fees are charged per unit (e.g., per user, per month).",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_is_other",
@@ -3799,7 +4212,8 @@
           "section": "Payment",
           "description": "Set to true when a custom fee structure applies. Describe in custom_fee_structure.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_may_increase",
@@ -3808,7 +4222,8 @@
           "section": "Payment",
           "description": "Set to true when fees may increase up to a specified percentage upon renewal.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_will_increase",
@@ -3817,7 +4232,8 @@
           "section": "Payment",
           "description": "Set to true when fees will automatically increase upon renewal.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_inclusive_of_taxes",
@@ -3826,7 +4242,8 @@
           "section": "Payment",
           "description": "Set to true when fees are inclusive of taxes, modifying Section 4.1 of the Standard Terms.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "payment_by_invoice",
@@ -3835,7 +4252,8 @@
           "section": "Payment",
           "description": "Set to true when payment is by invoice (not automatic payment).",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "no_auto_renew",
@@ -3844,7 +4262,8 @@
           "section": "Terms",
           "description": "Set to true when this Order Form does not automatically renew, modifying Section 5.1 of the Standard Terms.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_target_uptime",
@@ -3853,7 +4272,8 @@
           "section": "Service",
           "description": "Set to true when a Target Uptime percentage is specified in the SLA.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_target_response_time",
@@ -3862,7 +4282,8 @@
           "section": "Service",
           "description": "Set to true when Target Response Times are specified in the SLA.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "professional_services_by_reference",
@@ -3871,7 +4292,8 @@
           "section": "Service",
           "description": "Set to true when professional services are described by reference to an external SOW or PSA.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "professional_services_described",
@@ -3880,7 +4302,8 @@
           "section": "Service",
           "description": "Set to true when professional services are described inline in the Order Form.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "professional_services_payment",
@@ -3889,7 +4312,8 @@
           "section": "Payment",
           "description": "Set to true when a separate payment process applies to professional services.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_provider_covered_claims",
@@ -3898,7 +4322,8 @@
           "section": "Liability",
           "description": "Set to true when Provider Covered Claims (IP indemnification) are included.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_customer_covered_claims",
@@ -3907,7 +4332,8 @@
           "section": "Liability",
           "description": "Set to true when Customer Covered Claims (IP and restrictions indemnification) are included.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "general_cap_type",
@@ -3916,7 +4342,8 @@
           "section": "Liability",
           "description": "How the General Cap Amount (baseline liability limit) is calculated. \"multiplier\" uses a multiple of fees, \"dollar\" uses a fixed amount, \"greater_of\" uses the greater of a dollar amount or a multiple of fees.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_cap_type",
@@ -3925,7 +4352,8 @@
           "section": "Liability",
           "description": "How the Increased Cap Amount (higher liability limit for Increased Claims) is calculated. Same options as general_cap_type.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_claim_breach_privacy",
@@ -3934,7 +4362,8 @@
           "section": "Liability",
           "description": "Set to true when breach of Section 3 (Privacy & Security) should be classified as an Increased Claim with a higher liability cap.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_claim_breach_conf",
@@ -3943,7 +4372,8 @@
           "section": "Liability",
           "description": "Set to true when breach of Section 10 (Confidentiality) should be classified as an Increased Claim (excluding data or security breaches).",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_claim_indemnification",
@@ -3952,7 +4382,8 @@
           "section": "Liability",
           "description": "Set to true when indemnification obligations for Covered Claims should be classified as an Increased Claim.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_claim_breach_privacy_gross",
@@ -3961,7 +4392,8 @@
           "section": "Liability",
           "description": "Set to true when breach of Privacy & Security resulting from gross negligence is an Increased Claim.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_claim_breach_conf_gross",
@@ -3970,7 +4402,8 @@
           "section": "Liability",
           "description": "Set to true when breach of Confidentiality resulting from gross negligence is an Increased Claim.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_claim_other",
@@ -3979,7 +4412,8 @@
           "section": "Liability",
           "description": "Set to true to include a custom Increased Claim category. Specify in increased_claim_other_detail.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "unlimited_claim_indemnification",
@@ -3988,7 +4422,8 @@
           "section": "Liability",
           "description": "Set to true when indemnification for Covered Claims should have no liability cap (Unlimited Claim).",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "unlimited_claim_breach_privacy_gross",
@@ -3997,7 +4432,8 @@
           "section": "Liability",
           "description": "Set to true when breach of Privacy & Security resulting from gross negligence should have no liability cap (Unlimited Claim).",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "unlimited_claim_breach_conf_gross",
@@ -4006,7 +4442,8 @@
           "section": "Liability",
           "description": "Set to true when breach of Confidentiality resulting from gross negligence should have no liability cap (Unlimited Claim).",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "unlimited_claim_breach_privacy",
@@ -4015,7 +4452,8 @@
           "section": "Liability",
           "description": "Set to true when breach of Section 3 (Privacy & Security) should have no liability cap (Unlimited Claim).",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "unlimited_claim_breach_conf",
@@ -4024,7 +4462,8 @@
           "section": "Liability",
           "description": "Set to true when breach of Section 10 (Confidentiality) should have no liability cap (Unlimited Claim).",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "unlimited_claim_other",
@@ -4033,7 +4472,8 @@
           "section": "Liability",
           "description": "Set to true to include a custom Unlimited Claim category. Specify in unlimited_claim_other_detail.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "additional_warranty_by_provider",
@@ -4042,7 +4482,8 @@
           "section": "Legal",
           "description": "Set to true when Provider is providing additional warranties beyond the Standard Terms.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "additional_warranty_by_customer",
@@ -4051,7 +4492,8 @@
           "section": "Legal",
           "description": "Set to true when Customer is providing additional warranties beyond the Standard Terms.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "security_reasonable_efforts",
@@ -4060,7 +4502,8 @@
           "section": "Security",
           "description": "Set to true when Provider will use commercially reasonable efforts to secure the Cloud Service.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_security_policy",
@@ -4069,7 +4512,8 @@
           "section": "Security",
           "description": "Set to true when Provider has a Security Policy available at the specified DPA reference URL.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_security_certifications",
@@ -4078,7 +4522,8 @@
           "section": "Security",
           "description": "Set to true when Provider maintains annually updated security reports or certifications.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cert_iso_27001",
@@ -4087,7 +4532,8 @@
           "section": "Security",
           "description": "Set to true when Provider holds ISO 27001 certification.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cert_penetration_testing",
@@ -4096,7 +4542,8 @@
           "section": "Security",
           "description": "Set to true when Provider performs regular penetration testing.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cert_soc2_type1",
@@ -4105,7 +4552,8 @@
           "section": "Security",
           "description": "Set to true when Provider holds SOC 2 Type I certification.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cert_pci_level1",
@@ -4114,7 +4562,8 @@
           "section": "Security",
           "description": "Set to true when Provider holds PCI Level 1 certification.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cert_soc2_type2",
@@ -4123,7 +4572,8 @@
           "section": "Security",
           "description": "Set to true when Provider holds SOC 2 Type II certification.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cert_pci_level2",
@@ -4132,7 +4582,8 @@
           "section": "Security",
           "description": "Set to true when Provider holds PCI Level 2 certification.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cert_hitrust",
@@ -4141,7 +4592,8 @@
           "section": "Security",
           "description": "Set to true when Provider holds HITRUST certification.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cert_fedramp",
@@ -4150,7 +4602,8 @@
           "section": "Security",
           "description": "Set to true when Provider holds FedRAMP Authorization.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cert_other",
@@ -4159,7 +4612,8 @@
           "section": "Security",
           "description": "Set to true to include an additional security certification. Specify the certification in other_security_certification.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "insurance_commercial_liability",
@@ -4168,7 +4622,8 @@
           "section": "Insurance",
           "description": "Set to true when Provider must carry commercial general liability insurance with a minimum limit.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "insurance_workers_comp",
@@ -4177,7 +4632,8 @@
           "section": "Insurance",
           "description": "Set to true when Provider must carry workers' compensation or employers' liability insurance.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "insurance_errors_omissions",
@@ -4186,7 +4642,8 @@
           "section": "Insurance",
           "description": "Set to true when Provider must carry errors and omissions or professional liability insurance.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "insurance_cyber",
@@ -4195,7 +4652,8 @@
           "section": "Insurance",
           "description": "Set to true when Provider must carry cyber liability insurance with a minimum limit.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "insurance_additional_insured",
@@ -4204,7 +4662,8 @@
           "section": "Insurance",
           "description": "Set to true when Provider's policies will cover Customer as additional insured.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "additional_insured_commercial",
@@ -4213,7 +4672,8 @@
           "section": "Insurance",
           "description": "Set to true when Customer is additional insured on commercial general liability policy.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "additional_insured_eo",
@@ -4222,7 +4682,8 @@
           "section": "Insurance",
           "description": "Set to true when Customer is additional insured on errors and omissions or professional liability policy.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "additional_insured_cyber",
@@ -4231,7 +4692,8 @@
           "section": "Insurance",
           "description": "Set to true when Customer is additional insured on cyber liability policy.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "support_start_time",
@@ -4240,7 +4702,8 @@
           "section": "Service",
           "description": "Start time for support",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "support_end_time",
@@ -4249,7 +4712,8 @@
           "section": "Service",
           "description": "End time for support",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "support_days",
@@ -4258,7 +4722,8 @@
           "section": "Service",
           "description": "Days of the week for support",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "support_timezone",
@@ -4267,7 +4732,8 @@
           "section": "Service",
           "description": "Support timezone",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "response_time_unit",
@@ -4276,7 +4742,8 @@
           "section": "Service",
           "description": "Response time unit",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "resolution_time_unit",
@@ -4285,7 +4752,8 @@
           "section": "Service",
           "description": "Resolution time unit",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_type",
@@ -4294,7 +4762,8 @@
           "section": "Signature Block",
           "description": "Whether the Provider signatory is an entity or individual",
           "default": "entity",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_name",
@@ -4303,7 +4772,8 @@
           "section": "Signature Block",
           "description": "Full legal name of the Provider's signatory",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_title",
@@ -4312,7 +4782,8 @@
           "section": "Signature Block",
           "description": "Title/role of the Provider's signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_company",
@@ -4321,7 +4792,8 @@
           "section": "Signature Block",
           "description": "Company name for the Provider signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_email",
@@ -4330,7 +4802,8 @@
           "section": "Signature Block",
           "description": "Notice email address for the Provider",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_type",
@@ -4339,7 +4812,8 @@
           "section": "Signature Block",
           "description": "Whether the Customer signatory is an entity or individual",
           "default": "entity",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_name",
@@ -4348,7 +4822,8 @@
           "section": "Signature Block",
           "description": "Full legal name of the Customer's signatory",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_title",
@@ -4357,7 +4832,8 @@
           "section": "Signature Block",
           "description": "Title/role of the Customer's signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_company",
@@ -4366,7 +4842,8 @@
           "section": "Signature Block",
           "description": "Company name for the Customer signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_email",
@@ -4375,9 +4852,11 @@
           "section": "Signature Block",
           "description": "Notice email address for the Customer",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         }
-      ]
+      ],
+      "has_template_md": false
     },
     {
       "name": "common-paper-csa-without-sla",
@@ -4399,7 +4878,8 @@
           "section": "Parties",
           "description": "Company name (shown in header)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_name",
@@ -4408,7 +4888,8 @@
           "section": "Parties",
           "description": "Name of the Provider",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_name",
@@ -4417,7 +4898,8 @@
           "section": "Parties",
           "description": "Name of the Customer",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "key_terms_effective_date",
@@ -4426,7 +4908,8 @@
           "section": "Terms",
           "description": "Effective Date of the Key Terms",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cloud_service",
@@ -4435,7 +4918,8 @@
           "section": "Service",
           "description": "Description of the cloud service",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "custom_start_date",
@@ -4444,7 +4928,8 @@
           "section": "Terms",
           "description": "Custom start date",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "subscription_period",
@@ -4453,7 +4938,8 @@
           "section": "Service",
           "description": "Length of access to the service",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "pilot_period",
@@ -4462,7 +4948,8 @@
           "section": "Service",
           "description": "Length of pilot/trial period",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fees",
@@ -4471,7 +4958,8 @@
           "section": "Payment",
           "description": "Subscription fee amount",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_unit",
@@ -4480,7 +4968,8 @@
           "section": "Payment",
           "description": "Fee billing unit",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "custom_fee_structure",
@@ -4489,7 +4978,8 @@
           "section": "Payment",
           "description": "Custom fee structure description (used with fee_is_other)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "use_limitations",
@@ -4498,7 +4988,8 @@
           "section": "Service",
           "description": "Description of use limitations or prohibited uses of the Cloud Service",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "professional_services_billing",
@@ -4507,7 +4998,8 @@
           "section": "Payment",
           "description": "How professional services fees will be billed",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_increase_max_percent",
@@ -4516,7 +5008,8 @@
           "section": "Payment",
           "description": "Maximum fee increase percentage per renewal (used with fee_may_increase)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_increase_percent",
@@ -4525,7 +5018,8 @@
           "section": "Payment",
           "description": "Fee increase percentage per renewal (used with fee_will_increase)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "sla_terms",
@@ -4534,7 +5028,8 @@
           "section": "Service",
           "description": "Service level terms describing uptime commitments, remedies for SLA breaches, and refund policies",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_claim_other_detail",
@@ -4543,7 +5038,8 @@
           "section": "Liability",
           "description": "Description of a custom Increased Claim category",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "unlimited_claim_other_detail",
@@ -4552,7 +5048,8 @@
           "section": "Liability",
           "description": "Description of a custom Unlimited Claim category",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "additional_warranty_provider_detail",
@@ -4561,7 +5058,8 @@
           "section": "Terms",
           "description": "Additional warranty text provided by the Provider",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "additional_warranty_customer_detail",
@@ -4570,7 +5068,8 @@
           "section": "Terms",
           "description": "Additional warranty text provided by the Customer",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "other_security_certification",
@@ -4579,7 +5078,8 @@
           "section": "Security",
           "description": "Name of additional security certification (e.g. \"ISO 27701\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "payment_frequency",
@@ -4588,7 +5088,8 @@
           "section": "Payment",
           "description": "Payment frequency",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "payment_terms_days",
@@ -4597,7 +5098,8 @@
           "section": "Payment",
           "description": "Days to pay after invoice",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "payment_due_from",
@@ -4606,7 +5108,8 @@
           "section": "Payment",
           "description": "When payment terms start",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "non_renewal_notice_days",
@@ -4615,7 +5118,8 @@
           "section": "Terms",
           "description": "Non-renewal notice days",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "technical_support",
@@ -4624,7 +5128,8 @@
           "section": "Service",
           "description": "Description of support",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "support_policy_reference",
@@ -4633,7 +5138,8 @@
           "section": "Service",
           "description": "Reference to support policy",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "professional_services_reference",
@@ -4642,7 +5148,8 @@
           "section": "Service",
           "description": "SOW or PSA reference",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "professional_services_description",
@@ -4651,7 +5158,8 @@
           "section": "Service",
           "description": "Professional services description",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "custom_effective_date",
@@ -4660,7 +5168,8 @@
           "section": "Legal",
           "description": "Custom effective date",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "governing_law",
@@ -4669,7 +5178,8 @@
           "section": "Legal",
           "description": "Governing law",
           "default": "Delaware",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "jurisdiction",
@@ -4678,7 +5188,8 @@
           "section": "Legal",
           "description": "Jurisdiction",
           "default": "courts located in New Castle County, Delaware",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "general_cap_amount",
@@ -4687,7 +5198,8 @@
           "section": "Liability",
           "description": "General liability cap amount",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cap_multiplier",
@@ -4696,7 +5208,8 @@
           "section": "Liability",
           "description": "Liability cap multiplier",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_cap_amount",
@@ -4705,7 +5218,8 @@
           "section": "Liability",
           "description": "Increased liability cap amount",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "greater_of_dollar",
@@ -4714,7 +5228,8 @@
           "section": "Liability",
           "description": "Greater-of dollar amount",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "greater_of_multiplier",
@@ -4723,7 +5238,8 @@
           "section": "Liability",
           "description": "Greater-of multiplier",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "dpa_reference",
@@ -4732,7 +5248,8 @@
           "section": "Privacy",
           "description": "DPA reference",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "pilot_has_fee",
@@ -4741,7 +5258,8 @@
           "section": "Payment",
           "description": "Set to true when the Pilot Period has an associated fee (not a free trial).",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "pilot_modifications",
@@ -4750,7 +5268,8 @@
           "section": "Service",
           "description": "Set to true when modifications to the Agreement apply only during the Pilot Period.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_is_per_unit",
@@ -4759,7 +5278,8 @@
           "section": "Payment",
           "description": "Set to true when fees are charged per unit (e.g., per user, per month).",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_is_other",
@@ -4768,7 +5288,8 @@
           "section": "Payment",
           "description": "Set to true when a custom fee structure applies. Describe in custom_fee_structure.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_may_increase",
@@ -4777,7 +5298,8 @@
           "section": "Payment",
           "description": "Set to true when fees may increase up to a specified percentage upon renewal.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_will_increase",
@@ -4786,7 +5308,8 @@
           "section": "Payment",
           "description": "Set to true when fees will automatically increase upon renewal.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_inclusive_of_taxes",
@@ -4795,7 +5318,8 @@
           "section": "Payment",
           "description": "Set to true when fees are inclusive of taxes, modifying Section 4.1 of the Standard Terms.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "payment_by_invoice",
@@ -4804,7 +5328,8 @@
           "section": "Payment",
           "description": "Set to true when payment is by invoice (not automatic payment).",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "no_auto_renew",
@@ -4813,7 +5338,8 @@
           "section": "Terms",
           "description": "Set to true when this Order Form does not automatically renew, modifying Section 5.1 of the Standard Terms.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "professional_services_by_reference",
@@ -4822,7 +5348,8 @@
           "section": "Service",
           "description": "Set to true when professional services are described by reference to an external SOW or PSA.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "professional_services_described",
@@ -4831,7 +5358,8 @@
           "section": "Service",
           "description": "Set to true when professional services are described inline in the Order Form.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "professional_services_payment",
@@ -4840,7 +5368,8 @@
           "section": "Payment",
           "description": "Set to true when a separate payment process applies to professional services.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_provider_covered_claims",
@@ -4849,7 +5378,8 @@
           "section": "Liability",
           "description": "Set to true when Provider Covered Claims (IP indemnification) are included.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_customer_covered_claims",
@@ -4858,7 +5388,8 @@
           "section": "Liability",
           "description": "Set to true when Customer Covered Claims (IP and restrictions indemnification) are included.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "general_cap_type",
@@ -4867,7 +5398,8 @@
           "section": "Liability",
           "description": "How the General Cap Amount (baseline liability limit) is calculated. \"multiplier\" uses a multiple of fees, \"dollar\" uses a fixed amount, \"greater_of\" uses the greater of a dollar amount or a multiple of fees.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_cap_type",
@@ -4876,7 +5408,8 @@
           "section": "Liability",
           "description": "How the Increased Cap Amount (higher liability limit for Increased Claims) is calculated. Same options as general_cap_type.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_claim_breach_privacy",
@@ -4885,7 +5418,8 @@
           "section": "Liability",
           "description": "Set to true when breach of Section 3 (Privacy & Security) should be classified as an Increased Claim with a higher liability cap.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_claim_breach_conf",
@@ -4894,7 +5428,8 @@
           "section": "Liability",
           "description": "Set to true when breach of Section 10 (Confidentiality) should be classified as an Increased Claim (excluding data or security breaches).",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_claim_indemnification",
@@ -4903,7 +5438,8 @@
           "section": "Liability",
           "description": "Set to true when indemnification obligations for Covered Claims should be classified as an Increased Claim.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_claim_breach_privacy_gross",
@@ -4912,7 +5448,8 @@
           "section": "Liability",
           "description": "Set to true when breach of Privacy & Security resulting from gross negligence is an Increased Claim.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_claim_breach_conf_gross",
@@ -4921,7 +5458,8 @@
           "section": "Liability",
           "description": "Set to true when breach of Confidentiality resulting from gross negligence is an Increased Claim.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_claim_other",
@@ -4930,7 +5468,8 @@
           "section": "Liability",
           "description": "Set to true to include a custom Increased Claim category. Specify in increased_claim_other_detail.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "unlimited_claim_indemnification",
@@ -4939,7 +5478,8 @@
           "section": "Liability",
           "description": "Set to true when indemnification for Covered Claims should have no liability cap (Unlimited Claim).",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "unlimited_claim_breach_privacy_gross",
@@ -4948,7 +5488,8 @@
           "section": "Liability",
           "description": "Set to true when breach of Privacy & Security resulting from gross negligence should have no liability cap (Unlimited Claim).",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "unlimited_claim_breach_conf_gross",
@@ -4957,7 +5498,8 @@
           "section": "Liability",
           "description": "Set to true when breach of Confidentiality resulting from gross negligence should have no liability cap (Unlimited Claim).",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "unlimited_claim_breach_privacy",
@@ -4966,7 +5508,8 @@
           "section": "Liability",
           "description": "Set to true when breach of Section 3 (Privacy & Security) should have no liability cap (Unlimited Claim).",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "unlimited_claim_breach_conf",
@@ -4975,7 +5518,8 @@
           "section": "Liability",
           "description": "Set to true when breach of Section 10 (Confidentiality) should have no liability cap (Unlimited Claim).",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "unlimited_claim_other",
@@ -4984,7 +5528,8 @@
           "section": "Liability",
           "description": "Set to true to include a custom Unlimited Claim category. Specify in unlimited_claim_other_detail.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "additional_warranty_by_provider",
@@ -4993,7 +5538,8 @@
           "section": "Legal",
           "description": "Set to true when Provider is providing additional warranties beyond the Standard Terms.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "additional_warranty_by_customer",
@@ -5002,7 +5548,8 @@
           "section": "Legal",
           "description": "Set to true when Customer is providing additional warranties beyond the Standard Terms.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "security_reasonable_efforts",
@@ -5011,7 +5558,8 @@
           "section": "Security",
           "description": "Set to true when Provider will use commercially reasonable efforts to secure the Cloud Service.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_security_policy",
@@ -5020,7 +5568,8 @@
           "section": "Security",
           "description": "Set to true when Provider has a Security Policy available at the specified DPA reference URL.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_security_certifications",
@@ -5029,7 +5578,8 @@
           "section": "Security",
           "description": "Set to true when Provider maintains annually updated security reports or certifications.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cert_iso_27001",
@@ -5038,7 +5588,8 @@
           "section": "Security",
           "description": "Set to true when Provider holds ISO 27001 certification.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cert_penetration_testing",
@@ -5047,7 +5598,8 @@
           "section": "Security",
           "description": "Set to true when Provider performs regular penetration testing.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cert_soc2_type1",
@@ -5056,7 +5608,8 @@
           "section": "Security",
           "description": "Set to true when Provider holds SOC 2 Type I certification.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cert_pci_level1",
@@ -5065,7 +5618,8 @@
           "section": "Security",
           "description": "Set to true when Provider holds PCI Level 1 certification.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cert_soc2_type2",
@@ -5074,7 +5628,8 @@
           "section": "Security",
           "description": "Set to true when Provider holds SOC 2 Type II certification.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cert_pci_level2",
@@ -5083,7 +5638,8 @@
           "section": "Security",
           "description": "Set to true when Provider holds PCI Level 2 certification.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cert_hitrust",
@@ -5092,7 +5648,8 @@
           "section": "Security",
           "description": "Set to true when Provider holds HITRUST certification.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cert_fedramp",
@@ -5101,7 +5658,8 @@
           "section": "Security",
           "description": "Set to true when Provider holds FedRAMP Authorization.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cert_other",
@@ -5110,7 +5668,8 @@
           "section": "Security",
           "description": "Set to true to include an additional security certification. Specify the certification in other_security_certification.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "insurance_commercial_liability",
@@ -5119,7 +5678,8 @@
           "section": "Insurance",
           "description": "Set to true when Provider must carry commercial general liability insurance with a minimum limit.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "insurance_workers_comp",
@@ -5128,7 +5688,8 @@
           "section": "Insurance",
           "description": "Set to true when Provider must carry workers' compensation or employers' liability insurance.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "insurance_errors_omissions",
@@ -5137,7 +5698,8 @@
           "section": "Insurance",
           "description": "Set to true when Provider must carry errors and omissions or professional liability insurance.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "insurance_cyber",
@@ -5146,7 +5708,8 @@
           "section": "Insurance",
           "description": "Set to true when Provider must carry cyber liability insurance with a minimum limit.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "insurance_additional_insured",
@@ -5155,7 +5718,8 @@
           "section": "Insurance",
           "description": "Set to true when Provider's policies will cover Customer as additional insured.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "additional_insured_commercial",
@@ -5164,7 +5728,8 @@
           "section": "Insurance",
           "description": "Set to true when Customer is additional insured on commercial general liability policy.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "additional_insured_eo",
@@ -5173,7 +5738,8 @@
           "section": "Insurance",
           "description": "Set to true when Customer is additional insured on errors and omissions or professional liability policy.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "additional_insured_cyber",
@@ -5182,7 +5748,8 @@
           "section": "Insurance",
           "description": "Set to true when Customer is additional insured on cyber liability policy.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_type",
@@ -5191,7 +5758,8 @@
           "section": "Signature Block",
           "description": "Whether the Provider signatory is an entity or individual",
           "default": "entity",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_name",
@@ -5200,7 +5768,8 @@
           "section": "Signature Block",
           "description": "Full legal name of the Provider's signatory",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_title",
@@ -5209,7 +5778,8 @@
           "section": "Signature Block",
           "description": "Title/role of the Provider's signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_company",
@@ -5218,7 +5788,8 @@
           "section": "Signature Block",
           "description": "Company name for the Provider signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_email",
@@ -5227,7 +5798,8 @@
           "section": "Signature Block",
           "description": "Notice email address for the Provider",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_type",
@@ -5236,7 +5808,8 @@
           "section": "Signature Block",
           "description": "Whether the Customer signatory is an entity or individual",
           "default": "entity",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_name",
@@ -5245,7 +5818,8 @@
           "section": "Signature Block",
           "description": "Full legal name of the Customer's signatory",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_title",
@@ -5254,7 +5828,8 @@
           "section": "Signature Block",
           "description": "Title/role of the Customer's signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_company",
@@ -5263,7 +5838,8 @@
           "section": "Signature Block",
           "description": "Company name for the Customer signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_email",
@@ -5272,9 +5848,11 @@
           "section": "Signature Block",
           "description": "Notice email address for the Customer",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         }
-      ]
+      ],
+      "has_template_md": false
     },
     {
       "name": "common-paper-data-processing-agreement",
@@ -5296,7 +5874,8 @@
           "section": "Parties",
           "description": "Official company name",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "product_name",
@@ -5305,7 +5884,8 @@
           "section": "Service",
           "description": "Name of product or service",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "underlying_agreement",
@@ -5314,7 +5894,8 @@
           "section": "Terms",
           "description": "Name and date of the underlying agreement",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_contact_name",
@@ -5323,7 +5904,8 @@
           "section": "Parties",
           "description": "Customer contact name",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_contact_title",
@@ -5332,7 +5914,8 @@
           "section": "Parties",
           "description": "Customer contact title",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_address",
@@ -5341,7 +5924,8 @@
           "section": "Parties",
           "description": "Customer's physical address",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_contact_name",
@@ -5350,7 +5934,8 @@
           "section": "Parties",
           "description": "Provider contact name",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_contact_title",
@@ -5359,7 +5944,8 @@
           "section": "Parties",
           "description": "Provider contact title",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_address",
@@ -5368,7 +5954,8 @@
           "section": "Parties",
           "description": "Provider's physical address",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "physical_address",
@@ -5377,7 +5964,8 @@
           "section": "Parties",
           "description": "Physical address for notifications",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "contact_address",
@@ -5386,7 +5974,8 @@
           "section": "Parties",
           "description": "Email and/or physical address",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_role",
@@ -5395,7 +5984,8 @@
           "section": "Terms",
           "description": "Provider's role (Controller or Processor)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "governing_law",
@@ -5404,7 +5994,8 @@
           "section": "Legal",
           "description": "Governing law state/province/country",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "eu_member_state",
@@ -5413,7 +6004,8 @@
           "section": "Legal",
           "description": "EU Member State for disputes",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "uk_governing_law",
@@ -5422,7 +6014,8 @@
           "section": "Legal",
           "description": "UK governing law selection",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "subprocessor_name",
@@ -5431,7 +6024,8 @@
           "section": "Privacy",
           "description": "Subprocessor name",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "custom_option",
@@ -5440,7 +6034,8 @@
           "section": "Terms",
           "description": "Custom option for selections",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "custom_options",
@@ -5449,7 +6044,8 @@
           "section": "Terms",
           "description": "Multiple custom options",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "url",
@@ -5458,7 +6054,8 @@
           "section": "Terms",
           "description": "URL for references",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "countries_list",
@@ -5467,7 +6064,8 @@
           "section": "Privacy",
           "description": "List of all countries for data transfers",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "csa_reference",
@@ -5476,7 +6074,8 @@
           "section": "Terms",
           "description": "Common Paper CSA reference",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "non_csa_reference",
@@ -5485,7 +6084,8 @@
           "section": "Terms",
           "description": "Non-CSA agreement reference",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "security_measures",
@@ -5494,7 +6094,8 @@
           "section": "Privacy",
           "description": "Description of security measures",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "text_box",
@@ -5503,7 +6104,8 @@
           "section": "Terms",
           "description": "General text box entry",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "other_security_certification",
@@ -5512,7 +6114,8 @@
           "section": "Security",
           "description": "Name of additional security certification (e.g. \"ISO 27701 Privacy Information Management\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "dpa_covered_claims_detail",
@@ -5521,7 +6124,8 @@
           "section": "Legal",
           "description": "Specific scope of DPA Covered Claims (e.g., breach of DPA, gross negligence resulting in Security Incident)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cap_multiplier",
@@ -5530,7 +6134,8 @@
           "section": "Liability",
           "description": "Liability cap multiplier",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "greater_of_dollar",
@@ -5539,7 +6144,8 @@
           "section": "Liability",
           "description": "Dollar amount for the greater-of liability cap",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "policy_url",
@@ -5548,7 +6154,8 @@
           "section": "Privacy",
           "description": "URL of where to find policies",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_subprocessor",
@@ -5557,7 +6164,8 @@
           "section": "Privacy",
           "description": "Set to true when a pre-approved subprocessor is specified.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "dpa_security_reasonable_efforts",
@@ -5566,7 +6174,8 @@
           "section": "Security",
           "description": "Set to true when Provider will use commercially reasonable efforts to secure the Service from unauthorized access.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_dpa_security_policy",
@@ -5575,7 +6184,8 @@
           "section": "Security",
           "description": "Set to true when Provider has a Security Policy available at the specified policy_url.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_dpa_security_certifications",
@@ -5584,7 +6194,8 @@
           "section": "Security",
           "description": "Set to true when Provider maintains annually updated security reports or certifications.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cert_iso_27001",
@@ -5593,7 +6204,8 @@
           "section": "Security",
           "description": "Set to true when Provider holds ISO 27001 certification.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cert_penetration_testing",
@@ -5602,7 +6214,8 @@
           "section": "Security",
           "description": "Set to true when Provider performs regular penetration testing.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cert_soc2_type1",
@@ -5611,7 +6224,8 @@
           "section": "Security",
           "description": "Set to true when Provider holds SOC 2 Type I certification.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cert_pci_level1",
@@ -5620,7 +6234,8 @@
           "section": "Security",
           "description": "Set to true when Provider holds PCI Level 1 certification.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cert_soc2_type2",
@@ -5629,7 +6244,8 @@
           "section": "Security",
           "description": "Set to true when Provider holds SOC 2 Type II certification.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cert_pci_level2",
@@ -5638,7 +6254,8 @@
           "section": "Security",
           "description": "Set to true when Provider holds PCI Level 2 certification.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cert_hipaa",
@@ -5647,7 +6264,8 @@
           "section": "Security",
           "description": "Set to true when Provider holds HIPAA certification.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cert_fedramp",
@@ -5656,7 +6274,8 @@
           "section": "Security",
           "description": "Set to true when Provider holds FedRAMP Authorization.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cert_other",
@@ -5665,7 +6284,8 @@
           "section": "Security",
           "description": "Set to true to include an additional security certification. Specify the certification in other_security_certification.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "indemnification_csa_reference",
@@ -5674,7 +6294,8 @@
           "section": "Liability",
           "description": "Set to true when using Common Paper CSA-style indemnification reference for DPA Covered Claims.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "indemnification_non_csa_reference",
@@ -5683,7 +6304,8 @@
           "section": "Liability",
           "description": "Set to true when using non-CSA indemnification language for DPA Covered Claims.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cap_csa_reference",
@@ -5692,7 +6314,8 @@
           "section": "Liability",
           "description": "Set to true when using CSA-style Increased Claim cap for DPA Covered Claims.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cap_non_csa_reference",
@@ -5701,7 +6324,8 @@
           "section": "Liability",
           "description": "Set to true when using non-CSA liability cap language for DPA Covered Claims.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_dpa_governing_law",
@@ -5710,7 +6334,8 @@
           "section": "Legal",
           "description": "Set to true when DPA-specific governing law overrides the Agreement's governing law clause.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_ccpa_terms",
@@ -5719,7 +6344,8 @@
           "section": "Legal",
           "description": "Set to true when California Consumer Privacy Act (CCPA) terms are included in the DPA.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_eea_transfers",
@@ -5728,7 +6354,8 @@
           "section": "Privacy",
           "description": "Set to true when EEA data transfer mechanisms are specified.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_uk_transfers",
@@ -5737,7 +6364,8 @@
           "section": "Privacy",
           "description": "Set to true when UK data transfer mechanisms are specified.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "data_subject_end_users",
@@ -5746,7 +6374,8 @@
           "section": "Privacy",
           "description": "Set to true when end users or customers are included as data subjects.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "data_subject_employees",
@@ -5755,7 +6384,8 @@
           "section": "Privacy",
           "description": "Set to true when employees are included as data subjects.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "data_subject_custom",
@@ -5764,7 +6394,8 @@
           "section": "Privacy",
           "description": "Set to true to include a custom data subject category. Specify in custom_option.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "pd_name",
@@ -5773,7 +6404,8 @@
           "section": "Privacy",
           "description": "Set to true when Name is a category of personal data processed.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "pd_contact",
@@ -5782,7 +6414,8 @@
           "section": "Privacy",
           "description": "Set to true when contact information (email, phone, address) is a category of personal data processed.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "pd_employment",
@@ -5791,7 +6424,8 @@
           "section": "Privacy",
           "description": "Set to true when employment information (employee ID, compensation) is a category of personal data processed.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "pd_financial",
@@ -5800,7 +6434,8 @@
           "section": "Privacy",
           "description": "Set to true when financial information (bank account numbers) is a category of personal data processed.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "pd_professional",
@@ -5809,7 +6444,8 @@
           "section": "Privacy",
           "description": "Set to true when professional or biographic information (resume, CV) is a category of personal data processed.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "pd_transactional",
@@ -5818,7 +6454,8 @@
           "section": "Privacy",
           "description": "Set to true when transactional information (account info, purchases) is a category of personal data processed.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "pd_user_activity",
@@ -5827,7 +6464,8 @@
           "section": "Privacy",
           "description": "Set to true when user activity and analysis (device info, IP address) is a category of personal data processed.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "pd_location",
@@ -5836,7 +6474,8 @@
           "section": "Privacy",
           "description": "Set to true when location information is a category of personal data processed.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "pd_custom",
@@ -5845,7 +6484,8 @@
           "section": "Privacy",
           "description": "Set to true to include a custom personal data category. Specify in custom_option.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "security_measures_see_policy",
@@ -5854,7 +6494,8 @@
           "section": "Security",
           "description": "Set to true when security measures reference the Security Policy.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "security_measures_custom",
@@ -5863,7 +6504,8 @@
           "section": "Security",
           "description": "Set to true to include custom security measures. Specify in custom_option.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "processing_continuous",
@@ -5872,7 +6514,8 @@
           "section": "Privacy",
           "description": "Set to true when data processing is continuous.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "processing_frequency_custom",
@@ -5881,7 +6524,8 @@
           "section": "Privacy",
           "description": "Set to true to specify a custom processing frequency. Specify in custom_options.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "pa_receiving",
@@ -5890,7 +6534,8 @@
           "section": "Privacy",
           "description": "Set to true when receiving data (collection, accessing, retrieval) is a processing activity.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "pa_holding",
@@ -5899,7 +6544,8 @@
           "section": "Privacy",
           "description": "Set to true when holding data (storage, organization, structuring) is a processing activity.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "pa_using",
@@ -5908,7 +6554,8 @@
           "section": "Privacy",
           "description": "Set to true when using data (analysis, consultation, testing) is a processing activity.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "pa_updating",
@@ -5917,7 +6564,8 @@
           "section": "Privacy",
           "description": "Set to true when updating data (correcting, adaptation, alteration) is a processing activity.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "pa_protecting",
@@ -5926,7 +6574,8 @@
           "section": "Privacy",
           "description": "Set to true when protecting data (restricting, encrypting, testing) is a processing activity.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "pa_sharing",
@@ -5935,7 +6584,8 @@
           "section": "Privacy",
           "description": "Set to true when sharing data (disclosure, dissemination) is a processing activity.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "pa_returning",
@@ -5944,7 +6594,8 @@
           "section": "Privacy",
           "description": "Set to true when returning data to the data exporter or data subject is a processing activity.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "pa_erasing",
@@ -5953,7 +6604,8 @@
           "section": "Privacy",
           "description": "Set to true when erasing data (destruction, deletion) is a processing activity.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "pa_custom",
@@ -5962,7 +6614,8 @@
           "section": "Privacy",
           "description": "Set to true to include a custom processing activity. Specify in custom_options.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "sm_pseudonymization",
@@ -5971,7 +6624,8 @@
           "section": "Security",
           "description": "Set to true when pseudonymization and encryption of personal data is a security measure.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "sm_confidentiality",
@@ -5980,7 +6634,8 @@
           "section": "Security",
           "description": "Set to true when ensuring ongoing confidentiality, integrity, availability, and resilience is a security measure.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "sm_restore",
@@ -5989,7 +6644,8 @@
           "section": "Security",
           "description": "Set to true when ability to restore availability and access after incidents is a security measure.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "sm_testing",
@@ -5998,7 +6654,8 @@
           "section": "Security",
           "description": "Set to true when regular testing and evaluation of security measures is a security measure.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "sm_user_auth",
@@ -6007,7 +6664,8 @@
           "section": "Security",
           "description": "Set to true when user identification and authorization process protection is a security measure.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "sm_transit",
@@ -6016,7 +6674,8 @@
           "section": "Security",
           "description": "Set to true when protecting personal data during transmission (in transit) is a security measure.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "sm_storage",
@@ -6025,7 +6684,8 @@
           "section": "Security",
           "description": "Set to true when protecting personal data during storage (at rest) is a security measure.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "sm_physical",
@@ -6034,7 +6694,8 @@
           "section": "Security",
           "description": "Set to true when physical security of processing locations is a security measure.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "sm_logging",
@@ -6043,7 +6704,8 @@
           "section": "Security",
           "description": "Set to true when events logging is a security measure.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "sm_config",
@@ -6052,7 +6714,8 @@
           "section": "Security",
           "description": "Set to true when systems configuration and default configuration is a security measure.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "sm_governance",
@@ -6061,7 +6724,8 @@
           "section": "Security",
           "description": "Set to true when internal IT and IT security governance and management is a security measure.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "sm_certification",
@@ -6070,7 +6734,8 @@
           "section": "Security",
           "description": "Set to true when certification or assurance of processes and products is a security measure.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "sm_minimization",
@@ -6079,7 +6744,8 @@
           "section": "Security",
           "description": "Set to true when data minimization is a security measure.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "sm_quality",
@@ -6088,7 +6754,8 @@
           "section": "Security",
           "description": "Set to true when ensuring data quality is a security measure.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "sm_retention",
@@ -6097,7 +6764,8 @@
           "section": "Security",
           "description": "Set to true when ensuring limited data retention is a security measure.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "sm_accountability",
@@ -6106,7 +6774,8 @@
           "section": "Security",
           "description": "Set to true when ensuring accountability is a security measure.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "sm_portability",
@@ -6115,7 +6784,8 @@
           "section": "Security",
           "description": "Set to true when allowing data portability and ensuring erasure is a security measure.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_type",
@@ -6124,7 +6794,8 @@
           "section": "Signature Block",
           "description": "Whether the Provider signatory is an entity or individual",
           "default": "entity",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_name",
@@ -6133,7 +6804,8 @@
           "section": "Signature Block",
           "description": "Full legal name of the Provider's signatory",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_title",
@@ -6142,7 +6814,8 @@
           "section": "Signature Block",
           "description": "Title/role of the Provider's signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_company",
@@ -6151,7 +6824,8 @@
           "section": "Signature Block",
           "description": "Company name for the Provider signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_type",
@@ -6160,7 +6834,8 @@
           "section": "Signature Block",
           "description": "Whether the Customer signatory is an entity or individual",
           "default": "entity",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_name",
@@ -6169,7 +6844,8 @@
           "section": "Signature Block",
           "description": "Full legal name of the Customer's signatory",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_title",
@@ -6178,7 +6854,8 @@
           "section": "Signature Block",
           "description": "Title/role of the Customer's signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_company",
@@ -6187,9 +6864,11 @@
           "section": "Signature Block",
           "description": "Company name for the Customer signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         }
-      ]
+      ],
+      "has_template_md": false
     },
     {
       "name": "common-paper-design-partner-agreement",
@@ -6211,7 +6890,8 @@
           "section": "Parties",
           "description": "Official company name (shown in header)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "product_description",
@@ -6220,7 +6900,8 @@
           "section": "Service",
           "description": "Description of the product being developed",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "billing_period",
@@ -6229,7 +6910,8 @@
           "section": "Payment",
           "description": "Billing period (e.g. \"month\", \"quarter\", \"year\", \"term\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "term_length_unit",
@@ -6238,7 +6920,8 @@
           "section": "Terms",
           "description": "Unit for term length (e.g. \"months\", \"quarters\", \"years\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "discount_amount",
@@ -6247,7 +6930,8 @@
           "section": "Payment",
           "description": "Discount amount (flat amount or percentage)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "free_text",
@@ -6256,7 +6940,8 @@
           "section": "Terms",
           "description": "Free text entry for customizable sections",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "open_text",
@@ -6265,7 +6950,8 @@
           "section": "Terms",
           "description": "Open text entry for additional details",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "partner_other_details",
@@ -6274,7 +6960,8 @@
           "section": "Program",
           "description": "Additional partner commitments not listed above",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_other_details",
@@ -6283,7 +6970,8 @@
           "section": "Program",
           "description": "Additional provider commitments not listed above",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_partner_other_details",
@@ -6292,7 +6980,8 @@
           "section": "Program",
           "description": "Set to true when additional partner commitments are specified in partner_other_details.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_provider_other_details",
@@ -6301,7 +6990,8 @@
           "section": "Program",
           "description": "Set to true when additional provider commitments are specified in provider_other_details.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "partner_feedback_sessions",
@@ -6310,7 +7000,8 @@
           "section": "Program",
           "description": "Partner will participate in feedback sessions",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "partner_case_study",
@@ -6319,7 +7010,8 @@
           "section": "Program",
           "description": "Partner will provide a case study",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "partner_private_list",
@@ -6328,7 +7020,8 @@
           "section": "Program",
           "description": "Partner will appear in private customer lists",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "partner_public_list",
@@ -6337,7 +7030,8 @@
           "section": "Program",
           "description": "Partner will appear on public customer lists and website",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "partner_reference",
@@ -6346,7 +7040,8 @@
           "section": "Program",
           "description": "Partner will serve as a reference for prospective customers",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_discount",
@@ -6355,7 +7050,8 @@
           "section": "Program",
           "description": "Provider will give a discount for long-term agreement",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_develop_functionality",
@@ -6364,7 +7060,8 @@
           "section": "Program",
           "description": "Provider will develop specific product functionality",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_fees",
@@ -6373,7 +7070,8 @@
           "section": "Payment",
           "description": "Whether fees apply under this agreement",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "governing_law",
@@ -6382,7 +7080,8 @@
           "section": "Legal",
           "description": "State whose laws govern the agreement",
           "default": "Delaware",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "jurisdiction",
@@ -6391,7 +7090,8 @@
           "section": "Legal",
           "description": "Courts with jurisdiction over disputes",
           "default": "courts located in New Castle County, Delaware",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_type",
@@ -6400,7 +7100,8 @@
           "section": "Signature Block",
           "description": "Whether the Provider signatory is an entity or individual",
           "default": "entity",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_name",
@@ -6409,7 +7110,8 @@
           "section": "Signature Block",
           "description": "Full legal name of the Provider's signatory",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_title",
@@ -6418,7 +7120,8 @@
           "section": "Signature Block",
           "description": "Title/role of the Provider's signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_company",
@@ -6427,7 +7130,8 @@
           "section": "Signature Block",
           "description": "Company name for the Provider signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_email",
@@ -6436,7 +7140,8 @@
           "section": "Signature Block",
           "description": "Notice email address for the Provider",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "partner_signatory_type",
@@ -6445,7 +7150,8 @@
           "section": "Signature Block",
           "description": "Whether the Partner signatory is an entity or individual",
           "default": "entity",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "partner_signatory_name",
@@ -6454,7 +7160,8 @@
           "section": "Signature Block",
           "description": "Full legal name of the Partner's signatory",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "partner_signatory_title",
@@ -6463,7 +7170,8 @@
           "section": "Signature Block",
           "description": "Title/role of the Partner's signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "partner_signatory_company",
@@ -6472,7 +7180,8 @@
           "section": "Signature Block",
           "description": "Company name for the Partner signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "partner_signatory_email",
@@ -6481,9 +7190,11 @@
           "section": "Signature Block",
           "description": "Notice email address for the Partner",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         }
-      ]
+      ],
+      "has_template_md": false
     },
     {
       "name": "common-paper-independent-contractor-agreement",
@@ -6505,7 +7216,8 @@
           "section": "Parties",
           "description": "Name and address of the company engaging the contractor",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "contractor_name_and_address",
@@ -6514,7 +7226,8 @@
           "section": "Parties",
           "description": "Name, legal business name (if any), and address of the contractor",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "services_description",
@@ -6523,7 +7236,8 @@
           "section": "Service",
           "description": "Description of services to be provided",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "rates_and_fees",
@@ -6532,7 +7246,8 @@
           "section": "Payment",
           "description": "Applicable rates and maximum fees or hours",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "payment_terms",
@@ -6541,7 +7256,8 @@
           "section": "Payment",
           "description": "How and when contractor will submit invoices and be paid",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "timeline",
@@ -6550,7 +7266,8 @@
           "section": "Terms",
           "description": "Start date, end date, timeline, milestones, etc.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "other_terms",
@@ -6559,7 +7276,8 @@
           "section": "Terms",
           "description": "Additional terms relevant to the engagement (e.g., expense or travel reimbursements)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "governing_law",
@@ -6568,7 +7286,8 @@
           "section": "Legal",
           "description": "State whose laws govern the agreement",
           "default": "the State of California",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "jurisdiction",
@@ -6577,7 +7296,8 @@
           "section": "Legal",
           "description": "Courts with jurisdiction over disputes",
           "default": "San Francisco County, California",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "company_signatory_type",
@@ -6586,7 +7306,8 @@
           "section": "Signature Block",
           "description": "Whether the Company signatory is an entity or individual",
           "default": "entity",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "company_signatory_name",
@@ -6595,7 +7316,8 @@
           "section": "Signature Block",
           "description": "Full legal name of the Company's signatory",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "company_signatory_title",
@@ -6604,7 +7326,8 @@
           "section": "Signature Block",
           "description": "Title/role of the Company's signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "company_signatory_company",
@@ -6613,7 +7336,8 @@
           "section": "Signature Block",
           "description": "Company name for the Company signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "company_signatory_email",
@@ -6622,7 +7346,8 @@
           "section": "Signature Block",
           "description": "Notice email address for the Company",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "contractor_signatory_type",
@@ -6631,7 +7356,8 @@
           "section": "Signature Block",
           "description": "Whether the Contractor signatory is an entity or individual",
           "default": "entity",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "contractor_signatory_name",
@@ -6640,7 +7366,8 @@
           "section": "Signature Block",
           "description": "Full legal name of the Contractor's signatory",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "contractor_signatory_title",
@@ -6649,7 +7376,8 @@
           "section": "Signature Block",
           "description": "Title/role of the Contractor's signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "contractor_signatory_company",
@@ -6658,7 +7386,8 @@
           "section": "Signature Block",
           "description": "Company name for the Contractor signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "contractor_signatory_email",
@@ -6667,9 +7396,11 @@
           "section": "Signature Block",
           "description": "Notice email address for the Contractor",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         }
-      ]
+      ],
+      "has_template_md": false
     },
     {
       "name": "common-paper-letter-of-intent",
@@ -6691,7 +7422,8 @@
           "section": "Parties",
           "description": "Official name of the company sending the letter",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "product_name",
@@ -6700,7 +7432,8 @@
           "section": "Service",
           "description": "Name of the product or service",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "product_description",
@@ -6709,7 +7442,8 @@
           "section": "Service",
           "description": "Description of what the product will do",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "launch_date",
@@ -6718,7 +7452,8 @@
           "section": "Terms",
           "description": "Anticipated access or launch date",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fees_description",
@@ -6727,7 +7462,8 @@
           "section": "Payment",
           "description": "Description of fees and pricing",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "nda_date",
@@ -6736,7 +7472,8 @@
           "section": "Terms",
           "description": "Date of the existing NDA between the parties",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_type",
@@ -6745,7 +7482,8 @@
           "section": "Signature Block",
           "description": "Whether the Provider signatory is an entity or individual",
           "default": "entity",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_name",
@@ -6754,7 +7492,8 @@
           "section": "Signature Block",
           "description": "Full legal name of the Provider's signatory",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_title",
@@ -6763,7 +7502,8 @@
           "section": "Signature Block",
           "description": "Title/role of the Provider's signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_company",
@@ -6772,7 +7512,8 @@
           "section": "Signature Block",
           "description": "Company name for the Provider signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_email",
@@ -6781,7 +7522,8 @@
           "section": "Signature Block",
           "description": "Notice email address for the Provider",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_type",
@@ -6790,7 +7532,8 @@
           "section": "Signature Block",
           "description": "Whether the Customer signatory is an entity or individual",
           "default": "entity",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_name",
@@ -6799,7 +7542,8 @@
           "section": "Signature Block",
           "description": "Full legal name of the Customer's signatory",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_title",
@@ -6808,7 +7552,8 @@
           "section": "Signature Block",
           "description": "Title/role of the Customer's signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_company",
@@ -6817,7 +7562,8 @@
           "section": "Signature Block",
           "description": "Company name for the Customer signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_email",
@@ -6826,9 +7572,11 @@
           "section": "Signature Block",
           "description": "Notice email address for the Customer",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         }
-      ]
+      ],
+      "has_template_md": false
     },
     {
       "name": "common-paper-mutual-nda",
@@ -6850,7 +7598,8 @@
           "section": "Terms",
           "description": "How Confidential Information may be used",
           "default": "Evaluating whether to enter into a business relationship with the other party",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "effective_date",
@@ -6859,7 +7608,8 @@
           "section": "Terms",
           "description": "Date the NDA takes effect",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "mnda_term",
@@ -6868,7 +7618,8 @@
           "section": "Terms",
           "description": "Period for sharing Confidential Information (e.g. \"1 year\", \"2 years\")",
           "default": "1 year(s)",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "confidentiality_term",
@@ -6877,7 +7628,8 @@
           "section": "Terms",
           "description": "How long Confidential Information remains protected (e.g. \"1 year\", \"2 years\")",
           "default": "1 year(s)",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "confidentiality_term_start",
@@ -6886,7 +7638,8 @@
           "section": "Terms",
           "description": "When the confidentiality term begins counting",
           "default": "Effective Date",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "governing_law",
@@ -6895,7 +7648,8 @@
           "section": "Legal",
           "description": "State whose laws govern the agreement",
           "default": "Delaware",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "jurisdiction",
@@ -6904,7 +7658,8 @@
           "section": "Legal",
           "description": "Courts with jurisdiction over disputes",
           "default": "courts located in New Castle County, Delaware",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "changes_to_standard_terms",
@@ -6913,7 +7668,8 @@
           "section": "Legal",
           "description": "Any modifications to the Common Paper Standard Terms",
           "default": "None.",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_1_type",
@@ -6922,7 +7678,8 @@
           "section": "Signature Block",
           "description": "Whether the first party is an entity or individual",
           "default": "entity",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_1_name",
@@ -6931,7 +7688,8 @@
           "section": "Signature Block",
           "description": "Full legal name of the first party's signatory",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_1_title",
@@ -6940,7 +7698,8 @@
           "section": "Signature Block",
           "description": "Title/role of the first party's signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_1_company",
@@ -6949,7 +7708,8 @@
           "section": "Signature Block",
           "description": "Company name for the first party (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_1_email",
@@ -6958,7 +7718,8 @@
           "section": "Signature Block",
           "description": "Notice email address for the first party",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_2_type",
@@ -6967,7 +7728,8 @@
           "section": "Signature Block",
           "description": "Whether the second party is an entity or individual",
           "default": "entity",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_2_name",
@@ -6976,7 +7738,8 @@
           "section": "Signature Block",
           "description": "Full legal name of the second party's signatory",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_2_title",
@@ -6985,7 +7748,8 @@
           "section": "Signature Block",
           "description": "Title/role of the second party's signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_2_company",
@@ -6994,7 +7758,8 @@
           "section": "Signature Block",
           "description": "Company name for the second party (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_2_email",
@@ -7003,9 +7768,11 @@
           "section": "Signature Block",
           "description": "Notice email address for the second party",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         }
-      ]
+      ],
+      "has_template_md": false
     },
     {
       "name": "common-paper-one-way-nda",
@@ -7027,7 +7794,8 @@
           "section": "Parties",
           "description": "Company name and address of the Discloser",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "effective_date",
@@ -7036,7 +7804,8 @@
           "section": "Terms",
           "description": "Date the NDA takes effect",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "purpose",
@@ -7045,7 +7814,8 @@
           "section": "Terms",
           "description": "How Confidential Information may be used",
           "default": "Evaluating whether to enter into a business relationship with the other party.",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "nda_term",
@@ -7054,7 +7824,8 @@
           "section": "Terms",
           "description": "Period for sharing Confidential Information (e.g. \"1 year\", \"2 years\")",
           "default": "1 year(s)",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "confidentiality_term_start",
@@ -7063,7 +7834,8 @@
           "section": "Terms",
           "description": "When the confidentiality term begins counting (e.g. \"Effective Date\" or \"date of last disclosure\")",
           "default": "Effective Date",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "governing_law",
@@ -7072,7 +7844,8 @@
           "section": "Legal",
           "description": "State whose laws govern the agreement",
           "default": "Delaware",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "jurisdiction",
@@ -7081,7 +7854,8 @@
           "section": "Legal",
           "description": "Courts with jurisdiction over disputes",
           "default": "courts located in New Castle County, Delaware",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "changes_to_standard_terms",
@@ -7090,7 +7864,8 @@
           "section": "Legal",
           "description": "Any modifications to the Common Paper Standard Terms",
           "default": "None.",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "recipient_signatory_type",
@@ -7099,7 +7874,8 @@
           "section": "Signature Block",
           "description": "Whether the Recipient signatory is an entity or individual",
           "default": "entity",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "recipient_signatory_name",
@@ -7108,7 +7884,8 @@
           "section": "Signature Block",
           "description": "Full legal name of the Recipient's signatory",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "recipient_signatory_title",
@@ -7117,7 +7894,8 @@
           "section": "Signature Block",
           "description": "Title/role of the Recipient's signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "recipient_signatory_company",
@@ -7126,7 +7904,8 @@
           "section": "Signature Block",
           "description": "Company name for the Recipient signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "recipient_signatory_email",
@@ -7135,9 +7914,11 @@
           "section": "Signature Block",
           "description": "Notice email address for the Recipient",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         }
-      ]
+      ],
+      "has_template_md": false
     },
     {
       "name": "common-paper-order-form",
@@ -7159,7 +7940,8 @@
           "section": "Parties",
           "description": "Company name (shown in header)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_name",
@@ -7168,7 +7950,8 @@
           "section": "Parties",
           "description": "Name of the Provider",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_name",
@@ -7177,7 +7960,8 @@
           "section": "Parties",
           "description": "Name of the Customer",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "key_terms_effective_date",
@@ -7186,7 +7970,8 @@
           "section": "Terms",
           "description": "Effective Date of the Key Terms agreement",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cloud_service",
@@ -7195,7 +7980,8 @@
           "section": "Service",
           "description": "Description of the cloud service / product",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "custom_start_date",
@@ -7204,7 +7990,8 @@
           "section": "Terms",
           "description": "Custom start date (if not date of last signature)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "subscription_period",
@@ -7213,7 +8000,8 @@
           "section": "Service",
           "description": "Length of access to the service (e.g. \"12 months\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "pilot_period",
@@ -7222,7 +8010,8 @@
           "section": "Service",
           "description": "Length of pilot/trial period (e.g. \"3 months\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fees",
@@ -7231,7 +8020,8 @@
           "section": "Payment",
           "description": "Subscription fee amount (e.g. \"$10,000\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_unit",
@@ -7240,7 +8030,8 @@
           "section": "Payment",
           "description": "Fee billing unit (e.g. \"year\", \"month\", \"User\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "custom_fee_structure",
@@ -7249,7 +8040,8 @@
           "section": "Payment",
           "description": "Custom fee structure description (used with fee_is_other)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "use_limitations",
@@ -7258,7 +8050,8 @@
           "section": "Service",
           "description": "Description of use limitations or prohibited uses of the Cloud Service",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "professional_services_billing",
@@ -7267,7 +8060,8 @@
           "section": "Payment",
           "description": "How professional services fees will be billed (e.g. \"Invoices for these services will be sent monthly.\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "payment_frequency",
@@ -7276,7 +8070,8 @@
           "section": "Payment",
           "description": "Payment frequency (e.g. \"monthly\", \"quarterly\", \"annually\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "payment_terms_days",
@@ -7285,7 +8080,8 @@
           "section": "Payment",
           "description": "Number of days to pay after invoice",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "payment_due_from",
@@ -7294,7 +8090,8 @@
           "section": "Payment",
           "description": "When payment terms start (e.g. \"Customer's receipt of invoice\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "sla_terms",
@@ -7303,7 +8100,8 @@
           "section": "Service",
           "description": "Service level terms describing uptime commitments, remedies for SLA breaches, and refund policies",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "technical_support",
@@ -7312,7 +8110,8 @@
           "section": "Service",
           "description": "Description of included support",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "professional_services_description",
@@ -7321,7 +8120,8 @@
           "section": "Service",
           "description": "Description of professional services",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "professional_services_reference",
@@ -7330,7 +8130,8 @@
           "section": "Service",
           "description": "Reference to SOW or PSA for professional services",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "pilot_has_fee",
@@ -7339,7 +8140,8 @@
           "section": "Service",
           "description": "Whether pilot period has a fee (vs. free trial)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_is_per_unit",
@@ -7348,7 +8150,8 @@
           "section": "Payment",
           "description": "Fees charged per unit",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_is_other",
@@ -7357,7 +8160,8 @@
           "section": "Payment",
           "description": "Other fee structure applies",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_may_increase",
@@ -7366,7 +8170,8 @@
           "section": "Payment",
           "description": "Fees may increase up to a percentage per renewal",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_will_increase",
@@ -7375,7 +8180,8 @@
           "section": "Payment",
           "description": "Fees will increase a fixed percentage per renewal",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_increase_max_percent",
@@ -7384,7 +8190,8 @@
           "section": "Payment",
           "description": "Maximum fee increase percentage per renewal (used with fee_may_increase)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_increase_percent",
@@ -7393,7 +8200,8 @@
           "section": "Payment",
           "description": "Fee increase percentage per renewal (used with fee_will_increase)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_inclusive_of_taxes",
@@ -7402,7 +8210,8 @@
           "section": "Payment",
           "description": "Fees are inclusive of taxes (modifies Standard Terms Section 4.1)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "payment_by_invoice",
@@ -7411,7 +8220,8 @@
           "section": "Payment",
           "description": "Payment by invoice (vs. automatic payment)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "no_auto_renew",
@@ -7420,7 +8230,8 @@
           "section": "Terms",
           "description": "Order Form does not automatically renew",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "professional_services_by_reference",
@@ -7429,7 +8240,8 @@
           "section": "Service",
           "description": "Professional services per referenced SOW/PSA",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "professional_services_described",
@@ -7438,7 +8250,8 @@
           "section": "Service",
           "description": "Professional services described inline",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "professional_services_payment",
@@ -7447,7 +8260,8 @@
           "section": "Service",
           "description": "Payment process for professional services described",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_type",
@@ -7456,7 +8270,8 @@
           "section": "Signature Block",
           "description": "Whether the Provider signatory is an entity or individual",
           "default": "entity",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_name",
@@ -7465,7 +8280,8 @@
           "section": "Signature Block",
           "description": "Full legal name of the Provider's signatory",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_title",
@@ -7474,7 +8290,8 @@
           "section": "Signature Block",
           "description": "Title/role of the Provider's signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_company",
@@ -7483,7 +8300,8 @@
           "section": "Signature Block",
           "description": "Company name for the Provider signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_email",
@@ -7492,7 +8310,8 @@
           "section": "Signature Block",
           "description": "Notice email address for the Provider",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_type",
@@ -7501,7 +8320,8 @@
           "section": "Signature Block",
           "description": "Whether the Customer signatory is an entity or individual",
           "default": "entity",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_name",
@@ -7510,7 +8330,8 @@
           "section": "Signature Block",
           "description": "Full legal name of the Customer's signatory",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_title",
@@ -7519,7 +8340,8 @@
           "section": "Signature Block",
           "description": "Title/role of the Customer's signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_company",
@@ -7528,7 +8350,8 @@
           "section": "Signature Block",
           "description": "Company name for the Customer signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_email",
@@ -7537,9 +8360,11 @@
           "section": "Signature Block",
           "description": "Notice email address for the Customer",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         }
-      ]
+      ],
+      "has_template_md": false
     },
     {
       "name": "common-paper-order-form-with-sla",
@@ -7561,7 +8386,8 @@
           "section": "Parties",
           "description": "Company name (shown in header)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_name",
@@ -7570,7 +8396,8 @@
           "section": "Parties",
           "description": "Name of the Provider",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_name",
@@ -7579,7 +8406,8 @@
           "section": "Parties",
           "description": "Name of the Customer",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "key_terms_effective_date",
@@ -7588,7 +8416,8 @@
           "section": "Terms",
           "description": "Effective Date of the Key Terms agreement",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cloud_service",
@@ -7597,7 +8426,8 @@
           "section": "Service",
           "description": "Description of the cloud service / product",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "custom_start_date",
@@ -7606,7 +8436,8 @@
           "section": "Terms",
           "description": "Custom start date (if not date of last signature)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "subscription_period",
@@ -7615,7 +8446,8 @@
           "section": "Service",
           "description": "Length of access to the service (e.g. \"12 months\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "pilot_period",
@@ -7624,7 +8456,8 @@
           "section": "Service",
           "description": "Length of pilot/trial period (e.g. \"3 months\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fees",
@@ -7633,7 +8466,8 @@
           "section": "Payment",
           "description": "Subscription fee amount (e.g. \"$10,000\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_unit",
@@ -7642,7 +8476,8 @@
           "section": "Payment",
           "description": "Fee billing unit (e.g. \"year\", \"month\", \"User\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "custom_fee_structure",
@@ -7651,7 +8486,8 @@
           "section": "Payment",
           "description": "Custom fee structure description (used with fee_is_other)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "use_limitations",
@@ -7660,7 +8496,8 @@
           "section": "Service",
           "description": "Description of use limitations or prohibited uses of the Cloud Service",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "professional_services_billing",
@@ -7669,7 +8506,8 @@
           "section": "Payment",
           "description": "How professional services fees will be billed (e.g. \"Invoices for these services will be sent monthly.\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "target_uptime_percent",
@@ -7678,7 +8516,8 @@
           "section": "Service",
           "description": "Target uptime percentage for the SLA (e.g. \"99.9\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "payment_frequency",
@@ -7687,7 +8526,8 @@
           "section": "Payment",
           "description": "Payment frequency (e.g. \"monthly\", \"quarterly\", \"annually\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "payment_terms_days",
@@ -7696,7 +8536,8 @@
           "section": "Payment",
           "description": "Number of days to pay after invoice",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "payment_due_from",
@@ -7705,7 +8546,8 @@
           "section": "Payment",
           "description": "When payment terms start (e.g. \"Customer's receipt of invoice\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "technical_support",
@@ -7714,7 +8556,8 @@
           "section": "Service",
           "description": "Description of included support",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "professional_services_description",
@@ -7723,7 +8566,8 @@
           "section": "Service",
           "description": "Description of professional services",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "professional_services_reference",
@@ -7732,7 +8576,8 @@
           "section": "Service",
           "description": "Reference to SOW or PSA for professional services",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "support_start_time",
@@ -7741,7 +8586,8 @@
           "section": "Service",
           "description": "Start time for support availability",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "support_end_time",
@@ -7750,7 +8596,8 @@
           "section": "Service",
           "description": "End time for support availability",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "support_days",
@@ -7759,7 +8606,8 @@
           "section": "Service",
           "description": "Days of the week support is available",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "support_timezone",
@@ -7768,7 +8616,8 @@
           "section": "Service",
           "description": "Timezone for support hours",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "support_request_process",
@@ -7777,7 +8626,8 @@
           "section": "Service",
           "description": "How customers request support or file incident tickets (e.g. email address, helpdesk URL)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "response_time_unit",
@@ -7786,7 +8636,8 @@
           "section": "Service",
           "description": "Unit for response time targets (e.g. \"minutes\", \"hours\", \"days\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "resolution_time_unit",
@@ -7795,7 +8646,8 @@
           "section": "Service",
           "description": "Unit for resolution time targets (e.g. \"hours\", \"days\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "pilot_has_fee",
@@ -7804,7 +8656,8 @@
           "section": "Payment",
           "description": "Set to true when the Pilot Period has an associated fee (not a free trial).",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_is_per_unit",
@@ -7813,7 +8666,8 @@
           "section": "Payment",
           "description": "Set to true when fees are charged per unit (e.g., per user, per month).",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_is_other",
@@ -7822,7 +8676,8 @@
           "section": "Payment",
           "description": "Set to true when a custom fee structure applies. Describe in custom_fee_structure.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_may_increase",
@@ -7831,7 +8686,8 @@
           "section": "Payment",
           "description": "Set to true when fees may increase up to a specified percentage upon renewal.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_will_increase",
@@ -7840,7 +8696,8 @@
           "section": "Payment",
           "description": "Set to true when fees will automatically increase upon renewal.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_increase_max_percent",
@@ -7849,7 +8706,8 @@
           "section": "Payment",
           "description": "Maximum fee increase percentage per renewal (used with fee_may_increase)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_increase_percent",
@@ -7858,7 +8716,8 @@
           "section": "Payment",
           "description": "Fee increase percentage per renewal (used with fee_will_increase)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_inclusive_of_taxes",
@@ -7867,7 +8726,8 @@
           "section": "Payment",
           "description": "Set to true when fees are inclusive of taxes, modifying Section 4.1 of the Standard Terms.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "payment_by_invoice",
@@ -7876,7 +8736,8 @@
           "section": "Payment",
           "description": "Set to true when payment is by invoice (not automatic payment).",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "no_auto_renew",
@@ -7885,7 +8746,8 @@
           "section": "Terms",
           "description": "Set to true when this Order Form does not automatically renew, modifying Section 5.1 of the Standard Terms.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_target_uptime",
@@ -7894,7 +8756,8 @@
           "section": "Service",
           "description": "Set to true when a Target Uptime percentage is specified in the SLA.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_target_response_time",
@@ -7903,7 +8766,8 @@
           "section": "Service",
           "description": "Set to true when Target Response Times are specified in the SLA.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "professional_services_by_reference",
@@ -7912,7 +8776,8 @@
           "section": "Service",
           "description": "Set to true when professional services are described by reference to an external SOW or PSA.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "professional_services_described",
@@ -7921,7 +8786,8 @@
           "section": "Service",
           "description": "Set to true when professional services are described inline in the Order Form.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "professional_services_payment",
@@ -7930,7 +8796,8 @@
           "section": "Payment",
           "description": "Set to true when a separate payment process applies to professional services.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_type",
@@ -7939,7 +8806,8 @@
           "section": "Signature Block",
           "description": "Whether the Provider signatory is an entity or individual",
           "default": "entity",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_name",
@@ -7948,7 +8816,8 @@
           "section": "Signature Block",
           "description": "Full legal name of the Provider's signatory",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_title",
@@ -7957,7 +8826,8 @@
           "section": "Signature Block",
           "description": "Title/role of the Provider's signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_company",
@@ -7966,7 +8836,8 @@
           "section": "Signature Block",
           "description": "Company name for the Provider signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_email",
@@ -7975,7 +8846,8 @@
           "section": "Signature Block",
           "description": "Notice email address for the Provider",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_type",
@@ -7984,7 +8856,8 @@
           "section": "Signature Block",
           "description": "Whether the Customer signatory is an entity or individual",
           "default": "entity",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_name",
@@ -7993,7 +8866,8 @@
           "section": "Signature Block",
           "description": "Full legal name of the Customer's signatory",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_title",
@@ -8002,7 +8876,8 @@
           "section": "Signature Block",
           "description": "Title/role of the Customer's signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_company",
@@ -8011,7 +8886,8 @@
           "section": "Signature Block",
           "description": "Company name for the Customer signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_email",
@@ -8020,9 +8896,11 @@
           "section": "Signature Block",
           "description": "Notice email address for the Customer",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         }
-      ]
+      ],
+      "has_template_md": false
     },
     {
       "name": "common-paper-partnership-agreement",
@@ -8044,7 +8922,8 @@
           "section": "Parties",
           "description": "Official company name (shown in header)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "custom_effective_date",
@@ -8053,7 +8932,8 @@
           "section": "Terms",
           "description": "Custom effective date for the agreement",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "term_duration_unit",
@@ -8062,7 +8942,8 @@
           "section": "Terms",
           "description": "Duration unit for agreement term (e.g. \"days\", \"weeks\", \"months\", \"year\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "custom_end_date",
@@ -8071,7 +8952,8 @@
           "section": "Terms",
           "description": "Custom end date for the agreement",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "non_renewal_notice_days",
@@ -8080,7 +8962,8 @@
           "section": "Terms",
           "description": "Days of notice required before non-renewal",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "territory",
@@ -8089,7 +8972,8 @@
           "section": "Terms",
           "description": "Specific geographic areas for the partnership",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "term_duration_value",
@@ -8098,7 +8982,8 @@
           "section": "Terms",
           "description": "Numeric duration for the agreement term (e.g. \"6\", \"12\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "changes_to_standard_terms",
@@ -8107,7 +8992,8 @@
           "section": "Terms",
           "description": "List of specific changes to the Standard Terms",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "company_promotional_activities_detail",
@@ -8116,7 +9002,8 @@
           "section": "Obligations",
           "description": "Description of the promotional activities the Company will engage in",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "company_promotional_materials_detail",
@@ -8125,7 +9012,8 @@
           "section": "Obligations",
           "description": "Description of the promotional materials the Company will provide",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "company_sponsored_benefits_detail",
@@ -8134,7 +9022,8 @@
           "section": "Obligations",
           "description": "Description of the sponsored benefits the Company will provide",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "company_referral_criteria",
@@ -8143,7 +9032,8 @@
           "section": "Obligations",
           "description": "Criteria a third party must meet to qualify as a Referral to Partner",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "company_payment_to_partner_detail",
@@ -8152,7 +9042,8 @@
           "section": "Obligations",
           "description": "Amount the Company will pay Partner per the Payment Schedule",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "partner_promotional_activities_detail",
@@ -8161,7 +9052,8 @@
           "section": "Obligations",
           "description": "Description of the promotional activities the Partner will engage in",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "partner_promotional_materials_detail",
@@ -8170,7 +9062,8 @@
           "section": "Obligations",
           "description": "Description of the promotional materials the Partner will provide",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "partner_sponsored_benefits_detail",
@@ -8179,7 +9072,8 @@
           "section": "Obligations",
           "description": "Description of the sponsored benefits the Partner will provide",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "partner_referral_criteria",
@@ -8188,7 +9082,8 @@
           "section": "Obligations",
           "description": "Criteria a third party must meet to qualify as a Referral to Company",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "partner_payment_to_company_detail",
@@ -8197,7 +9092,8 @@
           "section": "Obligations",
           "description": "Amount the Partner will pay Company per the Payment Schedule",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "invoice_address",
@@ -8206,7 +9102,8 @@
           "section": "Payment",
           "description": "Address or email where invoices and bills for fees should be sent",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "company_covered_claims_detail",
@@ -8215,7 +9112,8 @@
           "section": "Liability",
           "description": "Detail of Company Covered Claims covering gross negligence and IP representations",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "partner_covered_claims_detail",
@@ -8224,7 +9122,8 @@
           "section": "Liability",
           "description": "Detail of Partner Covered Claims covering gross negligence and IP representations",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_claim_other_detail",
@@ -8233,7 +9132,8 @@
           "section": "Liability",
           "description": "Description of a custom Increased Claim category",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "unlimited_claim_other_detail",
@@ -8242,7 +9142,8 @@
           "section": "Liability",
           "description": "Description of a custom Unlimited Claim category",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "additional_warranty_company_detail",
@@ -8251,7 +9152,8 @@
           "section": "Terms",
           "description": "Additional warranty text provided by the Company",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "additional_warranty_partner_detail",
@@ -8260,7 +9162,8 @@
           "section": "Terms",
           "description": "Additional warranty text provided by the Partner",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "payment_schedule_detail",
@@ -8269,7 +9172,8 @@
           "section": "Payment",
           "description": "Payment schedule details (e.g. \"30 days from receipt of invoice\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "payment_terms_days",
@@ -8278,7 +9182,8 @@
           "section": "Payment",
           "description": "Number of days to pay after invoice",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "general_cap_amount",
@@ -8287,7 +9192,8 @@
           "section": "Liability",
           "description": "General liability cap dollar amount",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cap_multiplier",
@@ -8296,7 +9202,8 @@
           "section": "Liability",
           "description": "Liability cap multiplier (e.g. \"2\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_cap_amount",
@@ -8305,7 +9212,8 @@
           "section": "Liability",
           "description": "Increased liability cap dollar amount",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "dpa_reference",
@@ -8314,7 +9222,8 @@
           "section": "Privacy",
           "description": "Reference to or location of Data Processing Agreement",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "dpa_description",
@@ -8323,7 +9232,8 @@
           "section": "Privacy",
           "description": "Description of the Data Processing Agreement, or where to find it",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "company_promotional_activities",
@@ -8332,7 +9242,8 @@
           "section": "Obligations",
           "description": "Company will engage in promotional activities",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "company_promotional_materials",
@@ -8341,7 +9252,8 @@
           "section": "Obligations",
           "description": "Company will provide promotional materials",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "company_sponsored_benefits",
@@ -8350,7 +9262,8 @@
           "section": "Obligations",
           "description": "Company will provide sponsored benefits",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "company_makes_referrals",
@@ -8359,7 +9272,8 @@
           "section": "Obligations",
           "description": "Company will make referrals to Partner",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "company_pays_partner",
@@ -8368,7 +9282,8 @@
           "section": "Obligations",
           "description": "Company will pay Partner per payment schedule",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "company_brand_licensor",
@@ -8377,7 +9292,8 @@
           "section": "Obligations",
           "description": "Company provides Brand Elements as Licensor",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "partner_promotional_activities",
@@ -8386,7 +9302,8 @@
           "section": "Obligations",
           "description": "Partner will engage in promotional activities",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "partner_promotional_materials",
@@ -8395,7 +9312,8 @@
           "section": "Obligations",
           "description": "Partner will provide promotional materials",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "partner_sponsored_benefits",
@@ -8404,7 +9322,8 @@
           "section": "Obligations",
           "description": "Partner will provide sponsored benefits",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "partner_makes_referrals",
@@ -8413,7 +9332,8 @@
           "section": "Obligations",
           "description": "Partner will make referrals to Company",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "partner_pays_company",
@@ -8422,7 +9342,8 @@
           "section": "Obligations",
           "description": "Partner will pay Company per payment schedule",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "partner_brand_licensor",
@@ -8431,7 +9352,8 @@
           "section": "Obligations",
           "description": "Partner provides Brand Elements as Licensor",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "company_invoices_partner",
@@ -8440,7 +9362,8 @@
           "section": "Payment",
           "description": "Company will send invoices to Partner",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "partner_invoices_company",
@@ -8449,7 +9372,8 @@
           "section": "Payment",
           "description": "Partner will send invoices to Company",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_payment_schedule",
@@ -8458,7 +9382,8 @@
           "section": "Payment",
           "description": "Payment schedule applies",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_company_covered_claims",
@@ -8467,7 +9392,8 @@
           "section": "Liability",
           "description": "Company Covered Claims apply",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_partner_covered_claims",
@@ -8476,7 +9402,8 @@
           "section": "Liability",
           "description": "Partner Covered Claims apply",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "general_cap_type",
@@ -8485,7 +9412,8 @@
           "section": "Liability",
           "description": "Set to true to select how the General Cap Amount (baseline liability limit) is calculated. \"multiplier\" uses a multiple of fees paid, \"dollar\" uses a fixed dollar amount, \"greater_of\" uses the greater of a dollar amount or a multiple of fees.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_cap_type",
@@ -8494,7 +9422,8 @@
           "section": "Liability",
           "description": "Set to true to select how the Increased Cap Amount (higher liability limit for Increased Claims) is calculated. Same options as general_cap_type.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_claim_breach_conf",
@@ -8503,7 +9432,8 @@
           "section": "Liability",
           "description": "Set to true when breach of Section 11 (Confidentiality) should be classified as an Increased Claim with a higher liability cap.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_claim_indemnification",
@@ -8512,7 +9442,8 @@
           "section": "Liability",
           "description": "Set to true when an Indemnifying Party's indemnification obligations for its Covered Claims should be classified as an Increased Claim.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_claim_breach_conf_gross",
@@ -8521,7 +9452,8 @@
           "section": "Liability",
           "description": "Set to true when breach of confidentiality resulting from gross negligence or willful misconduct should be classified as an Increased Claim.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_claim_gross_willful",
@@ -8530,7 +9462,8 @@
           "section": "Liability",
           "description": "Set to true when claims resulting from a party's gross negligence or willful misconduct should be classified as an Increased Claim.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_claim_other",
@@ -8539,7 +9472,8 @@
           "section": "Liability",
           "description": "Set to true to include a custom Increased Claim category. Specify the claim type in the corresponding detail field.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "unlimited_claim_indemnification",
@@ -8548,7 +9482,8 @@
           "section": "Liability",
           "description": "Set to true when an Indemnifying Party's indemnification obligations for its Covered Claims should have no liability cap (Unlimited Claim).",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "unlimited_claim_breach_conf",
@@ -8557,7 +9492,8 @@
           "section": "Liability",
           "description": "Set to true when breach of Section 11 (Confidentiality) should have no liability cap (Unlimited Claim).",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "unlimited_claim_breach_conf_gross",
@@ -8566,7 +9502,8 @@
           "section": "Liability",
           "description": "Set to true when breach of confidentiality resulting from gross negligence or willful misconduct should have no liability cap (Unlimited Claim).",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "unlimited_claim_gross_willful",
@@ -8575,7 +9512,8 @@
           "section": "Liability",
           "description": "Set to true when claims resulting from a party's gross negligence or willful misconduct should have no liability cap (Unlimited Claim).",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "unlimited_claim_other",
@@ -8584,7 +9522,8 @@
           "section": "Liability",
           "description": "Set to true to include a custom Unlimited Claim category. Specify the claim type in the corresponding detail field.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "additional_terms_by_company",
@@ -8593,7 +9532,8 @@
           "section": "Terms",
           "description": "Additional terms from Company",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "additional_terms_by_partner",
@@ -8602,7 +9542,8 @@
           "section": "Terms",
           "description": "Additional terms from Partner",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "company_brand_guidelines",
@@ -8611,7 +9552,8 @@
           "section": "Terms",
           "description": "Company Brand Guidelines apply",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "partner_brand_guidelines",
@@ -8620,7 +9562,8 @@
           "section": "Terms",
           "description": "Partner Brand Guidelines apply",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "governing_law",
@@ -8629,7 +9572,8 @@
           "section": "Legal",
           "description": "State and/or country whose laws govern the agreement",
           "default": "Delaware",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "jurisdiction",
@@ -8638,7 +9582,8 @@
           "section": "Legal",
           "description": "Courts with jurisdiction over disputes",
           "default": "courts located in New Castle County, Delaware",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "company_signatory_type",
@@ -8647,7 +9592,8 @@
           "section": "Signature Block",
           "description": "Whether the Company signatory is an entity or individual",
           "default": "entity",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "company_signatory_name",
@@ -8656,7 +9602,8 @@
           "section": "Signature Block",
           "description": "Full legal name of the Company's signatory",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "company_signatory_title",
@@ -8665,7 +9612,8 @@
           "section": "Signature Block",
           "description": "Title/role of the Company's signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "company_signatory_company",
@@ -8674,7 +9622,8 @@
           "section": "Signature Block",
           "description": "Company name for the Company signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "company_signatory_email",
@@ -8683,7 +9632,8 @@
           "section": "Signature Block",
           "description": "Notice email address for the Company",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "partner_signatory_type",
@@ -8692,7 +9642,8 @@
           "section": "Signature Block",
           "description": "Whether the Partner signatory is an entity or individual",
           "default": "entity",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "partner_signatory_name",
@@ -8701,7 +9652,8 @@
           "section": "Signature Block",
           "description": "Full legal name of the Partner's signatory",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "partner_signatory_title",
@@ -8710,7 +9662,8 @@
           "section": "Signature Block",
           "description": "Title/role of the Partner's signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "partner_signatory_company",
@@ -8719,7 +9672,8 @@
           "section": "Signature Block",
           "description": "Company name for the Partner signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "partner_signatory_email",
@@ -8728,9 +9682,11 @@
           "section": "Signature Block",
           "description": "Notice email address for the Partner",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         }
-      ]
+      ],
+      "has_template_md": false
     },
     {
       "name": "common-paper-pilot-agreement",
@@ -8752,7 +9708,8 @@
           "section": "Parties",
           "description": "Official company name (shown in header)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "product_description",
@@ -8761,7 +9718,8 @@
           "section": "Service",
           "description": "Description of the product being piloted",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "pilot_period",
@@ -8770,7 +9728,8 @@
           "section": "Terms",
           "description": "Length of the pilot period (e.g. \"3 months\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "custom_start_date",
@@ -8779,7 +9738,8 @@
           "section": "Terms",
           "description": "Custom start date for the pilot",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "pilot_fee",
@@ -8788,7 +9748,8 @@
           "section": "Payment",
           "description": "Fee for the pilot period (dollar amount)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fees_description",
@@ -8797,7 +9758,8 @@
           "section": "Payment",
           "description": "Description of fees",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "payment_frequency",
@@ -8806,7 +9768,8 @@
           "section": "Payment",
           "description": "Payment frequency (e.g. \"monthly\", \"quarterly\", \"annually\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "payment_terms_days",
@@ -8815,7 +9778,8 @@
           "section": "Payment",
           "description": "Number of days to pay after invoice",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "payment_due_from",
@@ -8824,7 +9788,8 @@
           "section": "Payment",
           "description": "When payment terms start (e.g. \"Customer's receipt of invoice\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "technical_support",
@@ -8833,7 +9798,8 @@
           "section": "Service",
           "description": "Description of included support and how to access it",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "support_policy_reference",
@@ -8842,7 +9808,8 @@
           "section": "Service",
           "description": "Reference to or location of support policy",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "general_cap_amount",
@@ -8851,7 +9818,8 @@
           "section": "Liability",
           "description": "General liability cap dollar amount",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cap_multiplier",
@@ -8860,7 +9828,8 @@
           "section": "Liability",
           "description": "Liability cap multiplier (e.g. \"2\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "pilot_is_free",
@@ -8869,7 +9838,8 @@
           "section": "Payment",
           "description": "Whether the pilot is free (true) or paid (false)",
           "default": "false",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "payment_by_invoice",
@@ -8878,7 +9848,8 @@
           "section": "Payment",
           "description": "Whether customer pays by invoice",
           "default": "true",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "payment_automatic",
@@ -8887,7 +9858,8 @@
           "section": "Payment",
           "description": "Whether customer pays automatically",
           "default": "false",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cap_type",
@@ -8896,7 +9868,8 @@
           "section": "Liability",
           "description": "Liability cap type: multiplier, dollar, or greater_of",
           "default": "multiplier",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "governing_law",
@@ -8905,7 +9878,8 @@
           "section": "Legal",
           "description": "State, province, and/or country whose laws govern the agreement",
           "default": "Delaware",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "jurisdiction",
@@ -8914,7 +9888,8 @@
           "section": "Legal",
           "description": "Courts with jurisdiction over disputes",
           "default": "courts located in New Castle County, Delaware",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_type",
@@ -8923,7 +9898,8 @@
           "section": "Signature Block",
           "description": "Whether the Provider signatory is an entity or individual",
           "default": "entity",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_name",
@@ -8932,7 +9908,8 @@
           "section": "Signature Block",
           "description": "Full legal name of the Provider's signatory",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_title",
@@ -8941,7 +9918,8 @@
           "section": "Signature Block",
           "description": "Title/role of the Provider's signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_company",
@@ -8950,7 +9928,8 @@
           "section": "Signature Block",
           "description": "Company name for the Provider signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_email",
@@ -8959,7 +9938,8 @@
           "section": "Signature Block",
           "description": "Notice email address for the Provider",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_type",
@@ -8968,7 +9948,8 @@
           "section": "Signature Block",
           "description": "Whether the Customer signatory is an entity or individual",
           "default": "entity",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_name",
@@ -8977,7 +9958,8 @@
           "section": "Signature Block",
           "description": "Full legal name of the Customer's signatory",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_title",
@@ -8986,7 +9968,8 @@
           "section": "Signature Block",
           "description": "Title/role of the Customer's signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_company",
@@ -8995,7 +9978,8 @@
           "section": "Signature Block",
           "description": "Company name for the Customer signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_email",
@@ -9004,9 +9988,11 @@
           "section": "Signature Block",
           "description": "Notice email address for the Customer",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         }
-      ]
+      ],
+      "has_template_md": false
     },
     {
       "name": "common-paper-professional-services-agreement",
@@ -9028,7 +10014,8 @@
           "section": "Parties",
           "description": "Official company name",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_name",
@@ -9037,7 +10024,8 @@
           "section": "Parties",
           "description": "Official name of the Provider",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_name",
@@ -9046,7 +10034,8 @@
           "section": "Parties",
           "description": "Official name of the Customer",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "key_terms_effective_date",
@@ -9055,7 +10044,8 @@
           "section": "Terms",
           "description": "Effective Date of Key Terms",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "custom_effective_date",
@@ -9064,7 +10054,8 @@
           "section": "Terms",
           "description": "Custom effective date",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "custom_sow_date",
@@ -9073,7 +10064,8 @@
           "section": "Terms",
           "description": "Custom SOW date",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "sow_number",
@@ -9082,7 +10074,8 @@
           "section": "Terms",
           "description": "Statement of Work number",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "term_duration_unit",
@@ -9091,7 +10084,8 @@
           "section": "Terms",
           "description": "Duration unit for term",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "custom_end_date",
@@ -9100,7 +10094,8 @@
           "section": "Terms",
           "description": "Custom end date",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "payment_terms",
@@ -9109,7 +10104,8 @@
           "section": "Payment",
           "description": "Payment terms",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "invoice_frequency_unit",
@@ -9118,7 +10114,8 @@
           "section": "Payment",
           "description": "Invoice frequency unit",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "services_description",
@@ -9127,7 +10124,8 @@
           "section": "Terms",
           "description": "Description of the Services to be performed, including key individuals, timeline, and milestones",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_covered_claims_detail",
@@ -9136,7 +10134,8 @@
           "section": "Liability",
           "description": "Detail of Provider Covered Claims covering IP infringement, employee misclassification, and gross negligence",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_covered_claims_detail",
@@ -9145,7 +10144,8 @@
           "section": "Liability",
           "description": "Detail of Customer Covered Claims covering IP infringement and gross negligence",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "dpa_description",
@@ -9154,7 +10154,8 @@
           "section": "Privacy",
           "description": "Description of or reference to the Data Processing Agreement",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "term_duration_value",
@@ -9163,7 +10164,8 @@
           "section": "Terms",
           "description": "Numeric duration for the SOW term (e.g. \"6\", \"12\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "rejection_period_value",
@@ -9172,7 +10174,8 @@
           "section": "Deliverables",
           "description": "Number of time units for the deliverable rejection period",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "resubmission_period_value",
@@ -9181,7 +10184,8 @@
           "section": "Deliverables",
           "description": "Number of time units for the deliverable resubmission period",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "sow_changes_to_standard_terms",
@@ -9190,7 +10194,8 @@
           "section": "Terms",
           "description": "Changes to the Standard Terms that apply only to this SOW",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "changes_to_standard_terms",
@@ -9199,7 +10204,8 @@
           "section": "Terms",
           "description": "Changes to the Standard Terms that apply to the Agreement and all SOWs",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_description",
@@ -9208,7 +10214,8 @@
           "section": "Payment",
           "description": "Description of fees including hourly, project, or milestone-based rates and pass-through charges",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "invoice_cadence",
@@ -9217,7 +10224,8 @@
           "section": "Payment",
           "description": "Cadence for sending invoices (e.g. monthly, quarterly, upon acceptance, after each milestone)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_obligations",
@@ -9226,7 +10234,8 @@
           "section": "Terms",
           "description": "Customer obligations such as identifying a point of contact or geographic limitations",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_claim_other_detail",
@@ -9235,7 +10244,8 @@
           "section": "Liability",
           "description": "Description of a custom Increased Claim category",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "unlimited_claim_other_detail",
@@ -9244,7 +10254,8 @@
           "section": "Liability",
           "description": "Description of a custom Unlimited Claim category",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "additional_warranty_provider_detail",
@@ -9253,7 +10264,8 @@
           "section": "Terms",
           "description": "Additional warranty text provided by the Provider",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "additional_warranty_customer_detail",
@@ -9262,7 +10274,8 @@
           "section": "Terms",
           "description": "Additional warranty text provided by the Customer",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "other_security_certification",
@@ -9271,7 +10284,8 @@
           "section": "Security",
           "description": "Name of additional security certification (e.g. \"ISO 27701\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "payment_terms_days",
@@ -9280,7 +10294,8 @@
           "section": "Payment",
           "description": "Days to pay after invoice",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "non_renewal_notice_days",
@@ -9289,7 +10304,8 @@
           "section": "Terms",
           "description": "Non-renewal notice days",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "general_cap_amount",
@@ -9298,7 +10314,8 @@
           "section": "Liability",
           "description": "General liability cap",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cap_multiplier",
@@ -9307,7 +10324,8 @@
           "section": "Liability",
           "description": "Cap multiplier",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_cap_amount",
@@ -9316,7 +10334,8 @@
           "section": "Liability",
           "description": "Increased cap amount",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "greater_of_dollar",
@@ -9325,7 +10344,8 @@
           "section": "Liability",
           "description": "Greater-of dollar amount",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "include_in_progress_deliverables",
@@ -9334,7 +10354,8 @@
           "section": "Deliverables",
           "description": "Set to true when in-progress work should be included as Deliverables in addition to completed projects.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "deliverables_meet_specs",
@@ -9343,7 +10364,8 @@
           "section": "Deliverables",
           "description": "Set to true when Deliverables must meet attached specifications.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "deliverables_acceptance_process",
@@ -9352,7 +10374,8 @@
           "section": "Deliverables",
           "description": "Set to true when Deliverables are subject to an acceptance process before being considered final.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "ownership_upon_payment",
@@ -9361,7 +10384,8 @@
           "section": "Deliverables",
           "description": "Set to true when Customer owns Deliverables only upon full payment (not as they are created).",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "no_third_party_materials",
@@ -9370,7 +10394,8 @@
           "section": "Deliverables",
           "description": "Set to true when no Third-Party Materials will be incorporated into Deliverables.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_third_party_materials",
@@ -9379,7 +10404,8 @@
           "section": "Deliverables",
           "description": "Set to true when Third-Party Materials will be incorporated into Deliverables.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_procures_materials",
@@ -9388,7 +10414,8 @@
           "section": "Deliverables",
           "description": "Set to true when Provider is responsible for procuring required Third-Party Materials.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_procures_materials",
@@ -9397,7 +10424,8 @@
           "section": "Deliverables",
           "description": "Set to true when Customer is responsible for procuring required Third-Party Materials.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "additional_terms_by_provider",
@@ -9406,7 +10434,8 @@
           "section": "Terms",
           "description": "Set to true when Provider is adding additional terms to the agreement. Specify terms in additional_warranty_provider_detail.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "additional_terms_by_customer",
@@ -9415,7 +10444,8 @@
           "section": "Terms",
           "description": "Set to true when Customer is adding additional terms to the agreement. Specify terms in additional_warranty_customer_detail.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_security_policy",
@@ -9424,7 +10454,8 @@
           "section": "Security",
           "description": "Set to true when Provider has a Security Policy available at the specified DPA reference URL.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_security_certifications",
@@ -9433,7 +10464,8 @@
           "section": "Security",
           "description": "Set to true when Provider maintains annually updated security reports or certifications.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cert_iso_27001",
@@ -9442,7 +10474,8 @@
           "section": "Security",
           "description": "Set to true when Provider holds ISO 27001 certification.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cert_penetration_testing",
@@ -9451,7 +10484,8 @@
           "section": "Security",
           "description": "Set to true when Provider performs regular penetration testing.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cert_soc2_type1",
@@ -9460,7 +10494,8 @@
           "section": "Security",
           "description": "Set to true when Provider holds SOC 2 Type I certification.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cert_pci_level1",
@@ -9469,7 +10504,8 @@
           "section": "Security",
           "description": "Set to true when Provider holds PCI Level 1 certification.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cert_soc2_type2",
@@ -9478,7 +10514,8 @@
           "section": "Security",
           "description": "Set to true when Provider holds SOC 2 Type II certification.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cert_pci_level2",
@@ -9487,7 +10524,8 @@
           "section": "Security",
           "description": "Set to true when Provider holds PCI Level 2 certification.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cert_hitrust",
@@ -9496,7 +10534,8 @@
           "section": "Security",
           "description": "Set to true when Provider holds HITRUST certification.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cert_fedramp",
@@ -9505,7 +10544,8 @@
           "section": "Security",
           "description": "Set to true when Provider holds FedRAMP Authorization.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cert_other",
@@ -9514,7 +10554,8 @@
           "section": "Security",
           "description": "Set to true to include an additional security certification. Specify the certification in other_security_certification.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_may_use_logo",
@@ -9523,7 +10564,8 @@
           "section": "Publicity",
           "description": "Set to true when Provider may publicly identify Customer and use Customer's logo and trademarks in promotional materials.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_may_identify_nonpublic",
@@ -9532,7 +10574,8 @@
           "section": "Publicity",
           "description": "Set to true when Provider may identify Customer as a customer in non-public settings (e.g., sales conversations).",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "general_cap_type",
@@ -9541,7 +10584,8 @@
           "section": "Liability",
           "description": "How the General Cap Amount (baseline liability limit) is calculated. \"multiplier\" uses a multiple of fees, \"dollar\" uses a fixed amount, \"greater_of\" uses the greater of a dollar amount or a multiple of fees.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_cap_type",
@@ -9550,7 +10594,8 @@
           "section": "Liability",
           "description": "How the Increased Cap Amount (higher liability limit for Increased Claims) is calculated. Same options as general_cap_type.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_claim_breach_privacy",
@@ -9559,7 +10604,8 @@
           "section": "Liability",
           "description": "Set to true when breach of Section 3 (Privacy & Security) should be classified as an Increased Claim with a higher liability cap.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_claim_breach_conf",
@@ -9568,7 +10614,8 @@
           "section": "Liability",
           "description": "Set to true when breach of Section 11 (Confidentiality) should be classified as an Increased Claim (excluding Privacy & Security breaches).",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_claim_indemnification",
@@ -9577,7 +10624,8 @@
           "section": "Liability",
           "description": "Set to true when indemnification obligations for Covered Claims should be classified as an Increased Claim.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_claim_breach_privacy_gross",
@@ -9586,7 +10634,8 @@
           "section": "Liability",
           "description": "Set to true when breach of Privacy & Security resulting from gross negligence or willful misconduct is an Increased Claim.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_claim_breach_conf_gross",
@@ -9595,7 +10644,8 @@
           "section": "Liability",
           "description": "Set to true when breach of Confidentiality resulting from gross negligence or willful misconduct is an Increased Claim.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_claim_gross_willful",
@@ -9604,7 +10654,8 @@
           "section": "Liability",
           "description": "Set to true when claims from gross negligence or willful misconduct should be classified as Increased Claims.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "increased_claim_other",
@@ -9613,7 +10664,8 @@
           "section": "Liability",
           "description": "Set to true to include a custom Increased Claim category. Specify in increased_claim_other_detail.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "unlimited_claim_breach_privacy_gross",
@@ -9622,7 +10674,8 @@
           "section": "Liability",
           "description": "Set to true when breach of Privacy & Security resulting from gross negligence should have no liability cap (Unlimited Claim).",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "unlimited_claim_breach_conf_gross",
@@ -9631,7 +10684,8 @@
           "section": "Liability",
           "description": "Set to true when breach of Confidentiality resulting from gross negligence should have no liability cap (Unlimited Claim).",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "unlimited_claim_indemnification",
@@ -9640,7 +10694,8 @@
           "section": "Liability",
           "description": "Set to true when indemnification for Covered Claims should have no liability cap (Unlimited Claim).",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "unlimited_claim_breach_privacy",
@@ -9649,7 +10704,8 @@
           "section": "Liability",
           "description": "Set to true when breach of Section 3 (Privacy & Security) should have no liability cap (Unlimited Claim).",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "unlimited_claim_breach_conf",
@@ -9658,7 +10714,8 @@
           "section": "Liability",
           "description": "Set to true when breach of Section 11 (Confidentiality) should have no liability cap (Unlimited Claim).",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "unlimited_claim_gross_willful",
@@ -9667,7 +10724,8 @@
           "section": "Liability",
           "description": "Set to true when claims from gross negligence or willful misconduct should have no liability cap (Unlimited Claim).",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "unlimited_claim_other",
@@ -9676,7 +10734,8 @@
           "section": "Liability",
           "description": "Set to true to include a custom Unlimited Claim category. Specify in unlimited_claim_other_detail.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "governing_law",
@@ -9685,7 +10744,8 @@
           "section": "Legal",
           "description": "Governing law",
           "default": "Delaware",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "jurisdiction",
@@ -9694,7 +10754,8 @@
           "section": "Legal",
           "description": "Jurisdiction",
           "default": "courts in New Castle County, Delaware",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "travel_expense_policy",
@@ -9703,7 +10764,8 @@
           "section": "Payment",
           "description": "Travel and expense policy",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_owned_deliverables",
@@ -9712,7 +10774,8 @@
           "section": "Terms",
           "description": "Customer-owned deliverables",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "support_policy_reference",
@@ -9721,7 +10784,8 @@
           "section": "Service",
           "description": "Support policy reference",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "dpa_reference",
@@ -9730,7 +10794,8 @@
           "section": "Privacy",
           "description": "DPA reference",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_type",
@@ -9739,7 +10804,8 @@
           "section": "Signature Block",
           "description": "Whether the Provider signatory is an entity or individual",
           "default": "entity",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_name",
@@ -9748,7 +10814,8 @@
           "section": "Signature Block",
           "description": "Full legal name of the Provider's signatory",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_title",
@@ -9757,7 +10824,8 @@
           "section": "Signature Block",
           "description": "Title/role of the Provider's signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_company",
@@ -9766,7 +10834,8 @@
           "section": "Signature Block",
           "description": "Company name for the Provider signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_email",
@@ -9775,7 +10844,8 @@
           "section": "Signature Block",
           "description": "Notice email address for the Provider",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_type",
@@ -9784,7 +10854,8 @@
           "section": "Signature Block",
           "description": "Whether the Customer signatory is an entity or individual",
           "default": "entity",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_name",
@@ -9793,7 +10864,8 @@
           "section": "Signature Block",
           "description": "Full legal name of the Customer's signatory",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_title",
@@ -9802,7 +10874,8 @@
           "section": "Signature Block",
           "description": "Title/role of the Customer's signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_company",
@@ -9811,7 +10884,8 @@
           "section": "Signature Block",
           "description": "Company name for the Customer signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_email",
@@ -9820,9 +10894,11 @@
           "section": "Signature Block",
           "description": "Notice email address for the Customer",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         }
-      ]
+      ],
+      "has_template_md": false
     },
     {
       "name": "common-paper-software-license-agreement",
@@ -9836,7 +10912,8 @@
       "attribution_text": "Based on the Common Paper Software License Agreement, available at https://commonpaper.com. Licensed under CC BY 4.0. Copyright Common Paper, Inc.",
       "allow_derivatives": true,
       "credits": [],
-      "fields": []
+      "fields": [],
+      "has_template_md": false
     },
     {
       "name": "common-paper-statement-of-work",
@@ -9858,7 +10935,8 @@
           "section": "Parties",
           "description": "Company name (shown in header)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_name",
@@ -9867,7 +10945,8 @@
           "section": "Parties",
           "description": "Official name of the Provider on Key Terms",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_name",
@@ -9876,7 +10955,8 @@
           "section": "Parties",
           "description": "Official name of the Customer on Key Terms",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "key_terms_effective_date",
@@ -9885,7 +10965,8 @@
           "section": "Terms",
           "description": "Effective Date of the Key Terms agreement",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "sow_number",
@@ -9894,7 +10975,8 @@
           "section": "Terms",
           "description": "Statement of Work number (e.g. \"1\", \"2\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "custom_sow_date",
@@ -9903,7 +10985,8 @@
           "section": "Terms",
           "description": "Custom SOW date (if not date of last signature)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "custom_end_date",
@@ -9912,7 +10995,8 @@
           "section": "Terms",
           "description": "Custom end date for the SOW term",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "term_duration_unit",
@@ -9921,7 +11005,8 @@
           "section": "Terms",
           "description": "Duration unit for SOW term (e.g. \"days\", \"weeks\", \"months\", \"year\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "payment_terms",
@@ -9930,7 +11015,8 @@
           "section": "Payment",
           "description": "Payment terms (e.g. \"30 days from Customer's receipt of invoice\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "services_description",
@@ -9939,7 +11025,8 @@
           "section": "Terms",
           "description": "Description of the Services to be performed, including key individuals, timeline, and milestones",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fee_description",
@@ -9948,7 +11035,8 @@
           "section": "Payment",
           "description": "Description of fees including hourly, project, or milestone-based rates and pass-through charges",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "invoice_cadence",
@@ -9957,7 +11045,8 @@
           "section": "Payment",
           "description": "Cadence for sending invoices (e.g. monthly, quarterly, upon acceptance, after each milestone)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_obligations",
@@ -9966,7 +11055,8 @@
           "section": "Terms",
           "description": "Customer obligations such as identifying a point of contact or geographic limitations",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "term_duration_value",
@@ -9975,7 +11065,8 @@
           "section": "Terms",
           "description": "Numeric duration for the SOW term (e.g. \"6\", \"12\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "rejection_period_value",
@@ -9984,7 +11075,8 @@
           "section": "Deliverables",
           "description": "Number of time units for the deliverable rejection period",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "resubmission_period_value",
@@ -9993,7 +11085,8 @@
           "section": "Deliverables",
           "description": "Number of time units for the deliverable resubmission period",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "changes_to_standard_terms",
@@ -10002,7 +11095,8 @@
           "section": "Terms",
           "description": "List of specific changes to the Standard Terms for this SOW",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "invoice_frequency_unit",
@@ -10011,7 +11105,8 @@
           "section": "Payment",
           "description": "Invoice frequency unit (e.g. \"days\", \"weeks\", \"months\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "travel_expense_policy",
@@ -10020,7 +11115,8 @@
           "section": "Payment",
           "description": "Description of or reference to travel and expense policy",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "include_in_progress_deliverables",
@@ -10029,7 +11125,8 @@
           "section": "Deliverables",
           "description": "Include in-progress drafts or components as Deliverables",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "deliverables_meet_specs",
@@ -10038,7 +11135,8 @@
           "section": "Deliverables",
           "description": "Deliverables will meet attached specifications",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "deliverables_acceptance_process",
@@ -10047,7 +11145,8 @@
           "section": "Deliverables",
           "description": "Deliverables are subject to an acceptance process",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "ownership_upon_payment",
@@ -10056,7 +11155,8 @@
           "section": "Deliverables",
           "description": "Customer owns Deliverables upon payment (vs. as created)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "no_third_party_materials",
@@ -10065,7 +11165,8 @@
           "section": "Deliverables",
           "description": "No Third-Party Materials in Deliverables",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "has_third_party_materials",
@@ -10074,7 +11175,8 @@
           "section": "Deliverables",
           "description": "Third-Party Materials will be incorporated in Deliverables",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_procures_materials",
@@ -10083,7 +11185,8 @@
           "section": "Deliverables",
           "description": "Provider will procure Third-Party Materials",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_procures_materials",
@@ -10092,7 +11195,8 @@
           "section": "Deliverables",
           "description": "Customer will procure Third-Party Materials",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_owned_deliverables",
@@ -10101,7 +11205,8 @@
           "section": "Terms",
           "description": "Deliverables that will be owned by Customer under this SOW",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_type",
@@ -10110,7 +11215,8 @@
           "section": "Signature Block",
           "description": "Whether the Provider signatory is an entity or individual",
           "default": "entity",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_name",
@@ -10119,7 +11225,8 @@
           "section": "Signature Block",
           "description": "Full legal name of the Provider's signatory",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_title",
@@ -10128,7 +11235,8 @@
           "section": "Signature Block",
           "description": "Title/role of the Provider's signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_company",
@@ -10137,7 +11245,8 @@
           "section": "Signature Block",
           "description": "Company name for the Provider signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "provider_signatory_email",
@@ -10146,7 +11255,8 @@
           "section": "Signature Block",
           "description": "Notice email address for the Provider",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_type",
@@ -10155,7 +11265,8 @@
           "section": "Signature Block",
           "description": "Whether the Customer signatory is an entity or individual",
           "default": "entity",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_name",
@@ -10164,7 +11275,8 @@
           "section": "Signature Block",
           "description": "Full legal name of the Customer's signatory",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_title",
@@ -10173,7 +11285,8 @@
           "section": "Signature Block",
           "description": "Title/role of the Customer's signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_company",
@@ -10182,7 +11295,8 @@
           "section": "Signature Block",
           "description": "Company name for the Customer signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "customer_signatory_email",
@@ -10191,9 +11305,11 @@
           "section": "Signature Block",
           "description": "Notice email address for the Customer",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         }
-      ]
+      ],
+      "has_template_md": false
     },
     {
       "name": "common-paper-term-sheet",
@@ -10215,7 +11331,8 @@
           "section": "Parties",
           "description": "Official name of the company",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "topic",
@@ -10224,7 +11341,8 @@
           "section": "Terms",
           "description": "Topic or subject area of the term",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "topic_details",
@@ -10233,7 +11351,8 @@
           "section": "Terms",
           "description": "Details about the topic",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_1_signatory_type",
@@ -10242,7 +11361,8 @@
           "section": "Signature Block",
           "description": "Whether the first party signatory is an entity or individual",
           "default": "entity",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_1_signatory_name",
@@ -10251,7 +11371,8 @@
           "section": "Signature Block",
           "description": "Full legal name of the first party's signatory",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_1_signatory_title",
@@ -10260,7 +11381,8 @@
           "section": "Signature Block",
           "description": "Title/role of the first party's signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_1_signatory_company",
@@ -10269,7 +11391,8 @@
           "section": "Signature Block",
           "description": "Company name for the first party signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_1_signatory_email",
@@ -10278,7 +11401,8 @@
           "section": "Signature Block",
           "description": "Notice email address for the first party",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_2_signatory_type",
@@ -10287,7 +11411,8 @@
           "section": "Signature Block",
           "description": "Whether the second party signatory is an entity or individual",
           "default": "entity",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_2_signatory_name",
@@ -10296,7 +11421,8 @@
           "section": "Signature Block",
           "description": "Full legal name of the second party's signatory",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_2_signatory_title",
@@ -10305,7 +11431,8 @@
           "section": "Signature Block",
           "description": "Title/role of the second party's signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_2_signatory_company",
@@ -10314,7 +11441,8 @@
           "section": "Signature Block",
           "description": "Company name for the second party signatory (entity only)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "party_2_signatory_email",
@@ -10323,9 +11451,11 @@
           "section": "Signature Block",
           "description": "Notice email address for the second party",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         }
-      ]
+      ],
+      "has_template_md": false
     },
     {
       "name": "nvca-certificate-of-incorporation",
@@ -10347,7 +11477,8 @@
           "section": null,
           "description": "Full legal name of the corporation",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "registered_agent_address",
@@ -10356,7 +11487,8 @@
           "section": null,
           "description": "Street address of the registered agent in Delaware",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "registered_agent_city",
@@ -10365,7 +11497,8 @@
           "section": null,
           "description": "City of the registered agent office",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "registered_agent_county",
@@ -10374,7 +11507,8 @@
           "section": null,
           "description": "County of the registered agent office",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "registered_agent_name",
@@ -10383,7 +11517,8 @@
           "section": null,
           "description": "Name of the registered agent in Delaware",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "total_authorized_shares",
@@ -10392,7 +11527,8 @@
           "section": null,
           "description": "Total number of authorized shares of all classes",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "number_of_classes",
@@ -10401,7 +11537,8 @@
           "section": null,
           "description": "Number of classes of stock (e.g., two)",
           "default": "two",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "common_shares_authorized",
@@ -10410,7 +11547,8 @@
           "section": null,
           "description": "Number of authorized shares of Common Stock",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "preferred_shares_authorized",
@@ -10419,7 +11557,8 @@
           "section": null,
           "description": "Number of authorized shares of Preferred Stock",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "series_designation",
@@ -10428,7 +11567,8 @@
           "section": null,
           "description": "Series designation for preferred stock (e.g., A, B, C)",
           "default": "A",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "original_issue_price",
@@ -10437,7 +11577,8 @@
           "section": null,
           "description": "Original purchase price per share of Series A Preferred Stock",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "initial_purchase_price",
@@ -10446,7 +11587,8 @@
           "section": null,
           "description": "Initial Series A purchase price per share",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "liquidation_preference_multiple",
@@ -10455,7 +11597,8 @@
           "section": null,
           "description": "Liquidation preference multiple (e.g., 1, 1.5, 2)",
           "default": "1",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "dividend_rate_percent",
@@ -10464,7 +11607,8 @@
           "section": null,
           "description": "Annual dividend rate percentage on Preferred Stock",
           "default": "8",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "dividend_rate_per_share",
@@ -10473,7 +11617,8 @@
           "section": null,
           "description": "Dividend rate per annum per share of Preferred Stock (dollar amount)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "preferred_shares_outstanding_threshold",
@@ -10482,7 +11627,8 @@
           "section": null,
           "description": "Minimum shares of Preferred Stock outstanding for protective provisions to apply",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "preferred_director_seats",
@@ -10491,7 +11637,8 @@
           "section": null,
           "description": "Number of Preferred Director board seats",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "preferred_shares_designated_portion",
@@ -10500,7 +11647,8 @@
           "section": null,
           "description": "Portion of preferred shares designated as the named series",
           "default": "all",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "original_incorporation_name",
@@ -10509,7 +11657,8 @@
           "section": null,
           "description": "Original incorporation name, if different from current company name (leave blank if same)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "redemption_start_date",
@@ -10518,7 +11667,8 @@
           "section": null,
           "description": "Earliest date on which preferred stock may be redeemed",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "qualified_financing_notice_days",
@@ -10527,7 +11677,8 @@
           "section": null,
           "description": "Days of prior notice required for qualified financing",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "no_cumulative_voting",
@@ -10536,7 +11687,8 @@
           "section": null,
           "description": "Include 'no cumulative voting' clause",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "common_stock_voting_limitation",
@@ -10545,7 +11697,8 @@
           "section": null,
           "description": "Include clause limiting common stock from vetoing preferred-only amendments",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "authorized_shares_vote_provision",
@@ -10554,7 +11707,8 @@
           "section": null,
           "description": "Include simplified vote provision for changing authorized Common Stock count",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "include_officer_indemnification",
@@ -10563,7 +11717,8 @@
           "section": null,
           "description": "Include officer indemnification alongside director indemnification",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "include_redemption_cross_ref",
@@ -10572,7 +11727,8 @@
           "section": null,
           "description": "Include cross-reference to Section 6.1 (Redemption)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "signature_page_marker",
@@ -10581,7 +11737,8 @@
           "section": null,
           "description": "Signature page marker text",
           "default": "Signature Page Follows",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "time_zone",
@@ -10590,7 +11747,8 @@
           "section": null,
           "description": "Time zone for notices and deadlines (e.g., Eastern, Pacific)",
           "default": "Eastern",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "par_value",
@@ -10599,7 +11757,8 @@
           "section": null,
           "description": "Par value per share of common and preferred stock",
           "default": "0.001",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "specify_percentage",
@@ -10608,7 +11767,8 @@
           "section": null,
           "description": "Percentage threshold for specified provisions",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "effective_date",
@@ -10617,7 +11777,8 @@
           "section": null,
           "description": "Effective date of the certificate of incorporation",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "adjustment_notice_days",
@@ -10626,7 +11787,8 @@
           "section": null,
           "description": "Days to provide notice of conversion price adjustments",
           "default": "10",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "redemption_interest_rate",
@@ -10635,7 +11797,8 @@
           "section": null,
           "description": "Annual interest rate on unredeemed shares (percentage)",
           "default": "12",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "conversion_notice_days",
@@ -10644,7 +11807,8 @@
           "section": null,
           "description": "Days prior to record date for mandatory conversion notice",
           "default": "10",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "dividend_formula_prefix",
@@ -10653,7 +11817,8 @@
           "section": null,
           "description": "Non-cumulative dividend formula prefix phrase",
           "default": "the greater of",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "dividend_formula_alt",
@@ -10662,7 +11827,8 @@
           "section": null,
           "description": "Alternative dividend formula phrase",
           "default": "the sum of",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "acquisition_exception_shares",
@@ -10671,7 +11837,8 @@
           "section": null,
           "description": "Max shares issuable as acquisition consideration without triggering anti-dilution",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "strategic_partnership_exception_shares",
@@ -10680,7 +11847,8 @@
           "section": null,
           "description": "Max shares issuable for strategic partnerships without triggering anti-dilution",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "dividend_type",
@@ -10689,7 +11857,8 @@
           "section": null,
           "description": "Dividend structure: non_cumulative_as_converted (>95%), non_cumulative_fixed, or cumulative",
           "default": "non_cumulative_as_converted",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "liquidation_participation",
@@ -10698,7 +11867,8 @@
           "section": null,
           "description": "Liquidation participation type: non_participating (94-96%) or participating",
           "default": "non_participating",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "anti_dilution_type",
@@ -10707,7 +11877,8 @@
           "section": null,
           "description": "Anti-dilution formula: broad_based_weighted_average (>98%) or full_ratchet",
           "default": "broad_based_weighted_average",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "include_pay_to_play",
@@ -10716,7 +11887,8 @@
           "section": null,
           "description": "Include Section 5A pay-to-play conversion provisions (<5% of deals)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "include_redemption",
@@ -10725,7 +11897,8 @@
           "section": null,
           "description": "Include Article Sixth full redemption provisions (2-5% of deals)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         }
       ],
       "market_data_citations": [
@@ -10741,7 +11914,8 @@
           "id": "fenwick-2024",
           "label": "Fenwick Silicon Valley Venture Capital Survey 2024"
         }
-      ]
+      ],
+      "has_template_md": false
     },
     {
       "name": "nvca-indemnification-agreement",
@@ -10763,7 +11937,8 @@
           "section": null,
           "description": "Full legal name of the indemnitee (director or officer)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "indemnitee_address",
@@ -10772,7 +11947,8 @@
           "section": null,
           "description": "Address of the indemnitee",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "company_name",
@@ -10781,7 +11957,8 @@
           "section": null,
           "description": "Name of the corporation providing indemnification",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "agreement_effective_date",
@@ -10790,7 +11967,8 @@
           "section": null,
           "description": "Effective date in the opening clause (e.g., March 20, 2026)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "fund_sponsor_name",
@@ -10799,7 +11977,8 @@
           "section": null,
           "description": "Name of the sponsoring fund or entity appointing the indemnitee",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "indemnitee_role",
@@ -10808,7 +11987,8 @@
           "section": null,
           "description": "Primary role being indemnified (e.g. director)",
           "default": "director",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "indemnitee_role_plural",
@@ -10817,7 +11997,8 @@
           "section": null,
           "description": "Plural form of the primary role (e.g. directors)",
           "default": "directors",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "indemnitee_role_secondary",
@@ -10826,7 +12007,8 @@
           "section": null,
           "description": "Secondary role being indemnified (e.g. officer)",
           "default": "officer",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "indemnitee_role_secondary_plural",
@@ -10835,7 +12017,8 @@
           "section": null,
           "description": "Plural form of the secondary role (e.g. officers)",
           "default": "officers",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "indemnitee_pronoun_possessive",
@@ -10844,7 +12027,8 @@
           "section": null,
           "description": "Possessive pronoun for the indemnitee entity (e.g. its)",
           "default": "its",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "indemnitee_pronoun_possessive_plural",
@@ -10853,7 +12037,8 @@
           "section": null,
           "description": "Plural possessive pronoun for the indemnitee (e.g. their)",
           "default": "their",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "bylaws_name",
@@ -10862,7 +12047,8 @@
           "section": null,
           "description": "Name of the company's bylaws document",
           "default": "Bylaws",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "certificate_name",
@@ -10871,7 +12057,8 @@
           "section": null,
           "description": "Name of the company's certificate of incorporation",
           "default": "Certificate of Incorporation",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "and_appointing_stockholder",
@@ -10880,7 +12067,8 @@
           "section": null,
           "description": "Optional additional party text or empty string",
           "default": "",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "appointing_stockholder_ipo_termination_clause",
@@ -10889,7 +12077,8 @@
           "section": null,
           "description": "Optional clause text that terminates Appointing Stockholder rights at IPO closing",
           "default": "",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "indemnification_section_letter",
@@ -10898,7 +12087,8 @@
           "section": null,
           "description": "Section reference letter for indemnification provisions in the certificate",
           "default": "E",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "signature_page_marker",
@@ -10907,9 +12097,11 @@
           "section": null,
           "description": "Signature page marker text",
           "default": "Signature Page Follows",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         }
-      ]
+      ],
+      "has_template_md": false
     },
     {
       "name": "nvca-investors-rights-agreement",
@@ -10931,7 +12123,8 @@
           "section": null,
           "description": "Full legal name of the company (e.g. Acme Corp, Inc.)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "company_name_short",
@@ -10940,7 +12133,8 @@
           "section": null,
           "description": "Short name of the company used in running text (e.g. Acme or the Company)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "investor_name",
@@ -10949,7 +12143,8 @@
           "section": null,
           "description": "Full legal name of the lead investor",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "company_counsel",
@@ -10958,7 +12153,8 @@
           "section": null,
           "description": "Name and address of company's legal counsel",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "counsel_cc",
@@ -10967,7 +12163,8 @@
           "section": null,
           "description": "Additional counsel to CC on notices, or empty string if none",
           "default": "",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "state_of_incorporation",
@@ -10976,7 +12173,8 @@
           "section": null,
           "description": "State of incorporation (e.g. Delaware)",
           "default": "Delaware",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "state_lower",
@@ -10985,7 +12183,8 @@
           "section": null,
           "description": "State of incorporation in lowercase (e.g. delaware)",
           "default": "delaware",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "judicial_district",
@@ -10994,7 +12193,8 @@
           "section": null,
           "description": "Federal judicial district for dispute resolution (e.g. District of Delaware)",
           "default": "District of Delaware",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "amended_restated_upper",
@@ -11003,7 +12203,8 @@
           "section": null,
           "description": "Uppercase prefix if amending a prior agreement (e.g. AMENDED AND RESTATED) or empty string",
           "default": "",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "amended_restated",
@@ -11012,7 +12213,8 @@
           "section": null,
           "description": "Title-case prefix if amending a prior agreement (e.g. Amended and Restated) or empty string",
           "default": "",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "business_description",
@@ -11021,7 +12223,8 @@
           "section": null,
           "description": "Brief description of the company's business",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "signature_page_marker",
@@ -11030,7 +12233,8 @@
           "section": null,
           "description": "Signature page marker text",
           "default": "Signature Page Follows",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "effective_date",
@@ -11039,7 +12243,8 @@
           "section": null,
           "description": "Effective date of the agreement (e.g. January 15, 2025)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "checklist_delivery_date",
@@ -11048,9 +12253,11 @@
           "section": null,
           "description": "Date the compliance checklist is being delivered",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         }
-      ]
+      ],
+      "has_template_md": false
     },
     {
       "name": "nvca-management-rights-letter",
@@ -11072,7 +12279,8 @@
           "section": null,
           "description": "Company name in uppercase",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "investor_name",
@@ -11081,7 +12289,8 @@
           "section": null,
           "description": "Full name of the investor",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "investor_name_upper",
@@ -11090,7 +12299,8 @@
           "section": null,
           "description": "Investor name in uppercase",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "city",
@@ -11099,7 +12309,8 @@
           "section": null,
           "description": "City for the company address",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "state",
@@ -11108,7 +12319,8 @@
           "section": null,
           "description": "State for the company address",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "street_address",
@@ -11117,7 +12329,8 @@
           "section": null,
           "description": "Street address for the company",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "zip_code",
@@ -11126,7 +12339,8 @@
           "section": null,
           "description": "ZIP code for the company address",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "company_letterhead",
@@ -11135,7 +12349,8 @@
           "section": null,
           "description": "Portfolio company letterhead text",
           "default": "",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "signature_page_marker",
@@ -11144,9 +12359,11 @@
           "section": null,
           "description": "Signature page marker text",
           "default": "Signature Page Follows",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         }
-      ]
+      ],
+      "has_template_md": false
     },
     {
       "name": "nvca-rofr-co-sale-agreement",
@@ -11168,7 +12385,8 @@
           "section": null,
           "description": "Full legal name of the company (e.g. Acme Corp, Inc.)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "investor_name",
@@ -11177,7 +12395,8 @@
           "section": null,
           "description": "Full legal name of the lead investor",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "key_holder_name",
@@ -11186,7 +12405,8 @@
           "section": null,
           "description": "Full name of the key holder (founder or executive)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "company_counsel",
@@ -11195,7 +12415,8 @@
           "section": null,
           "description": "Name and address of company's legal counsel",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "counsel_cc",
@@ -11204,7 +12425,8 @@
           "section": null,
           "description": "Additional counsel to CC on notices, or empty string if none",
           "default": "",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "optional_blank_value",
@@ -11213,7 +12435,8 @@
           "section": null,
           "description": "Empty-value replacement used to clear optional bracketed drafting text and formatting artifacts",
           "default": "",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "amended_restated_upper",
@@ -11222,7 +12445,8 @@
           "section": null,
           "description": "Uppercase prefix if amending a prior agreement (e.g. AMENDED AND RESTATED) or empty string",
           "default": "",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "amended_restated",
@@ -11231,7 +12455,8 @@
           "section": null,
           "description": "Title-case prefix if amending a prior agreement (e.g. Amended and Restated) or empty string",
           "default": "",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "judicial_district",
@@ -11240,7 +12465,8 @@
           "section": null,
           "description": "Federal judicial district for dispute resolution (e.g. District of Delaware)",
           "default": "District of Delaware",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "state_lower",
@@ -11249,7 +12475,8 @@
           "section": null,
           "description": "State of incorporation in lowercase (e.g. delaware)",
           "default": "delaware",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "business_description",
@@ -11258,7 +12485,8 @@
           "section": null,
           "description": "Brief description of the company's business",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "signature_page_marker",
@@ -11267,7 +12495,8 @@
           "section": null,
           "description": "Signature page marker text",
           "default": "Signature Page Follows",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "effective_date",
@@ -11276,7 +12505,8 @@
           "section": null,
           "description": "Effective date of the agreement (e.g. January 15, 2025)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "specify_percentage",
@@ -11285,7 +12515,8 @@
           "section": null,
           "description": "Specified percentage threshold for key holder transfers",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "rofr_response_days",
@@ -11294,7 +12525,8 @@
           "section": null,
           "description": "Number of days for the company and investors to respond to a ROFR notice (default 45)",
           "default": "45",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "key_holders_label",
@@ -11303,9 +12535,11 @@
           "section": null,
           "description": "Label for the key holders group (e.g. Key Holders or Founders)",
           "default": "Key Holders",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         }
-      ]
+      ],
+      "has_template_md": false
     },
     {
       "name": "nvca-stock-purchase-agreement",
@@ -11327,7 +12561,8 @@
           "section": null,
           "description": "Full legal name of the company",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "investor_name",
@@ -11336,7 +12571,8 @@
           "section": null,
           "description": "Full name of the investor",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "company_counsel",
@@ -11345,7 +12581,8 @@
           "section": null,
           "description": "Company counsel name and address",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "investor_counsel",
@@ -11354,7 +12591,8 @@
           "section": null,
           "description": "Investor counsel name and address",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "company_counsel_name",
@@ -11363,7 +12601,8 @@
           "section": null,
           "description": "Name of the company's counsel",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "lead_purchaser_name",
@@ -11372,7 +12611,8 @@
           "section": null,
           "description": "Name of the lead purchaser",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "series_designation",
@@ -11381,7 +12621,8 @@
           "section": null,
           "description": "Series designation shown in the agreement title and share definitions",
           "default": "A",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "agreement_date_month_day",
@@ -11390,7 +12631,8 @@
           "section": null,
           "description": "Month/day portion of the agreement date in the opening paragraph",
           "default": "January 15",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "agreement_year_two_digits",
@@ -11399,7 +12641,8 @@
           "section": null,
           "description": "Two-digit year suffix used in opening date format 20[__]",
           "default": "26",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "par_value_per_share",
@@ -11408,7 +12651,8 @@
           "section": null,
           "description": "Par value per share inserted in the opening purchase clause",
           "default": "0.0001",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "purchase_price_per_share",
@@ -11417,7 +12661,8 @@
           "section": null,
           "description": "Purchase price per share inserted in the opening purchase clause",
           "default": "1.00",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "applicable_word",
@@ -11426,7 +12671,8 @@
           "section": null,
           "description": "Optional word inserted before Closing in bracketed templates",
           "default": "",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "include_convertible_securities",
@@ -11435,7 +12681,8 @@
           "section": null,
           "description": "Include convertible securities conversion clause in Section 1.1(b)",
           "default": "false",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "include_closing_reference",
@@ -11444,7 +12691,8 @@
           "section": null,
           "description": "Include \"with respect to such Closing\" bracket in purchase clause",
           "default": "false",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "purchaser_scope",
@@ -11453,7 +12701,8 @@
           "section": null,
           "description": "Convertible securities consent scope word — set by computed.json from bind_all_convertible_holders_to_convert",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "optional_plural_suffix",
@@ -11462,7 +12711,8 @@
           "section": null,
           "description": "Optional plural suffix — set by computed.json defaults",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "closing_heading",
@@ -11471,7 +12721,8 @@
           "section": null,
           "description": "Heading text — set by computed.json defaults",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "initial_word_lower",
@@ -11480,7 +12731,8 @@
           "section": null,
           "description": "Lowercase qualifier — set by computed.json defaults and rules",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "initial_word_title",
@@ -11489,7 +12741,8 @@
           "section": null,
           "description": "Titlecase qualifier — set by computed.json defaults and rules",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "bind_all_convertible_holders_to_convert",
@@ -11498,7 +12751,8 @@
           "section": null,
           "description": "Purchasers agree on behalf of all convertible security holders to convert (not just their own)",
           "default": "true",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "closing_type",
@@ -11507,7 +12761,8 @@
           "section": null,
           "description": "Single closing or additional closings",
           "default": "single",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "dispute_resolution_mode",
@@ -11516,7 +12771,8 @@
           "section": null,
           "description": "Dispute resolution alternative in SPA (Alternative 1 arbitration or Alternative 2 courts)",
           "default": "courts",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "arbitration_location",
@@ -11525,7 +12781,8 @@
           "section": null,
           "description": "Arbitration venue for Dispute Resolution Alternative 1",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "judicial_district",
@@ -11534,7 +12791,8 @@
           "section": null,
           "description": "Federal judicial district for disputes",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "balance_sheet_date",
@@ -11543,7 +12801,8 @@
           "section": null,
           "description": "Date of the company's most recent balance sheet",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "benefit_plan_name",
@@ -11552,7 +12811,8 @@
           "section": null,
           "description": "Plan year and name of the employee benefit plan",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "signature_page_marker",
@@ -11561,7 +12821,8 @@
           "section": null,
           "description": "Signature page marker text",
           "default": "Signature Page Follows",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "state_lower",
@@ -11570,7 +12831,8 @@
           "section": null,
           "description": "State name (lowercase)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "specify_percentage",
@@ -11579,7 +12841,8 @@
           "section": null,
           "description": "Specified percentage threshold",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "financial_reporting_period",
@@ -11588,7 +12851,8 @@
           "section": null,
           "description": "Financial reporting period (e.g., monthly, quarterly)",
           "default": "monthly",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "director_names",
@@ -11597,7 +12861,8 @@
           "section": null,
           "description": "List of individual director names",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "board_size",
@@ -11606,7 +12871,8 @@
           "section": null,
           "description": "Authorized number of board seats at the Initial Closing",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "minimum_shares_initial_closing",
@@ -11615,7 +12881,8 @@
           "section": null,
           "description": "Minimum number of shares required to be sold at the Initial Closing",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "applicable_purchasers",
@@ -11624,9 +12891,11 @@
           "section": null,
           "description": "Names of the applicable purchasers",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         }
-      ]
+      ],
+      "has_template_md": false
     },
     {
       "name": "nvca-voting-agreement",
@@ -11648,7 +12917,8 @@
           "section": null,
           "description": "Full legal name of the company",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "investor_name",
@@ -11657,7 +12927,8 @@
           "section": null,
           "description": "Full name of the lead investor",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "investor_2_name",
@@ -11666,7 +12937,8 @@
           "section": null,
           "description": "Full name of the second investor (if applicable)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "key_holder_name",
@@ -11675,7 +12947,8 @@
           "section": null,
           "description": "Name of the key holder (typically founder/CEO)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "effective_date",
@@ -11684,7 +12957,8 @@
           "section": null,
           "description": "Effective date of the agreement (e.g. January 15, 2025)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "company_counsel",
@@ -11693,7 +12967,8 @@
           "section": null,
           "description": "Company counsel name and address",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "counsel_cc",
@@ -11702,7 +12977,8 @@
           "section": null,
           "description": "Additional counsel to CC on notices, or empty string if none",
           "default": "",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "judicial_district",
@@ -11711,7 +12987,8 @@
           "section": null,
           "description": "Federal judicial district for disputes (e.g. District of Delaware)",
           "default": "District of Delaware",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "state_of_incorporation_lower",
@@ -11720,7 +12997,8 @@
           "section": null,
           "description": "State of incorporation in lowercase (e.g. delaware)",
           "default": "delaware",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "specify_percentage",
@@ -11729,7 +13007,8 @@
           "section": null,
           "description": "Percentage threshold for drag-along and amendment provisions (number only, e.g. 60)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "amended_restated_upper",
@@ -11738,7 +13017,8 @@
           "section": null,
           "description": "AMENDED AND RESTATED or empty string",
           "default": "",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "amended_restated",
@@ -11747,7 +13027,8 @@
           "section": null,
           "description": "Amended and Restated or empty string",
           "default": "",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "signature_page_marker",
@@ -11756,9 +13037,11 @@
           "section": null,
           "description": "Signature page marker text",
           "default": "Signature Page Follows",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         }
-      ]
+      ],
+      "has_template_md": false
     },
     {
       "name": "openagreements-board-consent-safe",
@@ -11787,7 +13070,8 @@
           "section": "Parties",
           "description": "Full legal name of the company",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "effective_date",
@@ -11796,7 +13080,8 @@
           "section": "Terms",
           "description": "Date the consent is effective",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "purchase_amount",
@@ -11805,7 +13090,8 @@
           "section": "Deal Terms",
           "description": "Aggregate SAFE purchase amount (for example, \"500,000\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "board_members",
@@ -11823,11 +13109,14 @@
               "section": null,
               "description": "Full name of a director signing the consent",
               "default": null,
-              "default_value_rationale": null
+              "default_value_rationale": null,
+              "display_label": null
             }
-          ]
+          ],
+          "display_label": null
         }
-      ]
+      ],
+      "has_template_md": true
     },
     {
       "name": "openagreements-due-diligence-request-list",
@@ -11849,7 +13138,8 @@
           "section": "Cover Sheet",
           "description": "Legal name of the buyer's law firm sending the request",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "target_company_name",
@@ -11858,7 +13148,8 @@
           "section": "Cover Sheet",
           "description": "Legal name of the target company receiving the request",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "project_code_name",
@@ -11867,7 +13158,8 @@
           "section": "Cover Sheet",
           "description": "Project code name or pseudonym used to refer to the transaction",
           "default": "",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "request_date",
@@ -11876,7 +13168,8 @@
           "section": "Cover Sheet",
           "description": "Date the request list is delivered to the target",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "response_due_date",
@@ -11885,7 +13178,8 @@
           "section": "Cover Sheet",
           "description": "Date by which the target's first-round response is due",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "lead_buyer_counsel_name",
@@ -11894,7 +13188,8 @@
           "section": "Cover Sheet",
           "description": "Name of the lead attorney at the requesting firm",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "lead_buyer_counsel_email",
@@ -11903,7 +13198,8 @@
           "section": "Cover Sheet",
           "description": "Email of the lead attorney at the requesting firm",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "primary_target_contact_name",
@@ -11912,7 +13208,8 @@
           "section": "Cover Sheet",
           "description": "Name of the target's primary point of contact for diligence responses",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "currency",
@@ -11921,7 +13218,8 @@
           "section": "Cover Sheet",
           "description": "Currency for materiality and financial threshold inputs",
           "default": "USD",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "data_room_url",
@@ -11930,7 +13228,8 @@
           "section": "Cover Sheet",
           "description": "URL of the virtual data room (optional; included in cover-sheet instructions if provided)",
           "default": "",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "materiality_threshold_usd",
@@ -11939,7 +13238,8 @@
           "section": "Materiality and Lookback",
           "description": "Dollar floor for material-contracts requests. Stored as a pre-formatted string (e.g., \"$100,000\") because the fill engine has no currency formatter. Adjust upward for larger deals, downward for early-stage targets.",
           "default": "$100,000",
-          "default_value_rationale": "$100,000 is the consensus dollar floor for mid-market deals across public DDRLs (Cooley, Skadden, Bloomberg). Tune up for larger targets (e.g., \"$1,000,000\" for $100M+ deals) or down for early-stage."
+          "default_value_rationale": "$100,000 is the consensus dollar floor for mid-market deals across public DDRLs (Cooley, Skadden, Bloomberg). Tune up for larger targets (e.g., \"$1,000,000\" for $100M+ deals) or down for early-stage.",
+          "display_label": null
         },
         {
           "name": "materiality_threshold_revenue_pct",
@@ -11948,7 +13248,8 @@
           "section": "Materiality and Lookback",
           "description": "Relative materiality threshold expressed as a percentage of gross revenue. The lower of dollar floor and revenue percentage governs. Stored as a pre-formatted string for consistency with the dollar threshold.",
           "default": "5%",
-          "default_value_rationale": "5% of gross revenue is the consensus relative-materiality qualifier in BigLaw practice. Tune down for asset-light targets where individual contract size is small but each one is operationally critical."
+          "default_value_rationale": "5% of gross revenue is the consensus relative-materiality qualifier in BigLaw practice. Tune down for asset-light targets where individual contract size is small but each one is operationally critical.",
+          "display_label": null
         },
         {
           "name": "lookback_years",
@@ -11957,7 +13258,8 @@
           "section": "Materiality and Lookback",
           "description": "Default lookback window in years for litigation, compliance, and operational history. Per-category overrides may extend specific sections.",
           "default": "3",
-          "default_value_rationale": "3 years is consensus baseline for litigation, compliance, and operational history. Tax often warrants 6+ to mirror IRS statute of limitations; regulatory correspondence is conventionally open-ended."
+          "default_value_rationale": "3 years is consensus baseline for litigation, compliance, and operational history. Tax often warrants 6+ to mirror IRS statute of limitations; regulatory correspondence is conventionally open-ended.",
+          "display_label": null
         },
         {
           "name": "litigation_lookback_years",
@@ -11966,7 +13268,8 @@
           "section": "Materiality and Lookback",
           "description": "Optional per-category override for the litigation lookback window. If blank, falls through to lookback_years. 5 years is appropriate for regulated targets or where prior litigation revealed systemic process failures.",
           "default": "",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "tax_lookback_years",
@@ -11975,7 +13278,8 @@
           "section": "Materiality and Lookback",
           "description": "Optional per-category override for the tax lookback window. If blank, falls through to lookback_years. 6 years mirrors the IRS substantial- omission statute of limitations and is the safe default for most deals.",
           "default": "",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "compliance_lookback_years",
@@ -11984,7 +13288,8 @@
           "section": "Materiality and Lookback",
           "description": "Optional per-category override for routine compliance certifications. Regulatory correspondence regarding investigations, settlements, and consent decrees should be requested open-ended regardless of this value.",
           "default": "",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "deal_type",
@@ -11993,7 +13298,8 @@
           "section": "Deal Type",
           "description": "Type of transaction the DDRL supports",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "transaction_stage",
@@ -12002,7 +13308,8 @@
           "section": "Deal Type",
           "description": "Stage of the transaction. Pre-LOI uses lighter scope; post-LOI uses the full base form plus all triggered riders.",
           "default": "post_loi_pre_signing",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "tech_rider_enabled",
@@ -12011,7 +13318,8 @@
           "section": "Industry Riders",
           "description": "Enable Section O (Tech / SaaS rider) covering OSS schedules with copyleft flagging, source-code escrow, hosted-services agreements, SOC 2 / ISO 27001 audits, data-flow architecture, SLAs, security- incident history, and cloud-agreement change-of-control. Recommended on for software, SaaS, platform, marketplace, or data-heavy targets.",
           "default": "false",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "life_sciences_rider_enabled",
@@ -12020,7 +13328,8 @@
           "section": "Industry Riders",
           "description": "Enable Section P (Life Sciences rider) covering FDA correspondence, clinical trials, CRO agreements, Form 483s, Warning Letters, CIA, and controlled-substance registrations. Recommended on for biotech, pharma, medical-device, and diagnostics targets with FDA-regulated pipelines.",
           "default": "false",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "healthcare_provider_rider_enabled",
@@ -12029,7 +13338,8 @@
           "section": "Industry Riders",
           "description": "Enable Section Q (Healthcare Provider rider) covering HIPAA breach logs, billing/coding compliance, payer audits, malpractice claims, and Anti-Kickback / Stark / Sunshine Act compliance. Recommended on for clinics, hospitals, physician groups, and telehealth providers with payer-reimbursement exposure.",
           "default": "false",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "cross_border_rider_enabled",
@@ -12038,7 +13348,8 @@
           "section": "Industry Riders",
           "description": "Enable Section R (Cross-Border / Trade Compliance rider) covering sanctions/OFAC screening, export-control classifications, AML/KYC, FCPA compliance, government-customer exposure, and foreign-investment- screening filings. Recommended on whenever the target has foreign subsidiaries, foreign customers, government customers, or sensitive- jurisdiction exposure. Increasingly mandatory after the 2023 DOJ M&A Safe Harbor Policy.",
           "default": "false",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "countries_of_operation",
@@ -12047,7 +13358,8 @@
           "section": "Cross-Border Specifics",
           "description": "Comma-separated list of countries where the target operates, sells, or has employees. Optional; populated when the cross-border rider is enabled to focus the request on specific jurisdictions.",
           "default": "",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "government_customer_exposure",
@@ -12056,7 +13368,8 @@
           "section": "Cross-Border Specifics",
           "description": "Set true if the target has government customers (federal, state, local, or foreign) where flow-down compliance obligations may apply. When true, additional government-contracts requests render in Section R.",
           "default": "false",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "additional_questions_tech",
@@ -12074,9 +13387,11 @@
               "section": null,
               "description": "The custom question text to render in Section O",
               "default": null,
-              "default_value_rationale": null
+              "default_value_rationale": null,
+              "display_label": null
             }
-          ]
+          ],
+          "display_label": null
         },
         {
           "name": "additional_questions_life_sciences",
@@ -12094,9 +13409,11 @@
               "section": null,
               "description": "The custom question text to render in Section P",
               "default": null,
-              "default_value_rationale": null
+              "default_value_rationale": null,
+              "display_label": null
             }
-          ]
+          ],
+          "display_label": null
         },
         {
           "name": "additional_questions_healthcare_provider",
@@ -12114,9 +13431,11 @@
               "section": null,
               "description": "The custom question text to render in Section Q",
               "default": null,
-              "default_value_rationale": null
+              "default_value_rationale": null,
+              "display_label": null
             }
-          ]
+          ],
+          "display_label": null
         },
         {
           "name": "additional_questions_cross_border",
@@ -12134,9 +13453,11 @@
               "section": null,
               "description": "The custom question text to render in Section R",
               "default": null,
-              "default_value_rationale": null
+              "default_value_rationale": null,
+              "display_label": null
             }
-          ]
+          ],
+          "display_label": null
         },
         {
           "name": "additional_questions_general",
@@ -12154,11 +13475,14 @@
               "section": null,
               "description": "The custom question text to render at end of document",
               "default": null,
-              "default_value_rationale": null
+              "default_value_rationale": null,
+              "display_label": null
             }
-          ]
+          ],
+          "display_label": null
         }
-      ]
+      ],
+      "has_template_md": true
     },
     {
       "name": "openagreements-employee-ip-inventions-assignment",
@@ -12180,7 +13504,8 @@
           "section": "Parties",
           "description": "Legal name of employer",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Company"
         },
         {
           "name": "employee_name",
@@ -12189,7 +13514,8 @@
           "section": "Parties",
           "description": "Full legal name of employee",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Employee"
         },
         {
           "name": "effective_date",
@@ -12198,7 +13524,8 @@
           "section": "Timing",
           "description": "Effective date of this agreement",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Effective Date"
         },
         {
           "name": "prior_inventions_disclosure",
@@ -12207,7 +13534,8 @@
           "section": "Inventions",
           "description": "List of prior inventions excluded from assignment, or None",
           "default": "None listed",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Prior Inventions Disclosure"
         },
         {
           "name": "excluded_inventions_statement",
@@ -12216,7 +13544,8 @@
           "section": "Inventions",
           "description": "Carveout statement for independently developed inventions",
           "default": "Inventions developed entirely on personal time without use of company equipment, supplies, facilities, confidential information, or trade secrets are excluded to the extent permitted by applicable law.",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Excluded Inventions Statement"
         },
         {
           "name": "confidential_information_definition",
@@ -12225,7 +13554,8 @@
           "section": "Confidentiality",
           "description": "Definition summary for confidential information obligations",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Confidential Information Definition"
         },
         {
           "name": "return_of_materials_timing",
@@ -12234,7 +13564,8 @@
           "section": "Confidentiality",
           "description": "Timing for return or deletion of company materials",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Return of Materials Timing"
         },
         {
           "name": "post_termination_assistance",
@@ -12243,7 +13574,8 @@
           "section": "Inventions",
           "description": "Cooperation obligations after termination",
           "default": "reasonable assistance with filings and signatures related to assigned inventions",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Post-Termination Assistance"
         },
         {
           "name": "governing_law",
@@ -12252,7 +13584,8 @@
           "section": "Legal",
           "description": "Governing law state",
           "default": "California",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Governing Law"
         },
         {
           "name": "venue",
@@ -12261,7 +13594,8 @@
           "section": "Legal",
           "description": "Venue for disputes",
           "default": "state and federal courts in the governing law state",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Venue"
         },
         {
           "name": "cloud_drive_id",
@@ -12270,7 +13604,8 @@
           "section": "Document Management",
           "description": "Optional document-system URI or file ID for execution copy traceability",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Cloud Drive ID"
         },
         {
           "name": "cloud_drive_id_footer",
@@ -12279,9 +13614,11 @@
           "section": "Document Management",
           "description": "Internal computed footer text for document-system traceability",
           "default": "",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Cloud Drive ID Footer"
         }
-      ]
+      ],
+      "has_template_md": true
     },
     {
       "name": "openagreements-employment-confidentiality-acknowledgement",
@@ -12303,7 +13640,8 @@
           "section": "Parties",
           "description": "Legal name of the company",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Company"
         },
         {
           "name": "employee_name",
@@ -12312,7 +13650,8 @@
           "section": "Parties",
           "description": "Full legal name of employee",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Employee"
         },
         {
           "name": "policy_effective_date",
@@ -12321,7 +13660,8 @@
           "section": "Timing",
           "description": "Effective date for this acknowledgement",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Policy Effective Date"
         },
         {
           "name": "approved_tools_scope",
@@ -12330,7 +13670,8 @@
           "section": "Data Handling",
           "description": "Approved tools/systems scope for company data",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Approved Tools Scope"
         },
         {
           "name": "data_access_scope",
@@ -12339,7 +13680,8 @@
           "section": "Data Handling",
           "description": "Permitted access scope and business purpose",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Data Access Scope"
         },
         {
           "name": "security_reporting_contact",
@@ -12348,7 +13690,8 @@
           "section": "Reporting",
           "description": "Contact for reporting incidents or accidental disclosure",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Security Reporting Contact"
         },
         {
           "name": "post_employment_obligations",
@@ -12357,7 +13700,8 @@
           "section": "Post-Employment",
           "description": "Obligations after employment ends",
           "default": "no retention, sharing, or use of company confidential information after termination",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Post-Employment Obligations"
         },
         {
           "name": "acknowledgement_date",
@@ -12366,7 +13710,8 @@
           "section": "Signature",
           "description": "Date of employee acknowledgement",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Acknowledgement Date"
         },
         {
           "name": "signatory_name",
@@ -12375,7 +13720,8 @@
           "section": "Signature",
           "description": "Printed name used in signature block",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Signatory Name"
         },
         {
           "name": "cloud_drive_id",
@@ -12384,7 +13730,8 @@
           "section": "Document Management",
           "description": "Optional document-system URI or file ID for execution copy traceability",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Cloud Drive ID"
         },
         {
           "name": "cloud_drive_id_footer",
@@ -12393,9 +13740,11 @@
           "section": "Document Management",
           "description": "Internal computed footer text for document-system traceability",
           "default": "",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Cloud Drive ID Footer"
         }
-      ]
+      ],
+      "has_template_md": true
     },
     {
       "name": "openagreements-employment-offer-letter",
@@ -12417,7 +13766,8 @@
           "section": "Parties",
           "description": "Legal name of the employer",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Employer"
         },
         {
           "name": "employee_name",
@@ -12426,7 +13776,8 @@
           "section": "Parties",
           "description": "Full legal name of the employee",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Employee"
         },
         {
           "name": "position_title",
@@ -12435,7 +13786,8 @@
           "section": "Role",
           "description": "Offered role title",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Position Title"
         },
         {
           "name": "employment_type",
@@ -12444,7 +13796,8 @@
           "section": "Role",
           "description": "Employment basis",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Employment Type"
         },
         {
           "name": "start_date",
@@ -12453,7 +13806,8 @@
           "section": "Timing",
           "description": "Employment start date",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Start Date"
         },
         {
           "name": "reporting_manager",
@@ -12462,7 +13816,8 @@
           "section": "Role",
           "description": "Manager or role this position reports to",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Reporting Manager"
         },
         {
           "name": "base_salary",
@@ -12471,7 +13826,8 @@
           "section": "Compensation",
           "description": "Base salary or hourly amount",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Base Salary"
         },
         {
           "name": "bonus_terms",
@@ -12480,7 +13836,8 @@
           "section": "Compensation",
           "description": "Bonus eligibility summary",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Bonus Terms"
         },
         {
           "name": "equity_terms",
@@ -12489,7 +13846,8 @@
           "section": "Compensation",
           "description": "Equity grant summary, if any",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Equity Terms"
         },
         {
           "name": "work_location",
@@ -12498,7 +13856,8 @@
           "section": "Work Model",
           "description": "Primary work location and/or remote status",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Primary Work Location"
         },
         {
           "name": "governing_law",
@@ -12507,7 +13866,8 @@
           "section": "Legal",
           "description": "Governing law state for the offer letter",
           "default": "California",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Governing Law"
         },
         {
           "name": "offer_expiration_date",
@@ -12516,7 +13876,8 @@
           "section": "Timing",
           "description": "Date by which the offer must be accepted",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Offer Expiration Date"
         },
         {
           "name": "cloud_drive_id",
@@ -12525,7 +13886,8 @@
           "section": "Document Management",
           "description": "Optional document-system URI or file ID for execution copy traceability",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Cloud Drive ID"
         },
         {
           "name": "cloud_drive_id_footer",
@@ -12534,9 +13896,11 @@
           "section": "Document Management",
           "description": "Internal computed footer text for document-system traceability",
           "default": "",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Cloud Drive ID Footer"
         }
-      ]
+      ],
+      "has_template_md": true
     },
     {
       "name": "openagreements-restrictive-covenant-wyoming",
@@ -12558,7 +13922,8 @@
           "section": "Parties",
           "description": "Legal name of the employer",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Employer"
         },
         {
           "name": "employee_name",
@@ -12567,7 +13932,8 @@
           "section": "Parties",
           "description": "Full legal name of the employee",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Employee"
         },
         {
           "name": "employee_title",
@@ -12576,7 +13942,8 @@
           "section": "Parties",
           "description": "Employee job title or position (optional)",
           "default": "",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Employee Title / Position"
         },
         {
           "name": "effective_date",
@@ -12585,7 +13952,8 @@
           "section": "Timing",
           "description": "Effective date of this agreement",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Effective Date"
         },
         {
           "name": "governing_law",
@@ -12594,7 +13962,8 @@
           "section": "Legal",
           "description": "Governing law state",
           "default": "Wyoming",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Governing Law"
         },
         {
           "name": "worker_category",
@@ -12603,7 +13972,8 @@
           "section": "AI Analysis",
           "description": "Employee role classification under Wyo. Stat. section 1-23-108. AI-only field that drives memo warnings. Not shown in the output document.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Worker Category"
         },
         {
           "name": "restriction_pathways",
@@ -12612,7 +13982,8 @@
           "section": "AI Analysis",
           "description": "Wyoming restriction pathway(s) under Wyo. Stat. section 1-23-108. AI-only field that drives memo warnings and conditional gating. Not shown in the output document. Options: Executive or Management Personnel, Trade Secret Protection, None.",
           "default": "None",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Restriction Pathways"
         },
         {
           "name": "confidentiality_trade_secret_duration",
@@ -12621,7 +13992,8 @@
           "section": "Confidentiality",
           "description": "Duration of confidentiality obligations for trade secrets",
           "default": "Perpetual",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Confidentiality - Trade Secrets Duration"
         },
         {
           "name": "confidentiality_other_duration",
@@ -12630,7 +14002,8 @@
           "section": "Confidentiality",
           "description": "Duration of confidentiality obligations for non-trade-secret information",
           "default": "24 months",
-          "default_value_rationale": "24 months is common for non-trade-secret confidentiality obligations in employment agreements."
+          "default_value_rationale": "24 months is common for non-trade-secret confidentiality obligations in employment agreements.",
+          "display_label": "Confidentiality - Other Confidential Information Duration"
         },
         {
           "name": "employee_nonsolicit_included",
@@ -12639,7 +14012,8 @@
           "section": "Employee Non-Solicitation",
           "description": "Whether the employee non-solicitation covenant is included",
           "default": "true",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Include Employee Non-Solicitation"
         },
         {
           "name": "employee_nonsolicit_duration",
@@ -12648,7 +14022,8 @@
           "section": "Employee Non-Solicitation",
           "description": "Duration of employee non-solicitation restriction",
           "default": "12 months",
-          "default_value_rationale": "12 months is the most common enforceable duration. Mayer Brown guidance states 1-2 years is the outer range of reasonableness."
+          "default_value_rationale": "12 months is the most common enforceable duration. Mayer Brown guidance states 1-2 years is the outer range of reasonableness.",
+          "display_label": "Employee Non-Solicitation - Duration"
         },
         {
           "name": "covered_employee_period",
@@ -12657,7 +14032,8 @@
           "section": "Employee Non-Solicitation",
           "description": "Lookback period for determining which employees are covered by the non-solicitation restriction.",
           "default": "12 months",
-          "default_value_rationale": "12 months is the most common lookback period for employee non-solicitation scope."
+          "default_value_rationale": "12 months is the most common lookback period for employee non-solicitation scope.",
+          "display_label": "Covered Employees Lookback Period"
         },
         {
           "name": "customer_nonsolicit_included",
@@ -12666,7 +14042,8 @@
           "section": "Customer Non-Solicitation",
           "description": "Whether the customer/partner non-solicitation covenant is included",
           "default": "true",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Include Customer Non-Solicitation"
         },
         {
           "name": "customer_nonsolicit_duration",
@@ -12675,7 +14052,8 @@
           "section": "Customer Non-Solicitation",
           "description": "Duration of customer/partner non-solicitation restriction",
           "default": "12 months",
-          "default_value_rationale": "12 months is the most common enforceable duration. Compass Minerals uses 12 months for non-CEO employees and 24 months for CEO."
+          "default_value_rationale": "12 months is the most common enforceable duration. Compass Minerals uses 12 months for non-CEO employees and 24 months for CEO.",
+          "display_label": "Customer Non-Solicitation - Duration"
         },
         {
           "name": "covered_customer_period",
@@ -12684,7 +14062,8 @@
           "section": "Customer Non-Solicitation",
           "description": "Lookback period for determining which customers are covered by the non-solicitation and non-dealing restrictions.",
           "default": "12 months",
-          "default_value_rationale": "12 months is the most common lookback period for customer non-solicitation scope."
+          "default_value_rationale": "12 months is the most common lookback period for customer non-solicitation scope.",
+          "display_label": "Covered Customers Lookback Period"
         },
         {
           "name": "noncompete_included",
@@ -12693,7 +14072,8 @@
           "section": "Non-Competition",
           "description": "Whether the non-competition covenant is included. Requires a lawful restriction pathway under Wyo. Stat. section 1-23-108.",
           "default": "false",
-          "default_value_rationale": "Wyo. Stat. section 1-23-108 voids most non-compete covenants. The drafter must affirmatively include this covenant only when a statutory pathway applies."
+          "default_value_rationale": "Wyo. Stat. section 1-23-108 voids most non-compete covenants. The drafter must affirmatively include this covenant only when a statutory pathway applies.",
+          "display_label": "Include Non-Competition"
         },
         {
           "name": "noncompete_duration",
@@ -12702,7 +14082,8 @@
           "section": "Non-Competition",
           "description": "Duration of non-competition restriction",
           "default": "12 months",
-          "default_value_rationale": "12 months is the most common enforceable duration. Hassler v. Circle C Resources (2022 WY 28) struck down a 24-month provision with broad scope. No Wyoming court has upheld a non-compete exceeding 24 months."
+          "default_value_rationale": "12 months is the most common enforceable duration. Hassler v. Circle C Resources (2022 WY 28) struck down a 24-month provision with broad scope. No Wyoming court has upheld a non-compete exceeding 24 months.",
+          "display_label": "Non-Competition - Duration"
         },
         {
           "name": "territory",
@@ -12711,7 +14092,8 @@
           "section": "Non-Competition",
           "description": "Geographic scope of the non-competition restriction",
           "default": "the geographic area in which Employee provided services",
-          "default_value_rationale": "Tied to the employee's actual service area. Narrower scope improves enforceability under Wyoming's strict scrutiny."
+          "default_value_rationale": "Tied to the employee's actual service area. Narrower scope improves enforceability under Wyoming's strict scrutiny.",
+          "display_label": "Non-Competition - Restricted Territory"
         },
         {
           "name": "competitive_business_definition",
@@ -12720,7 +14102,8 @@
           "section": "Non-Competition",
           "description": "Description of the business activities that constitute competition with the employer.",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Non-Competition - Competitive Business"
         },
         {
           "name": "specified_competitors",
@@ -12729,7 +14112,8 @@
           "section": "Non-Competition",
           "description": "Optional named list of specific competitors. Narrowing the restriction to named competitors strengthens enforceability.",
           "default": "",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Non-Competition - Specified Competitors"
         },
         {
           "name": "nondealing_included",
@@ -12738,7 +14122,8 @@
           "section": "No Business with Covered Customers",
           "description": "Whether the no-business-with-covered-customers covenant is included. Requires a lawful restriction pathway under Wyo. Stat. section 1-23-108.",
           "default": "false",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Include No Business with Covered Customers"
         },
         {
           "name": "nondealing_duration",
@@ -12747,7 +14132,8 @@
           "section": "No Business with Covered Customers",
           "description": "Duration of the no-business-with-covered-customers restriction",
           "default": "12 months",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "No Business with Covered Customers - Duration"
         },
         {
           "name": "passive_public_holdings_threshold",
@@ -12756,7 +14142,8 @@
           "section": "Definitions",
           "description": "Maximum ownership percentage of publicly traded securities permitted under the Passive Public Holdings carveout.",
           "default": "five percent",
-          "default_value_rationale": "Five percent of any class of publicly traded securities is the standard passive investment carveout across Fortune 500 restrictive covenant agreements."
+          "default_value_rationale": "Five percent of any class of publicly traded securities is the standard passive investment carveout across Fortune 500 restrictive covenant agreements.",
+          "display_label": "Passive Public Holdings Threshold"
         },
         {
           "name": "noninvestment_included",
@@ -12765,7 +14152,8 @@
           "section": "Non-Investment",
           "description": "Whether the non-investment covenant is included. Requires a lawful restriction pathway under Wyo. Stat. section 1-23-108.",
           "default": "false",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Include Non-Investment"
         },
         {
           "name": "noninvestment_duration",
@@ -12774,7 +14162,8 @@
           "section": "Non-Investment",
           "description": "Duration of non-investment restriction",
           "default": "12 months",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Non-Investment - Duration"
         },
         {
           "name": "nondisparagement_duration",
@@ -12783,7 +14172,8 @@
           "section": "Non-Disparagement",
           "description": "Duration of non-disparagement obligation (measured from termination)",
           "default": "24 months",
-          "default_value_rationale": "24 months is common for employment non-disparagement provisions."
+          "default_value_rationale": "24 months is common for employment non-disparagement provisions.",
+          "display_label": "Non-Disparagement - Duration"
         },
         {
           "name": "cloud_drive_id",
@@ -12792,7 +14182,8 @@
           "section": "Document Management",
           "description": "Optional document-system URI or file ID for execution copy traceability",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Cloud Drive ID"
         },
         {
           "name": "cloud_drive_id_footer",
@@ -12801,9 +14192,11 @@
           "section": "Document Management",
           "description": "Internal computed footer text for document-system traceability",
           "default": "",
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": "Cloud Drive ID Footer"
         }
-      ]
+      ],
+      "has_template_md": true
     },
     {
       "name": "openagreements-stockholder-consent-safe",
@@ -12832,7 +14225,8 @@
           "section": "Parties",
           "description": "Full legal name of the company",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "effective_date",
@@ -12841,7 +14235,8 @@
           "section": "Terms",
           "description": "Date the stockholder consent is executed",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "purchase_amount",
@@ -12850,7 +14245,8 @@
           "section": "Deal Terms",
           "description": "Aggregate SAFE purchase amount (for example, \"500,000\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "stockholders",
@@ -12868,11 +14264,14 @@
               "section": null,
               "description": "Full name of a stockholder signing the consent",
               "default": null,
-              "default_value_rationale": null
+              "default_value_rationale": null,
+              "display_label": null
             }
-          ]
+          ],
+          "display_label": null
         }
-      ]
+      ],
+      "has_template_md": true
     },
     {
       "name": "working-group-list",
@@ -12894,7 +14293,8 @@
           "section": null,
           "description": "Name of the deal or transaction",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "updated_at",
@@ -12903,7 +14303,8 @@
           "section": null,
           "description": "ISO date when the list was last updated",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "working_group",
@@ -12912,9 +14313,11 @@
           "section": null,
           "description": "Array of working group members (name, organization, role, email)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         }
-      ]
+      ],
+      "has_template_md": false
     },
     {
       "name": "yc-safe-discount",
@@ -12936,7 +14339,8 @@
           "section": "Parties",
           "description": "Full legal name of the company",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "investor_name",
@@ -12945,7 +14349,8 @@
           "section": "Parties",
           "description": "Full legal name of the investor",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "purchase_amount",
@@ -12954,7 +14359,8 @@
           "section": "Deal Terms",
           "description": "Dollar amount of the investment (e.g., \"100,000\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "discount_rate",
@@ -12963,7 +14369,8 @@
           "section": "Deal Terms",
           "description": "Discount rate as a percentage, expressed as 100 minus the discount (e.g., \"80\" for a 20% discount)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "date_of_safe",
@@ -12972,7 +14379,8 @@
           "section": "Deal Terms",
           "description": "Date the SAFE is executed",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "state_of_incorporation",
@@ -12981,7 +14389,8 @@
           "section": "Company Details",
           "description": "State where the company is incorporated (e.g., \"Delaware\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "governing_law_jurisdiction",
@@ -12990,7 +14399,8 @@
           "section": "Company Details",
           "description": "State whose laws govern the agreement (e.g., \"Delaware\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "company",
@@ -12999,7 +14409,8 @@
           "section": "Signatures",
           "description": "Company name as used in the signature block (typically matches company_name)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "company_name_caps",
@@ -13008,7 +14419,8 @@
           "section": "Signatures",
           "description": "Company name in uppercase as used in the header (e.g., \"ACME INC.\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "name",
@@ -13017,7 +14429,8 @@
           "section": "Signatures",
           "description": "Name of the company signatory",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "title",
@@ -13026,9 +14439,11 @@
           "section": "Signatures",
           "description": "Title of the company signatory (e.g., \"CEO\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         }
-      ]
+      ],
+      "has_template_md": false
     },
     {
       "name": "yc-safe-mfn",
@@ -13050,7 +14465,8 @@
           "section": "Parties",
           "description": "Full legal name of the company",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "investor_name",
@@ -13059,7 +14475,8 @@
           "section": "Parties",
           "description": "Full legal name of the investor",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "purchase_amount",
@@ -13068,7 +14485,8 @@
           "section": "Deal Terms",
           "description": "Dollar amount of the investment (e.g., \"100,000\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "date_of_safe",
@@ -13077,7 +14495,8 @@
           "section": "Deal Terms",
           "description": "Date the SAFE is executed",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "state_of_incorporation",
@@ -13086,7 +14505,8 @@
           "section": "Company Details",
           "description": "State where the company is incorporated (e.g., \"Delaware\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "governing_law_jurisdiction",
@@ -13095,7 +14515,8 @@
           "section": "Company Details",
           "description": "State whose laws govern the agreement (e.g., \"Delaware\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "company",
@@ -13104,7 +14525,8 @@
           "section": "Signatures",
           "description": "Company name as used in the signature block (typically matches company_name)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "company_name_caps",
@@ -13113,7 +14535,8 @@
           "section": "Signatures",
           "description": "Company name in uppercase as used in the header (e.g., \"ACME INC.\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "name",
@@ -13122,7 +14545,8 @@
           "section": "Signatures",
           "description": "Name of the company signatory",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "title",
@@ -13131,9 +14555,11 @@
           "section": "Signatures",
           "description": "Title of the company signatory (e.g., \"CEO\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         }
-      ]
+      ],
+      "has_template_md": false
     },
     {
       "name": "yc-safe-pro-rata-side-letter",
@@ -13155,7 +14581,8 @@
           "section": "Parties",
           "description": "Full legal name of the company",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "investor_name",
@@ -13164,7 +14591,8 @@
           "section": "Parties",
           "description": "Full legal name of the investor",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "date_of_safe",
@@ -13173,7 +14601,8 @@
           "section": "Deal Terms",
           "description": "Date of the related SAFE agreement",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "company_name_caps",
@@ -13182,7 +14611,8 @@
           "section": "Signatures",
           "description": "Company name in uppercase as used in the header (e.g., \"ACME INC.\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "investor_name_caps",
@@ -13191,7 +14621,8 @@
           "section": "Signatures",
           "description": "Investor name in uppercase as used in the header (e.g., \"JANE DOE\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "name",
@@ -13200,7 +14631,8 @@
           "section": "Signatures",
           "description": "Name of the company signatory",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "title",
@@ -13209,9 +14641,11 @@
           "section": "Signatures",
           "description": "Title of the company signatory (e.g., \"CEO\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         }
-      ]
+      ],
+      "has_template_md": false
     },
     {
       "name": "yc-safe-valuation-cap",
@@ -13233,7 +14667,8 @@
           "section": "Parties",
           "description": "Full legal name of the company",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "investor_name",
@@ -13242,7 +14677,8 @@
           "section": "Parties",
           "description": "Full legal name of the investor",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "purchase_amount",
@@ -13251,7 +14687,8 @@
           "section": "Deal Terms",
           "description": "Dollar amount of the investment (e.g., \"100,000\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "valuation_cap",
@@ -13260,7 +14697,8 @@
           "section": "Deal Terms",
           "description": "Post-money valuation cap in dollars (e.g., \"10,000,000\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "date_of_safe",
@@ -13269,7 +14707,8 @@
           "section": "Deal Terms",
           "description": "Date the SAFE is executed",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "state_of_incorporation",
@@ -13278,7 +14717,8 @@
           "section": "Company Details",
           "description": "State where the company is incorporated (e.g., \"Delaware\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "governing_law_jurisdiction",
@@ -13287,7 +14727,8 @@
           "section": "Company Details",
           "description": "State whose laws govern the agreement (e.g., \"Delaware\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "company",
@@ -13296,7 +14737,8 @@
           "section": "Signatures",
           "description": "Company name as used in the signature block (typically matches company_name)",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "name",
@@ -13305,7 +14747,8 @@
           "section": "Signatures",
           "description": "Name of the company signatory",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         },
         {
           "name": "title",
@@ -13314,9 +14757,11 @@
           "section": "Signatures",
           "description": "Title of the company signatory (e.g., \"CEO\")",
           "default": null,
-          "default_value_rationale": null
+          "default_value_rationale": null,
+          "display_label": null
         }
-      ]
+      ],
+      "has_template_md": false
     }
   ]
 }

--- a/integration-tests/api-shared.test.ts
+++ b/integration-tests/api-shared.test.ts
@@ -116,6 +116,18 @@ describe('_shared.ts — discovery (handleListTemplates / handleGetTemplate)', (
     },
   );
 
+  itDiscovery.openspec('OA-CLI-025')(
+    'handleGetTemplate surfaces has_template_md and curated field display labels for canonical OA templates',
+    () => {
+      const item = handleGetTemplate('openagreements-employment-offer-letter');
+      expect(item).not.toBeNull();
+      expect(item?.has_template_md).toBe(true);
+
+      const employerField = item?.fields.find((field) => field.name === 'employer_name');
+      expect(employerField?.display_label).toBe('Employer');
+    },
+  );
+
   // (unbound) Behaviour — handleFill rejects unknown templates with a
   // structured failure envelope. There is no canonical OpenSpec scenario
   // describing this surface explicitly; a binding would be padding.

--- a/integration-tests/list-command.inprocess.test.ts
+++ b/integration-tests/list-command.inprocess.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, describe, expect, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   allureJsonAttachment,
   allureStep,
@@ -21,9 +24,10 @@ interface TemplateMeta {
     name: string;
     type: string;
     description: string;
+    display_label?: string;
     section?: string;
     default?: string;
-    items?: Array<{ name: string; type: string; description: string; section?: string; default?: string }>;
+    items?: Array<{ name: string; type: string; description: string; display_label?: string; section?: string; default?: string }>;
   }>;
   priority_fields: string[];
   credits?: Array<{ name: string; role: string; profile_url?: string }>;
@@ -208,11 +212,13 @@ describe('runList in-process coverage', () => {
     const aTemplate = envelope.items.find((item: { name: string }) => item.name === 'a-template');
     expect(zTemplate.source).toBe('Common Paper');
     expect(aTemplate.source).toBeNull();
+    expect(zTemplate.has_template_md).toBe(false);
 
     expect(zTemplate.fields[0]).toMatchObject({
       name: 'company_name',
       required: true,
       section: null,
+      display_label: null,
       default: null,
     });
     expect(zTemplate.fields[1]).toMatchObject({
@@ -311,6 +317,51 @@ describe('runList in-process coverage', () => {
         default_value_rationale: null,
       },
     ]);
+  });
+
+  itDiscovery.openspec('OA-CLI-025')('projects display_label and has_template_md in JSON output', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'oa-list-display-label-'));
+    const templateDir = join(root, 'display-template');
+    mkdirSync(templateDir, { recursive: true });
+    writeFileSync(join(templateDir, 'template.md'), '# Display Template\n', 'utf-8');
+
+    try {
+      const harness = await loadListHarness({
+        templateEntries: [
+          { id: 'display-template', dir: templateDir, baseDir: root },
+        ],
+        templateByDir: {
+          [templateDir]: {
+            ...templateMeta('Display Template', 'https://example.com/display'),
+            fields: [
+              {
+                name: 'employer_name',
+                type: 'string',
+                description: 'Legal name of the employer',
+                display_label: 'Employer',
+              },
+            ],
+            priority_fields: [],
+          },
+        },
+      });
+
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      harness.runList({ json: true });
+
+      const envelope = JSON.parse(String(logSpy.mock.calls[0][0]));
+      await allureJsonAttachment('list-json-display-label-and-markdown.json', envelope);
+
+      const template = envelope.items.find((item: { name: string }) => item.name === 'display-template');
+      expect(template.has_template_md).toBe(true);
+      expect(template.fields[0]).toMatchObject({
+        name: 'employer_name',
+        display_label: 'Employer',
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   itDiscovery.openspec('OA-TMP-039')('projects credits and derived_from onto internal and external templates; omits them on recipes', async () => {

--- a/integration-tests/list.test.ts
+++ b/integration-tests/list.test.ts
@@ -88,6 +88,18 @@ describe('list --json envelope', () => {
       );
     }
   });
+
+  it.openspec('OA-CLI-025')('first-party templates project has_template_md and curated display labels', () => {
+    if (!available || !parsed) return;
+
+    const offerLetter = parsed.items.find((item) => item.name === 'openagreements-employment-offer-letter');
+    expect(offerLetter).toBeDefined();
+    expect(offerLetter?.has_template_md).toBe(true);
+
+    const employerField = (offerLetter?.fields as Array<Record<string, unknown>>)
+      .find((field) => field.name === 'employer_name');
+    expect(employerField?.display_label).toBe('Employer');
+  });
 });
 
 describe('list options', () => {

--- a/openspec/changes/add-template-display-labels-and-markdown-availability/proposal.md
+++ b/openspec/changes/add-template-display-labels-and-markdown-availability/proposal.md
@@ -1,0 +1,32 @@
+# Change: Add template display labels and markdown availability to discovery surfaces
+
+## Why
+
+Downstream consumers currently need to reconstruct human-facing field labels
+from field names or enrich them from legacy template-spec JSON. They also do
+not have a canonical discovery flag for whether a template directory actually
+ships a `template.md` artifact. Both gaps create avoidable coupling and drift.
+
+## What Changes
+
+- Add an optional `display_label` property to template field definitions in
+  `metadata.yaml`.
+- Project `display_label` through metadata loading, `list --json`, and the
+  committed `data/templates-snapshot.json`.
+- Add `has_template_md` to machine-readable template discovery output so
+  external consumers can tell whether a listed template has a canonical
+  `template.md` file.
+- Seed curated `display_label` values into first-party OpenAgreements
+  employment template metadata that previously relied on legacy JSON for label
+  curation.
+
+## Impact
+
+- Affected specs: `open-agreements`
+- Affected code:
+  - `src/core/metadata.ts`
+  - `src/core/template-listing.ts`
+  - `src/commands/list.ts`
+  - `scripts/export-templates-snapshot.mjs`
+  - API / MCP discovery helpers that project template metadata
+  - first-party template `metadata.yaml` files

--- a/openspec/changes/add-template-display-labels-and-markdown-availability/specs/open-agreements/spec.md
+++ b/openspec/changes/add-template-display-labels-and-markdown-availability/specs/open-agreements/spec.md
@@ -1,0 +1,74 @@
+## MODIFIED Requirements
+
+### Requirement: Template Metadata Schema
+
+Each template directory SHALL contain a `metadata.yaml` validated by Zod schema
+with fields: `name`, `source_url`, `version`, `license` (enum: CC-BY-4.0,
+CC0-1.0), `allow_derivatives` (boolean), `attribution_text`, and `fields`
+(array of field definitions with `name`, `type`, `description`, and optional
+field metadata such as `display_label`, defaults, sections, enum options, and
+nested `items` definitions for array fields).
+
+#### Scenario: [OA-TMP-009] Valid metadata passes validation
+- **GIVEN** a template directory with a `metadata.yaml` containing all required fields with valid values
+- **WHEN** the system validates the metadata
+- **THEN** validation passes with no errors
+
+#### Scenario: [OA-TMP-010] Missing metadata field fails validation
+- **GIVEN** a template directory with a `metadata.yaml` missing the `license` field
+- **WHEN** the system validates the metadata
+- **THEN** validation fails with an error identifying the missing field
+
+#### Scenario: [OA-TMP-011] Invalid license enum fails validation
+- **GIVEN** a template directory with `metadata.yaml` containing `license: MIT`
+- **WHEN** the system validates the metadata
+- **THEN** validation fails with an error indicating the license value is not in the allowed enum (CC-BY-4.0, CC0-1.0)
+
+#### Scenario: [OA-TMP-028] Array field item schemas pass validation
+- **GIVEN** a template metadata file with an array field that declares nested `items` field definitions
+- **WHEN** the metadata is validated
+- **THEN** validation accepts the array field schema
+- **AND** nested item field definitions use the same field-definition rules as top-level fields
+
+#### Scenario: [OA-TMP-033] Field metadata accepts curated display labels
+- **GIVEN** a template metadata file with a field that declares `display_label`
+- **WHEN** the metadata is validated
+- **THEN** validation accepts the field definition
+- **AND** the parsed field metadata preserves the `display_label` value
+
+### Requirement: Machine-Readable Template Discovery
+
+The `list` command SHALL support a `--json` flag that outputs template metadata
+including all field definitions, enabling programmatic field discovery by agent
+skills. Output SHALL be sorted by name. Templates SHALL include `source_url`,
+`attribution_text`, and `has_template_md`. Field definitions SHALL include
+optional `display_label` values when declared in metadata. Array fields with
+nested item schemas SHALL include those nested item definitions in discovery
+output. The committed `data/templates-snapshot.json` SHALL be regenerated from
+the CLI JSON output so the snapshot carries the same contract. Repo-local
+catalog builders MAY derive higher-level capability booleans directly from
+template contents instead of consuming the raw `has_template_md` discovery
+field.
+
+#### Scenario: [OA-CLI-012] JSON output includes full metadata sorted by name
+- **GIVEN** templates are available
+- **WHEN** the user runs `open-agreements list --json`
+- **THEN** the output is a valid JSON envelope with `schema_version`, `cli_version`, and `items` array sorted by name, where each item includes `name`, `description`, `license`, `source_url`, `source`, `attribution_text`, and `fields`
+
+#### Scenario: [OA-CLI-013] --json-strict exits non-zero on metadata errors
+- **GIVEN** a template with invalid metadata exists
+- **WHEN** the user runs `open-agreements list --json-strict`
+- **THEN** the command prints errors to stderr and exits with non-zero status
+
+#### Scenario: [OA-CLI-024] JSON output preserves array item schemas
+- **GIVEN** a template with an array field that declares nested `items`
+- **WHEN** the user runs `open-agreements list --json`
+- **THEN** the matching template entry includes the array field
+- **AND** the array field includes its nested item schema in the JSON output
+
+#### Scenario: [OA-CLI-025] JSON discovery projects display labels and markdown availability
+- **GIVEN** an internal template with a `template.md` file and fields that declare `display_label`
+- **WHEN** the user runs `open-agreements list --json`
+- **THEN** the matching template entry includes `has_template_md: true`
+- **AND** each declared field includes its curated `display_label`
+- **AND** templates without a `template.md` file include `has_template_md: false`

--- a/openspec/changes/add-template-display-labels-and-markdown-availability/tasks.md
+++ b/openspec/changes/add-template-display-labels-and-markdown-availability/tasks.md
@@ -1,0 +1,17 @@
+## 1. Implementation
+
+- [x] 1.1 Extend template field metadata schema with optional `display_label`.
+- [x] 1.2 Project `display_label` through `mapFields()` and all list/discovery surfaces.
+- [x] 1.3 Add `has_template_md` to template discovery output and the committed snapshot.
+- [x] 1.4 Seed curated `display_label` values into first-party OpenAgreements employment template metadata.
+- [x] 1.5 Update downstream-facing helpers (API, MCP, and repo-local catalog helpers) to consume the new metadata without legacy label derivation, while allowing repo-local catalog code to derive richer capability booleans directly from template contents.
+
+## 2. Validation
+
+- [x] 2.1 Add or update focused tests for metadata parsing and list/discovery projection.
+- [x] 2.2 Regenerate `data/templates-snapshot.json`.
+- [ ] 2.3 Run `node scripts/export-templates-snapshot.mjs --check`.
+- [ ] 2.4 Run focused Vitest coverage for metadata, list/discovery, API, and MCP surfaces.
+- [x] 2.5 Run `openspec validate add-template-display-labels-and-markdown-availability --strict`.
+
+Note: `2.3` and `2.4` remain open in this worktree because local build/test artifacts are unavailable here (`node_modules/` and `dist/` are absent, and `npm run build` fails with `tsc: command not found`).

--- a/packages/contract-templates-mcp/src/core/tools.ts
+++ b/packages/contract-templates-mcp/src/core/tools.ts
@@ -33,6 +33,7 @@ interface TemplateField {
   required: boolean;
   section: string | null;
   description: string;
+  display_label?: string | null;
   default: string | null;
   default_value_rationale?: string | null;
   items?: TemplateField[];
@@ -46,6 +47,7 @@ interface TemplateRecord {
   source_url: string;
   source: string | null;
   attribution_text?: string;
+  has_template_md?: boolean;
   fields: TemplateField[];
 }
 
@@ -360,6 +362,7 @@ function normalizeTemplate(template: TemplateRecord): Record<string, unknown> {
     source_url: template.source_url,
     source: template.source,
     attribution_text: template.attribution_text ?? null,
+    has_template_md: template.has_template_md ?? false,
     fields: template.fields,
   };
 }

--- a/packages/contract-templates-mcp/tests/tools.test.ts
+++ b/packages/contract-templates-mcp/tests/tools.test.ts
@@ -326,6 +326,46 @@ describe('contract-templates-mcp tools', () => {
       ]);
     });
 
+    it.openspec('OA-CLI-025')('list_templates full mode preserves has_template_md and display_label', async () => {
+      _setModuleOverride(mockModules({
+        listTemplateItems: () => [
+          {
+            name: 'openagreements-employment-offer-letter',
+            category: 'employment',
+            description: 'Employment Offer Letter',
+            license: 'CC-BY-4.0',
+            source_url: 'https://github.com/open-agreements/open-agreements',
+            source: 'OpenAgreements',
+            attribution_text: 'Authored by OpenAgreements contributors.',
+            has_template_md: true,
+            fields: [
+              {
+                name: 'employer_name',
+                type: 'string',
+                required: true,
+                section: 'Parties',
+                description: 'Legal name of the employer',
+                display_label: 'Employer',
+                default: null,
+              },
+            ],
+          },
+        ],
+      }));
+
+      const result = await callTool('list_templates', { mode: 'full' });
+      const payload = getPayload(result);
+      expect(result.isError).toBeUndefined();
+      expect(payload.ok).toBe(true);
+
+      const data = payload.data as Record<string, unknown>;
+      const templates = data.templates as Array<Record<string, unknown>>;
+      expect(templates[0].has_template_md).toBe(true);
+
+      const fields = templates[0].fields as Array<Record<string, unknown>>;
+      expect(fields[0].display_label).toBe('Employer');
+    });
+
     it.openspec('OA-DST-032')('fill_template returns FILL_FAILED on engine error', async () => {
       _setModuleOverride(mockModules({
         fillTemplate: async () => { throw new Error('engine failure'); },

--- a/scripts/lib/catalog-data.mjs
+++ b/scripts/lib/catalog-data.mjs
@@ -219,7 +219,7 @@ export function buildCatalog({ rootDir = REPO_ROOT } = {}) {
     if (hasPreview) {
       templateData.fields = item.fields.map((field) => ({
         name: field.name,
-        displayName: formatFieldName(field.name),
+        displayName: field.display_label || formatFieldName(field.name),
         type: field.type,
         required: field.required,
         section: field.section || "General",

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,7 +1,12 @@
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { loadMetadata, loadRecipeMetadata, loadExternalMetadata } from '../core/metadata.js';
-import { categoryFromId, sourceName, mapFields } from '../core/template-listing.js';
+import {
+  categoryFromId,
+  sourceName,
+  mapFields,
+  hasTemplateMarkdownSource,
+} from '../core/template-listing.js';
 import { listExternalEntries, listRecipeEntries, listTemplateEntries } from '../utils/paths.js';
 
 const pkgPath = fileURLToPath(new URL('../../package.json', import.meta.url));
@@ -45,6 +50,7 @@ function runListJson(opts: ListOptions): void {
         source: sourceName(meta.source_url),
         attribution_text: meta.attribution_text,
         allow_derivatives: meta.allow_derivatives,
+        has_template_md: hasTemplateMarkdownSource(dir),
         credits: meta.credits ?? [],
         derived_from: meta.derived_from,
         fields: mapFields(meta.fields, meta.priority_fields),
@@ -71,6 +77,7 @@ function runListJson(opts: ListOptions): void {
           source: sourceName(meta.source_url),
           attribution_text: meta.attribution_text,
           allow_derivatives: meta.allow_derivatives,
+          has_template_md: false,
           credits: meta.credits ?? [],
           derived_from: meta.derived_from,
           fields: mapFields(meta.fields, meta.priority_fields),
@@ -98,6 +105,7 @@ function runListJson(opts: ListOptions): void {
           source_version: meta.source_version,
           optional: meta.optional,
           allow_derivatives: false,
+          has_template_md: false,
           fields: mapFields(meta.fields, meta.priority_fields),
         };
         if (meta.market_data_citations) {

--- a/src/core/metadata.test.ts
+++ b/src/core/metadata.test.ts
@@ -49,6 +49,23 @@ describe('FieldDefinitionSchema', () => {
     );
   });
 
+  it.openspec('OA-TMP-033')('accepts a field with a curated display_label', async () => {
+    const parsed = await allureStep('Parse field with curated display label', () =>
+      FieldDefinitionSchema.parse({
+        name: 'employer_name',
+        type: 'string',
+        description: 'Legal name of the employer',
+        display_label: 'Employer',
+      })
+    );
+
+    await allureJsonAttachment('field-definition-display-label.json', parsed);
+
+    await allureStep('Assert display_label is preserved', () => {
+      expect(parsed.display_label).toBe('Employer');
+    });
+  });
+
   it.openspec('OA-TMP-028')('accepts an array field with nested item schema', async () => {
     await expectSafeParseOutcome(
       'FieldDefinitionSchema',

--- a/src/core/metadata.ts
+++ b/src/core/metadata.ts
@@ -13,6 +13,7 @@ export interface FieldDefinition {
   name: string;
   type: FieldType;
   description: string;
+  display_label?: string;
   default?: string;
   default_value_rationale?: string;
   options?: string[];
@@ -25,6 +26,7 @@ export const FieldDefinitionSchema: z.ZodType<FieldDefinition> = z.lazy(() =>
     name: z.string(),
     type: FieldTypeEnum,
     description: z.string(),
+    display_label: z.string().optional(),
     default: z.string().optional(),
     default_value_rationale: z.string().optional(),
     options: z.array(z.string()).optional(),

--- a/src/core/template-listing.ts
+++ b/src/core/template-listing.ts
@@ -7,6 +7,8 @@
  * - MCP `tools.ts` (via dynamic import or npm dependency)
  */
 
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
 import { loadMetadata, type FieldDefinition } from './metadata.js';
 import { listTemplateEntries } from '../utils/paths.js';
 
@@ -20,6 +22,7 @@ export interface TemplateListField {
   required: boolean;
   section: string | null;
   description: string;
+  display_label: string | null;
   default: string | null;
   default_value_rationale: string | null;
   items?: TemplateListField[];
@@ -35,6 +38,7 @@ export interface TemplateListItem {
   source: string | null;
   attribution_text?: string;
   allow_derivatives: boolean;
+  has_template_md: boolean;
   fields: TemplateListField[];
 }
 
@@ -110,10 +114,15 @@ export function mapFields(
     required: required.has(f.name),
     section: f.section ?? null,
     description: f.description,
+    display_label: f.display_label ?? null,
     default: f.default ?? null,
     default_value_rationale: f.default_value_rationale ?? null,
     ...(f.items ? { items: mapFields(f.items, []) } : {}),
   }));
+}
+
+export function hasTemplateMarkdownSource(templateDir: string): boolean {
+  return existsSync(join(templateDir, 'template.md'));
 }
 
 // ---------------------------------------------------------------------------
@@ -136,6 +145,7 @@ export function listTemplateItems(): TemplateListItem[] {
         source: sourceName(meta.source_url),
         attribution_text: meta.attribution_text,
         allow_derivatives: meta.allow_derivatives,
+        has_template_md: hasTemplateMarkdownSource(entry.dir),
         fields: mapFields(meta.fields, meta.priority_fields),
       });
     } catch {


### PR DESCRIPTION
## Summary
- add optional field display labels to template metadata and project them through discovery surfaces
- expose has_template_md in list/API/MCP/catalog outputs and the committed snapshot
- seed curated labels for first-party employment templates and add focused coverage

## Validation
- openspec validate add-template-display-labels-and-markdown-availability --strict
- git diff --check origin/main...HEAD
- could not run build-backed snapshot or Vitest in this worktree because node_modules/ and dist/ are absent here (npm run build fails with tsc: command not found)
