### PR TITLE
Surface display labels in template metadata listings

### DIFF
--- a/content/templates/openagreements-restrictive-covenant-wyoming/metadata.yaml
+++ b/content/templates/openagreements-restrictive-covenant-wyoming/metadata.yaml
@@ -20,23 +20,28 @@ fields:
   - name: employer_name
     type: string
     description: Legal name of the employer
+    display_label: Employer
     section: Parties
   - name: employee_name
     type: string
     description: Full legal name of the employee
+    display_label: Employee
     section: Parties
   - name: employee_title
     type: string
     description: Employee job title or position (optional)
+    display_label: Employee Title / Position
     default: ''
     section: Parties
   - name: effective_date
     type: date
     description: Effective date of this agreement
+    display_label: Effective Date
     section: Timing
   - name: governing_law
     type: string
     description: Governing law state
+    display_label: Governing Law
     default: Wyoming
     section: Legal
 
@@ -46,6 +51,7 @@ fields:
     description: >-
       Employee role classification under Wyo. Stat. section 1-23-108.
       AI-only field that drives memo warnings. Not shown in the output document.
+    display_label: Worker Category
     options:
       - Executive
       - Management
@@ -60,6 +66,7 @@ fields:
       AI-only field that drives memo warnings and conditional gating.
       Not shown in the output document. Options: Executive or Management
       Personnel, Trade Secret Protection, None.
+    display_label: Restriction Pathways
     default: None
     section: AI Analysis
 
@@ -67,11 +74,13 @@ fields:
   - name: confidentiality_trade_secret_duration
     type: string
     description: Duration of confidentiality obligations for trade secrets
+    display_label: Trade Secrets Duration
     default: Perpetual
     section: Confidentiality
   - name: confidentiality_other_duration
     type: string
     description: Duration of confidentiality obligations for non-trade-secret information
+    display_label: Other Confidential Information Duration
     default: 24 months
     default_value_rationale: >-
       24 months is common for non-trade-secret confidentiality obligations
@@ -82,11 +91,13 @@ fields:
   - name: employee_nonsolicit_included
     type: boolean
     description: Whether the employee non-solicitation covenant is included
+    display_label: Employee Non-Solicitation Included
     default: 'true'
     section: Employee Non-Solicitation
   - name: employee_nonsolicit_duration
     type: string
     description: Duration of employee non-solicitation restriction
+    display_label: Employee Non-Solicitation Duration
     default: 12 months
     default_value_rationale: >-
       12 months is the most common enforceable duration. Mayer Brown guidance
@@ -97,6 +108,7 @@ fields:
     description: >-
       Lookback period for determining which employees are covered by
       the non-solicitation restriction.
+    display_label: Covered Employee Period
     default: 12 months
     default_value_rationale: >-
       12 months is the most common lookback period for employee
@@ -107,11 +119,13 @@ fields:
   - name: customer_nonsolicit_included
     type: boolean
     description: Whether the customer/partner non-solicitation covenant is included
+    display_label: Customer Non-Solicitation Included
     default: 'true'
     section: Customer Non-Solicitation
   - name: customer_nonsolicit_duration
     type: string
     description: Duration of customer/partner non-solicitation restriction
+    display_label: Customer Non-Solicitation Duration
     default: 12 months
     default_value_rationale: >-
       12 months is the most common enforceable duration. Compass Minerals uses
@@ -122,6 +136,7 @@ fields:
     description: >-
       Lookback period for determining which customers are covered by
       the non-solicitation and non-dealing restrictions.
+    display_label: Covered Customer Period
     default: 12 months
     default_value_rationale: >-
       12 months is the most common lookback period for customer
@@ -134,6 +149,7 @@ fields:
     description: >-
       Whether the non-competition covenant is included. Requires a lawful
       restriction pathway under Wyo. Stat. section 1-23-108.
+    display_label: Non-Competition Included
     default: 'false'
     default_value_rationale: >-
       Wyo. Stat. section 1-23-108 voids most non-compete covenants. The
@@ -143,6 +159,7 @@ fields:
   - name: noncompete_duration
     type: string
     description: Duration of non-competition restriction
+    display_label: Non-Competition Duration
     default: 12 months
     default_value_rationale: >-
       12 months is the most common enforceable duration. Hassler v. Circle C
@@ -152,6 +169,7 @@ fields:
   - name: territory
     type: string
     description: Geographic scope of the non-competition restriction
+    display_label: Restricted Territory
     default: the geographic area in which Employee provided services
     default_value_rationale: >-
       Tied to the employee's actual service area. Narrower scope improves
@@ -162,12 +180,14 @@ fields:
     description: >-
       Description of the business activities that constitute competition
       with the employer.
+    display_label: Competitive Business
     section: Non-Competition
   - name: specified_competitors
     type: string
     description: >-
       Optional named list of specific competitors. Narrowing the restriction
       to named competitors strengthens enforceability.
+    display_label: Specified Competitors
     default: ''
     section: Non-Competition
 
@@ -177,11 +197,13 @@ fields:
     description: >-
       Whether the no-business-with-covered-customers covenant is included.
       Requires a lawful restriction pathway under Wyo. Stat. section 1-23-108.
+    display_label: No Business with Covered Customers Included
     default: 'false'
     section: No Business with Covered Customers
   - name: nondealing_duration
     type: string
     description: Duration of the no-business-with-covered-customers restriction
+    display_label: No Business with Covered Customers Duration
     default: 12 months
     section: No Business with Covered Customers
 
@@ -191,6 +213,7 @@ fields:
     description: >-
       Maximum ownership percentage of publicly traded securities permitted
       under the Passive Public Holdings carveout.
+    display_label: Passive Public Holdings Threshold
     default: five percent
     default_value_rationale: >-
       Five percent of any class of publicly traded securities is the standard
@@ -204,11 +227,13 @@ fields:
     description: >-
       Whether the non-investment covenant is included. Requires a lawful
       restriction pathway under Wyo. Stat. section 1-23-108.
+    display_label: Non-Investment Included
     default: 'false'
     section: Non-Investment
   - name: noninvestment_duration
     type: string
     description: Duration of non-investment restriction
+    display_label: Non-Investment Duration
     default: 12 months
     section: Non-Investment
 
@@ -216,6 +241,7 @@ fields:
   - name: nondisparagement_duration
     type: string
     description: Duration of non-disparagement obligation (measured from termination)
+    display_label: Non-Disparagement Duration
     default: 24 months
     default_value_rationale: >-
       24 months is common for employment non-disparagement provisions.
@@ -225,10 +251,12 @@ fields:
   - name: cloud_drive_id
     type: string
     description: Optional document-system URI or file ID for execution copy traceability
+    display_label: Cloud Drive ID
     section: Document Management
   - name: cloud_drive_id_footer
     type: string
     description: Internal computed footer text for document-system traceability
+    display_label: Cloud Drive ID Footer
     default: ''
     section: Document Management
 priority_fields:

--- a/content/templates/openagreements-restrictive-covenant-wyoming/metadata.yaml
+++ b/content/templates/openagreements-restrictive-covenant-wyoming/metadata.yaml
@@ -51,7 +51,6 @@ fields:
     description: >-
       Employee role classification under Wyo. Stat. section 1-23-108.
       AI-only field that drives memo warnings. Not shown in the output document.
-    display_label: Worker Category
     options:
       - Executive
       - Management
@@ -66,7 +65,6 @@ fields:
       AI-only field that drives memo warnings and conditional gating.
       Not shown in the output document. Options: Executive or Management
       Personnel, Trade Secret Protection, None.
-    display_label: Restriction Pathways
     default: None
     section: AI Analysis
 
@@ -256,7 +254,6 @@ fields:
   - name: cloud_drive_id_footer
     type: string
     description: Internal computed footer text for document-system traceability
-    display_label: Cloud Drive ID Footer
     default: ''
     section: Document Management
 priority_fields:

--- a/data/templates-snapshot.json
+++ b/data/templates-snapshot.json
@@ -7014,7 +7014,7 @@
       "category": "confidentiality",
       "description": "A one-way (unilateral) non-disclosure agreement cover page based on Common Paper's standard terms. The Discloser shares confidential information with the Receiver, but not vice versa. References the Standard Terms posted at commonpaper.com.",
       "license": "CC-BY-4.0",
-      "source_url": "https://commonpaper.com/standards/one-way-nda/1.0",
+      "source_url": "https://commonpaper.com/standards/one-way-nda",
       "source": "Common Paper",
       "attribution_text": "Based on the Common Paper One-Way NDA, available at https://commonpaper.com. Licensed under CC BY 4.0. Copyright Common Paper, Inc.",
       "allow_derivatives": true,
@@ -11830,344 +11830,13 @@
       ]
     },
     {
-      "name": "openagreements-due-diligence-request-list",
-      "tier": "internal",
-      "display_name": "OpenAgreements Legal Due Diligence Request List",
-      "category": "deals-partnerships",
-      "description": "Modular legal due diligence request list (DDRL) for corporate transactions. Ships a base form covering organization, capitalization, contracts, IP, employment, litigation, compliance, tax, insurance, debt, property, and privacy/cybersecurity. Four optional industry riders gate via boolean toggles: tech / SaaS, life sciences, healthcare provider, and cross-border / trade compliance. Drafted clean-room from public-source consensus across 15 Am Law firm, bar association, and legal publisher DDRLs; no public source language is reused. Includes per-section AI-augmentable arrays so AI workflows can append target-specific custom questions to any rider.",
-      "license": "CC-BY-4.0",
-      "source_url": "https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-due-diligence-request-list",
-      "source": "OpenAgreements",
-      "attribution_text": "Authored by OpenAgreements contributors. Category structure and consensus framing informed by publicly available DDRLs and commentary from Cooley, Skadden, Morgan Lewis, Gunderson Dettmer, Lowenstein Sandler, Holland & Knight, Foley & Lardner, Software Equity Group, the International Bar Association, the American Bar Association, Bass Berry & Sims, and Carta. See practice note for sources. Drafted clean-room; no source language was reused. Licensed under CC BY 4.0.",
-      "allow_derivatives": true,
-      "credits": [],
-      "fields": [
-        {
-          "name": "requesting_firm_name",
-          "type": "string",
-          "required": true,
-          "section": "Cover Sheet",
-          "description": "Legal name of the buyer's law firm sending the request",
-          "default": null,
-          "default_value_rationale": null
-        },
-        {
-          "name": "target_company_name",
-          "type": "string",
-          "required": true,
-          "section": "Cover Sheet",
-          "description": "Legal name of the target company receiving the request",
-          "default": null,
-          "default_value_rationale": null
-        },
-        {
-          "name": "project_code_name",
-          "type": "string",
-          "required": false,
-          "section": "Cover Sheet",
-          "description": "Project code name or pseudonym used to refer to the transaction",
-          "default": "",
-          "default_value_rationale": null
-        },
-        {
-          "name": "request_date",
-          "type": "date",
-          "required": false,
-          "section": "Cover Sheet",
-          "description": "Date the request list is delivered to the target",
-          "default": null,
-          "default_value_rationale": null
-        },
-        {
-          "name": "response_due_date",
-          "type": "date",
-          "required": false,
-          "section": "Cover Sheet",
-          "description": "Date by which the target's first-round response is due",
-          "default": null,
-          "default_value_rationale": null
-        },
-        {
-          "name": "lead_buyer_counsel_name",
-          "type": "string",
-          "required": false,
-          "section": "Cover Sheet",
-          "description": "Name of the lead attorney at the requesting firm",
-          "default": null,
-          "default_value_rationale": null
-        },
-        {
-          "name": "lead_buyer_counsel_email",
-          "type": "string",
-          "required": false,
-          "section": "Cover Sheet",
-          "description": "Email of the lead attorney at the requesting firm",
-          "default": null,
-          "default_value_rationale": null
-        },
-        {
-          "name": "primary_target_contact_name",
-          "type": "string",
-          "required": false,
-          "section": "Cover Sheet",
-          "description": "Name of the target's primary point of contact for diligence responses",
-          "default": null,
-          "default_value_rationale": null
-        },
-        {
-          "name": "currency",
-          "type": "enum",
-          "required": false,
-          "section": "Cover Sheet",
-          "description": "Currency for materiality and financial threshold inputs",
-          "default": "USD",
-          "default_value_rationale": null
-        },
-        {
-          "name": "data_room_url",
-          "type": "string",
-          "required": false,
-          "section": "Cover Sheet",
-          "description": "URL of the virtual data room (optional; included in cover-sheet instructions if provided)",
-          "default": "",
-          "default_value_rationale": null
-        },
-        {
-          "name": "materiality_threshold_usd",
-          "type": "string",
-          "required": true,
-          "section": "Materiality and Lookback",
-          "description": "Dollar floor for material-contracts requests. Stored as a pre-formatted string (e.g., \"$100,000\") because the fill engine has no currency formatter. Adjust upward for larger deals, downward for early-stage targets.",
-          "default": "$100,000",
-          "default_value_rationale": "$100,000 is the consensus dollar floor for mid-market deals across public DDRLs (Cooley, Skadden, Bloomberg). Tune up for larger targets (e.g., \"$1,000,000\" for $100M+ deals) or down for early-stage."
-        },
-        {
-          "name": "materiality_threshold_revenue_pct",
-          "type": "string",
-          "required": false,
-          "section": "Materiality and Lookback",
-          "description": "Relative materiality threshold expressed as a percentage of gross revenue. The lower of dollar floor and revenue percentage governs. Stored as a pre-formatted string for consistency with the dollar threshold.",
-          "default": "5%",
-          "default_value_rationale": "5% of gross revenue is the consensus relative-materiality qualifier in BigLaw practice. Tune down for asset-light targets where individual contract size is small but each one is operationally critical."
-        },
-        {
-          "name": "lookback_years",
-          "type": "number",
-          "required": true,
-          "section": "Materiality and Lookback",
-          "description": "Default lookback window in years for litigation, compliance, and operational history. Per-category overrides may extend specific sections.",
-          "default": "3",
-          "default_value_rationale": "3 years is consensus baseline for litigation, compliance, and operational history. Tax often warrants 6+ to mirror IRS statute of limitations; regulatory correspondence is conventionally open-ended."
-        },
-        {
-          "name": "litigation_lookback_years",
-          "type": "number",
-          "required": false,
-          "section": "Materiality and Lookback",
-          "description": "Optional per-category override for the litigation lookback window. If blank, falls through to lookback_years. 5 years is appropriate for regulated targets or where prior litigation revealed systemic process failures.",
-          "default": "",
-          "default_value_rationale": null
-        },
-        {
-          "name": "tax_lookback_years",
-          "type": "number",
-          "required": false,
-          "section": "Materiality and Lookback",
-          "description": "Optional per-category override for the tax lookback window. If blank, falls through to lookback_years. 6 years mirrors the IRS substantial- omission statute of limitations and is the safe default for most deals.",
-          "default": "",
-          "default_value_rationale": null
-        },
-        {
-          "name": "compliance_lookback_years",
-          "type": "number",
-          "required": false,
-          "section": "Materiality and Lookback",
-          "description": "Optional per-category override for routine compliance certifications. Regulatory correspondence regarding investigations, settlements, and consent decrees should be requested open-ended regardless of this value.",
-          "default": "",
-          "default_value_rationale": null
-        },
-        {
-          "name": "deal_type",
-          "type": "enum",
-          "required": true,
-          "section": "Deal Type",
-          "description": "Type of transaction the DDRL supports",
-          "default": null,
-          "default_value_rationale": null
-        },
-        {
-          "name": "transaction_stage",
-          "type": "enum",
-          "required": true,
-          "section": "Deal Type",
-          "description": "Stage of the transaction. Pre-LOI uses lighter scope; post-LOI uses the full base form plus all triggered riders.",
-          "default": "post_loi_pre_signing",
-          "default_value_rationale": null
-        },
-        {
-          "name": "tech_rider_enabled",
-          "type": "boolean",
-          "required": true,
-          "section": "Industry Riders",
-          "description": "Enable Section O (Tech / SaaS rider) covering OSS schedules with copyleft flagging, source-code escrow, hosted-services agreements, SOC 2 / ISO 27001 audits, data-flow architecture, SLAs, security- incident history, and cloud-agreement change-of-control. Recommended on for software, SaaS, platform, marketplace, or data-heavy targets.",
-          "default": "false",
-          "default_value_rationale": null
-        },
-        {
-          "name": "life_sciences_rider_enabled",
-          "type": "boolean",
-          "required": true,
-          "section": "Industry Riders",
-          "description": "Enable Section P (Life Sciences rider) covering FDA correspondence, clinical trials, CRO agreements, Form 483s, Warning Letters, CIA, and controlled-substance registrations. Recommended on for biotech, pharma, medical-device, and diagnostics targets with FDA-regulated pipelines.",
-          "default": "false",
-          "default_value_rationale": null
-        },
-        {
-          "name": "healthcare_provider_rider_enabled",
-          "type": "boolean",
-          "required": true,
-          "section": "Industry Riders",
-          "description": "Enable Section Q (Healthcare Provider rider) covering HIPAA breach logs, billing/coding compliance, payer audits, malpractice claims, and Anti-Kickback / Stark / Sunshine Act compliance. Recommended on for clinics, hospitals, physician groups, and telehealth providers with payer-reimbursement exposure.",
-          "default": "false",
-          "default_value_rationale": null
-        },
-        {
-          "name": "cross_border_rider_enabled",
-          "type": "boolean",
-          "required": true,
-          "section": "Industry Riders",
-          "description": "Enable Section R (Cross-Border / Trade Compliance rider) covering sanctions/OFAC screening, export-control classifications, AML/KYC, FCPA compliance, government-customer exposure, and foreign-investment- screening filings. Recommended on whenever the target has foreign subsidiaries, foreign customers, government customers, or sensitive- jurisdiction exposure. Increasingly mandatory after the 2023 DOJ M&A Safe Harbor Policy.",
-          "default": "false",
-          "default_value_rationale": null
-        },
-        {
-          "name": "countries_of_operation",
-          "type": "string",
-          "required": false,
-          "section": "Cross-Border Specifics",
-          "description": "Comma-separated list of countries where the target operates, sells, or has employees. Optional; populated when the cross-border rider is enabled to focus the request on specific jurisdictions.",
-          "default": "",
-          "default_value_rationale": null
-        },
-        {
-          "name": "government_customer_exposure",
-          "type": "boolean",
-          "required": false,
-          "section": "Cross-Border Specifics",
-          "description": "Set true if the target has government customers (federal, state, local, or foreign) where flow-down compliance obligations may apply. When true, additional government-contracts requests render in Section R.",
-          "default": "false",
-          "default_value_rationale": null
-        },
-        {
-          "name": "additional_questions_tech",
-          "type": "array",
-          "required": false,
-          "section": "AI Augmentation",
-          "description": "AI-augmentable list of target-specific custom questions appended to the Tech / SaaS rider. Each item is an object with a `question` field. Empty by default. Renders only when tech_rider_enabled is true.",
-          "default": "[]",
-          "default_value_rationale": null,
-          "items": [
-            {
-              "name": "question",
-              "type": "string",
-              "required": false,
-              "section": null,
-              "description": "The custom question text to render in Section O",
-              "default": null,
-              "default_value_rationale": null
-            }
-          ]
-        },
-        {
-          "name": "additional_questions_life_sciences",
-          "type": "array",
-          "required": false,
-          "section": "AI Augmentation",
-          "description": "AI-augmentable list of target-specific custom questions appended to the Life Sciences rider. Empty by default. Renders only when life_sciences_rider_enabled is true.",
-          "default": "[]",
-          "default_value_rationale": null,
-          "items": [
-            {
-              "name": "question",
-              "type": "string",
-              "required": false,
-              "section": null,
-              "description": "The custom question text to render in Section P",
-              "default": null,
-              "default_value_rationale": null
-            }
-          ]
-        },
-        {
-          "name": "additional_questions_healthcare_provider",
-          "type": "array",
-          "required": false,
-          "section": "AI Augmentation",
-          "description": "AI-augmentable list of target-specific custom questions appended to the Healthcare Provider rider. Empty by default. Renders only when healthcare_provider_rider_enabled is true.",
-          "default": "[]",
-          "default_value_rationale": null,
-          "items": [
-            {
-              "name": "question",
-              "type": "string",
-              "required": false,
-              "section": null,
-              "description": "The custom question text to render in Section Q",
-              "default": null,
-              "default_value_rationale": null
-            }
-          ]
-        },
-        {
-          "name": "additional_questions_cross_border",
-          "type": "array",
-          "required": false,
-          "section": "AI Augmentation",
-          "description": "AI-augmentable list of target-specific custom questions appended to the Cross-Border / Trade Compliance rider. Empty by default. Renders only when cross_border_rider_enabled is true.",
-          "default": "[]",
-          "default_value_rationale": null,
-          "items": [
-            {
-              "name": "question",
-              "type": "string",
-              "required": false,
-              "section": null,
-              "description": "The custom question text to render in Section R",
-              "default": null,
-              "default_value_rationale": null
-            }
-          ]
-        },
-        {
-          "name": "additional_questions_general",
-          "type": "array",
-          "required": false,
-          "section": "AI Augmentation",
-          "description": "AI-augmentable list of cross-cutting custom questions that do not belong to any specific rider. Renders at the end of the closing Response Protocol section. Empty by default.",
-          "default": "[]",
-          "default_value_rationale": null,
-          "items": [
-            {
-              "name": "question",
-              "type": "string",
-              "required": false,
-              "section": null,
-              "description": "The custom question text to render at end of document",
-              "default": null,
-              "default_value_rationale": null
-            }
-          ]
-        }
-      ]
-    },
-    {
       "name": "openagreements-employee-ip-inventions-assignment",
       "tier": "internal",
       "display_name": "OpenAgreements Employee IP and Inventions Assignment",
       "category": "employment",
       "description": "Employee proprietary information and inventions assignment agreement with explicit prior-inventions and personal-project carveout language placeholders.",
       "license": "CC-BY-4.0",
-      "source_url": "https://github.com/open-agreements/open-agreements/tree/main/templates/openagreements-employee-ip-inventions-assignment",
+      "source_url": "https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-employee-ip-inventions-assignment",
       "source": "OpenAgreements",
       "attribution_text": "Authored by OpenAgreements contributors. Baseline structure inspired by permissive public references including the Balanced Employee IP Agreement (CC0) and Papertrail legal-docs (CC0). Licensed under CC BY 4.0.",
       "allow_derivatives": true,
@@ -12290,7 +11959,7 @@
       "category": "employment",
       "description": "Employee confidentiality and acceptable-use acknowledgement companion for onboarding packets, including reporting and post-employment handling.",
       "license": "CC-BY-4.0",
-      "source_url": "https://github.com/open-agreements/open-agreements/tree/main/templates/openagreements-employment-confidentiality-acknowledgement",
+      "source_url": "https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-employment-confidentiality-acknowledgement",
       "source": "OpenAgreements",
       "attribution_text": "Authored by OpenAgreements contributors using permissive public reference patterns from Papertrail legal-docs (CC0) and open policy frameworks. Licensed under CC BY 4.0.",
       "allow_derivatives": true,
@@ -12404,7 +12073,7 @@
       "category": "employment",
       "description": "A startup-focused employment offer letter template for full-time or part-time hiring with compensation, equity summary, and at-will framing.",
       "license": "CC-BY-4.0",
-      "source_url": "https://github.com/open-agreements/open-agreements/tree/main/templates/openagreements-employment-offer-letter",
+      "source_url": "https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-employment-offer-letter",
       "source": "OpenAgreements",
       "attribution_text": "Authored by OpenAgreements contributors. Drafting structure informed by publicly available permissive sources including the DocuSign template library (MIT) and Papertrail legal-docs (CC0). Licensed under CC BY 4.0.",
       "allow_derivatives": true,
@@ -12545,7 +12214,7 @@
       "category": "employment",
       "description": "Wyoming-specific employee restrictive covenant agreement with modular covenant structure (non-compete, non-solicitation, non-dealing, non-investment, confidentiality, non-disparagement). Incorporates Wyo. Stat. section 1-23-108 (SF 107, 2025) pathway gating for non-compete-adjacent covenants. Drafted as a starting point for licensed counsel review.",
       "license": "CC-BY-4.0",
-      "source_url": "https://github.com/open-agreements/open-agreements/tree/main/templates/openagreements-restrictive-covenant-wyoming",
+      "source_url": "https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-restrictive-covenant-wyoming",
       "source": "OpenAgreements",
       "attribution_text": "Authored by OpenAgreements contributors. Wyoming-specific analysis informed by publicly available commentary from Am Law firms including Ogletree Deakins, Fisher Phillips, Littler Mendelson, Foley & Lardner, Faegre Drinker, and Vinson & Elkins. See practice note for sources. Licensed under CC BY 4.0.",
       "allow_derivatives": true,
@@ -12557,6 +12226,7 @@
           "required": true,
           "section": "Parties",
           "description": "Legal name of the employer",
+          "display_label": "Employer",
           "default": null,
           "default_value_rationale": null
         },
@@ -12566,6 +12236,7 @@
           "required": true,
           "section": "Parties",
           "description": "Full legal name of the employee",
+          "display_label": "Employee",
           "default": null,
           "default_value_rationale": null
         },
@@ -12575,6 +12246,7 @@
           "required": false,
           "section": "Parties",
           "description": "Employee job title or position (optional)",
+          "display_label": "Employee Title / Position",
           "default": "",
           "default_value_rationale": null
         },
@@ -12584,6 +12256,7 @@
           "required": false,
           "section": "Timing",
           "description": "Effective date of this agreement",
+          "display_label": "Effective Date",
           "default": null,
           "default_value_rationale": null
         },
@@ -12593,6 +12266,7 @@
           "required": false,
           "section": "Legal",
           "description": "Governing law state",
+          "display_label": "Governing Law",
           "default": "Wyoming",
           "default_value_rationale": null
         },
@@ -12602,6 +12276,7 @@
           "required": false,
           "section": "AI Analysis",
           "description": "Employee role classification under Wyo. Stat. section 1-23-108. AI-only field that drives memo warnings. Not shown in the output document.",
+          "display_label": "Worker Category",
           "default": null,
           "default_value_rationale": null
         },
@@ -12611,6 +12286,7 @@
           "required": false,
           "section": "AI Analysis",
           "description": "Wyoming restriction pathway(s) under Wyo. Stat. section 1-23-108. AI-only field that drives memo warnings and conditional gating. Not shown in the output document. Options: Executive or Management Personnel, Trade Secret Protection, None.",
+          "display_label": "Restriction Pathways",
           "default": "None",
           "default_value_rationale": null
         },
@@ -12620,6 +12296,7 @@
           "required": false,
           "section": "Confidentiality",
           "description": "Duration of confidentiality obligations for trade secrets",
+          "display_label": "Trade Secrets Duration",
           "default": "Perpetual",
           "default_value_rationale": null
         },
@@ -12629,6 +12306,7 @@
           "required": false,
           "section": "Confidentiality",
           "description": "Duration of confidentiality obligations for non-trade-secret information",
+          "display_label": "Other Confidential Information Duration",
           "default": "24 months",
           "default_value_rationale": "24 months is common for non-trade-secret confidentiality obligations in employment agreements."
         },
@@ -12638,6 +12316,7 @@
           "required": false,
           "section": "Employee Non-Solicitation",
           "description": "Whether the employee non-solicitation covenant is included",
+          "display_label": "Employee Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
         },
@@ -12647,6 +12326,7 @@
           "required": false,
           "section": "Employee Non-Solicitation",
           "description": "Duration of employee non-solicitation restriction",
+          "display_label": "Employee Non-Solicitation Duration",
           "default": "12 months",
           "default_value_rationale": "12 months is the most common enforceable duration. Mayer Brown guidance states 1-2 years is the outer range of reasonableness."
         },
@@ -12656,6 +12336,7 @@
           "required": false,
           "section": "Employee Non-Solicitation",
           "description": "Lookback period for determining which employees are covered by the non-solicitation restriction.",
+          "display_label": "Covered Employee Period",
           "default": "12 months",
           "default_value_rationale": "12 months is the most common lookback period for employee non-solicitation scope."
         },
@@ -12665,6 +12346,7 @@
           "required": false,
           "section": "Customer Non-Solicitation",
           "description": "Whether the customer/partner non-solicitation covenant is included",
+          "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
         },
@@ -12674,6 +12356,7 @@
           "required": false,
           "section": "Customer Non-Solicitation",
           "description": "Duration of customer/partner non-solicitation restriction",
+          "display_label": "Customer Non-Solicitation Duration",
           "default": "12 months",
           "default_value_rationale": "12 months is the most common enforceable duration. Compass Minerals uses 12 months for non-CEO employees and 24 months for CEO."
         },
@@ -12683,6 +12366,7 @@
           "required": false,
           "section": "Customer Non-Solicitation",
           "description": "Lookback period for determining which customers are covered by the non-solicitation and non-dealing restrictions.",
+          "display_label": "Covered Customer Period",
           "default": "12 months",
           "default_value_rationale": "12 months is the most common lookback period for customer non-solicitation scope."
         },
@@ -12692,6 +12376,7 @@
           "required": false,
           "section": "Non-Competition",
           "description": "Whether the non-competition covenant is included. Requires a lawful restriction pathway under Wyo. Stat. section 1-23-108.",
+          "display_label": "Non-Competition Included",
           "default": "false",
           "default_value_rationale": "Wyo. Stat. section 1-23-108 voids most non-compete covenants. The drafter must affirmatively include this covenant only when a statutory pathway applies."
         },
@@ -12701,6 +12386,7 @@
           "required": false,
           "section": "Non-Competition",
           "description": "Duration of non-competition restriction",
+          "display_label": "Non-Competition Duration",
           "default": "12 months",
           "default_value_rationale": "12 months is the most common enforceable duration. Hassler v. Circle C Resources (2022 WY 28) struck down a 24-month provision with broad scope. No Wyoming court has upheld a non-compete exceeding 24 months."
         },
@@ -12710,6 +12396,7 @@
           "required": false,
           "section": "Non-Competition",
           "description": "Geographic scope of the non-competition restriction",
+          "display_label": "Restricted Territory",
           "default": "the geographic area in which Employee provided services",
           "default_value_rationale": "Tied to the employee's actual service area. Narrower scope improves enforceability under Wyoming's strict scrutiny."
         },
@@ -12719,6 +12406,7 @@
           "required": false,
           "section": "Non-Competition",
           "description": "Description of the business activities that constitute competition with the employer.",
+          "display_label": "Competitive Business",
           "default": null,
           "default_value_rationale": null
         },
@@ -12728,6 +12416,7 @@
           "required": false,
           "section": "Non-Competition",
           "description": "Optional named list of specific competitors. Narrowing the restriction to named competitors strengthens enforceability.",
+          "display_label": "Specified Competitors",
           "default": "",
           "default_value_rationale": null
         },
@@ -12737,6 +12426,7 @@
           "required": false,
           "section": "No Business with Covered Customers",
           "description": "Whether the no-business-with-covered-customers covenant is included. Requires a lawful restriction pathway under Wyo. Stat. section 1-23-108.",
+          "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
         },
@@ -12746,6 +12436,7 @@
           "required": false,
           "section": "No Business with Covered Customers",
           "description": "Duration of the no-business-with-covered-customers restriction",
+          "display_label": "No Business with Covered Customers Duration",
           "default": "12 months",
           "default_value_rationale": null
         },
@@ -12755,6 +12446,7 @@
           "required": false,
           "section": "Definitions",
           "description": "Maximum ownership percentage of publicly traded securities permitted under the Passive Public Holdings carveout.",
+          "display_label": "Passive Public Holdings Threshold",
           "default": "five percent",
           "default_value_rationale": "Five percent of any class of publicly traded securities is the standard passive investment carveout across Fortune 500 restrictive covenant agreements."
         },
@@ -12764,6 +12456,7 @@
           "required": false,
           "section": "Non-Investment",
           "description": "Whether the non-investment covenant is included. Requires a lawful restriction pathway under Wyo. Stat. section 1-23-108.",
+          "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
         },
@@ -12773,6 +12466,7 @@
           "required": false,
           "section": "Non-Investment",
           "description": "Duration of non-investment restriction",
+          "display_label": "Non-Investment Duration",
           "default": "12 months",
           "default_value_rationale": null
         },
@@ -12782,6 +12476,7 @@
           "required": false,
           "section": "Non-Disparagement",
           "description": "Duration of non-disparagement obligation (measured from termination)",
+          "display_label": "Non-Disparagement Duration",
           "default": "24 months",
           "default_value_rationale": "24 months is common for employment non-disparagement provisions."
         },
@@ -12791,6 +12486,7 @@
           "required": false,
           "section": "Document Management",
           "description": "Optional document-system URI or file ID for execution copy traceability",
+          "display_label": "Cloud Drive ID",
           "default": null,
           "default_value_rationale": null
         },
@@ -12800,6 +12496,7 @@
           "required": false,
           "section": "Document Management",
           "description": "Internal computed footer text for document-system traceability",
+          "display_label": "Cloud Drive ID Footer",
           "default": "",
           "default_value_rationale": null
         }

--- a/data/templates-snapshot.json
+++ b/data/templates-snapshot.json
@@ -12276,7 +12276,6 @@
           "required": false,
           "section": "AI Analysis",
           "description": "Employee role classification under Wyo. Stat. section 1-23-108. AI-only field that drives memo warnings. Not shown in the output document.",
-          "display_label": "Worker Category",
           "default": null,
           "default_value_rationale": null
         },
@@ -12286,7 +12285,6 @@
           "required": false,
           "section": "AI Analysis",
           "description": "Wyoming restriction pathway(s) under Wyo. Stat. section 1-23-108. AI-only field that drives memo warnings and conditional gating. Not shown in the output document. Options: Executive or Management Personnel, Trade Secret Protection, None.",
-          "display_label": "Restriction Pathways",
           "default": "None",
           "default_value_rationale": null
         },
@@ -12496,7 +12494,6 @@
           "required": false,
           "section": "Document Management",
           "description": "Internal computed footer text for document-system traceability",
-          "display_label": "Cloud Drive ID Footer",
           "default": "",
           "default_value_rationale": null
         }

--- a/integration-tests/list-command.inprocess.test.ts
+++ b/integration-tests/list-command.inprocess.test.ts
@@ -318,6 +318,59 @@ describe('runList in-process coverage', () => {
     expect(template.fields[0].items[1]).not.toHaveProperty('display_label');
   });
 
+  itDiscovery.openspec('OA-TMP-043')('projects display_label through nested items, omitting on unlabeled siblings', async () => {
+    const harness = await loadListHarness({
+      templateEntries: [
+        { id: 'array-template', dir: '/templates/array-template', baseDir: '/templates' },
+      ],
+      templateByDir: {
+        '/templates/array-template': {
+          ...templateMeta('Array Template', 'https://example.com/array-template'),
+          fields: [
+            {
+              name: 'signers',
+              type: 'array',
+              description: 'Signers on the document',
+              items: [
+                {
+                  name: 'printed_name',
+                  type: 'string',
+                  description: 'Printed signer name',
+                  display_label: 'Printed Name',
+                },
+                {
+                  name: 'title',
+                  type: 'string',
+                  description: 'Printed signer title',
+                  default: '',
+                },
+              ],
+            },
+          ],
+          priority_fields: [],
+        },
+      },
+    });
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await allureStep('Run list in JSON mode for nested display_label projection', async () => {
+      harness.runList({ json: true });
+    });
+
+    const envelope = JSON.parse(String(logSpy.mock.calls[0][0]));
+    const template = envelope.items.find((item: { name: string }) => item.name === 'array-template');
+    expect(template.fields[0].items).toHaveLength(2);
+    expect(template.fields[0].items[0]).toMatchObject({
+      name: 'printed_name',
+      display_label: 'Printed Name',
+    });
+    expect(template.fields[0].items[1]).toMatchObject({
+      name: 'title',
+    });
+    expect(template.fields[0].items[1]).not.toHaveProperty('display_label');
+  });
+
   itDiscovery.openspec('OA-TMP-039')('projects credits and derived_from onto internal and external templates; omits them on recipes', async () => {
     const harness = await loadListHarness({
       templateEntries: [

--- a/integration-tests/list-command.inprocess.test.ts
+++ b/integration-tests/list-command.inprocess.test.ts
@@ -21,9 +21,10 @@ interface TemplateMeta {
     name: string;
     type: string;
     description: string;
+    display_label?: string;
     section?: string;
     default?: string;
-    items?: Array<{ name: string; type: string; description: string; section?: string; default?: string }>;
+    items?: Array<{ name: string; type: string; description: string; display_label?: string; section?: string; default?: string }>;
   }>;
   priority_fields: string[];
   credits?: Array<{ name: string; role: string; profile_url?: string }>;
@@ -66,7 +67,7 @@ const itDiscovery = itAllure.epic('Discovery & Metadata');
 
 function baseFields() {
   return [
-    { name: 'company_name', type: 'string', description: 'Company legal name' },
+    { name: 'company_name', type: 'string', description: 'Company legal name', display_label: 'Company Name' },
     { name: 'effective_date', type: 'date', description: 'Effective date', default: '2026-02-12' },
   ];
 }
@@ -211,6 +212,7 @@ describe('runList in-process coverage', () => {
 
     expect(zTemplate.fields[0]).toMatchObject({
       name: 'company_name',
+      display_label: 'Company Name',
       required: true,
       section: null,
       default: null,
@@ -220,6 +222,7 @@ describe('runList in-process coverage', () => {
       required: false,
       default: '2026-02-12',
     });
+    expect(zTemplate.fields[1]).not.toHaveProperty('display_label');
   });
 
   itDiscovery.openspec('OA-CLI-013')('exits non-zero in --json-strict mode when metadata loading fails', async () => {
@@ -311,6 +314,8 @@ describe('runList in-process coverage', () => {
         default_value_rationale: null,
       },
     ]);
+    expect(template.fields[0].items[0]).not.toHaveProperty('display_label');
+    expect(template.fields[0].items[1]).not.toHaveProperty('display_label');
   });
 
   itDiscovery.openspec('OA-TMP-039')('projects credits and derived_from onto internal and external templates; omits them on recipes', async () => {

--- a/openspec/changes/add-template-display-labels/proposal.md
+++ b/openspec/changes/add-template-display-labels/proposal.md
@@ -29,47 +29,57 @@ narrowly-scoped CLI projection and no MCP/A2A propagation.
   when the metadata does not declare a label (matches the `derived_from`
   precedent — undefined-means-omitted, never `null`).
 - Mirror the type on the contract-templates MCP `TemplateField` interface
-  for type-only forward compatibility. No MCP tool description or runtime
-  surface change in this proposal.
+  for type-only forward compatibility, and **strip `display_label` from
+  MCP tool payloads** (`list_templates`, `get_template`, including nested
+  `items`) so the MCP runtime surface is unchanged in this proposal. The
+  type addition is preparatory; the wire change is deferred.
 - Define a consumer fallback rule: when `display_label` is absent,
   consumers SHOULD title-case the canonical `name` (replacing `_` with
   spaces). The fallback is a consumer convention, not a CLI behavior.
 - Curate `display_label` on every user-facing field of
   `content/templates/openagreements-restrictive-covenant-wyoming/metadata.yaml`.
-  AI-only fields (e.g. `worker_category`, `restriction_pathways`) and
-  internal computed fields (e.g. `cloud_drive_id_footer`) SHALL NOT carry
-  a `display_label` — their description already says
-  "Not shown in the output document" and adding a label would
-  encourage consumers to surface them.
+  Author guidance: AI-only fields (e.g. `worker_category`,
+  `restriction_pathways`) and internal computed fields (e.g.
+  `cloud_drive_id_footer`) SHOULD NOT carry a `display_label` — their
+  description already says "Not shown in the output document," and
+  curating a human label would invite consumers to surface them.
 - Regenerate the committed `data/templates-snapshot.json` from the CLI
   JSON output.
 
 Non-goals:
 
-- No MCP `list_templates` / `get_template` tool description change in this
-  proposal. The MCP `TemplateField` interface adds `display_label` for
-  type alignment only; surfacing it to LLM agents is a follow-up.
+- No MCP `list_templates` / `get_template` tool description or payload
+  change in this proposal. The MCP `TemplateField` interface adds
+  `display_label` for type alignment only; tool payloads explicitly strip
+  it. Surfacing it to LLM agents is a follow-up.
 - No remote A2A/MCP API propagation.
 - No changes to `attribution_text`, `credits`, or `derived_from`.
 - No retroactive curation of labels across all templates. Wyoming is the
   first curated template; other templates remain unlabeled and rely on
   the consumer fallback.
+- No CI lint enforcement of the AI-only/internal authoring convention in
+  this proposal — it remains a guideline. A structured `visibility` field
+  is a candidate for a follow-up if the convention proves insufficient.
 
 ## Impact
 
 - Affected specs: `open-agreements` (one new requirement covering
-  display_label parsing + projection + visibility convention for
-  internal/AI-only fields).
+  display_label parsing, CLI projection, MCP payload omission, and the
+  authoring guideline for AI-only / internal fields).
 - Affected code:
   - `src/core/metadata.ts` — `FieldDefinition` + `FieldDefinitionSchema`
     additions.
   - `src/core/template-listing.ts` — `TemplateListField.display_label?`
     and conditional spread in `mapFields()`.
   - `packages/contract-templates-mcp/src/core/tools.ts` — type-only
-    `TemplateField.display_label?` mirror.
+    `TemplateField.display_label?` mirror plus runtime stripping of
+    `display_label` (and nested `items.display_label`) from
+    `list_templates` / `get_template` payloads.
   - `content/templates/openagreements-restrictive-covenant-wyoming/metadata.yaml`
     — curated labels for user-facing fields only.
   - `data/templates-snapshot.json` — regenerated.
   - `src/core/metadata.test.ts`,
-    `integration-tests/list-command.inprocess.test.ts` — new contract
-    assertions (positive parse + key-omission on the wire).
+    `integration-tests/list-command.inprocess.test.ts`,
+    `packages/contract-templates-mcp/tests/tools.test.ts` — new contract
+    assertions (positive parse, negative `null` parse, CLI key-omission
+    on the wire, MCP payload stripping).

--- a/openspec/changes/add-template-display-labels/proposal.md
+++ b/openspec/changes/add-template-display-labels/proposal.md
@@ -1,0 +1,75 @@
+# Change: Add Template Field Display Labels
+
+## Why
+
+Template fields today are identified by a stable canonical `name`
+(snake_case, used as the fill-key) and described by a free-form
+`description`. There is no structured, human-friendly label that downstream
+discovery consumers (UIs, MCP-driven agents, the docs site) can render in
+a form, table, or prompt without re-deriving one from the canonical name.
+
+Re-deriving labels at the consumer is brittle: snake_case → Title Case
+loses domain nuance ("nondealing" should not surface as "Nondealing"), and
+each consumer ends up with a slightly different rendering. A single
+optional `display_label` on the template metadata gives the template
+author one place to curate the human-facing string while keeping `name`
+stable for filling and automation.
+
+This mirrors the precedent set by `add-template-credits-metadata`
+(archived 2026-04-26): a small, additive metadata field with a
+narrowly-scoped CLI projection and no MCP/A2A propagation.
+
+## What Changes
+
+- Extend `FieldDefinitionSchema` with one optional field:
+  - `display_label: string` (optional, no default).
+- Project `display_label` through `mapFields()` in
+  `src/core/template-listing.ts` so it appears in the CLI `list --json`
+  output. Use a conditional spread so the JSON object **omits** the key
+  when the metadata does not declare a label (matches the `derived_from`
+  precedent — undefined-means-omitted, never `null`).
+- Mirror the type on the contract-templates MCP `TemplateField` interface
+  for type-only forward compatibility. No MCP tool description or runtime
+  surface change in this proposal.
+- Define a consumer fallback rule: when `display_label` is absent,
+  consumers SHOULD title-case the canonical `name` (replacing `_` with
+  spaces). The fallback is a consumer convention, not a CLI behavior.
+- Curate `display_label` on every user-facing field of
+  `content/templates/openagreements-restrictive-covenant-wyoming/metadata.yaml`.
+  AI-only fields (e.g. `worker_category`, `restriction_pathways`) and
+  internal computed fields (e.g. `cloud_drive_id_footer`) SHALL NOT carry
+  a `display_label` — their description already says
+  "Not shown in the output document" and adding a label would
+  encourage consumers to surface them.
+- Regenerate the committed `data/templates-snapshot.json` from the CLI
+  JSON output.
+
+Non-goals:
+
+- No MCP `list_templates` / `get_template` tool description change in this
+  proposal. The MCP `TemplateField` interface adds `display_label` for
+  type alignment only; surfacing it to LLM agents is a follow-up.
+- No remote A2A/MCP API propagation.
+- No changes to `attribution_text`, `credits`, or `derived_from`.
+- No retroactive curation of labels across all templates. Wyoming is the
+  first curated template; other templates remain unlabeled and rely on
+  the consumer fallback.
+
+## Impact
+
+- Affected specs: `open-agreements` (one new requirement covering
+  display_label parsing + projection + visibility convention for
+  internal/AI-only fields).
+- Affected code:
+  - `src/core/metadata.ts` — `FieldDefinition` + `FieldDefinitionSchema`
+    additions.
+  - `src/core/template-listing.ts` — `TemplateListField.display_label?`
+    and conditional spread in `mapFields()`.
+  - `packages/contract-templates-mcp/src/core/tools.ts` — type-only
+    `TemplateField.display_label?` mirror.
+  - `content/templates/openagreements-restrictive-covenant-wyoming/metadata.yaml`
+    — curated labels for user-facing fields only.
+  - `data/templates-snapshot.json` — regenerated.
+  - `src/core/metadata.test.ts`,
+    `integration-tests/list-command.inprocess.test.ts` — new contract
+    assertions (positive parse + key-omission on the wire).

--- a/openspec/changes/add-template-display-labels/specs/open-agreements/spec.md
+++ b/openspec/changes/add-template-display-labels/specs/open-agreements/spec.md
@@ -1,0 +1,75 @@
+## ADDED Requirements
+
+### Requirement: Template Field Display Labels
+
+Each template `metadata.yaml` field SHALL support an optional
+`display_label` (string) that carries a human-friendly label for the
+field. The canonical `name` SHALL remain the stable identifier used for
+filling and automation; `display_label` is purely a discovery /
+presentation hint and never replaces `name`.
+
+The CLI `list --json` output SHALL project `display_label` onto each
+field entry only when the metadata declares one. When the metadata does
+NOT declare a label, the JSON field object SHALL omit the
+`display_label` key entirely (no `null`, no empty string, no
+auto-derived value). Consumers (UIs, agents, the docs site) that need a
+human label when the key is absent SHOULD fall back to a title-cased
+rendering of the canonical `name` (replacing `_` with spaces).
+
+The CLI projection SHALL recurse into nested array `items` so that
+sub-field labels are surfaced under the same omit-when-absent rule. The
+committed `data/templates-snapshot.json` SHALL be regenerated from the
+CLI JSON output so the snapshot carries the same contract.
+
+Template authors SHALL NOT add `display_label` to fields whose
+`description` declares them "AI-only" or "Internal computed" (i.e.
+fields not intended to render in human-facing UIs or in the output
+document). The presence of a `display_label` is a signal to consumers
+that the field is safe to surface; absence on AI-only / internal fields
+preserves that signal.
+
+The contract-templates MCP package SHALL keep type alignment with the
+new field on its local `TemplateField` interface, but MCP tool
+descriptions and remote A2A/MCP API responses SHALL NOT change in this
+requirement; surfacing `display_label` to LLM agents is out of scope and
+will be handled by a follow-up change.
+
+#### Scenario: [OA-TMP-040] Field with display_label parses
+
+- **GIVEN** a template `metadata.yaml` with a field
+  `{ name: company_name, type: string, description: "…", display_label: "Company Name" }`
+- **WHEN** the system loads and validates the metadata
+- **THEN** validation passes
+- **AND** the parsed `FieldDefinition` exposes `display_label: "Company Name"`
+
+#### Scenario: [OA-TMP-041] Field without display_label parses
+
+- **GIVEN** a template `metadata.yaml` with a field that does not declare `display_label`
+- **WHEN** the system loads and validates the metadata
+- **THEN** validation passes
+- **AND** the parsed `FieldDefinition` has `display_label === undefined`
+
+#### Scenario: [OA-TMP-042] list --json omits display_label key when absent
+
+- **GIVEN** a template metadata fixture with two fields where only the first declares `display_label`
+- **WHEN** the user runs `open-agreements list --json`
+- **THEN** the first field's JSON object includes `display_label`
+- **AND** the second field's JSON object does NOT contain a `display_label`
+  property at all (verified via a hasOwnProperty-style assertion, not just `=== null`)
+
+#### Scenario: [OA-TMP-043] list --json projects display_label through nested items
+
+- **GIVEN** an array-typed field whose `items` declares `display_label` on
+  one sub-field and not on another
+- **WHEN** the user runs `open-agreements list --json`
+- **THEN** the labeled sub-field's JSON object includes `display_label`
+- **AND** the unlabeled sub-field's JSON object does NOT contain a `display_label` property
+
+#### Scenario: [OA-TMP-044] AI-only and internal fields do not carry display_label
+
+- **GIVEN** a template `metadata.yaml` whose `description` for a field
+  declares it "AI-only" or "Internal computed"
+- **WHEN** a contributor authors that field
+- **THEN** the field SHALL NOT include a `display_label`
+- **AND** the discovery contract treats absence-of-label as the signal
+  that the field is not safe to surface in human-facing UIs

--- a/openspec/changes/add-template-display-labels/specs/open-agreements/spec.md
+++ b/openspec/changes/add-template-display-labels/specs/open-agreements/spec.md
@@ -21,18 +21,21 @@ sub-field labels are surfaced under the same omit-when-absent rule. The
 committed `data/templates-snapshot.json` SHALL be regenerated from the
 CLI JSON output so the snapshot carries the same contract.
 
-Template authors SHALL NOT add `display_label` to fields whose
-`description` declares them "AI-only" or "Internal computed" (i.e.
-fields not intended to render in human-facing UIs or in the output
-document). The presence of a `display_label` is a signal to consumers
-that the field is safe to surface; absence on AI-only / internal fields
-preserves that signal.
+As an authoring guideline, template authors SHOULD NOT add a
+`display_label` to fields whose `description` declares them "AI-only"
+or "Internal computed" (i.e. fields not intended to render in
+human-facing UIs or in the output document). Curating a human label on
+those fields invites consumers to surface them, which the description
+already discourages. This is guidance only — the CLI does not enforce
+it, and absence-of-label on a user-facing field continues to mean
+"uncurated, fall back to title-case," not "unsafe to surface."
 
 The contract-templates MCP package SHALL keep type alignment with the
-new field on its local `TemplateField` interface, but MCP tool
-descriptions and remote A2A/MCP API responses SHALL NOT change in this
-requirement; surfacing `display_label` to LLM agents is out of scope and
-will be handled by a follow-up change.
+new field on its local `TemplateField` interface, but the MCP runtime
+SHALL strip `display_label` from `list_templates` and `get_template`
+tool payloads (including nested `items`) so MCP responses are unchanged
+in this requirement. Surfacing `display_label` to LLM agents is out of
+scope and will be handled by a follow-up change.
 
 #### Scenario: [OA-TMP-040] Field with display_label parses
 
@@ -70,6 +73,18 @@ will be handled by a follow-up change.
 - **GIVEN** a template `metadata.yaml` whose `description` for a field
   declares it "AI-only" or "Internal computed"
 - **WHEN** a contributor authors that field
-- **THEN** the field SHALL NOT include a `display_label`
-- **AND** the discovery contract treats absence-of-label as the signal
-  that the field is not safe to surface in human-facing UIs
+- **THEN** by the authoring guideline, the field SHOULD NOT include a
+  `display_label`
+- **AND** the discovery contract is unchanged for absent labels:
+  consumers fall back to title-casing the canonical `name`
+
+#### Scenario: [OA-TMP-045] MCP tool payloads strip display_label
+
+- **GIVEN** a template whose metadata declares `display_label` on one or
+  more fields (top-level or nested `items`)
+- **WHEN** an MCP client calls `list_templates` or `get_template`
+- **THEN** the returned tool payload SHALL NOT include a `display_label`
+  property on any field, at any depth
+- **AND** the type-only `TemplateField.display_label?` mirror in the
+  contract-templates MCP package remains for forward compatibility but
+  is not populated on the wire

--- a/openspec/changes/add-template-display-labels/tasks.md
+++ b/openspec/changes/add-template-display-labels/tasks.md
@@ -1,0 +1,42 @@
+## 1. Schema
+
+- [x] 1.1 Add `display_label?: string` to `FieldDefinition` and
+      `FieldDefinitionSchema` in `src/core/metadata.ts`
+- [x] 1.2 Add a positive parse test for `display_label` in
+      `src/core/metadata.test.ts`
+
+## 2. CLI projection
+
+- [x] 2.1 Add `display_label?: string` to `TemplateListField` in
+      `src/core/template-listing.ts`
+- [x] 2.2 Use a conditional spread in `mapFields()` so the key is omitted
+      when undefined (no `null` on the wire)
+- [x] 2.3 Assert key omission for unlabeled top-level fields and nested
+      `items` in `integration-tests/list-command.inprocess.test.ts`
+
+## 3. MCP type alignment
+
+- [x] 3.1 Mirror `display_label?: string` on the contract-templates MCP
+      `TemplateField` interface (type-only; no tool description change)
+
+## 4. Curation
+
+- [x] 4.1 Populate `display_label` on every user-facing field of
+      `content/templates/openagreements-restrictive-covenant-wyoming/metadata.yaml`
+- [x] 4.2 Confirm AI-only fields (`worker_category`, `restriction_pathways`)
+      and internal computed fields (`cloud_drive_id_footer`) do NOT carry
+      a `display_label`
+
+## 5. Snapshot
+
+- [ ] 5.1 Regenerate `data/templates-snapshot.json` via
+      `node scripts/export-templates-snapshot.mjs`
+- [ ] 5.2 Confirm `node scripts/export-templates-snapshot.mjs --check`
+      passes
+
+## 6. Validation
+
+- [ ] 6.1 `openspec validate add-template-display-labels --strict` passes
+- [ ] 6.2 `npm run build` passes
+- [ ] 6.3 Targeted vitest run passes:
+      `npx vitest run src/core/metadata.test.ts integration-tests/list-command.inprocess.test.ts packages/contract-templates-mcp/tests/tools.test.ts`

--- a/packages/contract-templates-mcp/src/core/tools.ts
+++ b/packages/contract-templates-mcp/src/core/tools.ts
@@ -33,7 +33,7 @@ interface TemplateField {
   required: boolean;
   section: string | null;
   description: string;
-  display_label?: string | null;
+  display_label?: string;
   default: string | null;
   default_value_rationale?: string | null;
   items?: TemplateField[];

--- a/packages/contract-templates-mcp/src/core/tools.ts
+++ b/packages/contract-templates-mcp/src/core/tools.ts
@@ -361,8 +361,15 @@ function normalizeTemplate(template: TemplateRecord): Record<string, unknown> {
     source_url: template.source_url,
     source: template.source,
     attribution_text: template.attribution_text ?? null,
-    fields: template.fields,
+    fields: stripDisplayLabels(template.fields),
   };
+}
+
+function stripDisplayLabels(fields: TemplateField[]): TemplateField[] {
+  return fields.map((field) => {
+    const { display_label: _label, items, ...rest } = field;
+    return items ? { ...rest, items: stripDisplayLabels(items) } : rest;
+  });
 }
 
 function compactTemplate(template: TemplateRecord): Record<string, unknown> {

--- a/packages/contract-templates-mcp/src/core/tools.ts
+++ b/packages/contract-templates-mcp/src/core/tools.ts
@@ -33,6 +33,7 @@ interface TemplateField {
   required: boolean;
   section: string | null;
   description: string;
+  display_label?: string | null;
   default: string | null;
   default_value_rationale?: string | null;
   items?: TemplateField[];

--- a/packages/contract-templates-mcp/tests/tools.test.ts
+++ b/packages/contract-templates-mcp/tests/tools.test.ts
@@ -326,6 +326,100 @@ describe('contract-templates-mcp tools', () => {
       ]);
     });
 
+    it.openspec('OA-TMP-045')('strips display_label from list_templates and get_template payloads (top-level + nested)', async () => {
+      _setModuleOverride(mockModules({
+        listTemplateItems: () => [
+          {
+            name: 'labeled-template',
+            category: 'general',
+            description: 'Labeled template',
+            license: null,
+            source_url: 'https://example.com/labeled-template',
+            source: null,
+            fields: [
+              {
+                name: 'company_name',
+                type: 'string',
+                required: true,
+                section: null,
+                description: 'Company name',
+                display_label: 'Company Name',
+                default: null,
+              },
+              {
+                name: 'signers',
+                type: 'array',
+                required: false,
+                section: null,
+                description: 'Signers',
+                display_label: 'Signers',
+                default: null,
+                items: [
+                  {
+                    name: 'printed_name',
+                    type: 'string',
+                    required: false,
+                    section: null,
+                    description: 'Printed signer name',
+                    display_label: 'Printed Name',
+                    default: null,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        loadMetadata: () => ({
+          name: 'Labeled Template',
+          source_url: 'https://example.com/labeled-template',
+          fields: [
+            {
+              name: 'company_name',
+              type: 'string',
+              description: 'Company name',
+              display_label: 'Company Name',
+            },
+            {
+              name: 'signers',
+              type: 'array',
+              description: 'Signers',
+              display_label: 'Signers',
+              items: [
+                {
+                  name: 'printed_name',
+                  type: 'string',
+                  description: 'Printed signer name',
+                  display_label: 'Printed Name',
+                },
+              ],
+            },
+          ],
+          priority_fields: [],
+        }),
+        mapFields: (fields: unknown[]) => fields,
+      }));
+
+      const listResult = await callTool('list_templates', { mode: 'full' });
+      const listPayload = getPayload(listResult);
+      const listData = listPayload.data as Record<string, unknown>;
+      const templates = listData.templates as Array<Record<string, unknown>>;
+      const listFields = templates[0].fields as Array<Record<string, unknown>>;
+      expect(listFields[0]).not.toHaveProperty('display_label');
+      expect(listFields[1]).not.toHaveProperty('display_label');
+      const listNestedItems = listFields[1].items as Array<Record<string, unknown>>;
+      expect(listNestedItems[0]).not.toHaveProperty('display_label');
+
+      const getResult = await callTool('get_template', { template_id: 'labeled-template' });
+      const getPayloadData = getPayload(getResult);
+      const getData = getPayloadData.data as Record<string, unknown>;
+      const template = getData.template as Record<string, unknown>;
+      const getFields = template.fields as Array<Record<string, unknown>>;
+      expect(getFields[0]).not.toHaveProperty('display_label');
+      expect(getFields[1]).not.toHaveProperty('display_label');
+      const getNestedItems = getFields[1].items as Array<Record<string, unknown>>;
+      expect(getNestedItems[0]).not.toHaveProperty('display_label');
+    });
+
     it.openspec('OA-DST-032')('fill_template returns FILL_FAILED on engine error', async () => {
       _setModuleOverride(mockModules({
         fillTemplate: async () => { throw new Error('engine failure'); },

--- a/src/core/metadata.test.ts
+++ b/src/core/metadata.test.ts
@@ -63,6 +63,20 @@ describe('FieldDefinitionSchema', () => {
     );
   });
 
+  it('rejects a null display_label on fields', async () => {
+    await expectSafeParseOutcome(
+      'FieldDefinitionSchema',
+      FieldDefinitionSchema,
+      {
+        name: 'company_name',
+        type: 'string',
+        description: 'Company name',
+        display_label: null,
+      },
+      false
+    );
+  });
+
   it.openspec('OA-TMP-028')('accepts an array field with nested item schema', async () => {
     await expectSafeParseOutcome(
       'FieldDefinitionSchema',

--- a/src/core/metadata.test.ts
+++ b/src/core/metadata.test.ts
@@ -49,6 +49,20 @@ describe('FieldDefinitionSchema', () => {
     );
   });
 
+  it('accepts an optional display_label on fields', async () => {
+    await expectSafeParseOutcome(
+      'FieldDefinitionSchema',
+      FieldDefinitionSchema,
+      {
+        name: 'company_name',
+        type: 'string',
+        description: 'Company name',
+        display_label: 'Company Name',
+      },
+      true
+    );
+  });
+
   it.openspec('OA-TMP-028')('accepts an array field with nested item schema', async () => {
     await expectSafeParseOutcome(
       'FieldDefinitionSchema',

--- a/src/core/metadata.ts
+++ b/src/core/metadata.ts
@@ -13,6 +13,7 @@ export interface FieldDefinition {
   name: string;
   type: FieldType;
   description: string;
+  display_label?: string;
   default?: string;
   default_value_rationale?: string;
   options?: string[];
@@ -25,6 +26,7 @@ export const FieldDefinitionSchema: z.ZodType<FieldDefinition> = z.lazy(() =>
     name: z.string(),
     type: FieldTypeEnum,
     description: z.string(),
+    display_label: z.string().optional(),
     default: z.string().optional(),
     default_value_rationale: z.string().optional(),
     options: z.array(z.string()).optional(),

--- a/src/core/template-listing.ts
+++ b/src/core/template-listing.ts
@@ -20,7 +20,7 @@ export interface TemplateListField {
   required: boolean;
   section: string | null;
   description: string;
-  display_label?: string | null;
+  display_label?: string;
   default: string | null;
   default_value_rationale: string | null;
   items?: TemplateListField[];

--- a/src/core/template-listing.ts
+++ b/src/core/template-listing.ts
@@ -20,6 +20,7 @@ export interface TemplateListField {
   required: boolean;
   section: string | null;
   description: string;
+  display_label?: string | null;
   default: string | null;
   default_value_rationale: string | null;
   items?: TemplateListField[];
@@ -110,6 +111,7 @@ export function mapFields(
     required: required.has(f.name),
     section: f.section ?? null,
     description: f.description,
+    ...(f.display_label !== undefined ? { display_label: f.display_label } : {}),
     default: f.default ?? null,
     default_value_rationale: f.default_value_rationale ?? null,
     ...(f.items ? { items: mapFields(f.items, []) } : {}),


### PR DESCRIPTION
## What changed

- Added optional `display_label` support to template field metadata.
- Threaded `display_label` through the shared CLI list/snapshot surface so `open-agreements list --json` projects it (with key omitted when absent, never `null`, recursing into nested array `items`).
- Added curated `display_label` values for the Wyoming restrictive covenant template (user-facing fields only).
- Mirrored the type on the contract-templates MCP `TemplateField` interface for forward compatibility, and **strip `display_label` from MCP `list_templates` / `get_template` payloads** (top-level + nested `items`) so the MCP runtime surface stays unchanged in this proposal.
- Regenerated `data/templates-snapshot.json` from the current CLI output.

## Why

This keeps canonical field names stable for filling and automation while giving downstream discovery consumers a human-friendly label when they want one. CLI consumers get the curated label; MCP consumers see no surface change in this proposal — surfacing `display_label` to LLM agents is deferred to a follow-up.

## OpenSpec proposal

`openspec/changes/add-template-display-labels/`. Validates clean under `openspec validate add-template-display-labels --strict`. Mirrors the precedent set by the archived `add-template-credits-metadata` proposal.

## Snapshot drift breakdown

The committed snapshot is a generated artifact (`open-agreements list --json`), so regenerating it picks up any CLI output drift that has accumulated since the last regen.

**Pre-existing CLI drift (NOT introduced by this PR — would land in any snapshot regen against current `main`):**

- Common Paper one-way NDA `source_url` normalized to `https://commonpaper.com/standards/one-way-nda` (was `…/1.0`). Caused by upstream metadata change.
- The stale `openagreements-due-diligence-request-list` entry drops out because that template directory is not present in `main`'s tree (its snapshot entry was committed but the template was never merged).
- OpenAgreements `source_url` paths normalized from `/templates/...` to `/content/templates/...`.

**This PR's display_label additions (the actual feature surface):**

- `display_label` lines added under each user-facing field of the Wyoming restrictive covenant template (employer, employee, durations, territory, etc.).
- AI-only fields (`worker_category`, `restriction_pathways`) and internal computed fields (`cloud_drive_id_footer`) intentionally do NOT carry a `display_label` — this is an authoring guideline, not a wire-format signal. Absent labels still mean "consumer fallback to title-case."

If the drift coupling is a blocker for review, splitting the snapshot regen into a precursor `chore: regenerate snapshot` PR is on the table. Flagging here so reviewers can decide.

## Peer-review follow-ups

After running `/peer-review` (Codex + Gemini, parallel), the following blockers and gaps were addressed (commit `f32fbc6`):

- **Visibility contract reframed.** The previous spec said both "absence means uncurated, fall back to title-case" and "absence means the field is not safe to surface" — internally inconsistent given Wyoming-only curation. Now: AI-only / internal-fields rule is an authoring guideline (SHOULD NOT), and the discovery contract is unchanged for absent labels.
- **MCP payloads stripped of `display_label`.** Earlier framing claimed "type-only mirror, no MCP runtime surface change," but `list_templates` / `get_template` were already passing `mapFields()` output through to the MCP wire. `normalizeTemplate()` now strips `display_label` recursively at the MCP boundary; the type mirror remains for forward compatibility. New OA-TMP-045 scenario + positive-stripping assertions in the contract-templates-mcp tests.
- **Labeled-nested-item positive coverage.** The original test only asserted omission on unlabeled nested items. Added a dedicated OA-TMP-043 test that pairs a labeled nested item with an unlabeled sibling and asserts both behaviors.
- **Negative parse coverage for `display_label: null`.** Schema accepts only `string | undefined`; added a negative parse test so the omit-vs-null wire contract is enforced at the schema level.
- **Type alignment** (commit `2345269`) — `display_label?: string | null` → `display_label?: string` in `template-listing.ts` and the contract-templates MCP `tools.ts`.

## Validation

- `npm run build`
- `node scripts/export-templates-snapshot.mjs --check`
- `git diff --check`
- `npx vitest run src/core/metadata.test.ts integration-tests/list-command.inprocess.test.ts packages/contract-templates-mcp/tests/tools.test.ts` — 58 passed, 3 skipped (same `.skip` markers as the credits work)
- `openspec validate add-template-display-labels --strict`