### PR TITLE
docs(openspec): propose trimming site/ to a thin protocol-host

### DIFF
--- a/openspec/changes/trim-site-to-thin-protocol-host/design.md
+++ b/openspec/changes/trim-site-to-thin-protocol-host/design.md
@@ -1,0 +1,73 @@
+# Design: Trim site/ to a thin protocol-host
+
+## Context
+
+The Vercel deployment of this repo at `openagreements.{org,ai}` started life as the OpenAgreements public site — homepage, template browser, docs, trust pages. In late 2026 the marketing surface migrated to `usejunior.com/developer-tools/open-agreements`. PR #196 added 301 redirects in `vercel.json` for `/`, `/templates`, `/templates/:name`, `/docs/*`, `/trust/*` to the new host. `eleventy.config.js`'s `REDIRECT_MODE=1` was added at the same time to skip rendering those pages during the Vercel build.
+
+What remained of the deployment was a thin **protocol-host**: `/.well-known/{mcp-server-card,api-catalog,agent-card.json,ai/entity.json,arp/pubkey.json}`, the `/api/*` Vercel functions, `/schemas/*.schema.json`, and `/downloads/*.docx` blanks. PR #247 canonicalized those to `openagreements.org` (with `.ai` as a Vercel serving alias).
+
+What hasn't been cleaned up is the source for the marketing pages. They're never built, never served — but they're still in the repo, still in code review diffs, still show up when someone greps `site/`. This change removes them.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Repo state matches deployment reality: no source for pages that don't exist in `_site/`
+- `eleventy.config.js` and `package.json` scripts no longer carry `REDIRECT_MODE=1` conditionals
+- `site/trust/system-card.md` is classified consistently — either it's a rendered page (and we keep the layout) or it's a source-only artifact (and we don't)
+- Build pipeline still emits exactly the deployed surface: `_site/{.well-known,schemas,downloads,assets/previews}/**` plus the generated `_site/.well-known/ai/index.json` and `_site/.well-known/arp/index.sig`
+
+**Non-Goals:**
+- Fixing the broken Allure deploy pipeline (issue #250) — orthogonal
+- Removing Eleventy entirely from the build — possible follow-up, deferred
+- Changing the wildcard ALIAS DNS routing — out of scope
+- Touching `site/.well-known/`, `site/schemas/`, `site/downloads/`, `site/assets/previews/`, or `site/_data/{templateEvidence,systemCardRuntime}.json` — those are load-bearing
+
+## Decisions
+
+### Decision 1: `system-card.md` becomes source-only (Option A)
+
+**What:** Strip `layout: trust-layout.njk` frontmatter from `site/trust/system-card.md`. Stop emitting that frontmatter in `scripts/generate_system_card.mjs`. Delete `_includes/trust-layout.njk` along with the other dead layouts.
+
+**Why:** Today the file claims to be a rendered page (frontmatter declares a layout), but `REDIRECT_MODE=1` ignores it at build, so the claim is a lie. The CI freshness gate `check:system-card` (in `package.json:104`) reads the file as raw markdown, doesn't care about layouts. Re-classifying it as a source-only traceability artifact aligns the file with how it's actually used.
+
+**Alternative considered (Option B):** Keep `_includes/{trust-layout,base}.njk` and therefore `styles.css`/`main.js` (which `base.njk:20,82` references). Smaller cleanup, but defers the "what is this file?" question and keeps ~5 dead files alive. Rejected because Option A is the principled answer.
+
+### Decision 2: Keep `site/_data/{templateEvidence,systemCardRuntime}.json`, drop `changelog.json`
+
+**Why:** `templateEvidence.json` and `systemCardRuntime.json` are freshness-gated by CI (`check:template-evidence` and the system-card runtime check). Deleting them would break those gates. `changelog.json` is consumed only by `site/trust/changelog.njk` (which is being deleted); it has no freshness gate and no other consumers. Drop it.
+
+### Decision 3: Update or delete `integration-tests/trust-signal-surfaces.test.ts`
+
+**Context:** The test currently reads `site/index.njk` directly (lines 20–26) and asserts trust-signal content is present. After PR 3, that file doesn't exist.
+
+**What:** Rewrite the test to assert against `_site/.well-known/{mcp-server-card,api-catalog,agent-card.json}` — those are the actual public trust surfaces post-cleanup. The README and the generated `system-card.md` are the human-facing trust surfaces; either is fine to assert against.
+
+**Alternative:** Delete the test outright and rely on the freshness gates. Rejected because the test asserts behavior worth keeping (trust signals exist on a public surface).
+
+### Decision 4: Keep Eleventy in the build pipeline for now
+
+**Why:** With the deletions, Eleventy's job reduces to "passthrough copy `site/{.well-known,schemas,downloads,assets}` to `_site/`." That's a small enough job that you could replace it with `cp -r`, but Eleventy also handles the build chain that produces `_site/.well-known/ai/index.json` (signed manifest) and `_site/sitemap.xml` (`scripts/generate_site_indexes.mjs`). Removing Eleventy is a follow-up, not part of this change.
+
+## Risks / Trade-offs
+
+- **Risk:** Translated READMEs (`README.{de,es,pt-br,zh}.md`) describe `site/index.njk`, `site/templates.njk`, `site/template-detail.njk`, `site/styles.css` as project structure (lines 262–270). After delete, those descriptions are wrong. **Mitigation:** Update those sections in the same PR to describe the thin-protocol-host structure.
+- **Risk:** `docs/changelog-release-process.md:108` tells readers to open `_site/trust/changelog/index.html` to verify the rendered changelog. After delete, that file doesn't exist. **Mitigation:** Update the doc to reference the GitHub Releases page (or remove the verification step).
+- **Risk:** Some external system or marketing collateral might link to `https://openagreements.org/templates` or `/trust/` etc. **Mitigation:** The 301 redirects in `vercel.json` continue to work — those external links still resolve, just to usejunior.com. No regression.
+- **Trade-off:** The `redirects[]` block in `vercel.json` becomes load-bearing for *every* user of the old URLs. If it's ever removed, those links 404. Worth a comment in `vercel.json` to make the intent explicit.
+
+## Migration Plan
+
+1. **Cut the OpenSpec proposal** (this file). Get approval before any code changes.
+2. **Land a single PR** implementing all deletions + modifications + test/doc updates. Don't split — the build pipeline can't be in a half-stripped state.
+3. **CI must pass** (`npm run preflight:ci`, integration tests, system-card freshness, template-evidence freshness, template previews).
+4. **Post-merge verification:**
+   - `curl https://openagreements.org/.well-known/{mcp-server-card,api-catalog,agent-card.json}` unchanged
+   - `curl https://openagreements.org/schemas/forms-catalog.schema.json` unchanged
+   - `curl https://openagreements.org/downloads/openagreements-mutual-nda.docx` returns the DOCX
+   - `curl -I https://openagreements.org/` returns 308 to `usejunior.com` (existing redirect)
+5. **Rollback:** straightforward git revert. The deleted source is recoverable from git history; the build pipeline restores via revert.
+
+## Open Questions
+
+- Does the OpenSpec capability need a new requirement specifically for "Thin Protocol Host Deployment," or is modifying `Public Trust Signal Surfaces` enough? (Proposed: yes, add the new requirement — codifies what `_site/` contents must be.)
+- Should `site/main.js` line 176 (`const canonical = 'https://openagreements.ai';`) get its `.ai` reference flipped before deletion, for grep-cleanliness during the PR-2 → PR-3 transition? (Proposed: no — the file is being deleted, flipping it is wasted churn.)

--- a/openspec/changes/trim-site-to-thin-protocol-host/proposal.md
+++ b/openspec/changes/trim-site-to-thin-protocol-host/proposal.md
@@ -1,0 +1,24 @@
+# Change: Trim site/ to a thin protocol-host
+
+## Why
+
+The marketing site for OpenAgreements has moved to `usejunior.com/developer-tools/open-agreements`. `vercel.json` already 301-redirects all marketing paths, and `eleventy.config.js`'s `REDIRECT_MODE=1` skips rendering them at build. The Vercel deployment of this repo at `openagreements.{org,ai}` only really exists to host the protocol/discovery surface (`/.well-known/*`, `/api/*`, `/schemas/*`, `/downloads/*`).
+
+But the repo on `main` still carries a full marketing/trust Eleventy site under `site/` whose `.njk` pages, `_includes`, `src/` (Tailwind input), and `docs/` are dead code under `REDIRECT_MODE=1`. They never get built, never served — but their source still lives in the repo and shows up in code review, makes the repo look sloppy, and adds maintenance noise. A peer-reviewed (Codex + Gemini) cleanup plan identified this as the third of three sequenced PRs (after #235 cleanup and #247 canonicalization, both merged or queued).
+
+## What Changes
+
+- Strip `site/` to the surfaces that actually serve users on `openagreements.{org,ai}`.
+- Re-classify `site/trust/system-card.md` from a *rendered Eleventy page* (with `layout: trust-layout.njk` frontmatter) to a *source-only traceability artifact* (frontmatter stripped). The CI freshness gate `check:system-card` continues to enforce it.
+- Remove `REDIRECT_MODE=1` ignore semantics from `eleventy.config.js`. With marketing pages deleted, the conditional becomes redundant.
+- **BREAKING (deployed surface):** the Vercel deployment for `openagreements.{org,ai}` no longer ships HTML for `/`, `/templates`, `/templates/:name`, `/docs/*`, `/trust/*`. These paths have been 301-redirected since PR #196; this change removes the underlying source as well.
+- Update tests, translated READMEs, and release docs that currently describe deleted paths.
+
+## Impact
+
+- **Affected specs:** `open-agreements` capability — `Public Trust Signal Surfaces` requirement scenarios are modified to reflect that the landing-page trust signals now live on `usejunior.com` rather than in this repo's `_site/`. New `Thin Protocol Host Deployment` requirement codifies what the Vercel deploy must continue to serve.
+- **Affected code:**
+  - Deletes: `site/{index,templates,template-detail}.njk`; `site/trust/{index,template-evidence,evidence-story,changelog}.njk`; `site/{main.js,templates-filter.js,styles.css}`; `site/src/**`; `site/_includes/**`; `site/docs/**`; `site/_data/changelog.json`
+  - Modifies: `eleventy.config.js`, `package.json` scripts (`build:css`, `build:docs`, `build:site:vercel`), `scripts/generate_system_card.mjs` (stop emitting `layout:` frontmatter), `integration-tests/trust-signal-surfaces.test.ts`, `README.{de,es,pt-br,zh}.md`, `docs/changelog-release-process.md`
+  - Keeps: `site/.well-known/**`, `site/schemas/**`, `site/downloads/**`, `site/assets/previews/**`, `site/_data/{docsNav.js, catalog.js, github.js, templateEvidence.json, systemCardRuntime.json}`, `site/trust/system-card.md`
+- **Latent issue NOT addressed here:** the broken Allure deploy pipeline at `tests.openagreements.{ai,org}` (issue #250). Orthogonal to this change.

--- a/openspec/changes/trim-site-to-thin-protocol-host/specs/open-agreements/spec.md
+++ b/openspec/changes/trim-site-to-thin-protocol-host/specs/open-agreements/spec.md
@@ -1,0 +1,52 @@
+## MODIFIED Requirements
+
+### Requirement: Public Trust Signal Surfaces
+The project SHALL expose trust signals that help users and AI agents quickly verify maintenance quality and testing posture from public surfaces.
+
+#### Scenario: [OA-DST-006] README exposes trust evidence at first glance
+- **WHEN** a visitor opens the repository README
+- **THEN** the top section shows trust signals for CI status and coverage
+- **AND** identifies the active JavaScript test framework (Vitest or Jest)
+
+#### Scenario: [OA-DST-007] External landing page exposes trust evidence without scrolling deep
+- **WHEN** a visitor opens the OpenAgreements landing page on `usejunior.com/developer-tools/open-agreements`
+- **THEN** the Trust section links to npm package, CI status, coverage dashboard, and source repository
+- **AND** includes an explicit signal for the active JavaScript test framework (Vitest or Jest)
+- **AND** this content is owned and served by the `usejunior.com` deployment, not by the `openagreements.{org,ai}` Vercel deployment
+
+#### Scenario: [OA-DST-006b] System card is published as a source-only traceability artifact
+- **WHEN** the project regenerates trust artifacts via `npm run trust:rebuild`
+- **THEN** `site/trust/system-card.md` is written as plain markdown without Eleventy layout frontmatter
+- **AND** `npm run check:system-card` enforces the file is up-to-date relative to OpenSpec scenarios and Allure runtime data
+- **AND** the file is committed to git as the canonical traceability record (not as a rendered HTML page)
+
+## ADDED Requirements
+
+### Requirement: Thin Protocol Host Deployment
+The Vercel deployment for `openagreements.{org,ai}` SHALL serve only the protocol/discovery surface plus generated indexes and existing 301 redirects to the marketing host. Marketing pages, template browser pages, and trust HTML pages SHALL NOT be present in the deployed `_site/` output.
+
+#### Scenario: [OA-DST-027] Deployed protocol surface is present
+- **WHEN** the project builds the Vercel deployment via `npm run build:site:vercel`
+- **THEN** `_site/.well-known/{mcp-server-card,api-catalog,agent-card.json,ai/entity.json,ai/index.json,arp/pubkey.json,arp/index.sig}` are emitted
+- **AND** `_site/schemas/{forms-catalog,conventions}.schema.json` are emitted
+- **AND** `_site/downloads/*.docx` are emitted for templates whose metadata advertises a static blank download
+- **AND** `_site/assets/previews/**.png` are emitted for templates with CI-validated preview images
+
+#### Scenario: [OA-DST-028] Deployed marketing surface is absent
+- **WHEN** the project builds the Vercel deployment via `npm run build:site:vercel`
+- **THEN** `_site/index.html` is NOT emitted
+- **AND** `_site/templates/index.html` is NOT emitted
+- **AND** `_site/templates/<slug>/index.html` is NOT emitted
+- **AND** `_site/docs/**` is NOT emitted
+- **AND** `_site/trust/{index,template-evidence,evidence-story,changelog}/index.html` are NOT emitted
+
+#### Scenario: [OA-DST-029] Marketing paths return 301 redirects to the external marketing host
+- **WHEN** an HTTP GET hits `https://openagreements.org/`, `/templates`, `/templates/<slug>`, `/docs`, `/docs/<slug>`, `/trust`, `/trust/system-card`, `/trust/template-evidence`, `/trust/evidence-story`, or `/trust/changelog`
+- **THEN** Vercel responds with a 301 redirect to the corresponding `usejunior.com/developer-tools/open-agreements` path
+- **AND** the redirect rules are codified in `vercel.json`
+
+#### Scenario: [OA-DST-030] Generated site indexes advertise the canonical origin
+- **WHEN** the project builds and emits `_site/{llms.txt,llms-full.txt,sitemap.xml}`
+- **THEN** all URLs in those indexes use `https://openagreements.org` as the origin
+- **AND** the deployed indexes do not advertise `openagreements.ai` as a canonical URL
+

--- a/openspec/changes/trim-site-to-thin-protocol-host/tasks.md
+++ b/openspec/changes/trim-site-to-thin-protocol-host/tasks.md
@@ -1,0 +1,63 @@
+# Tasks: Trim site/ to a thin protocol-host
+
+## 1. Source deletions
+
+- [ ] 1.1 Delete `site/index.njk`, `site/templates.njk`, `site/template-detail.njk`
+- [ ] 1.2 Delete `site/trust/{index,template-evidence,evidence-story,changelog}.njk`
+- [ ] 1.3 Delete `site/main.js`, `site/templates-filter.js`, `site/styles.css`
+- [ ] 1.4 Delete `site/src/**` (Tailwind input)
+- [ ] 1.5 Delete `site/_includes/{base,docs-layout,trust-layout}.njk`
+- [ ] 1.6 Delete `site/docs/**` (gitignored copy of `docs/`; remove the dir)
+- [ ] 1.7 Delete `site/_data/changelog.json`
+
+## 2. Re-classify `system-card.md` as source-only
+
+- [ ] 2.1 Strip `layout: trust-layout.njk` frontmatter from `site/trust/system-card.md`
+- [ ] 2.2 Update `scripts/generate_system_card.mjs` (~line 834) to stop emitting layout frontmatter
+- [ ] 2.3 Run `npm run trust:rebuild` to regenerate; verify diff matches expectation
+
+## 3. Build pipeline updates
+
+- [ ] 3.1 In `eleventy.config.js`, remove the `REDIRECT_MODE=1` ignore block (lines 27–34)
+- [ ] 3.2 In `eleventy.config.js`, remove passthrough for `site/main.js`, `site/templates-filter.js`, `site/styles.css` (lines 202, 203, 205)
+- [ ] 3.3 In `package.json`, drop `build:css` script (line 87)
+- [ ] 3.4 In `package.json`, drop `build:docs` script (line 88)
+- [ ] 3.5 In `package.json`, adjust `build:site:vercel` to not invoke removed scripts; verify it still emits the protocol surface
+- [ ] 3.6 In `vercel.json`, add a comment near `redirects[]` noting the redirects are load-bearing (source deleted)
+
+## 4. Test and doc updates
+
+- [ ] 4.1 Rewrite `integration-tests/trust-signal-surfaces.test.ts` (lines 20–26) to assert against `_site/.well-known/*` outputs instead of `site/index.njk`
+- [ ] 4.2 Update `README.de.md` (lines 262–270) — replace `site/` structure description with thin-protocol-host
+- [ ] 4.3 Update `README.es.md` (lines 262–270) — same
+- [ ] 4.4 Update `README.pt-br.md` (lines 262–270) — same
+- [ ] 4.5 Update `README.zh.md` (lines 262–270) — same
+- [ ] 4.6 Update `docs/changelog-release-process.md:108` — replace `_site/trust/changelog/index.html` reference with GitHub Releases link or remove the verification step
+- [ ] 4.7 Run `npm run generate:readme` to refresh `README.md` if any structure-description sections are present
+
+## 5. OpenSpec deltas
+
+- [ ] 5.1 Modify `Public Trust Signal Surfaces` scenarios: OA-DST-007 and any others that reference the landing page in this repo's deployment
+- [ ] 5.2 Add new requirement `Thin Protocol Host Deployment` codifying what `_site/` must contain
+- [ ] 5.3 Update `openspec/specs/open-agreements/spec.md` after this change archives (Stage 3)
+
+## 6. Verification
+
+- [ ] 6.1 `npm run preflight:ci` passes
+- [ ] 6.2 `REDIRECT_MODE=1 npm run build:site:vercel` (or its updated form) succeeds
+- [ ] 6.3 `_site/` contains only `.well-known/`, `schemas/`, `downloads/`, `assets/`, `trust/system-card.md`, generated indexes (`llms.txt`, `llms-full.txt`, `sitemap.xml`)
+- [ ] 6.4 `_site/` contains NO `index.html`, `templates/`, `template/`, `trust/index.html`, `docs/`
+- [ ] 6.5 `npm run check:system-card` and `npm run check:template-evidence` pass
+- [ ] 6.6 `npx vitest run integration-tests/` passes (incl. rewritten trust-signal-surfaces test)
+- [ ] 6.7 Open the resulting deploy preview and confirm:
+  - `https://<preview>.vercel.app/.well-known/mcp-server-card` returns 200
+  - `https://<preview>.vercel.app/.well-known/agent-card.json` returns 200 with `.org` URLs
+  - `https://<preview>.vercel.app/schemas/forms-catalog.schema.json` returns 200
+  - `https://<preview>.vercel.app/downloads/openagreements-mutual-nda.docx` returns 200 (sample one)
+  - `https://<preview>.vercel.app/` returns 301 → usejunior.com (existing redirect still works)
+
+## 7. Stage 3 (post-merge, separate PR)
+
+- [ ] 7.1 Run `openspec archive trim-site-to-thin-protocol-host --yes`
+- [ ] 7.2 Update `openspec/specs/open-agreements/spec.md` with the modified/added requirements
+- [ ] 7.3 Run `openspec validate --strict` to confirm


### PR DESCRIPTION
## Summary

OpenSpec proposal for **issue #249** (PR 3 of the peer-reviewed canonicalization cleanup plan, after #235 cleanup and #247 `.org` canonicalization).

This is a **proposal-only PR** — no code changes. Approval here unblocks the implementation PR that will delete the marketing source under `site/`.

## Files

- `openspec/changes/trim-site-to-thin-protocol-host/proposal.md` — why, what changes, impact
- `openspec/changes/trim-site-to-thin-protocol-host/design.md` — design decisions, alternatives, risks, migration plan
- `openspec/changes/trim-site-to-thin-protocol-host/tasks.md` — implementation checklist (28 items across 7 sections)
- `openspec/changes/trim-site-to-thin-protocol-host/specs/open-agreements/spec.md` — spec deltas:
  - **MODIFY** `Public Trust Signal Surfaces` — OA-DST-007 reframed: trust signals on the landing page are owned by `usejunior.com`, not by this repo's `_site/`. Add OA-DST-006b: system-card.md is a source-only traceability artifact.
  - **ADD** `Thin Protocol Host Deployment` — codifies what the Vercel deploy must contain (`.well-known/`, `schemas/`, `downloads/`, `assets/previews/`) and what it must NOT contain (marketing HTML, template browser, trust HTML). Adds scenarios for existing 301 redirects and `.org` canonical advertisement in generated indexes.

## Pre-decision baked in

`site/trust/system-card.md` becomes a **source-only artifact** (Option A from the plan), not a rendered HTML page (Option B). This means stripping its `layout: trust-layout.njk` frontmatter, deleting `_includes/trust-layout.njk`, and updating `scripts/generate_system_card.mjs` to stop emitting the layout. Rationale in `design.md`.

## Test plan

- [x] `npx openspec validate trim-site-to-thin-protocol-host --strict` → valid
- [ ] Approval from maintainer (this PR is the approval gate per OpenSpec workflow)

## Out of scope

- The broken Allure deploy pipeline at `tests.openagreements.{ai,org}` — tracked separately as #250.

Refs #249.