### PR TITLE
fix(ci): retire broken GH Pages deploy, push Allure to Vercel project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
+---
 name: CI
 
-on:
+"on":
   push:
     branches: [main]
   pull_request:
@@ -185,14 +186,18 @@ jobs:
     if: github.ref == 'refs/heads/main'
     needs: [test]
     runs-on: ubuntu-latest
-    permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+    env:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_TESTS_OPENAGREEMENTS }}
+      VERCEL_DEPLOY_ENABLED: >-
+        ${{
+          secrets.VERCEL_TOKEN != '' &&
+          secrets.VERCEL_ORG_ID != '' &&
+          secrets.VERCEL_PROJECT_ID_TESTS_OPENAGREEMENTS != ''
+        }}
     concurrency:
-      group: pages
+      group: deploy-allure-vercel
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
@@ -214,14 +219,25 @@ jobs:
       - name: Generate and brand Allure report
         run: npm run report:allure
 
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: allure-report
+      - name: Prepare static Vercel build output
+        if: ${{ env.VERCEL_DEPLOY_ENABLED == 'true' }}
+        run: |
+          output_dir="$RUNNER_TEMP/allure-vercel/.vercel/output"
+          rm -rf "$RUNNER_TEMP/allure-vercel"
+          mkdir -p "$output_dir/static"
+          cp -R allure-report/. "$output_dir/static/"
+          printf '%s\n' '{"version":3}' > "$output_dir/config.json"
 
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      - name: Install Vercel CLI
+        if: ${{ env.VERCEL_DEPLOY_ENABLED == 'true' }}
+        run: npm install --global vercel@latest
+
+      - name: Deploy Allure report to Vercel (tests-openagreements)
+        if: ${{ env.VERCEL_DEPLOY_ENABLED == 'true' }}
+        run: |
+          cd "$RUNNER_TEMP/allure-vercel"
+          vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
+          vercel deploy --prebuilt --prod --token="$VERCEL_TOKEN"
 
   source-drift-canary:
     runs-on: ubuntu-latest
@@ -241,7 +257,8 @@ jobs:
 
       - name: Source drift canary (strict on main, permissive on PR)
         run: |
-          if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then
+          if [ "${{ github.event_name }}" = "push" ] &&
+             [ "${{ github.ref }}" = "refs/heads/main" ]; then
             echo "Running strict source drift canary on main."
             node scripts/source_drift_canary.mjs --download --strict-missing
           else

--- a/scripts/deploy_allure_report.mjs
+++ b/scripts/deploy_allure_report.mjs
@@ -3,20 +3,35 @@
 /**
  * Allure report deployment information.
  *
- * Production deployments are handled automatically by CI via GitHub Pages.
+ * Production deployments are handled automatically by CI via Vercel.
  * See .github/workflows/ci.yml → deploy-allure job.
  *
- * The workflow uses OIDC (id-token: write) — no static secrets needed.
- * Push to main → CI deploys to https://tests.openagreements.ai
+ * Push to main → CI deploys the generated static report to the
+ * tests-openagreements Vercel project when the required GitHub Actions secrets
+ * are configured:
+ *   - VERCEL_TOKEN
+ *   - VERCEL_ORG_ID
+ *   - VERCEL_PROJECT_ID_TESTS_OPENAGREEMENTS
+ *
+ * The production report is served at:
+ *   - https://tests.openagreements.ai
+ *   - https://tests.openagreements.org
  *
  * To preview the report locally:
  *   npm run report:allure    # generates ./allure-report
  *   npx allure open allure-report
  */
 
-console.log("Allure report deployment is handled by CI via GitHub Pages.");
+console.log("Allure report deployment is handled by CI via the tests-openagreements Vercel project.");
 console.log("");
-console.log("Push to main → CI auto-deploys to https://tests.openagreements.ai");
+console.log("Push to main → CI auto-deploys to:");
+console.log("  https://tests.openagreements.ai");
+console.log("  https://tests.openagreements.org");
+console.log("");
+console.log("Required GitHub Actions secrets:");
+console.log("  VERCEL_TOKEN");
+console.log("  VERCEL_ORG_ID");
+console.log("  VERCEL_PROJECT_ID_TESTS_OPENAGREEMENTS");
 console.log("");
 console.log("To preview locally:");
 console.log("  npm run report:allure");


### PR DESCRIPTION
## Summary
- retire the `deploy-allure` GitHub Pages upload/deploy flow and target the existing `tests-openagreements` Vercel project instead
- gate the Vercel deploy behind GitHub Actions secrets so the job skips cleanly until repo settings are populated
- update `scripts/deploy_allure_report.mjs` so the local helper output matches the Vercel-based deployment path

## Why
CI has been generating fresh Allure artifacts, but users reach `tests.openagreements.{ai,org}` through the `tests-openagreements` Vercel project rather than the broken GitHub Pages origin. This change switches the deploy job to publish the generated static Allure report to the Vercel project that actually serves those domains.

## Secrets Required
Add these repository secrets in Settings -> Secrets and variables -> Actions:
- `VERCEL_TOKEN`: create at https://vercel.com/account/tokens and scope it to the `use-junior` team
- `VERCEL_ORG_ID`: the `use-junior` team ID; find it via `vercel teams ls --json`
- `VERCEL_PROJECT_ID_TESTS_OPENAGREEMENTS`: `prj_Fdu23NeAREdDUVQsAWr35csxvLSm`

Until all three secrets are added, the Vercel deploy steps no-op and do not fail CI.

After the first successful Vercel-based deploy lands on `main`, disable GitHub Pages for this repo in Settings -> Pages -> `None` so the broken Pages certificate can be retired.

## Test Plan
- [x] `gh workflow view ci.yml --repo open-agreements/open-agreements`
- [x] `yamllint .github/workflows/ci.yml`
- [x] `actionlint .github/workflows/ci.yml`
- [ ] `npm run preflight:ci` *(fails in this sandbox because `packages/signing/tests/gcloud-storage.test.ts` needs outbound DNS/network access to `oauth2.googleapis.com`; unrelated to this workflow change)*

Refs #250
