### PR TITLE
feat(schema): add multiselect field type with derive_booleans flag (closes #220)

### DIFF
--- a/docs/adding-templates.md
+++ b/docs/adding-templates.md
@@ -76,6 +76,32 @@ derived_from: Publicly available materials from ...
 | `boolean` | true/false |
 | `enum` | One of a fixed set of options (use `options` array) |
 | `array` | Repeating list of objects or values (use nested `items` definitions when you need object fields) |
+| `multiselect` | Zero or more values from a fixed allowlist (use `options` array) |
+
+#### Multiselect fields
+
+Use `multiselect` when the user should choose zero or more values from a
+closed set and the template needs a shared allowlist.
+
+```yaml
+- name: industry_modules
+  type: multiselect
+  description: Industry riders to include
+  options: [tech_rider, life_sciences_rider, healthcare_provider_rider, cross_border_rider]
+  derive_booleans: true
+  default: '[]'
+  section: Industry Riders
+```
+
+When `derive_booleans: true` is set, the fill engine emits
+`<option>_enabled: boolean` keys for every option, based on whether that
+option appears in the selected array. DOCX templates can then gate
+sections with `{IF tech_rider_enabled}`-style conditionals without
+needing separate user-facing boolean fields.
+
+Do not reference the multiselect field itself directly in `{IF ...}`
+blocks. `{IF industry_modules}` is invalid because empty arrays are
+truthy in the template runtime; the validator will reject it.
 
 #### License values
 

--- a/integration-tests/fill-pipeline.test.ts
+++ b/integration-tests/fill-pipeline.test.ts
@@ -7,6 +7,7 @@ import { tmpdir } from 'node:os';
 import AdmZip from 'adm-zip';
 import { detectCurrencyFields, sanitizeCurrencyValuesFromDocx, verifyTemplateFill, BLANK_PLACEHOLDER } from '../src/core/fill-utils.js';
 import { prepareFillData, fillDocx } from '../src/core/fill-pipeline.js';
+import { runFillPipeline } from '../src/core/unified-pipeline.js';
 import { loadMetadata } from '../src/core/metadata.js';
 import { fillTemplate } from '../src/core/engine.js';
 
@@ -258,6 +259,13 @@ describe('prepareFillData', () => {
     { name: 'is_free', type: 'boolean' as const, description: 'Is free' },
   ];
   const priorityFieldNames = ['company'];
+  const multiselectField = {
+    name: 'industry_modules',
+    type: 'multiselect' as const,
+    description: 'Industry riders',
+    options: ['a', 'b', 'c'],
+    derive_booleans: true,
+  };
 
   it.openspec('OA-FIL-008')('defaults optional fields to empty string when useBlankPlaceholder is false', () => {
     const result = prepareFillData({
@@ -365,6 +373,90 @@ describe('prepareFillData', () => {
       },
     });
     expect(callbackCalled).toBe(true);
+  });
+
+  it.openspec('OA-FIL-016')('normalizes multiselect arrays and derives booleans', () => {
+    const result = prepareFillData({
+      values: { industry_modules: ['a', 'c'] },
+      fields: [multiselectField],
+    });
+
+    expect(result.industry_modules).toEqual(['a', 'c']);
+    expect(result.a_enabled).toBe(true);
+    expect(result.b_enabled).toBe(false);
+    expect(result.c_enabled).toBe(true);
+  });
+
+  it.openspec('OA-FIL-016')('parses JSON-string multiselect input back into a real array', () => {
+    const result = prepareFillData({
+      values: { industry_modules: '["a","c"]' },
+      fields: [multiselectField],
+    });
+
+    expect(result.industry_modules).toEqual(['a', 'c']);
+    expect(Array.isArray(result.industry_modules)).toBe(true);
+    expect(result.a_enabled).toBe(true);
+    expect(result.c_enabled).toBe(true);
+  });
+
+  it.openspec('OA-FIL-016')('defaults omitted multiselect fields and derives false for every option', () => {
+    const result = prepareFillData({
+      values: {},
+      fields: [multiselectField],
+    });
+
+    expect(result.industry_modules).toEqual([]);
+    expect(result.a_enabled).toBe(false);
+    expect(result.b_enabled).toBe(false);
+    expect(result.c_enabled).toBe(false);
+  });
+
+  it.openspec('OA-FIL-016')('honors multiselect defaults declared in metadata', () => {
+    const result = prepareFillData({
+      values: {},
+      fields: [{ ...multiselectField, default: '["a"]' }],
+    });
+
+    expect(result.industry_modules).toEqual(['a']);
+    expect(result.a_enabled).toBe(true);
+    expect(result.b_enabled).toBe(false);
+    expect(result.c_enabled).toBe(false);
+  });
+
+  it('does not leak derived boolean keys when derive_booleans is absent', () => {
+    const field = {
+      ...multiselectField,
+      derive_booleans: undefined,
+    };
+    const result = prepareFillData({
+      values: { industry_modules: ['a'] },
+      fields: [field],
+    });
+
+    const metadataFieldNames = new Set([field.name]);
+    const leakedEnabledKeys = Object.keys(result).filter(
+      (key) => key.endsWith('_enabled') && !metadataFieldNames.has(key)
+    );
+    expect(leakedEnabledKeys).toEqual([]);
+  });
+
+  it.openspec('OA-FIL-016')('derives multiselect booleans before computeDisplayFields runs', () => {
+    let seenByCallback: Record<string, unknown> | undefined;
+
+    const result = prepareFillData({
+      values: { industry_modules: ['a'] },
+      fields: [multiselectField],
+      computeDisplayFields: (data) => {
+        seenByCallback = {
+          a_enabled: data.a_enabled,
+          b_enabled: data.b_enabled,
+        };
+        data['selection_summary'] = data.a_enabled === true ? 'A selected' : 'A missing';
+      },
+    });
+
+    expect(seenByCallback).toEqual({ a_enabled: true, b_enabled: false });
+    expect(result.selection_summary).toBe('A selected');
   });
 });
 
@@ -613,6 +705,37 @@ describe('Regression: behavioral divergence', () => {
     expect(spy).toHaveBeenCalledWith(expect.stringContaining('priority fields are unfilled'));
     expect(spy).toHaveBeenCalledWith(expect.stringContaining('name'));
     spy.mockRestore();
+  });
+});
+
+describe('runFillPipeline', () => {
+  it.openspec('OA-FIL-018')('excludes derived multiselect keys from fieldsUsed', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'fill-pipeline-fields-used-'));
+    const inputPath = join(tempDir, 'source.docx');
+    const outputPath = join(tempDir, 'output.docx');
+    writeFileSync(inputPath, buildDocxBuffer(docXml(['No placeholders needed'])));
+
+    try {
+      const result = await runFillPipeline({
+        inputPath,
+        outputPath,
+        values: { industry_modules: ['a'] },
+        fields: [
+          {
+            name: 'industry_modules',
+            type: 'multiselect',
+            description: 'Industry riders',
+            options: ['a', 'b'],
+            derive_booleans: true,
+          },
+        ],
+        verify: async () => ({ passed: true, checks: [] }),
+      });
+
+      expect(result.fieldsUsed).toEqual(['industry_modules']);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/integration-tests/fill-pipeline.test.ts
+++ b/integration-tests/fill-pipeline.test.ts
@@ -375,7 +375,7 @@ describe('prepareFillData', () => {
     expect(callbackCalled).toBe(true);
   });
 
-  it.openspec('OA-FIL-016')('normalizes multiselect arrays and derives booleans', () => {
+  it.openspec('OA-FIL-025')('normalizes multiselect arrays and derives booleans', () => {
     const result = prepareFillData({
       values: { industry_modules: ['a', 'c'] },
       fields: [multiselectField],
@@ -387,7 +387,7 @@ describe('prepareFillData', () => {
     expect(result.c_enabled).toBe(true);
   });
 
-  it.openspec('OA-FIL-016')('parses JSON-string multiselect input back into a real array', () => {
+  it.openspec('OA-FIL-025')('parses JSON-string multiselect input back into a real array', () => {
     const result = prepareFillData({
       values: { industry_modules: '["a","c"]' },
       fields: [multiselectField],
@@ -399,7 +399,7 @@ describe('prepareFillData', () => {
     expect(result.c_enabled).toBe(true);
   });
 
-  it.openspec('OA-FIL-016')('defaults omitted multiselect fields and derives false for every option', () => {
+  it.openspec('OA-FIL-025')('defaults omitted multiselect fields and derives false for every option', () => {
     const result = prepareFillData({
       values: {},
       fields: [multiselectField],
@@ -411,7 +411,7 @@ describe('prepareFillData', () => {
     expect(result.c_enabled).toBe(false);
   });
 
-  it.openspec('OA-FIL-016')('honors multiselect defaults declared in metadata', () => {
+  it.openspec('OA-FIL-025')('honors multiselect defaults declared in metadata', () => {
     const result = prepareFillData({
       values: {},
       fields: [{ ...multiselectField, default: '["a"]' }],
@@ -440,7 +440,7 @@ describe('prepareFillData', () => {
     expect(leakedEnabledKeys).toEqual([]);
   });
 
-  it.openspec('OA-FIL-016')('derives multiselect booleans before computeDisplayFields runs', () => {
+  it.openspec('OA-FIL-025')('derives multiselect booleans before computeDisplayFields runs', () => {
     let seenByCallback: Record<string, unknown> | undefined;
 
     const result = prepareFillData({
@@ -709,7 +709,7 @@ describe('Regression: behavioral divergence', () => {
 });
 
 describe('runFillPipeline', () => {
-  it.openspec('OA-FIL-018')('excludes derived multiselect keys from fieldsUsed', async () => {
+  it.openspec('OA-FIL-027')('excludes derived multiselect keys from fieldsUsed', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'fill-pipeline-fields-used-'));
     const inputPath = join(tempDir, 'source.docx');
     const outputPath = join(tempDir, 'output.docx');

--- a/integration-tests/template-validation.test.ts
+++ b/integration-tests/template-validation.test.ts
@@ -563,4 +563,78 @@ describe('validateTemplate multiselect coverage', () => {
       })
     ).toThrow('Required collection fields are empty: industry_modules');
   });
+
+  it.openspec('OA-TMP-053')('warns when a derive_booleans multiselect is declared but no derived key is referenced (direct DOCX)', () => {
+    const dir = createTemplateFixture({
+      docText: 'Body text without any rider conditional.',
+      fieldsYaml: multiselectFieldsYaml,
+    });
+
+    const result = validateTemplate(dir, 'fixture-derive-booleans-unused-direct');
+
+    expect(result.valid).toBe(true);
+    expect(result.warnings.join(' ')).toContain('Optional field "industry_modules"');
+  });
+
+  it.openspec('OA-TMP-053')('errors when a priority derive_booleans multiselect is declared but no derived key is referenced (direct DOCX)', () => {
+    const dir = createTemplateFixture({
+      docText: 'Body text without any rider conditional.',
+      fieldsYaml: multiselectFieldsYaml,
+      priorityFields: ['industry_modules'],
+    });
+
+    const result = validateTemplate(dir, 'fixture-derive-booleans-unused-direct-priority');
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.join(' ')).toContain('Priority field "industry_modules"');
+  });
+
+  it.openspec('OA-TMP-053')('warns when a derive_booleans multiselect is declared but no derived key is referenced (replacements mode)', () => {
+    const dir = createTemplateFixture({
+      docText: '[Industry riders]',
+      fieldsYaml: multiselectFieldsYaml,
+      replacements: {
+        '[Industry riders]': 'plain replacement text without any rider conditional',
+      },
+    });
+
+    const result = validateTemplate(dir, 'fixture-derive-booleans-unused-replacements');
+
+    expect(result.valid).toBe(true);
+    expect(result.warnings.join(' ')).toContain('Optional field "industry_modules"');
+  });
+
+  it.openspec('OA-FIL-019')('rejects multiselect runtime input with non-string entries', () => {
+    expect(() =>
+      prepareFillData({
+        values: { industry_modules: ['tech_rider', 7] as unknown[] },
+        fields: [
+          {
+            name: 'industry_modules',
+            type: 'multiselect',
+            description: 'Industry riders',
+            options: ['tech_rider', 'cross_border_rider'],
+            derive_booleans: true,
+          },
+        ],
+      })
+    ).toThrow('entry at index 1 must be a string');
+  });
+
+  it.openspec('OA-FIL-019')('rejects multiselect runtime input with unknown options', () => {
+    expect(() =>
+      prepareFillData({
+        values: { industry_modules: ['tech_rider', 'unknown_option'] },
+        fields: [
+          {
+            name: 'industry_modules',
+            type: 'multiselect',
+            description: 'Industry riders',
+            options: ['tech_rider', 'cross_border_rider'],
+            derive_booleans: true,
+          },
+        ],
+      })
+    ).toThrow('received unknown option "unknown_option"');
+  });
 });

--- a/integration-tests/template-validation.test.ts
+++ b/integration-tests/template-validation.test.ts
@@ -529,7 +529,7 @@ describe('validateTemplate multiselect coverage', () => {
     expect(result.errors.join(' ')).toContain('must not be referenced directly in {IF industry_modules}');
   });
 
-  it.openspec('OA-FIL-017')('throws a clear error for malformed multiselect JSON input', () => {
+  it.openspec('OA-FIL-026')('throws a clear error for malformed multiselect JSON input', () => {
     expect(() =>
       prepareFillData({
         values: { industry_modules: 'not-json' },
@@ -604,7 +604,23 @@ describe('validateTemplate multiselect coverage', () => {
     expect(result.warnings.join(' ')).toContain('Optional field "industry_modules"');
   });
 
-  it.openspec('OA-FIL-019')('rejects multiselect runtime input with non-string entries', () => {
+  it.openspec('OA-TMP-053')('errors when a priority derive_booleans multiselect is declared but no derived key is referenced (replacements mode)', () => {
+    const dir = createTemplateFixture({
+      docText: '[Industry riders]',
+      fieldsYaml: multiselectFieldsYaml,
+      priorityFields: ['industry_modules'],
+      replacements: {
+        '[Industry riders]': 'plain replacement text without any rider conditional',
+      },
+    });
+
+    const result = validateTemplate(dir, 'fixture-derive-booleans-unused-replacements-priority');
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.join(' ')).toContain('Priority field "industry_modules"');
+  });
+
+  it.openspec('OA-FIL-028')('rejects multiselect runtime input with non-string entries', () => {
     expect(() =>
       prepareFillData({
         values: { industry_modules: ['tech_rider', 7] as unknown[] },
@@ -621,7 +637,7 @@ describe('validateTemplate multiselect coverage', () => {
     ).toThrow('entry at index 1 must be a string');
   });
 
-  it.openspec('OA-FIL-019')('rejects multiselect runtime input with unknown options', () => {
+  it.openspec('OA-FIL-028')('rejects multiselect runtime input with unknown options', () => {
     expect(() =>
       prepareFillData({
         values: { industry_modules: ['tech_rider', 'unknown_option'] },

--- a/integration-tests/template-validation.test.ts
+++ b/integration-tests/template-validation.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os';
 import AdmZip from 'adm-zip';
 import { validateTemplate } from '../src/core/validation/template.js';
 import { validateMetadata } from '../src/core/metadata.js';
+import { prepareFillData } from '../src/core/fill-pipeline.js';
 import {
   allureAttachment,
   allureJsonAttachment,
@@ -449,5 +450,117 @@ describe('validateTemplate placeholder coverage', () => {
 
     expect(result.valid).toBe(true);
     expect(result.warnings.join(' ')).toContain('Optional field "optional_field"');
+  });
+});
+
+describe('validateTemplate multiselect coverage', () => {
+  const multiselectFieldsYaml = [
+    '  - name: industry_modules',
+    '    type: multiselect',
+    '    description: Industry riders',
+    '    options:',
+    '      - tech_rider',
+    '      - cross_border_rider',
+    '    derive_booleans: true',
+  ].join('\n');
+
+  const multiselectWithoutDerivationYaml = [
+    '  - name: industry_modules',
+    '    type: multiselect',
+    '    description: Industry riders',
+    '    options:',
+    '      - tech_rider',
+    '      - cross_border_rider',
+  ].join('\n');
+
+  it.openspec('OA-TMP-052')('does not warn about multiselect fields when direct DOCX conditionals use only derived keys', () => {
+    const dir = createTemplateFixture({
+      docText: '{IF tech_rider_enabled}{END-IF}',
+      fieldsYaml: multiselectFieldsYaml,
+    });
+
+    const result = validateTemplate(dir, 'fixture-direct-derived-multiselect');
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.warnings.join(' ')).not.toContain('industry_modules');
+  });
+
+  it.openspec('OA-TMP-052')('does not warn about multiselect fields when replacement values use only derived keys', () => {
+    const dir = createTemplateFixture({
+      docText: '[Industry riders]',
+      fieldsYaml: multiselectFieldsYaml,
+      replacements: {
+        '[Industry riders]': '{IF tech_rider_enabled}{END-IF}',
+      },
+    });
+
+    const result = validateTemplate(dir, 'fixture-replacements-derived-multiselect');
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.warnings.join(' ')).not.toContain('industry_modules');
+  });
+
+  it.openspec('OA-TMP-052')('rejects direct multiselect IF references in direct DOCX scanning mode', () => {
+    const dir = createTemplateFixture({
+      docText: '{IF industry_modules}{END-IF}',
+      fieldsYaml: multiselectFieldsYaml,
+    });
+
+    const result = validateTemplate(dir, 'fixture-direct-if-multiselect');
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.join(' ')).toContain('must not be referenced directly in {IF industry_modules}');
+  });
+
+  it.openspec('OA-TMP-052')('rejects direct multiselect IF references in replacements mode even without derive_booleans', () => {
+    const dir = createTemplateFixture({
+      docText: '[Industry riders]',
+      fieldsYaml: multiselectWithoutDerivationYaml,
+      replacements: {
+        '[Industry riders]': '{IF industry_modules}{END-IF}',
+      },
+    });
+
+    const result = validateTemplate(dir, 'fixture-replacements-if-multiselect');
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.join(' ')).toContain('must not be referenced directly in {IF industry_modules}');
+  });
+
+  it.openspec('OA-FIL-017')('throws a clear error for malformed multiselect JSON input', () => {
+    expect(() =>
+      prepareFillData({
+        values: { industry_modules: 'not-json' },
+        fields: [
+          {
+            name: 'industry_modules',
+            type: 'multiselect',
+            description: 'Industry riders',
+            options: ['tech_rider', 'cross_border_rider'],
+            derive_booleans: true,
+          },
+        ],
+      })
+    ).toThrow('Multiselect field "industry_modules" received malformed JSON input');
+  });
+
+  it('treats empty priority multiselect collections as unfilled after normalization', () => {
+    expect(() =>
+      prepareFillData({
+        values: { industry_modules: '[]' },
+        fields: [
+          {
+            name: 'industry_modules',
+            type: 'multiselect',
+            description: 'Industry riders',
+            options: ['tech_rider', 'cross_border_rider'],
+            derive_booleans: true,
+          },
+        ],
+        priorityFieldNames: ['industry_modules'],
+      })
+    ).toThrow('Required collection fields are empty: industry_modules');
   });
 });

--- a/openspec/changes/add-multiselect-field-type/proposal.md
+++ b/openspec/changes/add-multiselect-field-type/proposal.md
@@ -1,0 +1,63 @@
+# Change: Add Multiselect Field Type
+
+## Why
+
+Template metadata today has no first-class way to express "choose zero or
+more values from an allowlisted set." Authors can either model the choice
+as many separate boolean fields or accept an unvalidated free-form array.
+That is awkward for template UX and makes downstream boolean gating logic
+template-specific.
+
+The upcoming due-diligence request list template needs a single
+`industry_modules` field whose selected values also drive existing DOCX
+conditionals such as `{IF tech_rider_enabled}`. This change adds the
+engine-level multiselect primitive and a constrained `derive_booleans`
+mechanism so templates can model that pattern without inventing ad hoc
+compute paths.
+
+## What Changes
+
+- Extend field metadata with a new `type: multiselect`.
+- Require multiselect fields to declare a non-empty `options` allowlist.
+- Add optional `derive_booleans: true` for multiselect fields only.
+- Derive `<option>_enabled` boolean keys during fill preparation from the
+  selected multiselect values.
+- Parse multiselect defaults and JSON-string user input into real arrays
+  before priority checks, boolean coercion, and display-field computation.
+- Reject metadata that would create derived-key collisions with existing
+  field names or with another multiselect's derived keys.
+- Reject direct `{IF <multiselect_field>}` template references because
+  empty arrays are truthy in the template runtime; templates must use
+  derived `<option>_enabled` keys when boolean gating is needed.
+- Keep D3a wire shape stable: no production template migrations, no
+  `data/templates-snapshot.json` regeneration, and no MCP payload changes.
+- Widen CLI/template/recipe value typing to `Record<string, unknown>` so
+  array values from JSON input files flow through cleanly.
+- Filter synthetic derived keys out of `fieldsUsed` so reporting stays
+  user-facing.
+
+Non-goals:
+
+- No production template metadata changes in this proposal.
+- No snapshot regeneration.
+- No MCP or remote API expansion for multiselect `options` /
+  `derive_booleans`.
+
+## Impact
+
+- Affected specs: `open-agreements`
+- Affected code:
+  - `src/core/metadata.ts`
+  - `src/core/fill-pipeline.ts`
+  - `src/core/validation/template.ts`
+  - `src/core/unified-pipeline.ts`
+  - `src/cli/index.ts`
+  - `src/commands/fill.ts`
+  - `src/commands/recipe.ts`
+  - `src/core/recipe/types.ts`
+  - `src/core/recipe/bracket-normalizer.ts`
+  - `src/core/employment/memo.ts`
+  - `docs/adding-templates.md`
+  - `src/core/metadata.test.ts`
+  - `integration-tests/fill-pipeline.test.ts`
+  - `integration-tests/template-validation.test.ts`

--- a/openspec/changes/add-multiselect-field-type/specs/open-agreements/spec.md
+++ b/openspec/changes/add-multiselect-field-type/specs/open-agreements/spec.md
@@ -1,0 +1,107 @@
+## MODIFIED Requirements
+
+### Requirement: Metadata Schema Constraints
+
+The metadata schema MUST enforce type-specific constraints on field
+definitions. Fields with `type: enum` or `type: multiselect` MUST have a
+non-empty `options` array. Fields with a `default` value MUST have that
+default validate against the declared `type`.
+
+For `type: multiselect`, every option SHALL be unique and SHALL match the
+identifier pattern `^[A-Za-z_][A-Za-z0-9_]*$`. `derive_booleans` SHALL be
+allowed only when `type === "multiselect"`. When a multiselect field
+declares a `default`, the value SHALL be a JSON-encoded array of unique
+strings, and every entry SHALL appear in `options`.
+
+When a multiselect field sets `derive_booleans: true`, metadata validation
+SHALL reject any collision between a derived `<option>_enabled` key and
+another top-level field name, and SHALL also reject collisions between
+derived keys emitted by multiple multiselect fields. These collision rules
+apply to template, external-template, and recipe metadata.
+
+#### Scenario: [OA-TMP-049] Valid multiselect metadata parses
+
+- **GIVEN** metadata with a field
+  `{ name: industry_modules, type: multiselect, options: [tech_rider, cross_border_rider], default: "[\"tech_rider\"]" }`
+- **WHEN** the system loads and validates the metadata
+- **THEN** validation passes
+- **AND** the parsed field preserves the declared options and default
+
+#### Scenario: [OA-TMP-050] Invalid multiselect metadata is rejected
+
+- **GIVEN** metadata with a multiselect field that omits `options`,
+  declares an invalid option identifier, or sets a default outside the
+  allowlist
+- **WHEN** the system validates the metadata
+- **THEN** validation fails with a descriptive schema error
+
+#### Scenario: [OA-TMP-051] Derived boolean collisions are rejected
+
+- **GIVEN** metadata with `derive_booleans: true` on a multiselect field
+- **AND** a derived key such as `tech_rider_enabled` would collide with
+  another top-level field or another multiselect's derived key
+- **WHEN** the system validates the metadata
+- **THEN** validation fails before the template can be filled
+
+## ADDED Requirements
+
+### Requirement: Multiselect Derived Boolean Fill Behavior
+
+When a field has `type: multiselect`, the fill pipeline SHALL normalize
+its runtime value to a real array of strings before priority-field checks,
+boolean coercion, or template-specific display-field computation. The
+pipeline SHALL accept either an array value or a JSON-string value and
+SHALL throw a clear error when the provided JSON is malformed or does not
+decode to an array.
+
+When a multiselect field also sets `derive_booleans: true`, the fill
+pipeline SHALL emit `<option>_enabled` boolean keys for every declared
+option based on membership in the normalized selection array. These
+derived booleans SHALL be available to later fill-pipeline steps, but the
+synthetic keys SHALL NOT be reported in `fieldsUsed`; that output remains
+limited to user-facing inputs.
+
+Templates SHALL NOT reference a multiselect field directly in
+`{IF <field>}` because empty arrays are truthy in the template runtime.
+Validation SHALL reject such direct conditional references. A multiselect
+field with `derive_booleans: true` MAY be absent from raw DOCX placeholder
+coverage when the template references only derived `<option>_enabled`
+keys.
+
+#### Scenario: [OA-FIL-016] Multiselect selections derive booleans before display-field computation
+
+- **GIVEN** fill input `{ industry_modules: ["tech_rider", "cross_border_rider"] }`
+- **AND** metadata declares `industry_modules` as a multiselect with
+  `derive_booleans: true`
+- **WHEN** the fill pipeline prepares the data
+- **THEN** the normalized `industry_modules` value is an array
+- **AND** `tech_rider_enabled === true`
+- **AND** `cross_border_rider_enabled === true`
+- **AND** unselected options derive to `false`
+- **AND** later display-field computation can read those booleans
+
+#### Scenario: [OA-FIL-017] Malformed multiselect JSON input is rejected
+
+- **GIVEN** fill input where a multiselect field is provided as malformed
+  JSON text
+- **WHEN** the fill pipeline prepares the data
+- **THEN** it throws a clear error identifying the multiselect field
+
+#### Scenario: [OA-FIL-018] fieldsUsed excludes synthetic derived keys
+
+- **GIVEN** a fill run with a multiselect field that derives booleans
+- **WHEN** the unified fill pipeline returns its result
+- **THEN** `fieldsUsed` contains the multiselect field name
+- **AND** `fieldsUsed` does NOT contain any derived `<option>_enabled`
+  keys
+
+#### Scenario: [OA-TMP-052] Validator rejects direct multiselect IF references
+
+- **GIVEN** template metadata with a multiselect field named
+  `industry_modules`
+- **WHEN** the template contains `{IF industry_modules}`
+- **THEN** validation fails with an error telling the author not to
+  reference a multiselect directly in `{IF ...}`
+- **AND** a template that uses only derived `{IF tech_rider_enabled}`
+  conditionals does not receive a missing-placeholder warning for
+  `industry_modules`

--- a/openspec/changes/add-multiselect-field-type/specs/open-agreements/spec.md
+++ b/openspec/changes/add-multiselect-field-type/specs/open-agreements/spec.md
@@ -54,6 +54,11 @@ pipeline SHALL accept either an array value or a JSON-string value and
 SHALL throw a clear error when the provided JSON is malformed or does not
 decode to an array.
 
+The fill pipeline SHALL reject runtime multiselect input that contains
+non-string entries or values not present in the declared `options`
+allowlist. The closed allowlist applies symmetrically to schema-validated
+defaults and to runtime input.
+
 When a multiselect field also sets `derive_booleans: true`, the fill
 pipeline SHALL emit `<option>_enabled` boolean keys for every declared
 option based on membership in the normalized selection array. These
@@ -65,8 +70,11 @@ Templates SHALL NOT reference a multiselect field directly in
 `{IF <field>}` because empty arrays are truthy in the template runtime.
 Validation SHALL reject such direct conditional references. A multiselect
 field with `derive_booleans: true` MAY be absent from raw DOCX placeholder
-coverage when the template references only derived `<option>_enabled`
-keys.
+coverage ONLY when at least one derived `<option>_enabled` key for that
+field is actually referenced in the template. A `derive_booleans`
+multiselect whose field name is absent AND whose derived keys are all
+absent SHALL still trigger the standard missing-placeholder warning (or
+error if priority-listed), because the field is genuinely unused.
 
 #### Scenario: [OA-FIL-016] Multiselect selections derive booleans before display-field computation
 
@@ -105,3 +113,22 @@ keys.
 - **AND** a template that uses only derived `{IF tech_rider_enabled}`
   conditionals does not receive a missing-placeholder warning for
   `industry_modules`
+
+#### Scenario: [OA-TMP-053] Coverage suppression requires at least one derived key reference
+
+- **GIVEN** template metadata with a `derive_booleans: true` multiselect
+  field that is also priority-listed
+- **AND** a template that references neither the field name nor any of
+  its derived `<option>_enabled` keys
+- **WHEN** the validator runs
+- **THEN** the validator emits the priority-field error (or warning if
+  optional) for the multiselect field — coverage suppression does NOT
+  fire when the field is genuinely unused
+
+#### Scenario: [OA-FIL-019] Multiselect runtime input enforces the closed allowlist
+
+- **GIVEN** a multiselect field with `options: [tech_rider, cross_border_rider]`
+- **WHEN** fill input contains a non-string entry or an option name not
+  in the allowlist
+- **THEN** the fill pipeline throws a clear error identifying the
+  multiselect field and the offending entry

--- a/openspec/changes/add-multiselect-field-type/specs/open-agreements/spec.md
+++ b/openspec/changes/add-multiselect-field-type/specs/open-agreements/spec.md
@@ -76,7 +76,7 @@ multiselect whose field name is absent AND whose derived keys are all
 absent SHALL still trigger the standard missing-placeholder warning (or
 error if priority-listed), because the field is genuinely unused.
 
-#### Scenario: [OA-FIL-016] Multiselect selections derive booleans before display-field computation
+#### Scenario: [OA-FIL-025] Multiselect selections derive booleans before display-field computation
 
 - **GIVEN** fill input `{ industry_modules: ["tech_rider", "cross_border_rider"] }`
 - **AND** metadata declares `industry_modules` as a multiselect with
@@ -88,14 +88,14 @@ error if priority-listed), because the field is genuinely unused.
 - **AND** unselected options derive to `false`
 - **AND** later display-field computation can read those booleans
 
-#### Scenario: [OA-FIL-017] Malformed multiselect JSON input is rejected
+#### Scenario: [OA-FIL-026] Malformed multiselect JSON input is rejected
 
 - **GIVEN** fill input where a multiselect field is provided as malformed
   JSON text
 - **WHEN** the fill pipeline prepares the data
 - **THEN** it throws a clear error identifying the multiselect field
 
-#### Scenario: [OA-FIL-018] fieldsUsed excludes synthetic derived keys
+#### Scenario: [OA-FIL-027] fieldsUsed excludes synthetic derived keys
 
 - **GIVEN** a fill run with a multiselect field that derives booleans
 - **WHEN** the unified fill pipeline returns its result
@@ -125,7 +125,7 @@ error if priority-listed), because the field is genuinely unused.
   optional) for the multiselect field — coverage suppression does NOT
   fire when the field is genuinely unused
 
-#### Scenario: [OA-FIL-019] Multiselect runtime input enforces the closed allowlist
+#### Scenario: [OA-FIL-028] Multiselect runtime input enforces the closed allowlist
 
 - **GIVEN** a multiselect field with `options: [tech_rider, cross_border_rider]`
 - **WHEN** fill input contains a non-string entry or an option name not

--- a/openspec/changes/add-multiselect-field-type/tasks.md
+++ b/openspec/changes/add-multiselect-field-type/tasks.md
@@ -27,10 +27,14 @@
 
 ## 4. Validation and reporting
 
-- [x] 4.1 Skip missing-placeholder warnings for multiselect fields that
-      intentionally render only through derived keys
+- [x] 4.1 Skip missing-placeholder warnings for `derive_booleans`
+      multiselects ONLY when at least one derived `<option>_enabled` key
+      is actually referenced in the template; otherwise warn/error
+      normally so genuinely-unused multiselects still surface
 - [x] 4.2 Reject direct `{IF <multiselect_field>}` references
 - [x] 4.3 Filter synthetic derived keys out of `fieldsUsed`
+- [x] 4.4 Reject multiselect runtime input with non-string entries or
+      unknown options (closed-allowlist enforcement)
 
 ## 5. CLI and downstream typing
 

--- a/openspec/changes/add-multiselect-field-type/tasks.md
+++ b/openspec/changes/add-multiselect-field-type/tasks.md
@@ -1,0 +1,61 @@
+## 1. OpenSpec
+
+- [x] 1.1 Add `proposal.md`, `tasks.md`, and `specs/open-agreements/spec.md`
+      for `add-multiselect-field-type`
+- [x] 1.2 Validate the change with
+      `npx openspec validate add-multiselect-field-type --strict`
+
+## 2. Metadata schema
+
+- [x] 2.1 Add `multiselect` to `FieldTypeEnum`
+- [x] 2.2 Add `derive_booleans?: boolean` to `FieldDefinition` and the
+      Zod schema
+- [x] 2.3 Enforce multiselect-specific `options`, identifier, uniqueness,
+      `derive_booleans`, and `default` validation rules
+- [x] 2.4 Reject derived `<option>_enabled` key collisions across
+      template, external-template, and recipe metadata schemas
+
+## 3. Fill pipeline
+
+- [x] 3.1 Initialize omitted multiselect fields from parsed JSON defaults
+      or `[]`
+- [x] 3.2 Normalize multiselect runtime input and derive
+      `<option>_enabled` booleans before priority checks and boolean
+      coercion
+- [x] 3.3 Treat empty priority arrays and empty priority multiselects as
+      unfilled
+
+## 4. Validation and reporting
+
+- [x] 4.1 Skip missing-placeholder warnings for multiselect fields that
+      intentionally render only through derived keys
+- [x] 4.2 Reject direct `{IF <multiselect_field>}` references
+- [x] 4.3 Filter synthetic derived keys out of `fieldsUsed`
+
+## 5. CLI and downstream typing
+
+- [x] 5.1 Widen fill/recipe value types from `Record<string, string>` (or
+      `string | boolean`) to `Record<string, unknown>` across the D3a call
+      chain
+- [x] 5.2 Preserve existing CLI/list wire shape aside from the new
+      `type: "multiselect"` enum value
+
+## 6. Docs and tests
+
+- [x] 6.1 Document multiselect authoring and derived boolean usage in
+      `docs/adding-templates.md`
+- [x] 6.2 Add schema tests in `src/core/metadata.test.ts`
+- [x] 6.3 Add fill-pipeline multiselect tests in
+      `integration-tests/fill-pipeline.test.ts`
+- [x] 6.4 Add validator multiselect tests in
+      `integration-tests/template-validation.test.ts`
+
+## 7. Verification
+
+- [x] 7.1 `npm run build`
+- [x] 7.2 `npx vitest run src/core/metadata.test.ts integration-tests/fill-pipeline.test.ts integration-tests/template-validation.test.ts`
+- [x] 7.3 `npm run test:run`
+- [x] 7.4 `npm run lint`
+- [x] 7.5 `npx openspec validate add-multiselect-field-type --strict`
+- [x] 7.6 `node scripts/export-templates-snapshot.mjs --check`
+- [x] 7.7 `node bin/open-agreements.js validate openagreements-restrictive-covenant-wyoming`

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -59,7 +59,7 @@ export function createProgram(): Command {
         memoBaseline?: string;
       }
     ) => {
-      let values: Record<string, string> = {};
+      let values: Record<string, unknown> = {};
       const dataPath = opts.data ?? opts.values;
 
       if (dataPath) {

--- a/src/commands/fill.ts
+++ b/src/commands/fill.ts
@@ -31,11 +31,11 @@ interface FillMemoArgs {
 export interface FillArgs {
   template: string;
   output?: string;
-  values: Record<string, string>;
+  values: Record<string, unknown>;
   memo?: FillMemoArgs;
 }
 
-function validateTemplateFillRequest(templateDir: string, values: Record<string, string>): void {
+function validateTemplateFillRequest(templateDir: string, values: Record<string, unknown>): void {
   const metadata = loadMetadata(templateDir);
 
   if (!metadata.allow_derivatives) {
@@ -44,7 +44,10 @@ function validateTemplateFillRequest(templateDir: string, values: Record<string,
     );
   }
 
-  const missingPriority = metadata.priority_fields.filter((fieldName) => !values[fieldName]);
+  const missingPriority = metadata.priority_fields.filter((fieldName) => {
+    const value = values[fieldName];
+    return value === undefined || value === '' || (Array.isArray(value) && value.length === 0);
+  });
 
   if (missingPriority.length > 0) {
     console.warn(`Note: ${missingPriority.length} priority fields are unfilled: ${missingPriority.join(', ')}`);

--- a/src/commands/recipe.ts
+++ b/src/commands/recipe.ts
@@ -27,7 +27,7 @@ export async function runRecipeCommand(args: RecipeRunArgs): Promise<void> {
     process.exit(1);
   }
 
-  let values: Record<string, string | boolean> = {};
+  let values: Record<string, unknown> = {};
   if (args.data) {
     values = JSON.parse(readFileSync(args.data, 'utf-8'));
   }

--- a/src/core/employment/memo.ts
+++ b/src/core/employment/memo.ts
@@ -55,7 +55,7 @@ export interface EmploymentMemo {
 export interface GenerateEmploymentMemoOptions {
   templateId: string;
   templateMetadata: TemplateMetadata;
-  values: Record<string, string | boolean>;
+  values: Record<string, unknown>;
   generatedAt?: string;
   jurisdiction?: string;
   baselineTemplateId?: string;
@@ -532,7 +532,7 @@ export function renderEmploymentMemoMarkdown(memo: EmploymentMemo): string {
 
 function resolveEffectiveFieldValues(
   metadata: TemplateMetadata,
-  values: Record<string, string | boolean>
+  values: Record<string, unknown>
 ): Record<string, string> {
   const resolved: Record<string, string> = {};
 
@@ -544,6 +544,10 @@ function resolveEffectiveFieldValues(
     }
     if (typeof value === 'string' && value.trim().length > 0) {
       resolved[field.name] = value.trim();
+      continue;
+    }
+    if (Array.isArray(value) && value.every((entry) => typeof entry === 'string') && value.length > 0) {
+      resolved[field.name] = JSON.stringify(value);
       continue;
     }
     if (field.default && field.default.trim().length > 0) {

--- a/src/core/fill-pipeline.ts
+++ b/src/core/fill-pipeline.ts
@@ -136,7 +136,21 @@ export function prepareFillData(options: PrepareFillDataOptions): Record<string,
         `Multiselect field "${field.name}" must be a JSON array of strings; got ${typeof raw}`
       );
     }
-    const normalized = raw.filter((value): value is string => typeof value === 'string');
+    const allowed = new Set(field.options ?? []);
+    const normalized: string[] = [];
+    for (const [index, value] of raw.entries()) {
+      if (typeof value !== 'string') {
+        throw new Error(
+          `Multiselect field "${field.name}" entry at index ${index} must be a string; got ${typeof value}`
+        );
+      }
+      if (!allowed.has(value)) {
+        throw new Error(
+          `Multiselect field "${field.name}" received unknown option "${value}"; allowed: ${[...allowed].join(', ')}`
+        );
+      }
+      normalized.push(value);
+    }
     data[field.name] = normalized;
 
     if (field.derive_booleans === true) {

--- a/src/core/fill-pipeline.ts
+++ b/src/core/fill-pipeline.ts
@@ -77,10 +77,11 @@ const DEFAULT_STRIP_PATTERNS = [/\bDrafting note\b/i];
 
 /**
  * Prepare fill data with all normalization steps:
- * 1. Warn about unfilled priority fields
- * 2. Apply defaults for optional fields not provided
- * 3. Coerce boolean fields (optional)
- * 4. Compute display fields (optional, template-specific)
+ * 1. Apply defaults for optional fields not provided
+ * 2. Normalize multiselect fields and derive booleans (optional)
+ * 3. Warn about unfilled priority fields
+ * 4. Coerce boolean fields (optional)
+ * 5. Compute display fields (optional, template-specific)
  */
 export function prepareFillData(options: PrepareFillDataOptions): Record<string, unknown> {
   const {
@@ -107,32 +108,69 @@ export function prepareFillData(options: PrepareFillDataOptions): Record<string,
   }
   for (const field of fields) {
     if (!(field.name in data)) {
-      // Array fields default to empty array, not blank placeholder
       if (field.type === 'array') {
         data[field.name] = [];
+      } else if (field.type === 'multiselect') {
+        data[field.name] = field.default ? JSON.parse(field.default) : [];
       } else {
         data[field.name] = field.default ?? defaultValue;
       }
     }
   }
 
-  // Reject empty priority array fields outright. A consent template that loops
-  // over an empty signer array would silently render a Signatures heading with
-  // zero signatures — that's a correctness bug, not a soft warning.
+  for (const field of fields) {
+    if (field.type !== 'multiselect') continue;
+
+    let raw = data[field.name];
+    if (typeof raw === 'string') {
+      try {
+        raw = JSON.parse(raw);
+      } catch (err) {
+        throw new Error(
+          `Multiselect field "${field.name}" received malformed JSON input: ${(err as Error).message}`
+        );
+      }
+    }
+    if (!Array.isArray(raw)) {
+      throw new Error(
+        `Multiselect field "${field.name}" must be a JSON array of strings; got ${typeof raw}`
+      );
+    }
+    const normalized = raw.filter((value): value is string => typeof value === 'string');
+    data[field.name] = normalized;
+
+    if (field.derive_booleans === true) {
+      const selected = new Set(normalized);
+      for (const option of field.options ?? []) {
+        data[`${option}_enabled`] = selected.has(option);
+      }
+    }
+  }
+
+  // Reject empty priority collection fields outright. A consent template that
+  // loops over an empty signer array would silently render a Signatures
+  // heading with zero signatures — that's a correctness bug, not a soft warning.
   const prioritySet = new Set(priorityFieldNames);
   const emptyPriorityArrays = fields
-    .filter((f) => prioritySet.has(f.name) && f.type === 'array')
+    .filter((f) => prioritySet.has(f.name) && (f.type === 'array' || f.type === 'multiselect'))
     .filter((f) => !Array.isArray(data[f.name]) || (data[f.name] as unknown[]).length === 0)
     .map((f) => f.name);
   if (emptyPriorityArrays.length > 0) {
     throw new Error(
-      `Required array fields are empty: ${emptyPriorityArrays.join(', ')}. Provide at least one entry.`
+      `Required collection fields are empty: ${emptyPriorityArrays.join(', ')}. Provide at least one entry.`
     );
   }
 
   // Warn about priority fields that are still unfilled (no value, no default)
   const missing = fields
-    .filter((f) => prioritySet.has(f.name) && f.type !== 'array' && (data[f.name] === '' || data[f.name] === BLANK_PLACEHOLDER))
+    .filter((f) => prioritySet.has(f.name))
+    .filter((f) => {
+      const value = data[f.name];
+      if (Array.isArray(value)) {
+        return value.length === 0;
+      }
+      return value === '' || value === BLANK_PLACEHOLDER;
+    })
     .map((f) => f.name);
   if (missing.length > 0) {
     console.warn(`Note: ${missing.length} priority fields are unfilled: ${missing.join(', ')}`);

--- a/src/core/metadata.test.ts
+++ b/src/core/metadata.test.ts
@@ -7,6 +7,7 @@ import {
 } from '../../integration-tests/helpers/allure-test.js';
 import {
   TemplateMetadataSchema,
+  ExternalMetadataSchema,
   RecipeMetadataSchema,
   FieldDefinitionSchema,
   CleanConfigSchema,
@@ -144,6 +145,152 @@ describe('FieldDefinitionSchema', () => {
     );
   });
 
+  it.openspec('OA-TMP-049')('accepts a multiselect field with options, derive_booleans, and JSON default', async () => {
+    await expectSafeParseOutcome(
+      'FieldDefinitionSchema',
+      FieldDefinitionSchema,
+      {
+        name: 'industry_modules',
+        type: 'multiselect',
+        description: 'Industry riders',
+        options: ['tech_rider', 'cross_border_rider'],
+        derive_booleans: true,
+        default: '["tech_rider"]',
+      },
+      true
+    );
+  });
+
+  it.openspec('OA-TMP-050')('rejects multiselect fields without options', async () => {
+    await expectSafeParseOutcome(
+      'FieldDefinitionSchema',
+      FieldDefinitionSchema,
+      {
+        name: 'industry_modules',
+        type: 'multiselect',
+        description: 'Industry riders',
+      },
+      false
+    );
+  });
+
+  it.openspec('OA-TMP-050')('rejects multiselect options that are not valid identifiers', async () => {
+    await expectSafeParseOutcome(
+      'FieldDefinitionSchema',
+      FieldDefinitionSchema,
+      {
+        name: 'industry_modules',
+        type: 'multiselect',
+        description: 'Industry riders',
+        options: ['tech-rider', 'cross border'],
+      },
+      false
+    );
+  });
+
+  it.openspec('OA-TMP-050')('rejects duplicate multiselect options', async () => {
+    await expectSafeParseOutcome(
+      'FieldDefinitionSchema',
+      FieldDefinitionSchema,
+      {
+        name: 'industry_modules',
+        type: 'multiselect',
+        description: 'Industry riders',
+        options: ['tech_rider', 'tech_rider'],
+      },
+      false
+    );
+  });
+
+  it.openspec('OA-TMP-050')('rejects derive_booleans on non-multiselect fields', async () => {
+    await expectSafeParseOutcome(
+      'FieldDefinitionSchema',
+      FieldDefinitionSchema,
+      {
+        name: 'tech_rider_enabled',
+        type: 'boolean',
+        description: 'Tech rider toggle',
+        derive_booleans: true,
+      },
+      false
+    );
+  });
+
+  it.openspec('OA-TMP-049')('accepts an empty multiselect JSON default', async () => {
+    await expectSafeParseOutcome(
+      'FieldDefinitionSchema',
+      FieldDefinitionSchema,
+      {
+        name: 'industry_modules',
+        type: 'multiselect',
+        description: 'Industry riders',
+        options: ['tech_rider', 'cross_border_rider'],
+        default: '[]',
+      },
+      true
+    );
+  });
+
+  it.openspec('OA-TMP-050')('rejects multiselect defaults outside the options allowlist', async () => {
+    await expectSafeParseOutcome(
+      'FieldDefinitionSchema',
+      FieldDefinitionSchema,
+      {
+        name: 'industry_modules',
+        type: 'multiselect',
+        description: 'Industry riders',
+        options: ['tech_rider', 'cross_border_rider'],
+        default: '["unknown_rider"]',
+      },
+      false
+    );
+  });
+
+  it.openspec('OA-TMP-050')('rejects malformed multiselect JSON defaults', async () => {
+    await expectSafeParseOutcome(
+      'FieldDefinitionSchema',
+      FieldDefinitionSchema,
+      {
+        name: 'industry_modules',
+        type: 'multiselect',
+        description: 'Industry riders',
+        options: ['tech_rider', 'cross_border_rider'],
+        default: 'not-json',
+      },
+      false
+    );
+  });
+
+  it.openspec('OA-TMP-050')('rejects multiselect defaults with non-string entries', async () => {
+    await expectSafeParseOutcome(
+      'FieldDefinitionSchema',
+      FieldDefinitionSchema,
+      {
+        name: 'industry_modules',
+        type: 'multiselect',
+        description: 'Industry riders',
+        options: ['tech_rider', 'cross_border_rider'],
+        default: '[null]',
+      },
+      false
+    );
+  });
+
+  it.openspec('OA-TMP-050')('rejects multiselect defaults with duplicate entries', async () => {
+    await expectSafeParseOutcome(
+      'FieldDefinitionSchema',
+      FieldDefinitionSchema,
+      {
+        name: 'industry_modules',
+        type: 'multiselect',
+        description: 'Industry riders',
+        options: ['tech_rider', 'cross_border_rider'],
+        default: '["tech_rider","tech_rider"]',
+      },
+      false
+    );
+  });
+
   it.openspec('OA-TMP-004')('rejects number field with non-numeric default', async () => {
     await expectSafeParseOutcome(
       'FieldDefinitionSchema',
@@ -207,6 +354,40 @@ describe('FieldDefinitionSchema', () => {
   });
 });
 
+const BASE_TEMPLATE_METADATA = {
+  name: 'Test NDA',
+  source_url: 'https://example.com/nda',
+  version: '1.0',
+  license: 'CC-BY-4.0' as const,
+  allow_derivatives: true,
+  attribution_text: 'Based on Example NDA',
+};
+
+function buildTemplateMetadataPayload(fields: unknown[]) {
+  return {
+    ...BASE_TEMPLATE_METADATA,
+    fields,
+  };
+}
+
+function buildExternalMetadataPayload(fields: unknown[]) {
+  return {
+    ...BASE_TEMPLATE_METADATA,
+    source_sha256: 'a'.repeat(64),
+    fields,
+  };
+}
+
+function buildRecipeMetadataPayload(fields: unknown[]) {
+  return {
+    name: 'Fixture Recipe',
+    source_url: 'https://example.com/source.docx',
+    source_version: '1.0',
+    license_note: 'Not redistributable',
+    fields,
+  };
+}
+
 describe('TemplateMetadataSchema', () => {
   it.openspec('OA-TMP-009')('accepts valid template metadata', async () => {
     await expectSafeParseOutcome(
@@ -237,6 +418,52 @@ describe('TemplateMetadataSchema', () => {
         attribution_text: 'Based on Example NDA',
         fields: [],
       },
+      false
+    );
+  });
+
+  it.openspec('OA-TMP-051')('rejects top-level field collisions with derived boolean keys', async () => {
+    await expectSafeParseOutcome(
+      'TemplateMetadataSchema',
+      TemplateMetadataSchema,
+      buildTemplateMetadataPayload([
+        {
+          name: 'industry_modules',
+          type: 'multiselect',
+          description: 'Industry riders',
+          options: ['tech_rider'],
+          derive_booleans: true,
+        },
+        {
+          name: 'tech_rider_enabled',
+          type: 'boolean',
+          description: 'Conflicting top-level field',
+        },
+      ]),
+      false
+    );
+  });
+
+  it.openspec('OA-TMP-051')('rejects derived key collisions between multiselect fields', async () => {
+    await expectSafeParseOutcome(
+      'TemplateMetadataSchema',
+      TemplateMetadataSchema,
+      buildTemplateMetadataPayload([
+        {
+          name: 'industry_modules',
+          type: 'multiselect',
+          description: 'Industry riders',
+          options: ['tech_rider'],
+          derive_booleans: true,
+        },
+        {
+          name: 'additional_modules',
+          type: 'multiselect',
+          description: 'Additional riders',
+          options: ['tech_rider'],
+          derive_booleans: true,
+        },
+      ]),
       false
     );
   });
@@ -417,6 +644,50 @@ describe('RecipeMetadataSchema', () => {
     await allureStep('Assert optional defaults to false', () => {
       expect(parsed.optional).toBe(false);
     });
+  });
+
+  it.openspec('OA-TMP-051')('rejects derived key collisions in external metadata', async () => {
+    await expectSafeParseOutcome(
+      'ExternalMetadataSchema',
+      ExternalMetadataSchema,
+      buildExternalMetadataPayload([
+        {
+          name: 'industry_modules',
+          type: 'multiselect',
+          description: 'Industry riders',
+          options: ['tech_rider'],
+          derive_booleans: true,
+        },
+        {
+          name: 'tech_rider_enabled',
+          type: 'boolean',
+          description: 'Conflicting top-level field',
+        },
+      ]),
+      false
+    );
+  });
+
+  it.openspec('OA-TMP-051')('rejects derived key collisions in recipe metadata', async () => {
+    await expectSafeParseOutcome(
+      'RecipeMetadataSchema',
+      RecipeMetadataSchema,
+      buildRecipeMetadataPayload([
+        {
+          name: 'industry_modules',
+          type: 'multiselect',
+          description: 'Industry riders',
+          options: ['tech_rider'],
+          derive_booleans: true,
+        },
+        {
+          name: 'tech_rider_enabled',
+          type: 'boolean',
+          description: 'Conflicting top-level field',
+        },
+      ]),
+      false
+    );
   });
 });
 

--- a/src/core/metadata.ts
+++ b/src/core/metadata.ts
@@ -6,8 +6,9 @@ import yaml from 'js-yaml';
 export const LicenseEnum = z.enum(['CC-BY-4.0', 'CC0-1.0', 'CC-BY-ND-4.0']);
 export type License = z.infer<typeof LicenseEnum>;
 
-const FieldTypeEnum = z.enum(['string', 'date', 'number', 'boolean', 'enum', 'array']);
+const FieldTypeEnum = z.enum(['string', 'date', 'number', 'boolean', 'enum', 'array', 'multiselect']);
 export type FieldType = z.infer<typeof FieldTypeEnum>;
+const MULTISELECT_OPTION_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 export interface FieldDefinition {
   name: string;
@@ -17,6 +18,7 @@ export interface FieldDefinition {
   default?: string;
   default_value_rationale?: string;
   options?: string[];
+  derive_booleans?: boolean;
   section?: string;
   items?: FieldDefinition[];
 }
@@ -30,14 +32,48 @@ export const FieldDefinitionSchema: z.ZodType<FieldDefinition> = z.lazy(() =>
     default: z.string().optional(),
     default_value_rationale: z.string().optional(),
     options: z.array(z.string()).optional(),
+    derive_booleans: z.boolean().optional(),
     section: z.string().optional(),
     items: z.array(FieldDefinitionSchema).nonempty().optional(),
   }).superRefine((field, ctx) => {
-    if (field.type === 'enum' && (field.options === undefined || field.options.length === 0)) {
+    if (
+      (field.type === 'enum' || field.type === 'multiselect') &&
+      (field.options === undefined || field.options.length === 0)
+    ) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ['options'],
-        message: 'Fields with type "enum" must have a non-empty options array',
+        message: `Fields with type "${field.type}" must have a non-empty options array`,
+      });
+    }
+
+    if (field.type === 'multiselect' && field.options) {
+      const seenOptions = new Set<string>();
+      field.options.forEach((option, index) => {
+        if (!MULTISELECT_OPTION_RE.test(option)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['options', index],
+            message: 'Multiselect options must be valid identifiers matching /^[A-Za-z_][A-Za-z0-9_]*$/',
+          });
+        }
+        if (seenOptions.has(option)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['options', index],
+            message: `Duplicate multiselect option "${option}"`,
+          });
+          return;
+        }
+        seenOptions.add(option);
+      });
+    }
+
+    if (field.derive_booleans !== undefined && field.type !== 'multiselect') {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['derive_booleans'],
+        message: 'derive_booleans is only valid for fields with type "multiselect"',
       });
     }
 
@@ -63,6 +99,59 @@ export const FieldDefinitionSchema: z.ZodType<FieldDefinition> = z.lazy(() =>
           code: z.ZodIssueCode.custom,
           path: ['default'],
           message: 'Default value must be valid for the declared field type',
+        });
+      }
+
+      if (field.type === 'multiselect') {
+        let parsedDefault: unknown;
+        try {
+          parsedDefault = JSON.parse(field.default);
+        } catch {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['default'],
+            message: 'Default value must be a JSON-encoded array of strings for multiselect fields',
+          });
+          return;
+        }
+
+        if (!Array.isArray(parsedDefault)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['default'],
+            message: 'Default value must be a JSON-encoded array of strings for multiselect fields',
+          });
+          return;
+        }
+
+        const seenDefaults = new Set<string>();
+        parsedDefault.forEach((entry) => {
+          if (typeof entry !== 'string') {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ['default'],
+              message: 'Default value must be a JSON-encoded array of strings for multiselect fields',
+            });
+            return;
+          }
+
+          if (seenDefaults.has(entry)) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ['default'],
+              message: `Default value contains duplicate multiselect option "${entry}"`,
+            });
+            return;
+          }
+          seenDefaults.add(entry);
+
+          if (field.options && !field.options.includes(entry)) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ['default'],
+              message: `Default value references option "${entry}" which is not declared in options`,
+            });
+          }
         });
       }
     }
@@ -110,6 +199,41 @@ function validatePriorityFields(
   });
 }
 
+function validateDerivedBooleanCollisions(fields: FieldDefinition[], ctx: z.RefinementCtx): void {
+  const topLevelFieldNames = new Set(fields.map((field) => field.name));
+  const derivedKeyOwners = new Map<string, string>();
+
+  fields.forEach((field, fieldIndex) => {
+    if (field.type !== 'multiselect' || field.derive_booleans !== true || !field.options) {
+      return;
+    }
+
+    field.options.forEach((option, optionIndex) => {
+      const derivedKey = `${option}_enabled`;
+
+      if (topLevelFieldNames.has(derivedKey)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['fields', fieldIndex, 'options', optionIndex],
+          message: `Derived boolean key "${derivedKey}" from multiselect "${field.name}" collides with another top-level field name`,
+        });
+      }
+
+      const existingOwner = derivedKeyOwners.get(derivedKey);
+      if (existingOwner) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['fields', fieldIndex, 'options', optionIndex],
+          message: `Derived boolean key "${derivedKey}" from multiselect "${field.name}" collides with derived key from multiselect "${existingOwner}"`,
+        });
+        return;
+      }
+
+      derivedKeyOwners.set(derivedKey, field.name);
+    });
+  });
+}
+
 const TemplateMetadataBaseSchema = z.object({
   name: z.string(),
   description: z.string().optional(),
@@ -127,6 +251,7 @@ const TemplateMetadataBaseSchema = z.object({
 
 export const TemplateMetadataSchema = TemplateMetadataBaseSchema.superRefine((meta, ctx) => {
   validatePriorityFields(meta.fields, meta.priority_fields, ctx);
+  validateDerivedBooleanCollisions(meta.fields, ctx);
 });
 export type TemplateMetadata = z.infer<typeof TemplateMetadataSchema>;
 
@@ -136,6 +261,7 @@ export const ExternalMetadataSchema = TemplateMetadataBaseSchema.extend({
   source_sha256: z.string(),
 }).superRefine((meta, ctx) => {
   validatePriorityFields(meta.fields, meta.priority_fields, ctx);
+  validateDerivedBooleanCollisions(meta.fields, ctx);
 });
 export type ExternalMetadata = z.infer<typeof ExternalMetadataSchema>;
 
@@ -209,6 +335,7 @@ export const RecipeMetadataSchema = z.object({
   market_data_citations: z.array(MarketDataCitationSchema).optional(),
 }).superRefine((meta, ctx) => {
   validatePriorityFields(meta.fields, meta.priority_fields, ctx);
+  validateDerivedBooleanCollisions(meta.fields, ctx);
 });
 export type RecipeMetadata = z.infer<typeof RecipeMetadataSchema>;
 

--- a/src/core/recipe/bracket-normalizer.ts
+++ b/src/core/recipe/bracket-normalizer.ts
@@ -44,7 +44,7 @@ export interface DeclarativeNormalizeConfig {
 
 export interface BracketNormalizationOptions {
   rules?: DeclarativeParagraphNormalizeRule[];
-  fieldValues?: Record<string, string | boolean>;
+  fieldValues?: Record<string, unknown>;
   blankPlaceholder?: string;
 }
 
@@ -233,7 +233,7 @@ function applyDeclarativeRulesToParagraph(params: {
   text: string;
   heading: string;
   rules: DeclarativeParagraphNormalizeRule[];
-  fieldValues: Record<string, string | boolean>;
+  fieldValues: Record<string, unknown>;
   blankPlaceholder: string;
 }): { text: string; applied: boolean; rule_id?: string } {
   const { text, heading, rules, fieldValues, blankPlaceholder } = params;
@@ -290,13 +290,16 @@ function matchesHeading(rule: DeclarativeParagraphNormalizeRule, heading: string
 
 function resolveTemplateValue(
   template: string,
-  fieldValues: Record<string, string | boolean>,
+  fieldValues: Record<string, unknown>,
   blankPlaceholder: string
 ): string {
   return template.replace(/\{([a-zA-Z0-9_]+)\}/g, (_full, key: string) => {
     const value = fieldValues[key];
     if (typeof value === 'boolean') return value ? 'true' : 'false';
     if (typeof value === 'string' && value.trim().length > 0) return value;
+    if (Array.isArray(value) && value.every((entry) => typeof entry === 'string') && value.length > 0) {
+      return value.join(', ');
+    }
     return blankPlaceholder;
   });
 }

--- a/src/core/recipe/computed.ts
+++ b/src/core/recipe/computed.ts
@@ -63,7 +63,7 @@ export const ComputedProfileSchema = z.object({
   rules: z.array(ComputedRuleSchema).min(1),
 });
 
-export type ComputedPrimitive = z.infer<typeof PrimitiveSchema>;
+export type ComputedPrimitive = z.infer<typeof PrimitiveSchema> | string[];
 export type ComputedValueMap = Record<string, ComputedPrimitive>;
 export type ComputedPredicate = z.infer<typeof ComputedPredicateSchema>;
 export type ComputedRule = z.infer<typeof ComputedRuleSchema>;

--- a/src/core/recipe/index.ts
+++ b/src/core/recipe/index.ts
@@ -15,6 +15,21 @@ import {
 import { normalizeBracketArtifacts } from './bracket-normalizer.js';
 import { runFillPipeline } from '../unified-pipeline.js';
 import type { RecipeRunOptions, RecipeRunResult } from './types.js';
+import type { ComputedValueMap } from './computed.js';
+
+function toComputedValueMap(values: Record<string, unknown>): ComputedValueMap {
+  const computedValues: ComputedValueMap = {};
+  for (const [key, value] of Object.entries(values)) {
+    if (typeof value === 'string' || typeof value === 'boolean') {
+      computedValues[key] = value;
+      continue;
+    }
+    if (Array.isArray(value) && value.every((entry) => typeof entry === 'string')) {
+      computedValues[key] = [...value];
+    }
+  }
+  return computedValues;
+}
 
 /**
  * Run the full recipe pipeline: clean → patch → fill → verify.
@@ -49,9 +64,14 @@ export async function runRecipe(options: RecipeRunOptions): Promise<RecipeRunRes
   }
 
   const inputValues = { ...values };
+  const computedInputValues = toComputedValueMap(inputValues);
   const computedProfile = loadComputedProfile(recipeDir);
-  const computedEvaluation = computedProfile ? evaluateComputedProfile(computedProfile, inputValues) : null;
-  const effectiveValues = computedEvaluation ? computedEvaluation.fillValues : inputValues;
+  const computedEvaluation = computedProfile
+    ? evaluateComputedProfile(computedProfile, computedInputValues)
+    : null;
+  const effectiveValues = computedEvaluation
+    ? { ...inputValues, ...computedEvaluation.fillValues }
+    : inputValues;
   const verificationValues: Record<string, string> = {};
   for (const field of metadata.fields) {
     if (!replacementFieldNames.has(field.name)) {
@@ -65,11 +85,11 @@ export async function runRecipe(options: RecipeRunOptions): Promise<RecipeRunRes
   const computedArtifact = computedEvaluation && computedProfile
     ? buildComputedArtifact({
       recipeId,
-      inputValues,
+      inputValues: computedInputValues,
       evaluated: computedEvaluation,
       profileVersion: computedProfile.version,
     })
-    : (computedOutPath ? buildPassthroughArtifact({ recipeId, inputValues }) : undefined);
+    : (computedOutPath ? buildPassthroughArtifact({ recipeId, inputValues: computedInputValues }) : undefined);
 
   if (computedOutPath && computedArtifact) {
     writeComputedArtifact(computedOutPath, computedArtifact);

--- a/src/core/recipe/types.ts
+++ b/src/core/recipe/types.ts
@@ -5,7 +5,7 @@ export interface RecipeRunOptions {
   recipeId: string;
   inputPath?: string;
   outputPath: string;
-  values: Record<string, string | boolean>;
+  values: Record<string, unknown>;
   keepIntermediate?: boolean;
   computedOutPath?: string;
   normalizeBracketArtifacts?: boolean;

--- a/src/core/unified-pipeline.ts
+++ b/src/core/unified-pipeline.ts
@@ -93,6 +93,11 @@ export async function runFillPipeline(options: PipelineOptions): Promise<Pipelin
   } = options;
 
   const tempDir = mkdtempSync(join(tmpdir(), 'fill-pipeline-'));
+  const syntheticFieldKeys = new Set(
+    fields
+      .filter((field) => field.type === 'multiselect' && field.derive_booleans === true)
+      .flatMap((field) => (field.options ?? []).map((option) => `${option}_enabled`))
+  );
   let stages: PipelineResult['stages'] | undefined;
 
   try {
@@ -196,7 +201,7 @@ export async function runFillPipeline(options: PipelineOptions): Promise<Pipelin
 
     return {
       outputPath,
-      fieldsUsed: Object.keys(data),
+      fieldsUsed: Object.keys(data).filter((key) => !syntheticFieldKeys.has(key)),
       stages,
     };
   } finally {

--- a/src/core/validation/template.ts
+++ b/src/core/validation/template.ts
@@ -76,10 +76,19 @@ export function validateTemplate(templateDir: string, templateId: string): Templ
       .filter((field) => field.type === 'multiselect')
       .map((field) => field.name)
   );
-  const derivedBooleanMultiselectFieldNames = new Set(
-    metadata.fields
-      .filter((field) => field.type === 'multiselect' && field.derive_booleans === true)
-      .map((field) => field.name)
+  const derivedBooleanMultiselects = metadata.fields.filter(
+    (field) => field.type === 'multiselect' && field.derive_booleans === true
+  );
+  // Map from multiselect field name → set of derived `<option>_enabled` keys.
+  // Used below to suppress the "field not in DOCX" warning ONLY when at least
+  // one of the field's derived keys is actually referenced in the template.
+  // A derive_booleans multiselect with zero derived references is genuinely
+  // unused and should still warn (or error if priority-listed).
+  const derivedKeysByField = new Map<string, Set<string>>(
+    derivedBooleanMultiselects.map((field) => [
+      field.name,
+      new Set((field.options ?? []).map((option) => `${option}_enabled`)),
+    ])
   );
 
   const rejectDirectMultiselectConditionals = (foundConditionalFields: Set<string>): void => {
@@ -162,8 +171,17 @@ export function validateTemplate(templateDir: string, templateId: string): Templ
 
     // Check metadata fields are covered by tags
     for (const fieldName of metadataFieldNames) {
-      if (derivedBooleanMultiselectFieldNames.has(fieldName)) {
-        continue;
+      const derivedKeys = derivedKeysByField.get(fieldName);
+      if (derivedKeys) {
+        // Suppress coverage warning ONLY if at least one derived key is
+        // actually referenced. Otherwise the multiselect is dead weight and
+        // the warning/error should fire normally.
+        const anyDerivedReferenced = [...derivedKeys].some(
+          (key) => foundTags.has(key) || foundConditionalFields.has(key)
+        );
+        if (anyDerivedReferenced) {
+          continue;
+        }
       }
       const inTags = foundTags.has(fieldName) || foundConditionalFields.has(fieldName);
       if (!inTags) {
@@ -272,8 +290,16 @@ export function validateTemplate(templateDir: string, templateId: string): Templ
 
     // Check for fields in metadata but not in DOCX
     for (const fieldName of metadataFieldNames) {
-      if (derivedBooleanMultiselectFieldNames.has(fieldName)) {
-        continue;
+      const derivedKeys = derivedKeysByField.get(fieldName);
+      if (derivedKeys) {
+        // See the parallel branch above: only suppress when at least one
+        // derived key is actually referenced.
+        const anyDerivedReferenced = [...derivedKeys].some(
+          (key) => foundTags.has(key) || foundConditionalFields.has(key)
+        );
+        if (anyDerivedReferenced) {
+          continue;
+        }
       }
       const inDocx = foundTags.has(fieldName) || foundConditionalFields.has(fieldName);
       if (!inDocx) {

--- a/src/core/validation/template.ts
+++ b/src/core/validation/template.ts
@@ -71,6 +71,29 @@ export function validateTemplate(templateDir: string, templateId: string): Templ
 
   const metadataFieldNames = new Set(metadata.fields.map((f) => f.name));
   const priorityFieldNames = new Set(metadata.priority_fields);
+  const multiselectFieldNames = new Set(
+    metadata.fields
+      .filter((field) => field.type === 'multiselect')
+      .map((field) => field.name)
+  );
+  const derivedBooleanMultiselectFieldNames = new Set(
+    metadata.fields
+      .filter((field) => field.type === 'multiselect' && field.derive_booleans === true)
+      .map((field) => field.name)
+  );
+
+  const rejectDirectMultiselectConditionals = (foundConditionalFields: Set<string>): void => {
+    for (const fieldName of multiselectFieldNames) {
+      if (!foundConditionalFields.has(fieldName)) {
+        continue;
+      }
+      errors.push(
+        `Multiselect field "${fieldName}" must not be referenced directly in {IF ${fieldName}} ` +
+        `(empty arrays are truthy); use derived <option>_enabled keys ` +
+        `(when derive_booleans: true) or restructure your template logic.`
+      );
+    }
+  };
 
   // Check if this template uses declarative replacements
   const replacementsPath = join(templateDir, 'replacements.json');
@@ -135,8 +158,13 @@ export function validateTemplate(templateDir: string, templateId: string): Templ
       foundConditionalFields.add(docxCondMatch[1]);
     }
 
+    rejectDirectMultiselectConditionals(foundConditionalFields);
+
     // Check metadata fields are covered by tags
     for (const fieldName of metadataFieldNames) {
+      if (derivedBooleanMultiselectFieldNames.has(fieldName)) {
+        continue;
+      }
       const inTags = foundTags.has(fieldName) || foundConditionalFields.has(fieldName);
       if (!inTags) {
         if (priorityFieldNames.has(fieldName)) {
@@ -184,6 +212,8 @@ export function validateTemplate(templateDir: string, templateId: string): Templ
     while ((condMatch = conditionalRegex.exec(text)) !== null) {
       foundConditionalFields.add(condMatch[1]);
     }
+
+    rejectDirectMultiselectConditionals(foundConditionalFields);
 
     // Extract array field names + item bindings from FOR loop constructs.
     // Each loop has shape `{FOR <item> IN <field>}` and references look like
@@ -242,6 +272,9 @@ export function validateTemplate(templateDir: string, templateId: string): Templ
 
     // Check for fields in metadata but not in DOCX
     for (const fieldName of metadataFieldNames) {
+      if (derivedBooleanMultiselectFieldNames.has(fieldName)) {
+        continue;
+      }
       const inDocx = foundTags.has(fieldName) || foundConditionalFields.has(fieldName);
       if (!inDocx) {
         if (priorityFieldNames.has(fieldName)) {


### PR DESCRIPTION
## Summary

Adds the `multiselect` field type and `derive_booleans: true` flag to OpenAgreements metadata so templates can model "pick zero or more from an allowlisted set" without exploding into N parallel boolean fields. Closes #220 (D3a — engine infrastructure only). The follow-up DDRL migration (D3b) will land separately after #222 merges.

## Implementation

- **Schema** (`src/core/metadata.ts`): `multiselect` type, `derive_booleans?: boolean` flag, options regex `^[A-Za-z_][A-Za-z0-9_]*$`, options uniqueness, JSON-array default validation. New `validateDerivedBooleanCollisions` helper wired into `TemplateMetadataSchema`, `ExternalMetadataSchema`, and `RecipeMetadataSchema` `superRefine` blocks — rejects derived `<option>_enabled` colliding with another top-level field name or with another multiselect's derived keys.
- **Fill pipeline** (`src/core/fill-pipeline.ts`): defaults branch parses `field.default` JSON; new normalization+derivation step throws clear errors on malformed runtime input; priority-unfilled check treats empty arrays/multiselects as unfilled.
- **Validator** (`src/core/validation/template.ts`): skips "not found in DOCX" warning for `derive_booleans` multiselects; rejects `{IF <multiselect_field>}` direct references for **all** multiselects (empty arrays are JS-truthy).
- **Synthetic-key filter** (`src/core/unified-pipeline.ts`): centralized at `runFillPipeline` so `fieldsUsed` never reports engine-derived keys to any caller (fill, recipe, external).
- **CLI typing**: `Record<string, string>` → `Record<string, unknown>` widened across `cli/index.ts`, `commands/fill.ts`, `commands/recipe.ts`, `core/recipe/{types,bracket-normalizer,index,computed}.ts`, `core/employment/memo.ts` so multiselect arrays piped via `--data values.json` flow through cleanly.
- **OpenSpec**: `openspec/changes/add-multiselect-field-type/{proposal,tasks,specs/open-agreements/spec}.md` — `MODIFIED` metadata-schema constraints + `ADDED` multiselect-derived-boolean fill behavior + validator semantics. Validates strict.

## Verification

- [x] `npm run build` — clean (`tsc` exit 0).
- [x] `npm run test:run` — 941 pass, 7 skipped (pre-existing); `check:spec-coverage` passes (222 scenarios).
- [x] Targeted: `npx vitest run src/core/metadata.test.ts integration-tests/fill-pipeline.test.ts integration-tests/template-validation.test.ts` — 124 pass.
- [x] `npm run lint` — clean.
- [x] `npx openspec validate add-multiselect-field-type --strict` — valid.
- [x] `node scripts/export-templates-snapshot.mjs --check` — `data/templates-snapshot.json is up to date.` (D3a is wire-shape-stable; no production templates use multiselect yet.)
- [x] `node bin/open-agreements.js validate openagreements-restrictive-covenant-wyoming` — PASS metadata/template/license; only pre-existing optional-field warnings.
- [ ] Peer review (Gemini + Codex) — pending; will be appended below.

## Scope notes

- **D3a only.** No production-template touchpoints; multiselect coverage in this PR is fixture-only. The DDRL `industry_modules` migration is D3b (follow-up after #222 lands).
- Plan: `~/.claude/plans/handle-d3-open-agreements-open-agreement-enchanted-goblet.md` — peer-reviewed with Codex (primary, dynamic) + Gemini (secondary, static) in two rounds before delegation. Resolved review-cycle table at the bottom of the plan.

## Closes

- #220 (D3a)