### PR TITLE
Add due-diligence-request-list to templates-snapshot.json

### DIFF
--- a/data/templates-snapshot.json
+++ b/data/templates-snapshot.json
@@ -11830,6 +11830,337 @@
       ]
     },
     {
+      "name": "openagreements-due-diligence-request-list",
+      "tier": "internal",
+      "display_name": "OpenAgreements Legal Due Diligence Request List",
+      "category": "deals-partnerships",
+      "description": "Modular legal due diligence request list (DDRL) for corporate transactions. Ships a base form covering organization, capitalization, contracts, IP, employment, litigation, compliance, tax, insurance, debt, property, and privacy/cybersecurity. Four optional industry riders gate via boolean toggles: tech / SaaS, life sciences, healthcare provider, and cross-border / trade compliance. Drafted clean-room from public-source consensus across 15 Am Law firm, bar association, and legal publisher DDRLs; no public source language is reused. Includes per-section AI-augmentable arrays so AI workflows can append target-specific custom questions to any rider.",
+      "license": "CC-BY-4.0",
+      "source_url": "https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-due-diligence-request-list",
+      "source": "OpenAgreements",
+      "attribution_text": "Authored by OpenAgreements contributors. Category structure and consensus framing informed by publicly available DDRLs and commentary from Cooley, Skadden, Morgan Lewis, Gunderson Dettmer, Lowenstein Sandler, Holland & Knight, Foley & Lardner, Software Equity Group, the International Bar Association, the American Bar Association, Bass Berry & Sims, and Carta. See practice note for sources. Drafted clean-room; no source language was reused. Licensed under CC BY 4.0.",
+      "allow_derivatives": true,
+      "credits": [],
+      "fields": [
+        {
+          "name": "requesting_firm_name",
+          "type": "string",
+          "required": true,
+          "section": "Cover Sheet",
+          "description": "Legal name of the buyer's law firm sending the request",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "target_company_name",
+          "type": "string",
+          "required": true,
+          "section": "Cover Sheet",
+          "description": "Legal name of the target company receiving the request",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "project_code_name",
+          "type": "string",
+          "required": false,
+          "section": "Cover Sheet",
+          "description": "Project code name or pseudonym used to refer to the transaction",
+          "default": "",
+          "default_value_rationale": null
+        },
+        {
+          "name": "request_date",
+          "type": "date",
+          "required": false,
+          "section": "Cover Sheet",
+          "description": "Date the request list is delivered to the target",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "response_due_date",
+          "type": "date",
+          "required": false,
+          "section": "Cover Sheet",
+          "description": "Date by which the target's first-round response is due",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "lead_buyer_counsel_name",
+          "type": "string",
+          "required": false,
+          "section": "Cover Sheet",
+          "description": "Name of the lead attorney at the requesting firm",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "lead_buyer_counsel_email",
+          "type": "string",
+          "required": false,
+          "section": "Cover Sheet",
+          "description": "Email of the lead attorney at the requesting firm",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "primary_target_contact_name",
+          "type": "string",
+          "required": false,
+          "section": "Cover Sheet",
+          "description": "Name of the target's primary point of contact for diligence responses",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "currency",
+          "type": "enum",
+          "required": false,
+          "section": "Cover Sheet",
+          "description": "Currency for materiality and financial threshold inputs",
+          "default": "USD",
+          "default_value_rationale": null
+        },
+        {
+          "name": "data_room_url",
+          "type": "string",
+          "required": false,
+          "section": "Cover Sheet",
+          "description": "URL of the virtual data room (optional; included in cover-sheet instructions if provided)",
+          "default": "",
+          "default_value_rationale": null
+        },
+        {
+          "name": "materiality_threshold_usd",
+          "type": "string",
+          "required": true,
+          "section": "Materiality and Lookback",
+          "description": "Dollar floor for material-contracts requests. Stored as a pre-formatted string (e.g., \"$100,000\") because the fill engine has no currency formatter. Adjust upward for larger deals, downward for early-stage targets.",
+          "default": "$100,000",
+          "default_value_rationale": "$100,000 is the consensus dollar floor for mid-market deals across public DDRLs (Cooley, Skadden, Bloomberg). Tune up for larger targets (e.g., \"$1,000,000\" for $100M+ deals) or down for early-stage."
+        },
+        {
+          "name": "materiality_threshold_revenue_pct",
+          "type": "string",
+          "required": false,
+          "section": "Materiality and Lookback",
+          "description": "Relative materiality threshold expressed as a percentage of gross revenue. The lower of dollar floor and revenue percentage governs. Stored as a pre-formatted string for consistency with the dollar threshold.",
+          "default": "5%",
+          "default_value_rationale": "5% of gross revenue is the consensus relative-materiality qualifier in BigLaw practice. Tune down for asset-light targets where individual contract size is small but each one is operationally critical."
+        },
+        {
+          "name": "lookback_years",
+          "type": "number",
+          "required": true,
+          "section": "Materiality and Lookback",
+          "description": "Default lookback window in years for litigation, compliance, and operational history. Per-category overrides may extend specific sections.",
+          "default": "3",
+          "default_value_rationale": "3 years is consensus baseline for litigation, compliance, and operational history. Tax often warrants 6+ to mirror IRS statute of limitations; regulatory correspondence is conventionally open-ended."
+        },
+        {
+          "name": "litigation_lookback_years",
+          "type": "number",
+          "required": false,
+          "section": "Materiality and Lookback",
+          "description": "Optional per-category override for the litigation lookback window. If blank, falls through to lookback_years. 5 years is appropriate for regulated targets or where prior litigation revealed systemic process failures.",
+          "default": "",
+          "default_value_rationale": null
+        },
+        {
+          "name": "tax_lookback_years",
+          "type": "number",
+          "required": false,
+          "section": "Materiality and Lookback",
+          "description": "Optional per-category override for the tax lookback window. If blank, falls through to lookback_years. 6 years mirrors the IRS substantial- omission statute of limitations and is the safe default for most deals.",
+          "default": "",
+          "default_value_rationale": null
+        },
+        {
+          "name": "compliance_lookback_years",
+          "type": "number",
+          "required": false,
+          "section": "Materiality and Lookback",
+          "description": "Optional per-category override for routine compliance certifications. Regulatory correspondence regarding investigations, settlements, and consent decrees should be requested open-ended regardless of this value.",
+          "default": "",
+          "default_value_rationale": null
+        },
+        {
+          "name": "deal_type",
+          "type": "enum",
+          "required": true,
+          "section": "Deal Type",
+          "description": "Type of transaction the DDRL supports",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "transaction_stage",
+          "type": "enum",
+          "required": true,
+          "section": "Deal Type",
+          "description": "Stage of the transaction. Pre-LOI uses lighter scope; post-LOI uses the full base form plus all triggered riders.",
+          "default": "post_loi_pre_signing",
+          "default_value_rationale": null
+        },
+        {
+          "name": "tech_rider_enabled",
+          "type": "boolean",
+          "required": true,
+          "section": "Industry Riders",
+          "description": "Enable Section O (Tech / SaaS rider) covering OSS schedules with copyleft flagging, source-code escrow, hosted-services agreements, SOC 2 / ISO 27001 audits, data-flow architecture, SLAs, security- incident history, and cloud-agreement change-of-control. Recommended on for software, SaaS, platform, marketplace, or data-heavy targets.",
+          "default": "false",
+          "default_value_rationale": null
+        },
+        {
+          "name": "life_sciences_rider_enabled",
+          "type": "boolean",
+          "required": true,
+          "section": "Industry Riders",
+          "description": "Enable Section P (Life Sciences rider) covering FDA correspondence, clinical trials, CRO agreements, Form 483s, Warning Letters, CIA, and controlled-substance registrations. Recommended on for biotech, pharma, medical-device, and diagnostics targets with FDA-regulated pipelines.",
+          "default": "false",
+          "default_value_rationale": null
+        },
+        {
+          "name": "healthcare_provider_rider_enabled",
+          "type": "boolean",
+          "required": true,
+          "section": "Industry Riders",
+          "description": "Enable Section Q (Healthcare Provider rider) covering HIPAA breach logs, billing/coding compliance, payer audits, malpractice claims, and Anti-Kickback / Stark / Sunshine Act compliance. Recommended on for clinics, hospitals, physician groups, and telehealth providers with payer-reimbursement exposure.",
+          "default": "false",
+          "default_value_rationale": null
+        },
+        {
+          "name": "cross_border_rider_enabled",
+          "type": "boolean",
+          "required": true,
+          "section": "Industry Riders",
+          "description": "Enable Section R (Cross-Border / Trade Compliance rider) covering sanctions/OFAC screening, export-control classifications, AML/KYC, FCPA compliance, government-customer exposure, and foreign-investment- screening filings. Recommended on whenever the target has foreign subsidiaries, foreign customers, government customers, or sensitive- jurisdiction exposure. Increasingly mandatory after the 2023 DOJ M&A Safe Harbor Policy.",
+          "default": "false",
+          "default_value_rationale": null
+        },
+        {
+          "name": "countries_of_operation",
+          "type": "string",
+          "required": false,
+          "section": "Cross-Border Specifics",
+          "description": "Comma-separated list of countries where the target operates, sells, or has employees. Optional; populated when the cross-border rider is enabled to focus the request on specific jurisdictions.",
+          "default": "",
+          "default_value_rationale": null
+        },
+        {
+          "name": "government_customer_exposure",
+          "type": "boolean",
+          "required": false,
+          "section": "Cross-Border Specifics",
+          "description": "Set true if the target has government customers (federal, state, local, or foreign) where flow-down compliance obligations may apply. When true, additional government-contracts requests render in Section R.",
+          "default": "false",
+          "default_value_rationale": null
+        },
+        {
+          "name": "additional_questions_tech",
+          "type": "array",
+          "required": false,
+          "section": "AI Augmentation",
+          "description": "AI-augmentable list of target-specific custom questions appended to the Tech / SaaS rider. Each item is an object with a `question` field. Empty by default. Renders only when tech_rider_enabled is true.",
+          "default": "[]",
+          "default_value_rationale": null,
+          "items": [
+            {
+              "name": "question",
+              "type": "string",
+              "required": false,
+              "section": null,
+              "description": "The custom question text to render in Section O",
+              "default": null,
+              "default_value_rationale": null
+            }
+          ]
+        },
+        {
+          "name": "additional_questions_life_sciences",
+          "type": "array",
+          "required": false,
+          "section": "AI Augmentation",
+          "description": "AI-augmentable list of target-specific custom questions appended to the Life Sciences rider. Empty by default. Renders only when life_sciences_rider_enabled is true.",
+          "default": "[]",
+          "default_value_rationale": null,
+          "items": [
+            {
+              "name": "question",
+              "type": "string",
+              "required": false,
+              "section": null,
+              "description": "The custom question text to render in Section P",
+              "default": null,
+              "default_value_rationale": null
+            }
+          ]
+        },
+        {
+          "name": "additional_questions_healthcare_provider",
+          "type": "array",
+          "required": false,
+          "section": "AI Augmentation",
+          "description": "AI-augmentable list of target-specific custom questions appended to the Healthcare Provider rider. Empty by default. Renders only when healthcare_provider_rider_enabled is true.",
+          "default": "[]",
+          "default_value_rationale": null,
+          "items": [
+            {
+              "name": "question",
+              "type": "string",
+              "required": false,
+              "section": null,
+              "description": "The custom question text to render in Section Q",
+              "default": null,
+              "default_value_rationale": null
+            }
+          ]
+        },
+        {
+          "name": "additional_questions_cross_border",
+          "type": "array",
+          "required": false,
+          "section": "AI Augmentation",
+          "description": "AI-augmentable list of target-specific custom questions appended to the Cross-Border / Trade Compliance rider. Empty by default. Renders only when cross_border_rider_enabled is true.",
+          "default": "[]",
+          "default_value_rationale": null,
+          "items": [
+            {
+              "name": "question",
+              "type": "string",
+              "required": false,
+              "section": null,
+              "description": "The custom question text to render in Section R",
+              "default": null,
+              "default_value_rationale": null
+            }
+          ]
+        },
+        {
+          "name": "additional_questions_general",
+          "type": "array",
+          "required": false,
+          "section": "AI Augmentation",
+          "description": "AI-augmentable list of cross-cutting custom questions that do not belong to any specific rider. Renders at the end of the closing Response Protocol section. Empty by default.",
+          "default": "[]",
+          "default_value_rationale": null,
+          "items": [
+            {
+              "name": "question",
+              "type": "string",
+              "required": false,
+              "section": null,
+              "description": "The custom question text to render at end of document",
+              "default": null,
+              "default_value_rationale": null
+            }
+          ]
+        }
+      ]
+    },
+    {
       "name": "openagreements-employee-ip-inventions-assignment",
       "tier": "internal",
       "display_name": "OpenAgreements Employee IP and Inventions Assignment",


### PR DESCRIPTION
## Summary

Follow-up to #264. The PR that added the openagreements-due-diligence-request-list template did not include the corresponding entry in \`data/templates-snapshot.json\`, which dev-website fetches at build time to drive template page generation.

Without this entry: https://usejunior.com/templates/openagreements-due-diligence-request-list returns 404 in production even after #264 merged.

## Verified locally

Built dev-website with \`OPEN_AGREEMENTS_DIR\` pointed at this branch:

\`\`\`
A: 7 <p>     E: 4 <p>     I: 5 <p>     M: 3 <p>     Q: 8 <p>
B: 7 <p>     F: 9 <p>     J: 7 <p>     N: 3 <p>     R: 8 <p>
C: 3 <p>     G: 5 <p>     K: 5 <p>     O: 9 <p>
D: 7 <p>     H: 6 <p>     L: 4 <p>     P: 10 <p>
\`\`\`

Page renders, .docx download generates (44K valid OOXML), template appears in /templates index.

## Test plan

- [x] \`scripts/export-templates-snapshot.mjs\` produces this exact diff
- [x] dev-website build with this snapshot generates the page with all 95 numbered items as separate \`<p>\` tags
- [ ] After merge: dev-website Vercel rebuild fetches the updated snapshot and serves the page in prod