### PR TITLE
fix(vercel): remove $comment from vercel.json so preview deploys succeed (closes #279)

### DIFF
--- a/docs/well-known/redirects.md
+++ b/docs/well-known/redirects.md
@@ -1,0 +1,10 @@
+# Vercel Redirects
+
+## Load-Bearing Marketing And Trust Redirects
+
+The redirect block in `vercel.json` exists because the marketing and trust source
+pages were deleted from this repo. Those routes must keep forwarding to
+`https://usejunior.com`.
+
+Do not remove or change those redirects without first confirming the
+destinations still resolve and the replacement pages exist on `usejunior.com`.

--- a/vercel.json
+++ b/vercel.json
@@ -32,7 +32,6 @@
       ]
     }
   ],
-  "$comment": "Load-bearing redirects: the marketing and trust source pages were deleted from this repo, so these routes must keep forwarding to usejunior.com.",
   "redirects": [
     { "source": "/", "destination": "https://usejunior.com/developer-tools/open-agreements", "statusCode": 301 },
     { "source": "/templates", "destination": "https://usejunior.com/developer-tools/open-agreements/templates", "statusCode": 301 },


### PR DESCRIPTION
## Summary
Removes the inline `$comment` from `vercel.json` so Vercel's strict schema validation passes and preview deploys work again. Preserves the rationale in a new `docs/well-known/redirects.md`.

## Implementation
- `vercel.json:35` — `$comment` line removed; no other changes.
- `docs/well-known/redirects.md` — new file with section `## Load-Bearing Marketing And Trust Redirects` explaining why the redirect block exists and what to verify before changing it.

## Verification
- `vercel.json` keys: `$schema, framework, installCommand, buildCommand, outputDirectory, cleanUrls, trailingSlash, rewrites, headers, redirects, functions` (parses as JSON).
- `grep $comment vercel.json` → no matches.
- `npm run build` → exit 0.

## Closes
- #279