### PR TITLE
fix(canonical-source): handle escaped pipes in markdown table cells

### DIFF
--- a/integration-tests/canonical-source-authoring.test.ts
+++ b/integration-tests/canonical-source-authoring.test.ts
@@ -222,6 +222,66 @@ Legacy body.
     ]);
   });
 
+  it('parses cover-term cells that contain escaped pipes', () => {
+    // A literal "|" inside a table cell is written "\|" in GFM/CommonMark.
+    // Regression: a naive split on "|" miscounts the cells and trips the
+    // cell-count invariant before this case was handled. Covers escaped
+    // pipes mid-cell, at a cell boundary, consecutively, and a backslash
+    // that is not before a pipe (which must survive verbatim).
+    const source = buildCanonicalSource()
+      .replace(
+        '| row | Company | {company_name} | always |',
+        '| row | Company | {company_name} \\| Acme \\| Inc | always |',
+      )
+      .replace(
+        '| subrow | Purpose | {purpose} | purpose_included |',
+        '| subrow | Purpose | \\| leads \\|\\| C:\\Temp | purpose_included |',
+      );
+
+    const compiled = compileCanonicalSourceString(
+      source,
+      'inline escaped-pipe source',
+    );
+    const rows = compiled.contractSpec.sections.cover_terms.rows;
+
+    expect(rows[0]).toMatchObject({
+      kind: 'row',
+      label: 'Company',
+      value: '{company_name} | Acme | Inc',
+    });
+    expect(rows[2]).toMatchObject({
+      kind: 'subrow',
+      label: 'Purpose',
+      value: '| leads || C:\\Temp',
+    });
+  });
+
+  it('treats an escaped backslash before a pipe as a real delimiter', () => {
+    // `\\|` is an escaped backslash followed by a delimiter (GFM), NOT an
+    // escaped pipe. The extra cell must trip the cell-count invariant
+    // rather than be silently absorbed.
+    const source = buildCanonicalSource().replace(
+      '| row | Company | {company_name} | always |',
+      '| row | Company | {company_name} \\\\| Acme | always |',
+    );
+
+    expect(() =>
+      compileCanonicalSourceString(source, 'inline escaped-backslash source'),
+    ).toThrow(/cells; expected/);
+  });
+
+  it('rejects a table row missing its trailing pipe', () => {
+    // `.slice(1, -1)` would otherwise silently drop the last character.
+    const source = buildCanonicalSource().replace(
+      '| row | Company | {company_name} | always |',
+      '| row | Company | {company_name} | always',
+    );
+
+    expect(() =>
+      compileCanonicalSourceString(source, 'inline missing-pipe source'),
+    ).toThrow(/must start and end with a pipe/);
+  });
+
   it.openspec('OA-TMP-034')('rejects unresolved explicit references and alias collisions', () => {
     expect(() =>
       compileCanonicalSourceString(

--- a/scripts/template_renderer/canonical-source.mjs
+++ b/scripts/template_renderer/canonical-source.mjs
@@ -178,12 +178,65 @@ function paragraphTextFromLines(lines) {
   return paragraphsFromLines(lines).join('\n\n');
 }
 
+/**
+ * Split the inner content of a markdown table row into trimmed cells.
+ *
+ * A literal `|` inside a cell is written `\|` in GFM/CommonMark tables; a
+ * naive `.split('|')` miscounts cells. This splitter is escape-aware: a `|`
+ * is a delimiter unless the backslash immediately before it is itself
+ * unescaped. So `\|` is a literal pipe, but `\\|` is a literal backslash
+ * followed by a delimiter. Only the pipe escape is unwound — other
+ * backslash sequences are left verbatim, since cell contents are treated as
+ * opaque strings (no inline-markdown processing happens here).
+ */
+function splitTableRowCells(inner) {
+  const cells = [];
+  let current = '';
+  let escaped = false;
+  for (let i = 0; i < inner.length; i += 1) {
+    const ch = inner[i];
+    if (escaped) {
+      // The preceding backslash escapes this character: unwind it for a
+      // pipe, otherwise keep the backslash so non-pipe escapes survive.
+      current += ch === '|' ? '|' : `\\${ch}`;
+      escaped = false;
+      continue;
+    }
+    if (ch === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (ch === '|') {
+      cells.push(current.trim());
+      current = '';
+      continue;
+    }
+    current += ch;
+  }
+  if (escaped) {
+    // A trailing lone backslash is literal content.
+    current += '\\';
+  }
+  cells.push(current.trim());
+  return cells;
+}
+
 function parseMarkdownTable(lines, filePath) {
   invariant(lines.length >= 2, `Canonical source (${filePath}) has an incomplete markdown table`);
 
   const rows = lines
     .filter((line) => line.trim().startsWith('|'))
-    .map((line) => line.trim().slice(1, -1).split('|').map((cell) => cell.trim()));
+    .map((line) => {
+      const trimmed = line.trim();
+      // `splitTableRowCells` operates on the content between the outer
+      // pipes; require both so a missing trailing `|` fails loudly rather
+      // than silently dropping the last character.
+      invariant(
+        trimmed.endsWith('|'),
+        `Canonical source (${filePath}) table row must start and end with a pipe: "${trimmed}"`
+      );
+      return splitTableRowCells(trimmed.slice(1, -1));
+    });
 
   invariant(rows.length >= 2, `Canonical source (${filePath}) must include a header row and divider row`);
 


### PR DESCRIPTION
## Summary

`parseMarkdownTable` in `scripts/template_renderer/canonical-source.mjs` split table rows on a bare `|`, so a literal pipe written as `\|` (standard GFM/CommonMark table escaping) miscounted the cells and tripped the cell-count invariant.

## Changes

- Add `splitTableRowCells`, an escape-aware splitter:
  - `\|` is unwound to a literal pipe
  - `\\|` is a literal backslash followed by a real delimiter (a `|` is escaped only when its preceding backslash is itself unescaped)
  - non-pipe backslash sequences pass through verbatim — cell contents are opaque strings, no inline-markdown processing happens here
- Assert each table row ends with a pipe, so a missing trailing `|` fails loudly instead of silently dropping the last character via `.slice(1, -1)`.

## Verification

- 53/53 canonical tests pass (5 new escaped-pipe regression cases: mid-cell, cell boundary, consecutive `\|\|`, escaped-backslash, missing trailing pipe)
- Behavior-preserving: regenerating all 6 canonical templates produces identical content (verified with the fix applied and reverted — only DOCX-timestamp byte wobble differs)
- Reviewed by Gemini + Codex; the `\\|` escaped-backslash case and the trailing-pipe assertion were added in response to that review.