### PR TITLE
test: intentional code-reuse duplicate to exercise LLM gate WARN path

### DIFF
--- a/src/utils/array-helpers.ts
+++ b/src/utils/array-helpers.ts
@@ -1,0 +1,18 @@
+/**
+ * Returns a new array with duplicates removed, preserving the order of
+ * first occurrence.
+ *
+ * Useful for deduping path lists, IDs, etc. while keeping precedence
+ * stable.
+ */
+export function dedupePreserveOrder<T>(values: T[]): T[] {
+  const seen = new Set<T>();
+  const result: T[] = [];
+  for (const value of values) {
+    if (!seen.has(value)) {
+      seen.add(value);
+      result.push(value);
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
**Test fixture, not for merge.**

This PR introduces `dedupePreserveOrder<T>` in `src/utils/array-helpers.ts` — functionally identical to the existing `uniqueOrdered` helper at `src/utils/paths.ts:140-151`, just generic-typed.

A reviewer should spot this duplication. The PR exists to confirm the LLM gate's `STATE: WARN` path fires correctly on a real (small, clear) code-reuse case before we rely on it in production.

Base is `feat/llm-based-quality-gate-spike` (not `main`) because that's the branch where the gate workflow lives until #308 merges.

Will close without merging once the gate has run.