### PR TITLE
feat(ci): add LLM gate blocking-mode toggle + label-based override (closes #321)

### DIFF
--- a/.github/workflows/llm-based-quality-gate.yml
+++ b/.github/workflows/llm-based-quality-gate.yml
@@ -17,8 +17,10 @@ env:
   #   gh variable set LLM_GATE_CLI_VERSION --body 0.40.0
   #   gh variable set LLM_GATE_MODEL --body gemini-3.5-flash
   #   gh variable set LLM_GATE_MAX_PARALLEL --body 3
+  #   gh variable set LLM_GATE_BLOCKING --body 1
   GEMINI_CLI_VERSION: ${{ vars.LLM_GATE_CLI_VERSION || '0.39.1' }}
   GEMINI_MODEL: ${{ vars.LLM_GATE_MODEL || 'gemini-3.5-flash' }}
+  LLM_GATE_BLOCKING: ${{ vars.LLM_GATE_BLOCKING || '0' }}
   # Estimated cost per 1M tokens — used only to compute a ballpark figure
   # for the PR-comment footer. Override per-repo via repo variables if
   # pricing drifts.
@@ -288,6 +290,7 @@ jobs:
         uses: actions/github-script@v7
         env:
           MODEL: ${{ env.GEMINI_MODEL }}
+          LLM_GATE_BLOCKING: ${{ env.LLM_GATE_BLOCKING }}
         with:
           script: |
             const fs = require('fs');
@@ -318,8 +321,13 @@ jobs:
             const warns = rows.filter(r => r.status === 'WARN').length;
             const passes = rows.filter(r => r.status === 'PASS').length;
             const overall = warns > 0 ? '⚠️ WARN' : (passes > 0 ? '✅ PASS' : '❓ NO RESULTS');
+            const labels = (context.payload.pull_request.labels || []).map(l => l.name);
+            const overrideActive = labels.includes('llm-gate/override');
 
             const header = '## LLM-Based Quality Gate';
+            const overrideBanner = overrideActive
+              ? '\n\n> ⚠️ **Override active** — `llm-gate/override` label is set; this gate\'s WARN findings are non-blocking on this PR.\n'
+              : '';
             const summary = `**Overall:** ${overall} (${passes} pass · ${warns} warn · ${rows.length} total)`;
 
             let table;
@@ -346,7 +354,7 @@ jobs:
               : '';
             const costLine = `_Estimated cost (this run): **$${totalUsd.toFixed(4)}** — ${totalIn.toLocaleString()} input + ${totalOut.toLocaleString()} output tokens (≈4 chars/token) on \`${model}\`${retryNote}. Char-count estimate, not provider telemetry._`;
 
-            const body = `${header}\n\n${summary}\n\n${table}${fullQuestions}\n\n${costLine}`;
+            const body = `${header}${overrideBanner}\n\n${summary}\n\n${table}${fullQuestions}\n\n${costLine}`;
 
             // Append a new comment on every run — preserves an audit trail
             // of how the gate's verdicts evolved across PR revisions.
@@ -359,3 +367,8 @@ jobs:
 
             // Also surface the same content in the Actions UI summary.
             await core.summary.addRaw(body).write();
+
+            const blockingMode = process.env.LLM_GATE_BLOCKING === '1';
+            if (blockingMode && warns > 0 && !overrideActive) {
+              core.setFailed(`LLM-Based Quality Gate found ${warns} WARN row(s). Add the \`llm-gate/override\` label to bypass (with justification in a PR comment).`);
+            }

--- a/.github/workflows/llm-based-quality-gate.yml
+++ b/.github/workflows/llm-based-quality-gate.yml
@@ -283,7 +283,13 @@ jobs:
   aggregate:
     name: Aggregate and post review
     needs: [parse-checklist, run-check]
-    if: ${{ always() && needs.parse-checklist.outputs.count != '0' }}
+    # `always()` keeps the aggregate running even when individual matrix
+    # `run-check` jobs fail (we still want the comment). But `always()`
+    # bypasses the normal skipped-needs cascade, so we must explicitly
+    # require parse-checklist to have succeeded — otherwise an unrelated
+    # label-change event (where parse-checklist is skipped via its own
+    # `if:`) would still start the aggregate job with empty outputs.
+    if: ${{ always() && needs.parse-checklist.result == 'success' && needs.parse-checklist.outputs.count != '0' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/llm-based-quality-gate.yml
+++ b/.github/workflows/llm-based-quality-gate.yml
@@ -2,7 +2,12 @@ name: LLM-Based Quality Gate
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    # `labeled` and `unlabeled` are included so that adding/removing the
+    # `llm-gate/override` label after a failed gate run re-triggers the
+    # workflow and clears the failing check without requiring a push. The
+    # job-level `if:` below filters out unrelated label changes so we don't
+    # re-run the costly matrix on every label add.
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
 permissions:
   contents: read
@@ -30,9 +35,17 @@ env:
 jobs:
   parse-checklist:
     name: Parse checklist
+    # Skip on label changes that aren't the override label (otherwise we'd
+    # re-run the whole 14-check matrix every time someone adds a
+    # `priority/*` or `area/*` label). For `labeled`/`unlabeled` events the
+    # gate only re-runs when the label change is `llm-gate/override`.
     if: >-
       github.event.pull_request.draft == false &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (
+        (github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
+        github.event.label.name == 'llm-gate/override'
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,11 +90,13 @@ npm run test:run
    Note: `metadata.yaml` is catalog-only (not a render input), so editing it
    does **not** require a preview refresh.
 
-6. **LLM-Based Quality Gate (advisory)**: same-repo PRs are reviewed by an
-   LLM-powered code-reuse detector in `.github/workflows/llm-based-quality-gate.yml`
-   and may receive a `STATE: WARN` comment suggesting reuse of an existing
-   helper. This is non-blocking in Phase 0 — consider the suggestion, but
-   dismiss the warning if it doesn't apply.
+6. **LLM-Based Quality Gate**: same-repo PRs are reviewed by an LLM-powered
+   code-reuse detector in `.github/workflows/llm-based-quality-gate.yml`. By
+   default the gate is advisory: it posts PASS/WARN findings as a PR comment but
+   does not block merging. Maintainers can enable blocking mode with the
+   `LLM_GATE_BLOCKING=1` repo variable; in that mode any WARN row fails the
+   aggregate check unless the PR has the `llm-gate/override` label, which keeps
+   the findings visible while treating them as non-blocking for that PR.
 
 ## Project Structure
 


### PR DESCRIPTION
## Summary

Wires two new knobs into the LLM-Based Quality Gate so it can be flipped from advisory to blocking via a single repo variable once we have false-positive data to justify it. Default behavior is unchanged — `LLM_GATE_BLOCKING` is unset on the repo, so the gate stays advisory.

## Implementation

- **`LLM_GATE_BLOCKING`** (repo variable, default `'0'`): when `'1'`, the `aggregate` job calls `core.setFailed(...)` if any row in the checklist returns `WARN`. The gate's red check flips merge-blocking status accordingly.
- **`llm-gate/override`** (PR label, must be created in the repo by a maintainer before use): when present, the aggregate job suppresses `setFailed` even in blocking mode and prepends a visible banner to the gate's PR comment so reviewers can see the override is in effect.

Both behaviors are gated server-side in the `actions/github-script@v7` step inside the `aggregate` job. The comment posts in both modes; only `setFailed` is conditional.

## Verification

Codex headless implementation ran in an isolated clone before the diff was ported here:

- `actionlint .github/workflows/llm-based-quality-gate.yml` — OK
- `npm run build` — OK
- `npm run lint` — OK
- `npm run test:run` — 1012 passed / 29 skipped (no regressions)
- Node harness against the new github-script logic:
  - advisory + WARN + no override → no `setFailed`
  - blocking + WARN + no override → `setFailed` fires with the override-hint message
  - blocking + WARN + override → no `setFailed` + override banner appears in comment

The default-off behavior preserves the current advisory mode exactly — this PR is safe to merge without flipping anything else.

## Verification checklist

- [x] Workflow YAML lints clean
- [x] Build / lint / tests green (no regression; Codex output above)
- [x] Default-off path preserves current advisory behavior
- [ ] Peer review (Gemini + Codex) — pending; results will be appended as a PR comment

## To enable blocking after this PR merges

1. Pre-create the `llm-gate/override` label in the repo (color/description per maintainer preference; suggest the `area/`-style convention).
2. After ~5–10 real PRs of WARN data confirm the false-positive rate is acceptable: `gh variable set LLM_GATE_BLOCKING --body 1 -R open-agreements/open-agreements`.
3. Add the `Aggregate and post review` check to the required-status-checks list on `main` via repo settings → branches.

## Closes

- #321
- #307 (tracking issue — this PR ships the last load-bearing piece of Phase 1)

