### PR TITLE
docs(mcp-migration-v2): clarify INTERNAL_ERROR retriable note (closes #228)

### DIFF
--- a/docs/mcp-migration-v2.md
+++ b/docs/mcp-migration-v2.md
@@ -101,7 +101,27 @@ curl -L "$DOWNLOAD_URL" -o filled.docx
 | `DOWNLOAD_LINK_INVALID` | Malformed or signature-invalid download ID | `false` |
 | `DOWNLOAD_LINK_EXPIRED` | Download link expired | `false` |
 | `DOWNLOAD_LINK_NOT_FOUND` | Download ID not found in TTL store | `false` |
-| `INTERNAL_ERROR` | Unexpected server error during tool execution | `false` |
+| `INTERNAL_ERROR` | Unexpected server error during tool execution | usually `false` (see note) |
+
+> **`INTERNAL_ERROR` retriability:** defaults to `false`. The exception is when `error.details.reason === 'DOWNLOAD_STORE_UNAVAILABLE'` and `error.details.cause === 'runtime'` — in that case `retriable` is `true` to signal a transient KV/Upstash outage. Persistent misconfiguration surfaces as the same `reason` with `cause === 'configuration'` and `retriable: false`. Clients should branch on `error.details.reason` for the most precise retry signal.
+
+Example envelope for a transient download-store outage during `fill_template`:
+
+```json
+{
+  "status": "error",
+  "tool": "fill_template",
+  "error": {
+    "code": "INTERNAL_ERROR",
+    "message": "Download storage is unavailable: <details>",
+    "retriable": true,
+    "details": {
+      "reason": "DOWNLOAD_STORE_UNAVAILABLE",
+      "cause": "runtime"
+    }
+  }
+}
+```
 
 ## `/api/download` Contract
 


### PR DESCRIPTION
## Summary

The Error Code Taxonomy in `docs/mcp-migration-v2.md` listed `INTERNAL_ERROR` as `retriable: false` outright. The actual MCP code already returns `retriable: true` for the runtime-cause `DownloadStoreUnavailableError` path. v2 clients reading the docs as a contract reference would silently miss real retry signals on transient KV/Upstash outages.

## Implementation

Pure docs change to `docs/mcp-migration-v2.md`:

- Taxonomy row updated to `usually \`false\` (see note)`.
- Added a note explaining the runtime/configuration split (`error.details.reason === 'DOWNLOAD_STORE_UNAVAILABLE'`, `details.cause === 'runtime'` ⇒ retriable).
- Added an example envelope so clients can see the exact shape.

No code change — behavior already exists at `api/mcp.ts:1047-1068` and is covered by `integration-tests/api-endpoints.test.ts`.

## Verification

- [x] Code claim verified: `api/mcp.ts:1047-1068` confirms `retriable: cause === 'runtime'` with `details: { reason: 'DOWNLOAD_STORE_UNAVAILABLE', cause }`.
- [x] No code paths touched.

## Closes

- #228