### PR TITLE
docs(readme): lead with Available Templates and reorder sections

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -1,201 +1,212 @@
+<!-- This file is generated from README.template.md by scripts/generate_readme.mjs. Do not edit README.md directly. -->
+
 # OpenAgreements
 
 [![npm version](https://img.shields.io/npm/v/open-agreements)](https://www.npmjs.com/package/open-agreements)
 [![npm downloads](https://img.shields.io/npm/dm/open-agreements.svg)](https://npmjs.org/package/open-agreements)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![Agent Skill](https://img.shields.io/badge/agent--skill-open--agreements-purple)](https://skills.sh)
 [![CI](https://github.com/open-agreements/open-agreements/actions/workflows/ci.yml/badge.svg)](https://github.com/open-agreements/open-agreements/actions/workflows/ci.yml)
-[![MCP Server Status](https://img.shields.io/endpoint?url=https%3A%2F%2Fopenagreements.org%2Fapi%2Fstatus%3Fformat%3Dshields)](https://openagreements.openstatus.dev/)
 [![codecov](https://img.shields.io/codecov/c/github/open-agreements/open-agreements/main)](https://app.codecov.io/gh/open-agreements/open-agreements)
-[![GitHub stargazers](https://img.shields.io/github/stars/open-agreements/open-agreements?style=social)](https://github.com/open-agreements/open-agreements/stargazers)
-[![Tests: Vitest](https://img.shields.io/badge/tests-vitest-6E9F18)](https://vitest.dev/)
-[![OpenSpec Traceability](https://img.shields.io/badge/openspec-traceability%20gate-brightgreen)](./scripts/validate_openspec_coverage.mjs)
 [![Socket Badge](https://socket.dev/api/badge/npm/package/open-agreements)](https://socket.dev/npm/package/open-agreements)
+[![GitHub stargazers](https://img.shields.io/github/stars/open-agreements/open-agreements?style=social)](https://github.com/open-agreements/open-agreements/stargazers)
+[![Agent Skill](https://img.shields.io/badge/agent--skill-open--agreements-purple)](https://skills.sh)
+[![MCP Server Status](https://img.shields.io/endpoint?url=https%3A%2F%2Fopenagreements.org%2Fapi%2Fstatus%3Fformat%3Dshields)](https://openagreements.openstatus.dev/)
 [![install size](https://packagephobia.com/badge?p=open-agreements)](https://packagephobia.com/result?p=open-agreements)
 
-[English](./README.md) | [Español](./README.es.md) | [简体中文](./README.zh.md) | [Português (Brasil)](./README.pt-br.md) | [Deutsch](./README.de.md)
+[English](https://github.com/open-agreements/open-agreements/blob/main/README.md) | [Español](https://github.com/open-agreements/open-agreements/blob/main/README.es.md) | [简体中文](https://github.com/open-agreements/open-agreements/blob/main/README.zh.md) | [Português (Brasil)](https://github.com/open-agreements/open-agreements/blob/main/README.pt-br.md) | [Deutsch](https://github.com/open-agreements/open-agreements/blob/main/README.de.md)
 
-> **Übersetzungshinweis:** Das englische `README.md` ist die kanonische Quelle. Diese Übersetzung kann kurzzeitig hinterherhinken. Wichtige Änderungen im englischen README sollten innerhalb von 72 Stunden übernommen werden.
+Fülle standardisierte juristische Vertragsvorlagen aus und erhalte signierbare DOCX-Dateien. OpenAgreements umfasst über 40 Vorlagen für NDAs, Cloud-Service-Verträge, Beschäftigungsdokumente, Contractor-Verträge, SAFEs und NVCA-Finanzierungsdokumente.
 
-<!-- TODO: Add OpenSSF Scorecard badge once repo is indexed at securityscorecards.dev -->
-<!-- TODO: Add OpenSSF Best Practices badge after registration at bestpractices.dev -->
-<!-- TODO: Re-evaluate Snyk badge — Advisor migrated to security.snyk.io (July 2024) -->
+Funktioniert mit Claude Code, Gemini CLI, Cursor sowie lokalen MCP- oder CLI-Workflows.
+
+## Inhalt
+
+- [Verfügbare Vorlagen](#verfügbare-vorlagen)
+- [Verfügbare Skills](#verfügbare-skills)
+- [Pakete](#pakete)
+- [Schnellstart](#schnellstart)
+- [Installation](#installation)
+- [Dokumentation](#dokumentation)
+- [Datenschutz](#datenschutz)
+- [Siehe auch](#siehe-auch)
+- [Mitwirken](#mitwirken)
+- [Mit OpenAgreements gebaut](#mit-openagreements-gebaut)
+- [Lizenz](#lizenz)
 
 <p align="center">
-  <img src="docs/assets/demo-fill-nda.gif" alt="Fill a Mutual NDA in Claude Code — prompt, answer questions, get a signed-ready DOCX" width="720">
+  <img src="https://raw.githubusercontent.com/open-agreements/open-agreements/main/docs/assets/demo-fill-nda.gif" alt="Fill a Mutual NDA in Claude Code — prompt, answer questions, get a signed-ready DOCX" width="720">
 </p>
 
 > *Demo: Claude füllt ein Common Paper Mutual NDA in unter 2 Minuten aus. Für Kürze beschleunigt.*
 
-Fülle standardisierte juristische Vertragsvorlagen aus und erzeuge signierbare DOCX-Dateien. Die Vorlagen decken NDAs, Cloud-Bedingungen, Arbeitsdokumente, Contractor-Verträge, SAFEs und NVCA-Finanzierungsdokumente ab.
+## Verfügbare Vorlagen
 
-**Open Agreements** von [UseJunior](https://usejunior.com) — Teil der [UseJunior Developer Tools](https://usejunior.com/developer-tools/open-agreements). Produktiv im Einsatz bei Am Law 100 Kanzleien.
+Die Spalte „Quelle“ verweist auf den Upstream-Standard, das Quelldokument oder die kanonische Projektseite (je nach Publisher unterschiedlich). Die Spalte „Lizenz“ zeigt die Bedingungen für die Weiterverbreitung. Die Repo-Links verweisen auf das GitHub-Inhaltsverzeichnis der jeweiligen Vorlage oder des Recipes.
 
-## Qualitäts- und Vertrauenssignale
+### Vertraulichkeit
 
-- CI läuft bei Pull Requests und Pushes auf `main`.
-- Der Live-Service-Status wird über OpenStatus unter `openagreements.openstatus.dev` veröffentlicht.
-- Die Coverage wird in Codecov veröffentlicht, mit repositorydefinierten Patch-/Projekt-Gates in `codecov.yml`.
-- Das aktive JS-Testframework ist Vitest; JUnit-Testergebnisse werden für Codecov-Testanalysen hochgeladen.
-- OpenSpec-Szenario-Traceability wird über `npm run check:spec-coverage` erzwungen. Für einen lokalen Matrix-Export führe `npm run check:spec-coverage -- --write-matrix integration-tests/OPENSPEC_TRACEABILITY.md` aus.
-- Der Recipe-Source-Drift-Canary (`npm run check:source-drift`) prüft den erwarteten Source-Hash plus strukturelle Replacement-/Normalize-Anker.
-- Annahmebasierte Regressionen werden in `docs/assumptions.md` verfolgt und mit gezielten Regressionstests plus CI-Gates validiert.
-- Die LibreOffice-basierte DOCX-Visualisierung nutzt eine gepinnte Build-Konfiguration auf macOS (`config/libreoffice-headless.json`); führe vor visuellen Allure-Evidenztests `npm run check:libreoffice` aus.
-- Maintainer: [Steven Obiajulu](https://www.linkedin.com/in/steven-obiajulu/) (am MIT ausgebildeter Maschinenbauingenieur; juristisch ausgebildet an Harvard Law).
+| Vorlage | Website | Quelle | Lizenz | Repo |
+|----------|---------|--------|---------|------|
+| Bonterms Mutual NDA | [Website](https://usejunior.com/templates/bonterms-mutual-nda) | [Bonterms](https://bonterms.com/resources/mutual-nda-cover-page-example) | [CC0-1.0](https://creativecommons.org/publicdomain/zero/1.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/bonterms-mutual-nda) |
+| Common Paper Mutual NDA | [Website](https://usejunior.com/templates/common-paper-mutual-nda) | [Common Paper](https://commonpaper.com/standards/mutual-nda/1.0) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-mutual-nda) |
+| One Way NDA | [Website](https://usejunior.com/templates/common-paper-one-way-nda) | [Common Paper](https://commonpaper.com/standards/one-way-nda) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-one-way-nda) |
 
-## So funktioniert es
+### Vertrieb & Lizenzierung
 
-1. Schritt 1: Vorlage auswählen (36 Standardverträge)
-2. Schritt 2: Deine Angaben ausfüllen (interaktive Prompts oder MCP)
-3. Schritt 3: Professionell formatierte DOCX-Datei erhalten
+| Vorlage | Website | Quelle | Lizenz | Repo |
+|----------|---------|--------|---------|------|
+| Cloud Service Agreement | [Website](https://usejunior.com/templates/common-paper-cloud-service-agreement) | [Common Paper](https://commonpaper.com/standards/cloud-service-agreement/2.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-cloud-service-agreement) |
+| CSA Click Through | [Website](https://usejunior.com/templates/common-paper-csa-click-through) | [Common Paper](https://commonpaper.com/standards/cloud-service-agreement/2.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-csa-click-through) |
+| CSA With AI | [Website](https://usejunior.com/templates/common-paper-csa-with-ai) | [Common Paper](https://commonpaper.com/standards/cloud-service-agreement/2.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-csa-with-ai) |
+| CSA With SLA | [Website](https://usejunior.com/templates/common-paper-csa-with-sla) | [Common Paper](https://commonpaper.com/standards/cloud-service-agreement/2.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-csa-with-sla) |
+| CSA Without SLA | [Website](https://usejunior.com/templates/common-paper-csa-without-sla) | [Common Paper](https://commonpaper.com/standards/cloud-service-agreement/2.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-csa-without-sla) |
+| Order Form | [Website](https://usejunior.com/templates/common-paper-order-form) | [Common Paper](https://commonpaper.com/standards/cloud-service-agreement/2.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-order-form) |
+| Order Form With SLA | [Website](https://usejunior.com/templates/common-paper-order-form-with-sla) | [Common Paper](https://commonpaper.com/standards/cloud-service-agreement/2.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-order-form-with-sla) |
+| Software License Agreement | [Website](https://usejunior.com/templates/common-paper-software-license-agreement) | [Common Paper](https://commonpaper.com/standards/software-license-agreement/1.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-software-license-agreement) |
 
-OpenAgreements unterstützt zwei Ausführungsmodi mit unterschiedlichen Vertrauensgrenzen:
+### Daten & Compliance
 
-- Gehosteter Remote-MCP-Connector (`https://openagreements.org/api/mcp`) für schnelles Setup in Claude.
-- Vollständig lokale Paketausführung (`npx`, globale Installation oder lokales stdio-MCP-Paket) für machine-lokale Workflows.
+| Vorlage | Website | Quelle | Lizenz | Repo |
+|----------|---------|--------|---------|------|
+| AI Addendum | [Website](https://usejunior.com/templates/common-paper-ai-addendum) | [Common Paper](https://commonpaper.com/standards/ai-addendum/1.0) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-ai-addendum) |
+| AI Addendum In App | [Website](https://usejunior.com/templates/common-paper-ai-addendum-in-app) | [Common Paper](https://commonpaper.com/standards/ai-addendum/1.0) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-ai-addendum-in-app) |
+| Business Associate Agreement | [Website](https://usejunior.com/templates/common-paper-business-associate-agreement) | [Common Paper](https://commonpaper.com/standards/business-associate-agreement/1.0) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-business-associate-agreement) |
+| Data Processing Agreement | [Website](https://usejunior.com/templates/common-paper-data-processing-agreement) | [Common Paper](https://commonpaper.com/standards/data-processing-agreement/1.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-data-processing-agreement) |
 
-Es gibt keine globale Empfehlung für einen Standardmodus. Wähle je nach Dokument-Sensibilität, interner Policy und gewünschter Workflow-Geschwindigkeit. Siehe `docs/trust-checklist.md` für eine 60-Sekunden-Datenflussübersicht.
+### Professionelle Dienstleistungen
 
-### Schnelle Entscheidung
+| Vorlage | Website | Quelle | Lizenz | Repo |
+|----------|---------|--------|---------|------|
+| Bonterms Professional Services Agreement | [Website](https://usejunior.com/templates/bonterms-professional-services-agreement) | [Bonterms](https://bonterms.com/resources/psa-cover-page-example) | [CC0-1.0](https://creativecommons.org/publicdomain/zero/1.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/bonterms-professional-services-agreement) |
+| Independent Contractor Agreement | [Website](https://usejunior.com/templates/common-paper-independent-contractor-agreement) | [Common Paper](https://commonpaper.com/standards/independent-contractor-agreement) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-independent-contractor-agreement) |
+| Common Paper Professional Services Agreement | [Website](https://usejunior.com/templates/common-paper-professional-services-agreement) | [Common Paper](https://commonpaper.com/standards/professional-services-agreement/1.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-professional-services-agreement) |
+| Statement Of Work | [Website](https://usejunior.com/templates/common-paper-statement-of-work) | [Common Paper](https://commonpaper.com/standards/statement-of-work) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-statement-of-work) |
 
-- Wenn dein Dokument sensibel ist, nutze vollständig lokale Paketausführung.
-- Wenn du Bequemlichkeit priorisierst, nutze den gehosteten Remote-MCP-Connector.
+### Deals & Partnerschaften
 
-## Nutzung mit Claude Code
+| Vorlage | Website | Quelle | Lizenz | Repo |
+|----------|---------|--------|---------|------|
+| Amendment | [Website](https://usejunior.com/templates/common-paper-amendment) | [Common Paper](https://commonpaper.com/standards/amendment) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-amendment) |
+| Design Partner Agreement | [Website](https://usejunior.com/templates/common-paper-design-partner-agreement) | [Common Paper](https://commonpaper.com/standards/design-partner-agreement/1.3) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-design-partner-agreement) |
+| Letter Of Intent | [Website](https://usejunior.com/templates/common-paper-letter-of-intent) | [Common Paper](https://commonpaper.com/standards/letter-of-intent) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-letter-of-intent) |
+| Partnership Agreement | [Website](https://usejunior.com/templates/common-paper-partnership-agreement) | [Common Paper](https://commonpaper.com/standards/partnership-agreement/1.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-partnership-agreement) |
+| Pilot Agreement | [Website](https://usejunior.com/templates/common-paper-pilot-agreement) | [Common Paper](https://commonpaper.com/standards/pilot-agreement/1.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-pilot-agreement) |
+| Term Sheet | [Website](https://usejunior.com/templates/common-paper-term-sheet) | [Common Paper](https://commonpaper.com/standards/term-sheet) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-term-sheet) |
 
-OpenAgreements funktioniert als [Claude Code plugin](https://docs.anthropic.com/en/docs/claude-code/plugins) und [Agent Skill](https://agentskills.io). Keine Vorinstallation erforderlich — Claude lädt und startet die CLI bei Bedarf über `npx`.
+### Arbeitsverhältnis
 
-### Option 1: Agent Skill (empfohlen)
+| Vorlage | Website | Quelle | Lizenz | Repo |
+|----------|---------|--------|---------|------|
+| Employee IP Inventions Assignment | [Website](https://usejunior.com/templates/openagreements-employee-ip-inventions-assignment) | [OpenAgreements](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-employee-ip-inventions-assignment) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-employee-ip-inventions-assignment) |
+| Employment Confidentiality Acknowledgement | [Website](https://usejunior.com/templates/openagreements-employment-confidentiality-acknowledgement) | [OpenAgreements](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-employment-confidentiality-acknowledgement) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-employment-confidentiality-acknowledgement) |
+| Employment Offer Letter | [Website](https://usejunior.com/templates/openagreements-employment-offer-letter) | [OpenAgreements](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-employment-offer-letter) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-employment-offer-letter) |
+| Restrictive Covenant Wyoming | [Website](https://usejunior.com/templates/openagreements-restrictive-covenant-wyoming) | [OpenAgreements](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-restrictive-covenant-wyoming) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-restrictive-covenant-wyoming) |
 
-```bash
-npx skills add open-agreements/open-agreements
+### SAFEs
+
+| Vorlage | Website | Quelle | Lizenz | Repo |
+|----------|---------|--------|---------|------|
+| Discount | [Website](https://usejunior.com/templates/yc-safe-discount) | [Y Combinator](https://www.ycombinator.com/documents) | [CC-BY-ND-4.0](https://creativecommons.org/licenses/by-nd/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/external/yc-safe-discount) |
+| MFN | [Website](https://usejunior.com/templates/yc-safe-mfn) | [Y Combinator](https://www.ycombinator.com/documents) | [CC-BY-ND-4.0](https://creativecommons.org/licenses/by-nd/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/external/yc-safe-mfn) |
+| Pro Rata Side Letter | [Website](https://usejunior.com/templates/yc-safe-pro-rata-side-letter) | [Y Combinator](https://www.ycombinator.com/documents) | [CC-BY-ND-4.0](https://creativecommons.org/licenses/by-nd/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/external/yc-safe-pro-rata-side-letter) |
+| Valuation Cap | [Website](https://usejunior.com/templates/yc-safe-valuation-cap) | [Y Combinator](https://www.ycombinator.com/documents) | [CC-BY-ND-4.0](https://creativecommons.org/licenses/by-nd/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/external/yc-safe-valuation-cap) |
+
+### Venture-Finanzierung
+
+| Vorlage | Website | Quelle | Lizenz | Repo |
+|----------|---------|--------|---------|------|
+| Certificate Of Incorporation | [Website](https://usejunior.com/templates/nvca-certificate-of-incorporation) | [NVCA](https://nvca.org/wp-content/uploads/2025/10/NVCA-Model-COI-10-1-2025.docx) | Recipe | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/recipes/nvca-certificate-of-incorporation) |
+| Indemnification Agreement | [Website](https://usejunior.com/templates/nvca-indemnification-agreement) | [NVCA](https://nvca.org/wp-content/uploads/2021/12/NVCA-2020-Indemnification-Agreement.docx) | Recipe | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/recipes/nvca-indemnification-agreement) |
+| Investors Rights Agreement | [Website](https://usejunior.com/templates/nvca-investors-rights-agreement) | [NVCA](https://nvca.org/wp-content/uploads/2025/10/NVCA-Model-IRA-10-1-2025-2-1.docx) | Recipe | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/recipes/nvca-investors-rights-agreement) |
+| Management Rights Letter | [Website](https://usejunior.com/templates/nvca-management-rights-letter) | [NVCA](https://nvca.org/wp-content/uploads/2025/12/NVCA-2020-Management-Rights-Letter-1-1.docx) | Recipe | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/recipes/nvca-management-rights-letter) |
+| ROFR Co Sale Agreement | [Website](https://usejunior.com/templates/nvca-rofr-co-sale-agreement) | [NVCA](https://nvca.org/wp-content/uploads/2025/10/NVCA-Model-ROFRA-10-1-2025.docx) | Recipe | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/recipes/nvca-rofr-co-sale-agreement) |
+| Stock Purchase Agreement | [Website](https://usejunior.com/templates/nvca-stock-purchase-agreement) | [NVCA](https://nvca.org/wp-content/uploads/2025/10/NVCA-Model-SPA-10-28-2025-1.docx) | Recipe | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/recipes/nvca-stock-purchase-agreement) |
+| Voting Agreement | [Website](https://usejunior.com/templates/nvca-voting-agreement) | [NVCA](https://nvca.org/wp-content/uploads/2024/10/NVCA-Model-VA-10-1-2025.docx) | Recipe | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/recipes/nvca-voting-agreement) |
+
+### Sonstiges
+
+| Vorlage | Website | Quelle | Lizenz | Repo |
+|----------|---------|--------|---------|------|
+| Closing Checklist | [Website](https://usejunior.com/templates/closing-checklist) | [OpenAgreements](https://github.com/open-agreements/open-agreements) | [CC0-1.0](https://creativecommons.org/publicdomain/zero/1.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/closing-checklist) |
+| Board Consent SAFE | [Website](https://usejunior.com/templates/openagreements-board-consent-safe) | [OpenAgreements](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-board-consent-safe) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-board-consent-safe) |
+| Due Diligence Request List | [Website](https://usejunior.com/templates/openagreements-due-diligence-request-list) | [OpenAgreements](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-due-diligence-request-list) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-due-diligence-request-list) |
+| Stockholder Consent SAFE | [Website](https://usejunior.com/templates/openagreements-stockholder-consent-safe) | [OpenAgreements](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-stockholder-consent-safe) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-stockholder-consent-safe) |
+| Working Group List | [Website](https://usejunior.com/templates/working-group-list) | [OpenAgreements](https://github.com/open-agreements/open-agreements) | [CC0-1.0](https://creativecommons.org/publicdomain/zero/1.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/working-group-list) |
+
+## Verfügbare Skills
+
+### Vertragserstellung und -befüllung
+
+| Skill | Beschreibung |
+|-------|-------------|
+| [open-agreements](https://github.com/open-agreements/open-agreements/tree/main/skills/open-agreements) | Standardisierte juristische Vertragsvorlagen ausfüllen (NDAs, Cloud-Service-Verträge, SAFEs) und signierbare DOCX-Dateien erzeugen. Unterstützt Common Paper-, Bonterms- und Y-Combinator-Vorlagen. Verwende, wenn der Nutzer einen Vertrag entwerfen, eine NDA erstellen, eine Vertragsvorlage ausfüllen oder ein SAFE generieren möchte. Kann Verträge auch per DocuSign zur elektronischen Unterschrift versenden. |
+| [nda](https://github.com/open-agreements/open-agreements/tree/main/skills/nda) | NDA-Vorlagen entwerfen und ausfüllen — Mutual NDA, One-Way NDA, Vertraulichkeitsvereinbarung. Erzeugt signierbare DOCX-Dateien aus Common Paper- und Bonterms-Standardformularen. Verwende, wenn der Nutzer „NDA“, „Geheimhaltungsvereinbarung“, „Vertraulichkeitsvereinbarung“, „Mutual NDA“ oder „One-Way NDA“ sagt. |
+| [cloud-service-agreement](https://github.com/open-agreements/open-agreements/tree/main/skills/cloud-service-agreement) | SaaS-Vertragsvorlagen entwerfen und ausfüllen — Cloud-Vertrag, MSA, Order Form, Software-Lizenz, Pilot Agreement, Design Partner Agreement. Inklusive Varianten mit SLAs und KI-Bedingungen. Erzeugt signierbare DOCX aus Common Paper-Standardformularen. Verwende, wenn der Nutzer „SaaS-Vertrag“, „Cloud-Vertrag“, „MSA“, „Order Form“, „Softwarelizenz“, „Pilot Agreement“ oder „Design Partner Agreement“ sagt. |
+| [services-agreement](https://github.com/open-agreements/open-agreements/tree/main/skills/services-agreement) | Dienstleistungsvertragsvorlagen entwerfen und ausfüllen — Beratungsvertrag, Contractor-Vertrag, SOW, Statement of Work, Professional Services Agreement. Erzeugt signierbare DOCX-Dateien aus Common Paper- und Bonterms-Standardformularen. Verwende, wenn der Nutzer „Beratungsvertrag“, „Contractor-Vertrag“, „SOW“, „Statement of Work“, „Dienstleistungsvertrag“ oder „Freelancer-Vertrag“ sagt. |
+| [employment-contract](https://github.com/open-agreements/open-agreements/tree/main/skills/employment-contract) | Arbeitsvertragsvorlagen entwerfen und ausfüllen — Offer Letter, IP-Assignment, PIIA, Vertraulichkeitsbestätigung. Erzeugt signierbare DOCX-Dateien aus OpenAgreements-Standardformularen für die Einstellung von Mitarbeiter:innen. Verwende, wenn der Nutzer „Offer Letter“, „Arbeitsvertrag“, „PIIA“, „IP-Assignment“, „jemanden einstellen“ oder „Onboarding-Unterlagen“ sagt. |
+| [data-privacy-agreement](https://github.com/open-agreements/open-agreements/tree/main/skills/data-privacy-agreement) | Datenschutzvertragsvorlagen entwerfen und ausfüllen — DPA, Datenverarbeitungsvertrag, DSGVO, HIPAA BAA, Business Associate Agreement, KI-Addendum. Erzeugt signierbare DOCX-Dateien aus Common Paper-Standardformularen. Verwende, wenn der Nutzer „DPA“, „Datenverarbeitungsvertrag“, „HIPAA BAA“, „Business Associate Agreement“ oder „KI-Addendum“ sagt. |
+| [safe](https://github.com/open-agreements/open-agreements/tree/main/skills/safe) | Y-Combinator-SAFE-Vorlagen entwerfen und ausfüllen — Valuation Cap, Discount, MFN, Pro Rata Side Letter. Standardisierte Startup-Finanzierungsdokumente für wandelbare Beteiligungen. Erzeugt signierbare DOCX-Dateien. Verwende, wenn der Nutzer „SAFE“, „simple agreement for future equity“, „YC SAFE“, „Valuation Cap“, „Seed-Runden-Dokumente“ oder „Fundraising-Unterlagen“ sagt. |
+| [venture-financing](https://github.com/open-agreements/open-agreements/tree/main/skills/venture-financing) | NVCA-Modell-Dokumente entwerfen und ausfüllen — Stock Purchase Agreement, Certificate of Incorporation, Investors Rights Agreement, Voting Agreement, ROFR, Co-Sale, Indemnification, Management Rights Letter. Series-A- und Venture-Financing-Vorlagen. Erzeugt signierbare DOCX-Dateien. Verwende, wenn der Nutzer „Series-A-Dokumente“, „NVCA“, „Stock Purchase Agreement“, „Investors Rights Agreement“, „Voting Agreement“ oder „Venture-Financing-Docs“ sagt. |
+
+### Bearbeitung und Kundenworkflows
+
+| Skill | Beschreibung |
+|-------|-------------|
+| [edit-docx-agreement](https://github.com/open-agreements/open-agreements/tree/main/skills/edit-docx-agreement) | Maßgeschneiderte Änderungen an einer von OpenAgreements erzeugten (oder beliebigen bestehenden) DOCX-Vertragsdatei vornehmen — mit Safe-Docx-MCP-Tools für chirurgische, formatierungserhaltende Edits und Tracked-Changes-Ausgaben. Verwende, wenn der Nutzer „diesen Vertrag bearbeiten“, „eine Klausel ändern“, „den Vertrag anpassen“, „individuelle Änderungen an der DOCX“ oder „maßgeschneiderte Änderungen am Dokument“ sagt. |
+| [client-email](https://github.com/open-agreements/open-agreements/tree/main/skills/client-email) | Mandantengerichtete E-Mails für juristische Dienstleistungen entwerfen — Anschreiben für Vertrags-Lieferungen, Redline-Zusammenfassungen, Deal-Status-Updates und Follow-ups. Verwende beim Verfassen oder Überarbeiten von ausgehenden E-Mails an Mandant:innen zu juristischen Arbeitsergebnissen. Wird durch „Antwort entwerfen“, „E-Mail an Mandant“, „Anschreiben“, „zurückschreiben an“ oder beliebige Begleit-E-Mails zu juristischen Lieferungen ausgelöst. |
+| [delaware-franchise-tax](https://github.com/open-agreements/open-agreements/tree/main/skills/delaware-franchise-tax) | Reiche deine jährliche Delaware Franchise Tax und den Annual Report ein. Führt dich durch die Steuerberechnung (Authorized Shares- und Assumed-Par-Value-Capital-Methoden), den Einreichungsprozess über das eCorp-Portal sowie die Zahlung. Für Delaware C-Corps (Frist 1. März) und LLCs/LPs/GPs (Frist 1. Juni). Verwende, wenn der Nutzer „Delaware Franchise Tax“, „Annual Report Delaware“, „Franchise Tax einreichen“ oder „eCorp-Portal“ sagt. |
+
+### Compliance und Audit
+
+| Skill | Beschreibung |
+|-------|-------------|
+| [soc2-readiness](https://github.com/open-agreements/open-agreements/tree/main/skills/soc2-readiness) | SOC-2-Type-II-Readiness bewerten. Trust Services Criteria auf Controls abbilden, Lücken identifizieren und einen Remediation-Plan erstellen. Nutzt NIST SP 800-53 (Public Domain) als kanonische Referenz mit SOC-2-Cross-Mapping. Verwende, wenn der Nutzer „SOC-2-Readiness“, „SOC-2-Vorbereitung“, „SOC-2-Gap-Analyse“ oder „auf SOC-2-Audit vorbereiten“ sagt. |
+| [iso-27001-internal-audit](https://github.com/open-agreements/open-agreements/tree/main/skills/iso-27001-internal-audit) | Ein ISO-27001-internes Audit durchführen. Controls nach Domäne durchgehen, Lücken identifizieren, Evidenz sammeln und Findings mit Korrekturmaßnahmen-Empfehlungen erzeugen. Nutzt NIST SP 800-53 (Public Domain) als kanonische Referenz. Verwende, wenn der Nutzer „internes Audit durchführen“, „ISO-27001-Audit“, „Control-Assessment“, „Audit-Findings“ oder „ISMS-Assessment“ sagt. |
+| [iso-27001-evidence-collection](https://github.com/open-agreements/open-agreements/tree/main/skills/iso-27001-evidence-collection) | Evidenz für ISO-27001- und SOC-2-Audits sammeln, organisieren und validieren. API-First-Ansatz mit CLI-Befehlen für große Cloud-Plattformen. Erzeugt zeitgestempelte, auditbereite Evidenzpakete. Verwende, wenn der Nutzer „Audit-Evidenz sammeln“, „Evidenzpaket vorbereiten“, „Evidenz für den Auditor“, „Evidenz aktualisieren“ oder „Evidenz-Gap-Analyse“ sagt. |
+
+### Developer-Workflows
+
+| Skill | Beschreibung |
+|-------|-------------|
+| [recipe-quality-audit](https://github.com/open-agreements/open-agreements/tree/main/skills/recipe-quality-audit) | NVCA-Recipe-Qualität auditieren: Dateiinventar, Metadatenschema, Field-zu-Replacement-Coverage, mehrdeutige Keys, Smart Quotes, Testfixtures und Befüllungsqualität prüfen. Erzeugt eine strukturierte Scorecard pro Recipe mit Reifegrad-Klassifikation. Verwende, wenn der Nutzer „Recipe-Qualität auditieren“, „Recipe-Coverage prüfen“, „Recipe-Scorecard“ oder „NVCA-Recipe-Qualität“ sagt. |
+| [unit-test-philosophy](https://github.com/open-agreements/open-agreements/tree/main/skills/unit-test-philosophy) | Risikobasiertes Unit-Testing und Allure-lesbarer Behavioral-Spec-Stil für open-agreements. Verwende, wenn der Nutzer „Tests hinzufügen“, „Testqualität“, „Coverage erweitern“, „Unit-Test-Stil“ oder „Allure-Test-Spec“ sagt. Gilt beim Hinzufügen/Aktualisieren von Tests, beim Ausbau der Coverage oder beim Review der Testqualität in src, integration-tests und Workspace-Paketen. |
+
+### Template-Erstellung
+
+| Skill | Beschreibung |
+|-------|-------------|
+| [canonical-markdown-authoring](https://github.com/open-agreements/open-agreements/tree/main/skills/canonical-markdown-authoring) | Konvertiere einfache Markdown-Vertragsentwürfe in OpenAgreements’ kanonisches template.md-Authoring-Format — YAML-Frontmatter, Kind|Label|Value|Show-When-Cover-Term-Tabellen, oa:clause-Direktiven, [[Defined Term]]-Absätze und oa:signer-Direktiven, die zu validierten JSON-Specs und DOCX-Artefakten kompiliert werden. Verwende, wenn der Nutzer „in kanonisches Markdown konvertieren“, „eine neue OpenAgreements-Vorlage erstellen“, „Vorlage auf template.md migrieren“ oder „einen Vertrag in kanonischer Form schreiben“ sagt. |
+
+## Pakete
+
+| Paket | Beschreibung |
+|---------|-------------|
+| [open-agreements](https://www.npmjs.com/package/open-agreements) | Open-Source-CLI und -Bibliothek zum Befüllen juristischer Vorlagen |
+| [@open-agreements/contract-templates-mcp](https://github.com/open-agreements/open-agreements/blob/main/packages/contract-templates-mcp/README.md) | Lokaler stdio-MCP-Server für die Entdeckung und Befüllung von OpenAgreements-Vorlagen |
+| [@open-agreements/contracts-workspace](https://github.com/open-agreements/open-agreements/blob/main/packages/contracts-workspace/README.md) | Workspace-orientierte CLI zur Organisation und Nachverfolgung von Vertrags-Repositorys |
+| [@open-agreements/contracts-workspace-mcp](https://github.com/open-agreements/open-agreements/blob/main/packages/contracts-workspace-mcp/README.md) | Lokaler stdio-MCP-Server für Contracts-Workspace-Operationen |
+| [@open-agreements/checklist-mcp](https://github.com/open-agreements/open-agreements/blob/main/packages/checklist-mcp/README.md) | Lokaler stdio-MCP-Server für OpenAgreements-Checklist-Memory-Operationen |
+
+### Was installiert wird
+
+```text
+open-agreements/
+  bin/                    # CLI entry point
+  dist/                   # Compiled TypeScript
+  content/
+    templates/            # Fillable DOCX templates with {tag} placeholders
+    external/             # YC SAFE templates vendored unchanged
+    recipes/              # Recipe instructions for non-redistributable sources
+  skills/                 # Agent skill definitions
+  server.json             # MCP server manifest
+  gemini-extension.json   # Gemini CLI extension config
+  README.md, LICENSE
 ```
 
-Bitte Claude anschließend, einen Vertrag zu entwerfen:
+NVCA-Recipe-Vorlagen werden zur Laufzeit heruntergeladen und sind nicht im Paket enthalten.
 
-```
-> Draft an NDA between Acme Corp and Beta Inc
-```
-
-Claude erkennt verfügbare Vorlagen, fragt Feldwerte interaktiv ab und rendert eine signierbereite DOCX-Datei.
-
-### Option 2: Gemini CLI Extension
-
-```bash
-gemini extensions install https://github.com/open-agreements/open-agreements
-```
-
-Bitte Gemini anschließend, einen Vertrag zu entwerfen. Die Extension stellt MCP-Tools, Kontextdateien und Skills für Template-Discovery und Befüllung bereit.
-
-### Option 3: Direkt mit Claude Code
-
-Wenn du Node.js >= 20 hast, frage Claude einfach:
-
-```
-> Fill the Common Paper mutual NDA for my company
-```
-
-Claude führt `npx -y open-agreements@latest list --json` zur Vorlagenerkennung aus und danach `npx -y open-agreements@latest fill <template>` für die Ausgabe. Keine Installation.
-
-### Option 4: CLI
-
-```bash
-# Install globally
-npm install -g open-agreements
-
-# List available templates
-open-agreements list
-
-# Fill a template
-open-agreements fill common-paper-mutual-nda -d values.json -o my-nda.docx
-```
-
-### Was passiert
-
-1. Claude führt `list --json` aus, um verfügbare Vorlagen und Felder zu erkennen
-2. Claude fragt Feldwerte ab (nach Abschnitten gruppiert, bis zu 4 Fragen pro Runde)
-3. Claude führt `fill <template>` aus, um eine DOCX mit unverändertem Originalformat zu rendern
-4. Du prüfst und unterschreibst das Ausgabedokument
-
-## Nutzung mit Cursor
-
-Dieses Repository enthält ein Cursor-Plugin-Manifest mit MCP-Verdrahtung:
-
-- Plugin manifest: `.cursor-plugin/plugin.json`
-- MCP config: `mcp.json`
-- Skill: `skills/open-agreements/SKILL.md`
-
-Das Standard-MCP-Setup in `mcp.json` enthält:
-
-- Gehosteten OpenAgreements-MCP-Connector (`https://openagreements.org/api/mcp`)
-- Lokalen Workspace-MCP-Server (`npx -y @open-agreements/contracts-workspace-mcp`)
-- Lokalen Template-Drafting-MCP-Server (`npx -y @open-agreements/contract-templates-mcp`)
-
-Um dieses Plugin im Cursor Marketplace zu veröffentlichen, reiche dieses Repository ein unter:
-
-- https://cursor.com/marketplace/publish
-
-## Vorlagen
-
-28 Vorlagen in drei Tiers. Führe `open-agreements list` aus, um das vollständige Inventar zu sehen.
-
-| Tier | Anzahl | Quelle | Funktionsweise |
-|------|-------|--------|--------------|
-| Interne Vorlagen | 17 | [Common Paper](https://commonpaper.com), [Bonterms](https://bonterms.com), OpenAgreements | Im Paket enthalten, CC BY 4.0 |
-| Externe Vorlagen | 4 | [Y Combinator](https://www.ycombinator.com/documents) | Unverändert vendored, CC BY-ND 4.0 |
-| Recipes | 7 | [NVCA](https://nvca.org/model-legal-documents/) | Bei Bedarf heruntergeladen (nicht redistributable) |
-
-**Interne Vorlagen** (NDAs, Cloud-Bedingungen, Beschäftigungsformulare, Contractor-Verträge usw.) sind CC BY 4.0 — wir liefern DOCX-Dateien mit `{tag}`-Platzhaltern.
-
-**Externe Vorlagen** (YC SAFEs) sind CC BY-ND 4.0 — wir übernehmen das Original unverändert. Die ausgefüllte Ausgabe ist ein transient derivative auf deinem Rechner.
-
-**Recipes** (NVCA-Finanzierungsdokumente) sind frei herunterladbar, aber nicht redistributable — wir liefern nur Transformationsanweisungen und laden die Source-DOCX zur Laufzeit von nvca.org.
-
-### Guidance-Extraktion
-
-Source-Dokumente enthalten Expertenkommentare — Fußnoten, Drafting-Hinweise, `[Comment: ...]`-Blöcke — von Domänenexpert:innen (z. B. Wertpapierrechtler:innen). Der Recipe-Cleaner entfernt diese Inhalte, um ein ausfüllbares Dokument zu erzeugen, kann sie aber auch als strukturiertes JSON extrahieren:
-
-```bash
-open-agreements recipe clean source.docx -o cleaned.docx \
-  --recipe nvca-indemnification-agreement \
-  --extract-guidance guidance.json
-```
-
-Das erzeugt eine `guidance.json` mit jeder entfernten Fußnote, jedem Kommentar und jedem Drafting-Hinweis, getaggt nach Quelltyp und Dokumentposition. Guidance ist ein lokales Artefakt (wird nicht committed oder ausgeliefert), das AI-Agenten oder menschliche Autor:innen beim Ausfüllen referenzieren können. Siehe [Adding Recipes — Guidance Extraction](docs/adding-recipes.md#guidance-extraction) für Formatdetails.
-
-**Warum programmgesteuerte Extraktion?** Das Source-Dokument ist die Single Source of Truth. Nach einem Publisher-Update liefert erneute Extraktion ohne manuelle Arbeit aktuelle Guidance, bewahrt die exakte Sprache von Domänenexpert:innen und erfasst alles — eine KI kann ad hoc zusammenfassen, aber verworfene Inhalte nicht wiederherstellen.
-
-Jede Vorlage ist ein eigenständiges Verzeichnis:
-
-```
-content/templates/<name>/
-├── template.docx     # DOCX with {tag} placeholders
-├── metadata.yaml     # Fields, license, source, attribution
-└── README.md         # Template-specific documentation
-```
-
-## CLI-Befehle
-
-### `fill <template>`
-
-Rendert eine ausgefüllte DOCX aus einer Vorlage.
-
-```bash
-# Using a JSON data file
-open-agreements fill common-paper-mutual-nda -d data.json -o output.docx
-
-# Using inline --set flags
-open-agreements fill common-paper-mutual-nda --set party_1_name="Acme Corp" --set governing_law="Delaware"
-```
-
-### `validate [template]`
-
-Führt die Validierungspipeline für eine oder alle Vorlagen aus.
-
-```bash
-open-agreements validate                          # All templates
-open-agreements validate common-paper-mutual-nda  # One template
-```
+<details>
+<summary><strong>CLI-Referenz</strong></summary>
 
 ### `list`
 
@@ -204,174 +215,201 @@ Zeigt verfügbare Vorlagen mit Lizenzinformationen und Feldanzahl.
 ```bash
 open-agreements list
 
-# Machine-readable JSON output (for agent skills and automation)
+# Machine-readable JSON for agent skills and automation
 open-agreements list --json
 ```
 
-## Contracts Workspace CLI (separates Paket)
+### `fill <template>`
 
-OpenAgreements enthält jetzt ein Schwesterpaket für Repository-/Workspace-Operationen:
-
-- Package: `@open-agreements/contracts-workspace`
-- Binary: `open-agreements-workspace`
-- Docs: `docs/contracts-workspace.md`
-
-Dieses Paket ist bewusst von `open-agreements` getrennt, sodass Teams nutzen können:
-
-- nur Template-Befüllung
-- nur Workspace-Management
-- oder beides zusammen
-
-Kernfunktionen des Workspace-Pakets:
-
-- topic-first `init`-Planung (minimale empfohlene Struktur mit Top-Level-Domänen)
-- Form-Katalog mit URL- und SHA-256-Validierung
-- YAML-Status-Indexierung und Linting mit dateinamengetriebenem `_executed`-Status
-
-Das v1-Modell ist rein dateisystembasiert und funktioniert in lokal synchronisierten Cloud-Drive-Ordnern (z. B. Google-Drive-Sync). Keine Drive-API-/OAuth-Integration erforderlich.
-
-## Lokales MCP für Workspace-Demo
-
-Für lokale Connector-Demos gibt es ein lokales stdio-MCP-Paket:
-
-- Package: `@open-agreements/contracts-workspace-mcp`
-- Binary: `open-agreements-workspace-mcp`
-- Docs: `docs/contracts-workspace.md`
-
-Schnellstart:
+Rendert eine ausgefüllte DOCX aus einer Vorlage.
 
 ```bash
-npm run build:workspace-mcp
-node packages/contracts-workspace-mcp/bin/open-agreements-workspace-mcp.js
+# From a JSON data file
+open-agreements fill common-paper-mutual-nda -d data.json -o output.docx
+
+# With inline --set flags
+open-agreements fill common-paper-mutual-nda --set party_1_name="Acme Corp" --set governing_law="Delaware"
 ```
 
-## Lokales MCP für Template-Drafting
+### `validate [template]`
 
-Für lokale Gemini-/Cursor-Template-Drafting-Workflows nutze:
-
-- Package: `@open-agreements/contract-templates-mcp`
-- Binary: `open-agreements-contract-templates-mcp`
-
-Schnellstart:
+Führt die Validierungspipeline für eine oder alle Vorlagen aus.
 
 ```bash
-npm run build:contract-templates-mcp
-node packages/contract-templates-mcp/bin/open-agreements-contract-templates-mcp.js
+open-agreements validate
+open-agreements validate common-paper-mutual-nda
 ```
 
-## Website (Vercel)
+</details>
 
-`site/` ist ein schlanker Protocol-Host, der mit Eleventy gebaut wird.
+<details>
+<summary><strong>Agent-Setup-Details</strong></summary>
 
-- Discovery-Metadaten: `site/.well-known/`
-- JSON-Schemas: `site/schemas/`
-- Statische Blanko-DOCX-Downloads: `site/downloads/`
-- Vorschau-Assets: `site/assets/previews/`
-- Serverless-API-Handler: `api/`
-- Discovery outputs (generated during `npm run build:site`): `_site/llms.txt`, `_site/llms-full.txt`, `_site/sitemap.xml`, `_site/robots.txt`
-
-Lokale Vorschau:
+### Claude Code
 
 ```bash
-npm run build:site
-python3 -m http.server 8080 --directory _site
+npx skills add open-agreements/open-agreements
 ```
 
-Prüfe dann z. B. `http://localhost:8080/.well-known/mcp-server-card`, `http://localhost:8080/llms.txt` oder die erzeugten Dateien unter `_site/`.
+### Gemini CLI
 
-Vercel-Deploy-Hinweise:
+```bash
+gemini extensions install https://github.com/open-agreements/open-agreements
+```
 
-- Importiere dieses Repository in Vercel
-- Belasse das Projekt-Root auf dem Repository-Root
-- Das enthaltene `vercel.json` deployt `_site/` als statische Ausgabe
+### Cursor
 
-## Optionale Content-Roots (Future-Proofing)
+Dieses Repository enthält ein Cursor-Plugin-Manifest unter `.cursor-plugin/plugin.json` mit MCP-Verdrahtung in `mcp.json`.
 
-Um logische Entkopplung bei wachsenden Form-Bibliotheken zu unterstützen, kann `open-agreements` Inhalte aus zusätzlichen Roots laden über:
+### Lokale vs. gehostete Ausführung
 
-- env var: `OPEN_AGREEMENTS_CONTENT_ROOTS`
-- format: pfadgetrennte Liste absoluter/relativer Verzeichnisse (z. B. `dirA:dirB` auf macOS/Linux)
-- erwartete Struktur unter jedem Root: `templates/`, `external/` und/oder `recipes/` (oder verschachtelt unter `content/`)
+- **Lokal**: `npx`, globale Installation oder stdio-MCP. Die Verarbeitung erfolgt auf deinem Rechner.
+- **Gehostet**: `https://openagreements.org/api/mcp`. Die Vorlagenbefüllung läuft serverseitig für schnelleres Setup.
 
-Lookup-Priorität:
+Wähle je nach Dokumentsensibilität und interner Richtlinie. Siehe die Trust-Checklist unten für die Datenflussübersicht.
 
-1. Roots in `OPEN_AGREEMENTS_CONTENT_ROOTS` (in der angegebenen Reihenfolge)
-2. gebündelter Package-Content (Standard-Fallback)
+</details>
 
-So bleiben Standardinstallationen einfach, während fortgeschrittene Nutzer große Content-Bibliotheken außerhalb des Kernpakets ablegen können.
+## Schnellstart
+
+### Mit Claude Code
+
+Frage Claude:
+
+```text
+Fill the Common Paper mutual NDA for my company
+```
+
+Claude kann Vorlagen entdecken, dich nach Feldwerten befragen und eine signierbereite DOCX rendern.
+
+### Mit der CLI
+
+```bash
+# See all available templates
+open-agreements list
+
+# Fill a template from a JSON data file
+open-agreements fill common-paper-mutual-nda -d values.json -o my-nda.docx
+
+# Fill with inline values
+open-agreements fill common-paper-mutual-nda --set party_1_name="Acme Corp" --set governing_law="Delaware"
+```
+
+### Beispiel-Prompts
+
+- „Entwirf eine NDA für unseren Bau-Subunternehmer“
+- „Erstelle einen Beratungsvertrag für unsere Versicherungsagentur“
+- „Fülle den Independent-Contractor-Agreement für eine freiberufliche Designerin aus“
+- „Erzeuge ein SAFE mit einem Valuation Cap von 5 Mio. $“
+
+### Was passiert
+
+1. Der Agent führt `list --json` aus, um Vorlagen und ihre Felder zu entdecken.
+2. Er fragt dich nach Feldwerten, gruppiert nach Abschnitt.
+3. Er führt `fill <template>` aus, um eine DOCX unter Beibehaltung der ursprünglichen Formatierung zu rendern.
+4. Du prüfst und unterschreibst das Ausgabedokument.
+
+## Installation
+
+### Agent Skill (empfohlen)
+
+```bash
+npx skills add open-agreements/open-agreements
+```
+
+### Remote-MCP
+
+Verbinde jeden MCP-kompatiblen Agenten mit dem gehosteten Server unter `https://openagreements.org/api/mcp`.
+
+**Claude Code**
+
+```bash
+claude mcp add --transport http open-agreements https://openagreements.org/api/mcp
+```
+
+**Codex CLI**
+
+```bash
+codex mcp add open-agreements --url https://openagreements.org/api/mcp
+```
+
+**Andere Agenten** — richte deinen Client auf `https://openagreements.org/api/mcp` (streamable HTTP).
+
+### Gemini-CLI-Extension
+
+```bash
+gemini extensions install https://github.com/open-agreements/open-agreements
+```
+
+### CLI
+
+```bash
+npm install -g open-agreements
+```
+
+Oder direkt ohne Installation ausführen:
+
+```bash
+npx -y open-agreements@latest list
+```
+
+---
+
+## Dokumentation
+
+### Starte hier
+
+- [Getting Started](https://github.com/open-agreements/open-agreements/blob/main/docs/getting-started.md)
+
+### Anleitungen
+
+- [Adding Templates](https://github.com/open-agreements/open-agreements/blob/main/docs/adding-templates.md)
+- [Adding Recipes](https://github.com/open-agreements/open-agreements/blob/main/docs/adding-recipes.md)
+
+### Weitere Pakete
+
+- [Contracts Workspace CLI](https://github.com/open-agreements/open-agreements/blob/main/docs/contracts-workspace.md)
+
+### Referenz
+
+- [Licensing](https://github.com/open-agreements/open-agreements/blob/main/docs/licensing.md)
+- [Changelog & Release Process](https://github.com/open-agreements/open-agreements/blob/main/docs/changelog-release-process.md)
+- [Trust Checklist](https://github.com/open-agreements/open-agreements/blob/main/docs/trust-checklist.md)
+- [Supported Tools](https://github.com/open-agreements/open-agreements/blob/main/docs/supported-tools.md)
+- [Assumptions](https://github.com/open-agreements/open-agreements/blob/main/docs/assumptions.md)
+- [Employment Source Policy](https://github.com/open-agreements/open-agreements/blob/main/docs/employment-source-policy.md)
+
+**Links:** [Website](https://usejunior.com) | [Vorlagenkatalog](https://usejunior.com/templates) | [Docs](https://github.com/open-agreements/open-agreements/tree/main/docs) | [Trust](https://usejunior.com/security) | [npm](https://www.npmjs.com/package/open-agreements)
+
+## Datenschutz
+
+- **Lokaler Modus** (`npx`, globale Installation, stdio-MCP): Die gesamte Verarbeitung erfolgt auf deinem Rechner. Es werden keine Dokumentinhalte nach außen gesendet.
+- **Gehosteter Modus** (`https://openagreements.org/api/mcp`): Die Vorlagenbefüllung läuft serverseitig. Es werden keine ausgefüllten Dokumente nach der Rückgabe der Antwort gespeichert.
+
+Details in der [Datenschutzerklärung](https://usejunior.com/privacy_policy).
 
 ## Siehe auch
 
-- [safe-docx](https://github.com/UseJunior/safe-docx) — chirurgische Bearbeitung bestehender Word-Dokumente mit Coding-Agents (MCP-Server)
-- [UseJunior Developer Tools](https://usejunior.com/developer-tools/open-agreements) — Produktseite mit Installationsoptionen und Vorlagenkatalog
+- [safe-docx](https://github.com/UseJunior/safe-docx) — chirurgische Bearbeitung bestehender Word-Dokumente mit Coding-Agents
 
 ## Mitwirken
 
-Siehe [CONTRIBUTING.md](CONTRIBUTING.md), um Vorlagen, Recipes und andere Verbesserungen hinzuzufügen.
+Siehe [CONTRIBUTING.md](https://github.com/open-agreements/open-agreements/blob/main/CONTRIBUTING.md), um Vorlagen, Recipes und andere Verbesserungen hinzuzufügen.
 
-- [Adding templates](docs/adding-templates.md) (CC BY 4.0 / CC0-Quellen)
-- [Adding recipes](docs/adding-recipes.md) (nicht redistributable Quellen)
-- [Employment source policy](docs/employment-source-policy.md) (Trust- und Terms-Klassifikationen)
-- [Code of Conduct](CODE_OF_CONDUCT.md) (Community-Erwartungen und Durchsetzung)
+## Mit OpenAgreements gebaut
 
-## Releasing
+- [Safe Clause](https://safeclause.deltaxy.ai) — KI-gestützte Vertragsplattform für Startups. [#1 auf vibecode.law, März 2026](https://vibecode.law/showcase/safe-clause-317416).
 
-Releases laufen automatisiert über GitHub Actions mit npm Trusted Publishing (OIDC) und aktivierter Provenance.
-
-1. Aktualisiere Versionen im Root-Package und in veröffentlichbaren MCP-Packages.
-2. Push Commit + Tag mit `git push origin main --tags`
-3. Führe den lokalen Gemini-Extension-Gate aus (nach `~/.gemini/extensions/open-agreements` kopieren/symlinken und prüfen, dass beide lokalen MCP-Server starten/antworten).
-4. Der `Release`-Workflow veröffentlicht vom Tag, nachdem Build, Validierung, Tests, isolierter Runtime-Smoke und Package-Checks gelaufen sind.
-
-Workflow-Geländer:
-
-- Tag muss zu Root- und veröffentlichbaren Package-Versionen passen
-- Release-Commit muss in `origin/main` enthalten sein
-- Publish schlägt fehl, wenn eine Zielversion auf npm bereits existiert
-
-## Architektur
-
-- **Language**: TypeScript
-- **DOCX Engine**: [docx-templates](https://www.npmjs.com/package/docx-templates) (MIT)
-- **CLI**: [Commander.js](https://www.npmjs.com/package/commander)
-- **Validation**: [Zod](https://www.npmjs.com/package/zod) schemas
-- **Skill Pattern**: Agent-agnostic `ToolCommandAdapter` interface
-
-```
-content/                    # All content directories
-├── templates/              # Internal templates (CC BY 4.0)
-├── external/               # External templates (CC BY-ND 4.0)
-└── recipes/                # Recipes (downloaded at runtime)
-
-src/                        # TypeScript source + collocated unit tests
-├── cli/                    # Commander.js CLI
-├── commands/               # fill, validate, list, recipe, scan
-├── core/
-│   ├── engine.ts           # docx-templates wrapper
-│   ├── metadata.ts         # Zod schemas + loader
-│   ├── recipe/             # Recipe pipeline (clean → patch → fill → verify)
-│   ├── external/           # External template support
-│   ├── validation/         # template, license, output, recipe
-│   └── command-generation/
-│       ├── types.ts        # ToolCommandAdapter interface
-│       └── adapters/       # Claude Code adapter
-└── index.ts                # Public API
-
-integration-tests/          # Integration and end-to-end tests
-```
-
-## Ressourcen
-
-- [Claude Code Documentation](https://docs.anthropic.com/en/docs/claude-code)
-- [Claude Code Plugins Guide](https://docs.anthropic.com/en/docs/claude-code/plugins)
-- [Agent Skills Specification](https://agentskills.io)
+Baust du auf OpenAgreements auf? Eröffne einen PR, um dein Projekt aufzunehmen.
 
 ## Lizenz
 
-MIT
+MIT. Vorlageninhalte werden von ihren jeweiligen Autor:innen lizenziert:
 
-Template-Inhalte sind von ihren jeweiligen Autor:innen lizenziert — CC BY 4.0 (Common Paper, Bonterms), CC BY-ND 4.0 (Y Combinator) oder proprietär (NVCA, Laufzeit-Download). Siehe `metadata.yaml` jeder Vorlage für Details.
+- CC BY 4.0 für Common Paper-, Bonterms- und OpenAgreements-erstellte Vorlagen
+- CC BY-ND 4.0 für unverändert vendored Y-Combinator-SAFE-Vorlagen
+- proprietär oder nicht redistributable für NVCA-Quelldokumente, die über Recipe-Workflows abgewickelt werden
 
-## Haftungsausschluss
+Siehe `metadata.yaml` jeder Vorlage für quellen-spezifische Details.
 
-Dieses Tool erzeugt Dokumente aus Standardvorlagen. Es bietet keine Rechtsberatung. Eine Zugehörigkeit zu oder Billigung durch Common Paper, Bonterms, Y Combinator, NVCA oder andere Vorlagenquellen ist nicht impliziert. Konsultiere für Rechtsberatung eine Anwältin oder einen Anwalt.
+Dieses Tool erzeugt Dokumente aus Standardvorlagen. Es bietet keine Rechtsberatung. Konsultiere für Rechtsberatung eine Anwältin oder einen Anwalt.

--- a/README.es.md
+++ b/README.es.md
@@ -1,201 +1,214 @@
+<!-- This file is generated from README.template.md by scripts/generate_readme.mjs. Do not edit README.md directly. -->
+
 # OpenAgreements
 
 [![npm version](https://img.shields.io/npm/v/open-agreements)](https://www.npmjs.com/package/open-agreements)
 [![npm downloads](https://img.shields.io/npm/dm/open-agreements.svg)](https://npmjs.org/package/open-agreements)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![Agent Skill](https://img.shields.io/badge/agent--skill-open--agreements-purple)](https://skills.sh)
 [![CI](https://github.com/open-agreements/open-agreements/actions/workflows/ci.yml/badge.svg)](https://github.com/open-agreements/open-agreements/actions/workflows/ci.yml)
-[![MCP Server Status](https://img.shields.io/endpoint?url=https%3A%2F%2Fopenagreements.org%2Fapi%2Fstatus%3Fformat%3Dshields)](https://openagreements.openstatus.dev/)
 [![codecov](https://img.shields.io/codecov/c/github/open-agreements/open-agreements/main)](https://app.codecov.io/gh/open-agreements/open-agreements)
-[![GitHub stargazers](https://img.shields.io/github/stars/open-agreements/open-agreements?style=social)](https://github.com/open-agreements/open-agreements/stargazers)
-[![Tests: Vitest](https://img.shields.io/badge/tests-vitest-6E9F18)](https://vitest.dev/)
-[![OpenSpec Traceability](https://img.shields.io/badge/openspec-traceability%20gate-brightgreen)](./scripts/validate_openspec_coverage.mjs)
 [![Socket Badge](https://socket.dev/api/badge/npm/package/open-agreements)](https://socket.dev/npm/package/open-agreements)
+[![GitHub stargazers](https://img.shields.io/github/stars/open-agreements/open-agreements?style=social)](https://github.com/open-agreements/open-agreements/stargazers)
+[![Agent Skill](https://img.shields.io/badge/agent--skill-open--agreements-purple)](https://skills.sh)
+[![MCP Server Status](https://img.shields.io/endpoint?url=https%3A%2F%2Fopenagreements.org%2Fapi%2Fstatus%3Fformat%3Dshields)](https://openagreements.openstatus.dev/)
 [![install size](https://packagephobia.com/badge?p=open-agreements)](https://packagephobia.com/result?p=open-agreements)
 
-[English](./README.md) | [Español](./README.es.md) | [简体中文](./README.zh.md) | [Português (Brasil)](./README.pt-br.md) | [Deutsch](./README.de.md)
+[English](https://github.com/open-agreements/open-agreements/blob/main/README.md) | [Español](https://github.com/open-agreements/open-agreements/blob/main/README.es.md) | [简体中文](https://github.com/open-agreements/open-agreements/blob/main/README.zh.md) | [Português (Brasil)](https://github.com/open-agreements/open-agreements/blob/main/README.pt-br.md) | [Deutsch](https://github.com/open-agreements/open-agreements/blob/main/README.de.md)
 
 > **Nota de traducción:** `README.md` en inglés es la fuente canónica de verdad. Esta traducción puede tener un pequeño retraso. Los cambios importantes del README en inglés deben propagarse en un plazo de 72 horas.
 
-<!-- TODO: Add OpenSSF Scorecard badge once repo is indexed at securityscorecards.dev -->
-<!-- TODO: Add OpenSSF Best Practices badge after registration at bestpractices.dev -->
-<!-- TODO: Re-evaluate Snyk badge — Advisor migrated to security.snyk.io (July 2024) -->
+Completa plantillas estándar de acuerdos legales y obtén archivos DOCX listos para firma. OpenAgreements incluye más de 40 plantillas que cubren NDAs, acuerdos de servicios cloud, documentos laborales, acuerdos con contratistas, SAFEs y documentos de financiamiento NVCA.
+
+Funciona con Claude Code, Gemini CLI, Cursor y flujos de trabajo locales por MCP o CLI.
+
+## Contenidos
+
+- [Plantillas disponibles](#plantillas-disponibles)
+- [Skills disponibles](#skills-disponibles)
+- [Paquetes](#paquetes)
+- [Inicio rápido](#inicio-rápido)
+- [Instalación](#instalación)
+- [Documentación](#documentación)
+- [Privacidad](#privacidad)
+- [Ver también](#ver-también)
+- [Contribuir](#contribuir)
+- [Construido con OpenAgreements](#construido-con-openagreements)
+- [Licencia](#licencia)
 
 <p align="center">
-  <img src="docs/assets/demo-fill-nda.gif" alt="Fill a Mutual NDA in Claude Code — prompt, answer questions, get a signed-ready DOCX" width="720">
+  <img src="https://raw.githubusercontent.com/open-agreements/open-agreements/main/docs/assets/demo-fill-nda.gif" alt="Fill a Mutual NDA in Claude Code — prompt, answer questions, get a signed-ready DOCX" width="720">
 </p>
 
 > *Demo: Claude completa un Mutual NDA de Common Paper en menos de 2 minutos. Acelerado para brevedad.*
 
-Completa plantillas estándar de acuerdos legales y genera archivos DOCX listos para firma. Las plantillas cubren NDAs, términos cloud, documentos laborales, acuerdos con contratistas, SAFEs y documentos de financiamiento NVCA.
+## Plantillas disponibles
 
-**Open Agreements** por [UseJunior](https://usejunior.com) — parte de las [herramientas para desarrolladores de UseJunior](https://usejunior.com/developer-tools/open-agreements). En producción en firmas Am Law 100.
+La columna Fuente enlaza al estándar original, documento fuente o página canónica del proyecto (varía según el editor). La columna Licencia muestra los términos de redistribución. Los enlaces de Repo apuntan al directorio de contenido en GitHub de cada plantilla o recipe.
 
-## Calidad y señales de confianza
+### Confidencialidad
 
-- CI se ejecuta en pull requests y en pushes a `main`.
-- La salud del servicio en vivo se publica a través de OpenStatus en `openagreements.openstatus.dev`.
-- La cobertura se publica en Codecov con compuertas de patch/proyecto definidas en el repositorio en `codecov.yml`.
-- El framework de pruebas JS activo es Vitest, con resultados JUnit subidos para análisis de pruebas en Codecov.
-- La trazabilidad de escenarios de OpenSpec se aplica mediante `npm run check:spec-coverage`. Para exportar una matriz local, ejecuta `npm run check:spec-coverage -- --write-matrix integration-tests/OPENSPEC_TRACEABILITY.md`.
-- El canario de deriva de fuentes de recetas (`npm run check:source-drift`) verifica el hash esperado de la fuente junto con anclas estructurales de reemplazo/normalización.
-- Las regresiones a nivel de supuestos se rastrean en `docs/assumptions.md` y se validan con pruebas de regresión dirigidas + compuertas de CI.
-- El renderizado visual DOCX con LibreOffice usa una configuración fijada en macOS (`config/libreoffice-headless.json`); ejecuta `npm run check:libreoffice` antes de pruebas visuales de evidencia de Allure.
-- Maintainer: [Steven Obiajulu](https://www.linkedin.com/in/steven-obiajulu/) (ingeniero mecánico formado en MIT; abogado formado en Harvard Law).
+| Plantilla | Sitio web | Fuente | Licencia | Repo |
+|-----------|-----------|--------|----------|------|
+| Bonterms Mutual NDA | [Sitio web](https://usejunior.com/templates/bonterms-mutual-nda) | [Bonterms](https://bonterms.com/resources/mutual-nda-cover-page-example) | [CC0-1.0](https://creativecommons.org/publicdomain/zero/1.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/bonterms-mutual-nda) |
+| Common Paper Mutual NDA | [Sitio web](https://usejunior.com/templates/common-paper-mutual-nda) | [Common Paper](https://commonpaper.com/standards/mutual-nda/1.0) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-mutual-nda) |
+| One Way NDA | [Sitio web](https://usejunior.com/templates/common-paper-one-way-nda) | [Common Paper](https://commonpaper.com/standards/one-way-nda) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-one-way-nda) |
 
-## Cómo funciona
+### Ventas y Licencias
 
-1. Paso 1: Elige una plantilla (36 acuerdos estándar)
-2. Paso 2: Completa tus datos (prompts interactivos o MCP)
-3. Paso 3: Obtén un DOCX con formato profesional
+| Plantilla | Sitio web | Fuente | Licencia | Repo |
+|-----------|-----------|--------|----------|------|
+| Cloud Service Agreement | [Sitio web](https://usejunior.com/templates/common-paper-cloud-service-agreement) | [Common Paper](https://commonpaper.com/standards/cloud-service-agreement/2.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-cloud-service-agreement) |
+| CSA Click Through | [Sitio web](https://usejunior.com/templates/common-paper-csa-click-through) | [Common Paper](https://commonpaper.com/standards/cloud-service-agreement/2.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-csa-click-through) |
+| CSA With AI | [Sitio web](https://usejunior.com/templates/common-paper-csa-with-ai) | [Common Paper](https://commonpaper.com/standards/cloud-service-agreement/2.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-csa-with-ai) |
+| CSA With SLA | [Sitio web](https://usejunior.com/templates/common-paper-csa-with-sla) | [Common Paper](https://commonpaper.com/standards/cloud-service-agreement/2.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-csa-with-sla) |
+| CSA Without SLA | [Sitio web](https://usejunior.com/templates/common-paper-csa-without-sla) | [Common Paper](https://commonpaper.com/standards/cloud-service-agreement/2.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-csa-without-sla) |
+| Order Form | [Sitio web](https://usejunior.com/templates/common-paper-order-form) | [Common Paper](https://commonpaper.com/standards/cloud-service-agreement/2.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-order-form) |
+| Order Form With SLA | [Sitio web](https://usejunior.com/templates/common-paper-order-form-with-sla) | [Common Paper](https://commonpaper.com/standards/cloud-service-agreement/2.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-order-form-with-sla) |
+| Software License Agreement | [Sitio web](https://usejunior.com/templates/common-paper-software-license-agreement) | [Common Paper](https://commonpaper.com/standards/software-license-agreement/1.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-software-license-agreement) |
 
-OpenAgreements admite dos modos de ejecución con límites de confianza diferentes:
+### Datos y Cumplimiento
 
-- Conector MCP remoto alojado (`https://openagreements.org/api/mcp`) para configuración rápida en Claude.
-- Ejecución totalmente local del paquete (`npx`, instalación global o paquete MCP local por stdio) para flujos de trabajo locales en tu máquina.
+| Plantilla | Sitio web | Fuente | Licencia | Repo |
+|-----------|-----------|--------|----------|------|
+| AI Addendum | [Sitio web](https://usejunior.com/templates/common-paper-ai-addendum) | [Common Paper](https://commonpaper.com/standards/ai-addendum/1.0) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-ai-addendum) |
+| AI Addendum In App | [Sitio web](https://usejunior.com/templates/common-paper-ai-addendum-in-app) | [Common Paper](https://commonpaper.com/standards/ai-addendum/1.0) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-ai-addendum-in-app) |
+| Business Associate Agreement | [Sitio web](https://usejunior.com/templates/common-paper-business-associate-agreement) | [Common Paper](https://commonpaper.com/standards/business-associate-agreement/1.0) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-business-associate-agreement) |
+| Data Processing Agreement | [Sitio web](https://usejunior.com/templates/common-paper-data-processing-agreement) | [Common Paper](https://commonpaper.com/standards/data-processing-agreement/1.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-data-processing-agreement) |
 
-No existe una recomendación de modo global por defecto. Elige según sensibilidad del documento, políticas internas y necesidades de velocidad del flujo de trabajo. Consulta `docs/trust-checklist.md` para un resumen de flujo de datos en 60 segundos.
+### Servicios Profesionales
 
-### Decisión rápida
+| Plantilla | Sitio web | Fuente | Licencia | Repo |
+|-----------|-----------|--------|----------|------|
+| Bonterms Professional Services Agreement | [Sitio web](https://usejunior.com/templates/bonterms-professional-services-agreement) | [Bonterms](https://bonterms.com/resources/psa-cover-page-example) | [CC0-1.0](https://creativecommons.org/publicdomain/zero/1.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/bonterms-professional-services-agreement) |
+| Independent Contractor Agreement | [Sitio web](https://usejunior.com/templates/common-paper-independent-contractor-agreement) | [Common Paper](https://commonpaper.com/standards/independent-contractor-agreement) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-independent-contractor-agreement) |
+| Common Paper Professional Services Agreement | [Sitio web](https://usejunior.com/templates/common-paper-professional-services-agreement) | [Common Paper](https://commonpaper.com/standards/professional-services-agreement/1.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-professional-services-agreement) |
+| Statement Of Work | [Sitio web](https://usejunior.com/templates/common-paper-statement-of-work) | [Common Paper](https://commonpaper.com/standards/statement-of-work) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-statement-of-work) |
 
-- Si tu documento es sensible, usa ejecución totalmente local del paquete.
-- Si priorizas conveniencia, usa el conector MCP remoto alojado.
+### Acuerdos y Alianzas
 
-## Uso con Claude Code
+| Plantilla | Sitio web | Fuente | Licencia | Repo |
+|-----------|-----------|--------|----------|------|
+| Amendment | [Sitio web](https://usejunior.com/templates/common-paper-amendment) | [Common Paper](https://commonpaper.com/standards/amendment) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-amendment) |
+| Design Partner Agreement | [Sitio web](https://usejunior.com/templates/common-paper-design-partner-agreement) | [Common Paper](https://commonpaper.com/standards/design-partner-agreement/1.3) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-design-partner-agreement) |
+| Letter Of Intent | [Sitio web](https://usejunior.com/templates/common-paper-letter-of-intent) | [Common Paper](https://commonpaper.com/standards/letter-of-intent) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-letter-of-intent) |
+| Partnership Agreement | [Sitio web](https://usejunior.com/templates/common-paper-partnership-agreement) | [Common Paper](https://commonpaper.com/standards/partnership-agreement/1.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-partnership-agreement) |
+| Pilot Agreement | [Sitio web](https://usejunior.com/templates/common-paper-pilot-agreement) | [Common Paper](https://commonpaper.com/standards/pilot-agreement/1.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-pilot-agreement) |
+| Term Sheet | [Sitio web](https://usejunior.com/templates/common-paper-term-sheet) | [Common Paper](https://commonpaper.com/standards/term-sheet) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-term-sheet) |
 
-OpenAgreements funciona como [plugin de Claude Code](https://docs.anthropic.com/en/docs/claude-code/plugins) y [Agent Skill](https://agentskills.io). No se requiere instalación previa: Claude descarga y ejecuta el CLI bajo demanda vía `npx`.
+### Empleo
 
-### Opción 1: Agent Skill (recomendado)
+| Plantilla | Sitio web | Fuente | Licencia | Repo |
+|-----------|-----------|--------|----------|------|
+| Employee IP Inventions Assignment | [Sitio web](https://usejunior.com/templates/openagreements-employee-ip-inventions-assignment) | [OpenAgreements](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-employee-ip-inventions-assignment) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-employee-ip-inventions-assignment) |
+| Employment Confidentiality Acknowledgement | [Sitio web](https://usejunior.com/templates/openagreements-employment-confidentiality-acknowledgement) | [OpenAgreements](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-employment-confidentiality-acknowledgement) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-employment-confidentiality-acknowledgement) |
+| Employment Offer Letter | [Sitio web](https://usejunior.com/templates/openagreements-employment-offer-letter) | [OpenAgreements](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-employment-offer-letter) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-employment-offer-letter) |
+| Restrictive Covenant Wyoming | [Sitio web](https://usejunior.com/templates/openagreements-restrictive-covenant-wyoming) | [OpenAgreements](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-restrictive-covenant-wyoming) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-restrictive-covenant-wyoming) |
 
-```bash
-npx skills add open-agreements/open-agreements
+### SAFEs
+
+| Plantilla | Sitio web | Fuente | Licencia | Repo |
+|-----------|-----------|--------|----------|------|
+| Discount | [Sitio web](https://usejunior.com/templates/yc-safe-discount) | [Y Combinator](https://www.ycombinator.com/documents) | [CC-BY-ND-4.0](https://creativecommons.org/licenses/by-nd/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/external/yc-safe-discount) |
+| MFN | [Sitio web](https://usejunior.com/templates/yc-safe-mfn) | [Y Combinator](https://www.ycombinator.com/documents) | [CC-BY-ND-4.0](https://creativecommons.org/licenses/by-nd/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/external/yc-safe-mfn) |
+| Pro Rata Side Letter | [Sitio web](https://usejunior.com/templates/yc-safe-pro-rata-side-letter) | [Y Combinator](https://www.ycombinator.com/documents) | [CC-BY-ND-4.0](https://creativecommons.org/licenses/by-nd/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/external/yc-safe-pro-rata-side-letter) |
+| Valuation Cap | [Sitio web](https://usejunior.com/templates/yc-safe-valuation-cap) | [Y Combinator](https://www.ycombinator.com/documents) | [CC-BY-ND-4.0](https://creativecommons.org/licenses/by-nd/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/external/yc-safe-valuation-cap) |
+
+### Financiación de Capital de Riesgo
+
+| Plantilla | Sitio web | Fuente | Licencia | Repo |
+|-----------|-----------|--------|----------|------|
+| Certificate Of Incorporation | [Sitio web](https://usejunior.com/templates/nvca-certificate-of-incorporation) | [NVCA](https://nvca.org/wp-content/uploads/2025/10/NVCA-Model-COI-10-1-2025.docx) | Recipe | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/recipes/nvca-certificate-of-incorporation) |
+| Indemnification Agreement | [Sitio web](https://usejunior.com/templates/nvca-indemnification-agreement) | [NVCA](https://nvca.org/wp-content/uploads/2021/12/NVCA-2020-Indemnification-Agreement.docx) | Recipe | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/recipes/nvca-indemnification-agreement) |
+| Investors Rights Agreement | [Sitio web](https://usejunior.com/templates/nvca-investors-rights-agreement) | [NVCA](https://nvca.org/wp-content/uploads/2025/10/NVCA-Model-IRA-10-1-2025-2-1.docx) | Recipe | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/recipes/nvca-investors-rights-agreement) |
+| Management Rights Letter | [Sitio web](https://usejunior.com/templates/nvca-management-rights-letter) | [NVCA](https://nvca.org/wp-content/uploads/2025/12/NVCA-2020-Management-Rights-Letter-1-1.docx) | Recipe | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/recipes/nvca-management-rights-letter) |
+| ROFR Co Sale Agreement | [Sitio web](https://usejunior.com/templates/nvca-rofr-co-sale-agreement) | [NVCA](https://nvca.org/wp-content/uploads/2025/10/NVCA-Model-ROFRA-10-1-2025.docx) | Recipe | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/recipes/nvca-rofr-co-sale-agreement) |
+| Stock Purchase Agreement | [Sitio web](https://usejunior.com/templates/nvca-stock-purchase-agreement) | [NVCA](https://nvca.org/wp-content/uploads/2025/10/NVCA-Model-SPA-10-28-2025-1.docx) | Recipe | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/recipes/nvca-stock-purchase-agreement) |
+| Voting Agreement | [Sitio web](https://usejunior.com/templates/nvca-voting-agreement) | [NVCA](https://nvca.org/wp-content/uploads/2024/10/NVCA-Model-VA-10-1-2025.docx) | Recipe | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/recipes/nvca-voting-agreement) |
+
+### Otros
+
+| Plantilla | Sitio web | Fuente | Licencia | Repo |
+|-----------|-----------|--------|----------|------|
+| Closing Checklist | [Sitio web](https://usejunior.com/templates/closing-checklist) | [OpenAgreements](https://github.com/open-agreements/open-agreements) | [CC0-1.0](https://creativecommons.org/publicdomain/zero/1.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/closing-checklist) |
+| Board Consent SAFE | [Sitio web](https://usejunior.com/templates/openagreements-board-consent-safe) | [OpenAgreements](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-board-consent-safe) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-board-consent-safe) |
+| Due Diligence Request List | [Sitio web](https://usejunior.com/templates/openagreements-due-diligence-request-list) | [OpenAgreements](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-due-diligence-request-list) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-due-diligence-request-list) |
+| Stockholder Consent SAFE | [Sitio web](https://usejunior.com/templates/openagreements-stockholder-consent-safe) | [OpenAgreements](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-stockholder-consent-safe) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-stockholder-consent-safe) |
+| Working Group List | [Sitio web](https://usejunior.com/templates/working-group-list) | [OpenAgreements](https://github.com/open-agreements/open-agreements) | [CC0-1.0](https://creativecommons.org/publicdomain/zero/1.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/working-group-list) |
+
+## Skills disponibles
+
+### Redacción y llenado de acuerdos
+
+| Skill | Descripción |
+|-------|-------------|
+| [open-agreements](https://github.com/open-agreements/open-agreements/tree/main/skills/open-agreements) | Completa plantillas estándar de acuerdos legales (NDAs, acuerdos de servicios cloud, SAFEs) y produce archivos DOCX listos para firma. Soporta plantillas de Common Paper, Bonterms y Y Combinator. Úsalo cuando el usuario necesite redactar un acuerdo legal, crear un NDA, completar una plantilla de contrato o generar un SAFE. También puede enviar acuerdos para firma electrónica vía DocuSign. |
+| [nda](https://github.com/open-agreements/open-agreements/tree/main/skills/nda) | Redacta y completa plantillas de NDA — NDA mutuo, NDA unilateral, acuerdo de confidencialidad. Produce archivos DOCX listos para firma a partir de formularios estándar de Common Paper y Bonterms. Úsalo cuando el usuario diga "NDA", "acuerdo de confidencialidad", "NDA mutuo" o "NDA unilateral". |
+| [cloud-service-agreement](https://github.com/open-agreements/open-agreements/tree/main/skills/cloud-service-agreement) | Redacta y completa plantillas de acuerdos SaaS — contrato cloud, MSA, order form, licencia de software, acuerdo piloto, acuerdo de design partner. Incluye variantes con SLAs y términos de IA. Produce DOCX listos para firma a partir de formularios estándar de Common Paper. Úsalo cuando el usuario diga "acuerdo SaaS", "contrato cloud", "MSA", "order form", "licencia de software", "acuerdo piloto" o "acuerdo de design partner". |
+| [services-agreement](https://github.com/open-agreements/open-agreements/tree/main/skills/services-agreement) | Redacta y completa plantillas de acuerdos de servicios — contrato de consultoría, acuerdo con contratista, SOW, statement of work, acuerdo de servicios profesionales. Produce archivos DOCX listos para firma a partir de formularios estándar de Common Paper y Bonterms. Úsalo cuando el usuario diga "contrato de consultoría", "acuerdo con contratista", "SOW", "statement of work", "acuerdo de servicios" o "contrato freelance". |
+| [employment-contract](https://github.com/open-agreements/open-agreements/tree/main/skills/employment-contract) | Redacta y completa plantillas de acuerdos laborales — carta de oferta, cesión de PI, PIIA, acuse de confidencialidad. Produce archivos DOCX listos para firma a partir de formularios estándar de OpenAgreements para contratar empleados. Úsalo cuando el usuario diga "carta de oferta", "acuerdo laboral", "PIIA", "cesión de PI", "contratar a alguien" o "papeleo de onboarding". |
+| [data-privacy-agreement](https://github.com/open-agreements/open-agreements/tree/main/skills/data-privacy-agreement) | Redacta y completa plantillas de acuerdos de privacidad de datos — DPA, acuerdo de procesamiento de datos, GDPR, HIPAA BAA, business associate agreement, AI addendum. Produce archivos DOCX listos para firma a partir de formularios estándar de Common Paper. Úsalo cuando el usuario diga "DPA", "acuerdo de procesamiento de datos", "HIPAA BAA", "business associate agreement" o "AI addendum". |
+| [safe](https://github.com/open-agreements/open-agreements/tree/main/skills/safe) | Redacta y completa plantillas SAFE de Y Combinator — valuation cap, discount, MFN, pro rata side letter. Documentos estándar de financiación startup para equity convertible. Produce archivos DOCX listos para firma. Úsalo cuando el usuario diga "SAFE", "simple agreement for future equity", "YC SAFE", "valuation cap", "documentos de ronda seed" o "papeleo de fundraising". |
+| [venture-financing](https://github.com/open-agreements/open-agreements/tree/main/skills/venture-financing) | Redacta y completa documentos modelo NVCA — stock purchase agreement, certificate of incorporation, investors rights agreement, voting agreement, ROFR, co-sale, indemnification, management rights letter. Plantillas de Serie A y financiación de capital de riesgo. Produce archivos DOCX listos para firma. Úsalo cuando el usuario diga "documentos Serie A", "NVCA", "stock purchase agreement", "investors rights agreement", "voting agreement" o "docs de venture financing". |
+
+### Edición y flujos con clientes
+
+| Skill | Descripción |
+|-------|-------------|
+| [edit-docx-agreement](https://github.com/open-agreements/open-agreements/tree/main/skills/edit-docx-agreement) | Realiza ediciones a medida sobre un acuerdo DOCX generado por OpenAgreements (o cualquier DOCX existente), usando las herramientas Safe Docx MCP para ediciones quirúrgicas que preservan el formato y producen salidas con cambios rastreados. Úsalo cuando el usuario diga "edita este contrato", "cambia una cláusula", "modifica el acuerdo", "ediciones personalizadas al docx" o "cambios a medida en el documento". |
+| [client-email](https://github.com/open-agreements/open-agreements/tree/main/skills/client-email) | Redacta correos dirigidos a clientes para servicios legales — notas de remisión para entregables contractuales, resúmenes de redlines, actualizaciones de estado del deal y seguimientos. Úsalo al componer o revisar correos salientes a clientes sobre el trabajo legal. Se activa con "redacta una respuesta", "correo al cliente", "nota de remisión", "responde a" o cualquier correo saliente que acompañe un entregable legal. |
+| [delaware-franchise-tax](https://github.com/open-agreements/open-agreements/tree/main/skills/delaware-franchise-tax) | Presenta tu Delaware franchise tax anual y el annual report. Te guía por el cálculo del impuesto (métodos Authorized Shares y Assumed Par Value Capital), el proceso de presentación en el portal eCorp y el pago. Para Delaware C-Corps (fecha límite 1 de marzo) y LLCs/LPs/GPs (fecha límite 1 de junio). Úsalo cuando el usuario diga "Delaware franchise tax", "annual report Delaware", "presentar franchise tax" o "portal eCorp". |
+
+### Cumplimiento y auditoría
+
+| Skill | Descripción |
+|-------|-------------|
+| [soc2-readiness](https://github.com/open-agreements/open-agreements/tree/main/skills/soc2-readiness) | Evalúa la preparación para SOC 2 Type II. Mapea los Trust Services Criteria a controles, identifica brechas y construye un plan de remediación. Usa NIST SP 800-53 (dominio público) como referencia canónica con mapeo cruzado de criterios SOC 2. Úsalo cuando el usuario diga "preparación SOC 2", "preparación para SOC 2", "análisis de brechas SOC 2" o "preparar para auditoría SOC 2". |
+| [iso-27001-internal-audit](https://github.com/open-agreements/open-agreements/tree/main/skills/iso-27001-internal-audit) | Ejecuta una auditoría interna ISO 27001. Recorre los controles por dominio, identifica brechas, recopila evidencia y genera hallazgos con recomendaciones de acción correctiva. Usa NIST SP 800-53 (dominio público) como referencia canónica. Úsalo cuando el usuario diga "ejecutar auditoría interna", "auditoría ISO 27001", "evaluación de controles", "hallazgos de auditoría" o "evaluación del ISMS". |
+| [iso-27001-evidence-collection](https://github.com/open-agreements/open-agreements/tree/main/skills/iso-27001-evidence-collection) | Recopila, organiza y valida evidencia para auditorías ISO 27001 y SOC 2. Enfoque API-first con comandos CLI para las principales plataformas cloud. Produce paquetes de evidencia con marcas de tiempo y listos para auditor. Úsalo cuando el usuario diga "recopilar evidencia de auditoría", "preparar paquete de evidencia", "evidencia para el auditor", "refrescar evidencia" o "análisis de brechas de evidencia". |
+
+### Flujos para desarrolladores
+
+| Skill | Descripción |
+|-------|-------------|
+| [recipe-quality-audit](https://github.com/open-agreements/open-agreements/tree/main/skills/recipe-quality-audit) | Audita la calidad de los recipes NVCA: comprueba inventario de archivos, esquema de metadatos, cobertura de campo a reemplazo, claves ambiguas, comillas tipográficas, fixtures de pruebas y calidad del llenado. Produce un scorecard estructurado por recipe con clasificación de nivel de madurez. Úsalo cuando el usuario diga "auditar calidad de recipe", "comprobar cobertura del recipe", "scorecard de recipe" o "calidad de recipe NVCA". |
+| [unit-test-philosophy](https://github.com/open-agreements/open-agreements/tree/main/skills/unit-test-philosophy) | Pruebas unitarias basadas en riesgo y estilo de especificación de comportamiento legible por Allure para open-agreements. Úsalo cuando el usuario diga "añadir pruebas", "calidad de pruebas", "expansión de cobertura", "estilo de pruebas unitarias" o "spec de prueba Allure". Aplica al añadir/actualizar pruebas, expandir cobertura o revisar calidad de pruebas en src, integration-tests y paquetes del workspace. |
+
+### Autoría de plantillas
+
+| Skill | Descripción |
+|-------|-------------|
+| [canonical-markdown-authoring](https://github.com/open-agreements/open-agreements/tree/main/skills/canonical-markdown-authoring) | Convierte borradores de contrato en markdown plano al formato canónico de autoría template.md de OpenAgreements — YAML frontmatter, tablas Kind|Label|Value|Show When de cover-terms, directivas oa:clause, párrafos [[Defined Term]] y directivas oa:signer que compilan a specs JSON validados y artefactos DOCX. Úsalo cuando el usuario diga "convierte esto a markdown canónico", "crea una nueva plantilla de OpenAgreements", "migra plantilla a template.md" o "escribe un contrato en forma canónica". |
+
+## Paquetes
+
+| Paquete | Descripción |
+|---------|-------------|
+| [open-agreements](https://www.npmjs.com/package/open-agreements) | CLI y librería open-source para completar plantillas legales |
+| [@open-agreements/contract-templates-mcp](https://github.com/open-agreements/open-agreements/blob/main/packages/contract-templates-mcp/README.md) | Servidor MCP local por stdio para descubrimiento y llenado de plantillas OpenAgreements |
+| [@open-agreements/contracts-workspace](https://github.com/open-agreements/open-agreements/blob/main/packages/contracts-workspace/README.md) | CLI orientado al workspace para organizar y rastrear repositorios de contratos |
+| [@open-agreements/contracts-workspace-mcp](https://github.com/open-agreements/open-agreements/blob/main/packages/contracts-workspace-mcp/README.md) | Servidor MCP local por stdio para operaciones del workspace de contratos |
+| [@open-agreements/checklist-mcp](https://github.com/open-agreements/open-agreements/blob/main/packages/checklist-mcp/README.md) | Servidor MCP local por stdio para operaciones de memoria de checklist de OpenAgreements |
+
+### Qué se instala
+
+```text
+open-agreements/
+  bin/                    # CLI entry point
+  dist/                   # Compiled TypeScript
+  content/
+    templates/            # Fillable DOCX templates with {tag} placeholders
+    external/             # YC SAFE templates vendored unchanged
+    recipes/              # Recipe instructions for non-redistributable sources
+  skills/                 # Agent skill definitions
+  server.json             # MCP server manifest
+  gemini-extension.json   # Gemini CLI extension config
+  README.md, LICENSE
 ```
 
-Luego pide a Claude que redacte un acuerdo:
+Las plantillas de recipes NVCA se descargan en tiempo de ejecución y no se incluyen en el paquete.
 
-```
-> Draft an NDA between Acme Corp and Beta Inc
-```
-
-Claude descubre las plantillas disponibles, te entrevista para obtener los valores de campos y genera un DOCX listo para firma.
-
-### Opción 2: Extensión Gemini CLI
-
-```bash
-gemini extensions install https://github.com/open-agreements/open-agreements
-```
-
-Luego pide a Gemini que redacte un acuerdo. La extensión proporciona herramientas MCP, archivos de contexto y skills para descubrimiento y llenado de plantillas.
-
-### Opción 3: Directo con Claude Code
-
-Si tienes Node.js >= 20, solo pídeselo a Claude:
-
-```
-> Fill the Common Paper mutual NDA for my company
-```
-
-Claude ejecuta `npx -y open-agreements@latest list --json` para descubrir plantillas, y luego `npx -y open-agreements@latest fill <template>` para generar el resultado. Cero instalación.
-
-### Opción 4: CLI
-
-```bash
-# Install globally
-npm install -g open-agreements
-
-# List available templates
-open-agreements list
-
-# Fill a template
-open-agreements fill common-paper-mutual-nda -d values.json -o my-nda.docx
-```
-
-### Qué sucede
-
-1. Claude ejecuta `list --json` para descubrir plantillas disponibles y sus campos
-2. Claude te entrevista para obtener valores de campos (agrupados por sección, hasta 4 preguntas por ronda)
-3. Claude ejecuta `fill <template>` para generar un DOCX preservando todo el formato original
-4. Revisas y firmas el documento de salida
-
-## Uso con Cursor
-
-Este repositorio incluye un manifiesto de plugin de Cursor con integración MCP:
-
-- Plugin manifest: `.cursor-plugin/plugin.json`
-- MCP config: `mcp.json`
-- Skill: `skills/open-agreements/SKILL.md`
-
-La configuración MCP por defecto en `mcp.json` incluye:
-
-- Conector MCP OpenAgreements alojado (`https://openagreements.org/api/mcp`)
-- Servidor MCP local de workspace (`npx -y @open-agreements/contracts-workspace-mcp`)
-- Servidor MCP local para redacción de plantillas (`npx -y @open-agreements/contract-templates-mcp`)
-
-Para publicar este plugin en Cursor Marketplace, envía este repositorio en:
-
-- https://cursor.com/marketplace/publish
-
-## Plantillas
-
-28 plantillas en tres niveles. Ejecuta `open-agreements list` para el inventario completo.
-
-| Nivel | Cantidad | Fuente | Cómo funciona |
-|------|-------|--------|--------------|
-| Plantillas internas | 17 | [Common Paper](https://commonpaper.com), [Bonterms](https://bonterms.com), OpenAgreements | Incluidas en el paquete, CC BY 4.0 |
-| Plantillas externas | 4 | [Y Combinator](https://www.ycombinator.com/documents) | Vendorizadas sin cambios, CC BY-ND 4.0 |
-| Recipes | 7 | [NVCA](https://nvca.org/model-legal-documents/) | Se descargan bajo demanda (no redistribuibles) |
-
-**Plantillas internas** (NDAs, términos cloud, formularios laborales, acuerdos con contratistas, etc.) están bajo CC BY 4.0: enviamos el DOCX con placeholders `{tag}`.
-
-**Plantillas externas** (YC SAFEs) están bajo CC BY-ND 4.0: vendorizamos el original sin cambios. El resultado completado es un derivado transitorio en tu máquina.
-
-**Recipes** (documentos de financiamiento NVCA) se pueden descargar libremente pero no son redistribuibles: enviamos solo instrucciones de transformación y descargamos el DOCX fuente desde nvca.org en tiempo de ejecución.
-
-### Extracción de guidance
-
-Los documentos fuente contienen comentarios expertos (notas al pie, notas de redacción, bloques `[Comment: ...]`) escritos por especialistas del dominio (por ejemplo, abogados de valores). El limpiador de recipes elimina ese contenido para producir un documento rellenable, pero también puede extraerlo como JSON estructurado:
-
-```bash
-open-agreements recipe clean source.docx -o cleaned.docx \
-  --recipe nvca-indemnification-agreement \
-  --extract-guidance guidance.json
-```
-
-Esto produce un `guidance.json` con cada nota al pie, comentario y nota de redacción removidos, etiquetados por tipo de fuente y posición en el documento. El guidance es un artefacto solo local (no se commitea ni se distribuye) que agentes de IA o autores humanos pueden consultar al completar el formulario. Consulta [Adding Recipes — Guidance Extraction](docs/adding-recipes.md#guidance-extraction) para detalles de formato.
-
-**¿Por qué extracción programática?** El documento fuente es la fuente única de verdad. Re-ejecutar la extracción tras una actualización del editor produce guidance fresco sin esfuerzo manual, preserva el lenguaje exacto de expertos de dominio y captura todo: una IA puede resumir sobre la marcha, pero no puede recuperar contenido descartado.
-
-Cada plantilla es un directorio autocontenido:
-
-```
-content/templates/<name>/
-├── template.docx     # DOCX with {tag} placeholders
-├── metadata.yaml     # Fields, license, source, attribution
-└── README.md         # Template-specific documentation
-```
-
-## Comandos CLI
-
-### `fill <template>`
-
-Genera un DOCX completado desde una plantilla.
-
-```bash
-# Using a JSON data file
-open-agreements fill common-paper-mutual-nda -d data.json -o output.docx
-
-# Using inline --set flags
-open-agreements fill common-paper-mutual-nda --set party_1_name="Acme Corp" --set governing_law="Delaware"
-```
-
-### `validate [template]`
-
-Ejecuta el pipeline de validación sobre una o todas las plantillas.
-
-```bash
-open-agreements validate                          # All templates
-open-agreements validate common-paper-mutual-nda  # One template
-```
+<details>
+<summary><strong>Referencia del CLI</strong></summary>
 
 ### `list`
 
@@ -204,174 +217,201 @@ Muestra las plantillas disponibles con información de licencia y conteo de camp
 ```bash
 open-agreements list
 
-# Machine-readable JSON output (for agent skills and automation)
+# Machine-readable JSON for agent skills and automation
 open-agreements list --json
 ```
 
-## CLI de Contracts Workspace (paquete separado)
+### `fill <template>`
 
-OpenAgreements ahora incluye un paquete hermano para operaciones de repositorio/workspace:
-
-- Package: `@open-agreements/contracts-workspace`
-- Binary: `open-agreements-workspace`
-- Docs: `docs/contracts-workspace.md`
-
-Este paquete está intencionalmente separado de `open-agreements` para que los equipos puedan adoptar:
-
-- solo llenado de plantillas
-- solo gestión de workspace
-- o ambos juntos
-
-Funciones principales de workspace:
-
-- planificación `init` orientada por temas (estructura mínima sugerida con dominios de nivel superior)
-- catálogo de formularios con validación de URL + SHA-256
-- indexación y linting de estado YAML con estado `_executed` basado en nombre de archivo
-
-El modelo v1 es solo de sistema de archivos y funciona en carpetas de nube sincronizadas localmente (por ejemplo, sincronización de Google Drive). No se requiere integración Drive API/OAuth.
-
-## MCP local para demo de workspace
-
-Para demos de conectores locales, hay un paquete MCP local por stdio:
-
-- Package: `@open-agreements/contracts-workspace-mcp`
-- Binary: `open-agreements-workspace-mcp`
-- Docs: `docs/contracts-workspace.md`
-
-Inicio rápido:
+Genera un DOCX completado desde una plantilla.
 
 ```bash
-npm run build:workspace-mcp
-node packages/contracts-workspace-mcp/bin/open-agreements-workspace-mcp.js
+# From a JSON data file
+open-agreements fill common-paper-mutual-nda -d data.json -o output.docx
+
+# With inline --set flags
+open-agreements fill common-paper-mutual-nda --set party_1_name="Acme Corp" --set governing_law="Delaware"
 ```
 
-## MCP local para redacción de plantillas
+### `validate [template]`
 
-Para flujos locales Gemini/Cursor de redacción de plantillas, usa:
-
-- Package: `@open-agreements/contract-templates-mcp`
-- Binary: `open-agreements-contract-templates-mcp`
-
-Inicio rápido:
+Ejecuta el pipeline de validación sobre una o todas las plantillas.
 
 ```bash
-npm run build:contract-templates-mcp
-node packages/contract-templates-mcp/bin/open-agreements-contract-templates-mcp.js
+open-agreements validate
+open-agreements validate common-paper-mutual-nda
 ```
 
-## Sitio web (Vercel)
+</details>
 
-`site/` es un host de protocolo delgado que se construye con Eleventy.
+<details>
+<summary><strong>Detalles de configuración del agente</strong></summary>
 
-- Metadatos de descubrimiento: `site/.well-known/`
-- Esquemas JSON publicados: `site/schemas/`
-- Descargas estáticas de DOCX en blanco: `site/downloads/`
-- Assets de vista previa: `site/assets/previews/`
-- Handlers serverless de la API: `api/`
-- Discovery outputs (generated during `npm run build:site`): `_site/llms.txt`, `_site/llms-full.txt`, `_site/sitemap.xml`, `_site/robots.txt`
-
-Vista previa local:
+### Claude Code
 
 ```bash
-npm run build:site
-python3 -m http.server 8080 --directory _site
+npx skills add open-agreements/open-agreements
 ```
 
-Luego verifica, por ejemplo, `http://localhost:8080/.well-known/mcp-server-card`, `http://localhost:8080/llms.txt` o los archivos generados dentro de `_site/`.
+### Gemini CLI
 
-Notas de despliegue en Vercel:
+```bash
+gemini extensions install https://github.com/open-agreements/open-agreements
+```
 
-- Importa este repositorio en Vercel
-- Mantén la raíz del proyecto como la raíz del repositorio
-- El `vercel.json` incluido despliega `_site/` como salida estática
+### Cursor
 
-## Raíces de contenido opcionales (preparado para futuro)
+Este repositorio incluye un manifiesto de plugin de Cursor en `.cursor-plugin/plugin.json` con integración MCP en `mcp.json`.
 
-Para soportar desacoplamiento lógico a medida que crecen las bibliotecas de formularios, `open-agreements` puede cargar contenido desde raíces adicionales mediante:
+### Ejecución local vs alojada
 
-- env var: `OPEN_AGREEMENTS_CONTENT_ROOTS`
-- format: lista delimitada por separador de rutas de directorios absolutos/relativos (por ejemplo, `dirA:dirB` en macOS/Linux)
-- estructura esperada bajo cada raíz: `templates/`, `external/`, y/o `recipes/` (o anidados bajo `content/`)
+- **Local**: `npx`, instalación global o MCP por stdio. El procesamiento ocurre en tu máquina.
+- **Alojada**: `https://openagreements.org/api/mcp`. El llenado de plantillas se ejecuta del lado del servidor para una configuración más rápida.
 
-La precedencia de búsqueda es:
+Elige según la sensibilidad del documento y la política interna. Consulta la trust checklist más abajo para el resumen del flujo de datos.
 
-1. raíces en `OPEN_AGREEMENTS_CONTENT_ROOTS` (en el orden listado)
-2. contenido del paquete incluido (fallback por defecto)
+</details>
 
-Esto mantiene simples las instalaciones por defecto y permite a usuarios avanzados mover bibliotecas de contenido grandes fuera del paquete principal.
+## Inicio rápido
+
+### Con Claude Code
+
+Pídele a Claude:
+
+```text
+Fill the Common Paper mutual NDA for my company
+```
+
+Claude puede descubrir plantillas, entrevistarte para obtener los valores de los campos y generar un DOCX listo para firma.
+
+### Con el CLI
+
+```bash
+# See all available templates
+open-agreements list
+
+# Fill a template from a JSON data file
+open-agreements fill common-paper-mutual-nda -d values.json -o my-nda.docx
+
+# Fill with inline values
+open-agreements fill common-paper-mutual-nda --set party_1_name="Acme Corp" --set governing_law="Delaware"
+```
+
+### Prompts de ejemplo
+
+- "Draft an NDA for our construction subcontractor"
+- "Create a consulting agreement for our insurance agency"
+- "Fill the independent contractor agreement for a freelance designer"
+- "Generate a SAFE with a $5M valuation cap"
+
+### Qué sucede
+
+1. El agente ejecuta `list --json` para descubrir plantillas y sus campos.
+2. Te entrevista para obtener los valores de los campos agrupados por sección.
+3. Ejecuta `fill <template>` para generar un DOCX preservando el formato original.
+4. Revisas y firmas el documento de salida.
+
+## Instalación
+
+### Agent Skill (recomendado)
+
+```bash
+npx skills add open-agreements/open-agreements
+```
+
+### MCP remoto
+
+Conecta cualquier agente compatible con MCP al servidor alojado en `https://openagreements.org/api/mcp`.
+
+**Claude Code**
+
+```bash
+claude mcp add --transport http open-agreements https://openagreements.org/api/mcp
+```
+
+**Codex CLI**
+
+```bash
+codex mcp add open-agreements --url https://openagreements.org/api/mcp
+```
+
+**Otros agentes** — apunta tu cliente a `https://openagreements.org/api/mcp` (HTTP streameable).
+
+### Extensión Gemini CLI
+
+```bash
+gemini extensions install https://github.com/open-agreements/open-agreements
+```
+
+### CLI
+
+```bash
+npm install -g open-agreements
+```
+
+O ejecútalo directamente sin instalación:
+
+```bash
+npx -y open-agreements@latest list
+```
+
+---
+
+## Documentación
+
+### Empieza aquí
+
+- [Getting Started](https://github.com/open-agreements/open-agreements/blob/main/docs/getting-started.md)
+
+### Guías
+
+- [Adding Templates](https://github.com/open-agreements/open-agreements/blob/main/docs/adding-templates.md)
+- [Adding Recipes](https://github.com/open-agreements/open-agreements/blob/main/docs/adding-recipes.md)
+
+### Otros paquetes
+
+- [Contracts Workspace CLI](https://github.com/open-agreements/open-agreements/blob/main/docs/contracts-workspace.md)
+
+### Referencia
+
+- [Licensing](https://github.com/open-agreements/open-agreements/blob/main/docs/licensing.md)
+- [Changelog & Release Process](https://github.com/open-agreements/open-agreements/blob/main/docs/changelog-release-process.md)
+- [Trust Checklist](https://github.com/open-agreements/open-agreements/blob/main/docs/trust-checklist.md)
+- [Supported Tools](https://github.com/open-agreements/open-agreements/blob/main/docs/supported-tools.md)
+- [Assumptions](https://github.com/open-agreements/open-agreements/blob/main/docs/assumptions.md)
+- [Employment Source Policy](https://github.com/open-agreements/open-agreements/blob/main/docs/employment-source-policy.md)
+
+**Enlaces:** [Sitio web](https://usejunior.com) | [Catálogo de plantillas](https://usejunior.com/templates) | [Docs](https://github.com/open-agreements/open-agreements/tree/main/docs) | [Trust](https://usejunior.com/security) | [npm](https://www.npmjs.com/package/open-agreements)
+
+## Privacidad
+
+- **Modo local** (`npx`, instalación global, MCP por stdio): todo el procesamiento ocurre en tu máquina. No se envía contenido de documentos al exterior.
+- **Modo alojado** (`https://openagreements.org/api/mcp`): el llenado de plantillas se ejecuta del lado del servidor. No se almacenan documentos completados después de devolver la respuesta.
+
+Consulta la [Política de privacidad](https://usejunior.com/privacy_policy) para más detalles.
 
 ## Ver también
 
-- [safe-docx](https://github.com/UseJunior/safe-docx) — edición quirúrgica de documentos Word existentes con agentes de programación (servidor MCP)
-- [UseJunior Developer Tools](https://usejunior.com/developer-tools/open-agreements) — página del producto con opciones de instalación y catálogo de plantillas
+- [safe-docx](https://github.com/UseJunior/safe-docx) — edición quirúrgica de documentos Word existentes con agentes de programación
 
 ## Contribuir
 
-Consulta [CONTRIBUTING.md](CONTRIBUTING.md) para agregar plantillas, recipes y otras mejoras.
+Consulta [CONTRIBUTING.md](https://github.com/open-agreements/open-agreements/blob/main/CONTRIBUTING.md) para saber cómo agregar plantillas, recipes y otras mejoras.
 
-- [Adding templates](docs/adding-templates.md) (CC BY 4.0 / fuentes CC0)
-- [Adding recipes](docs/adding-recipes.md) (fuentes no redistribuibles)
-- [Employment source policy](docs/employment-source-policy.md) (clasificaciones de confianza y términos)
-- [Code of Conduct](CODE_OF_CONDUCT.md) (expectativas de comunidad y cumplimiento)
+## Construido con OpenAgreements
 
-## Lanzamientos
+- [Safe Clause](https://safeclause.deltaxy.ai) — plataforma de contratos impulsada por IA para startups. [#1 en vibecode.law, marzo de 2026](https://vibecode.law/showcase/safe-clause-317416).
 
-Los lanzamientos están automatizados mediante GitHub Actions usando publicación confiable de npm (OIDC) con provenance habilitado.
-
-1. Actualiza versiones en el paquete raíz + paquetes MCP publicables.
-2. Haz push del commit + etiqueta con `git push origin main --tags`
-3. Ejecuta la compuerta local de extensión Gemini (copia/symlink en `~/.gemini/extensions/open-agreements` y verifica que ambos servidores MCP locales inicien/respondan).
-4. El workflow `Release` publica desde la etiqueta después de ejecutar build, validación, pruebas, smoke de runtime aislado y chequeos de paquete.
-
-Compuertas del workflow:
-
-- la etiqueta debe coincidir con las versiones del paquete raíz + paquetes publicables
-- el commit de release debe estar contenido en `origin/main`
-- la publicación falla si alguna versión objetivo en npm ya existe
-
-## Arquitectura
-
-- **Language**: TypeScript
-- **DOCX Engine**: [docx-templates](https://www.npmjs.com/package/docx-templates) (MIT)
-- **CLI**: [Commander.js](https://www.npmjs.com/package/commander)
-- **Validation**: [Zod](https://www.npmjs.com/package/zod) schemas
-- **Skill Pattern**: Agent-agnostic `ToolCommandAdapter` interface
-
-```
-content/                    # All content directories
-├── templates/              # Internal templates (CC BY 4.0)
-├── external/               # External templates (CC BY-ND 4.0)
-└── recipes/                # Recipes (downloaded at runtime)
-
-src/                        # TypeScript source + collocated unit tests
-├── cli/                    # Commander.js CLI
-├── commands/               # fill, validate, list, recipe, scan
-├── core/
-│   ├── engine.ts           # docx-templates wrapper
-│   ├── metadata.ts         # Zod schemas + loader
-│   ├── recipe/             # Recipe pipeline (clean → patch → fill → verify)
-│   ├── external/           # External template support
-│   ├── validation/         # template, license, output, recipe
-│   └── command-generation/
-│       ├── types.ts        # ToolCommandAdapter interface
-│       └── adapters/       # Claude Code adapter
-└── index.ts                # Public API
-
-integration-tests/          # Integration and end-to-end tests
-```
-
-## Recursos
-
-- [Claude Code Documentation](https://docs.anthropic.com/en/docs/claude-code)
-- [Claude Code Plugins Guide](https://docs.anthropic.com/en/docs/claude-code/plugins)
-- [Agent Skills Specification](https://agentskills.io)
+¿Construyes algo con OpenAgreements? Abre un PR para añadir tu proyecto.
 
 ## Licencia
 
-MIT
+MIT. El contenido de las plantillas está licenciado por sus respectivos autores:
 
-El contenido de plantillas está licenciado por sus respectivos autores: CC BY 4.0 (Common Paper, Bonterms), CC BY-ND 4.0 (Y Combinator) o propietario (NVCA, descargado en tiempo de ejecución). Consulta `metadata.yaml` de cada plantilla para más detalles.
+- CC BY 4.0 para plantillas de Common Paper, Bonterms y de autoría OpenAgreements
+- CC BY-ND 4.0 para plantillas SAFE de Y Combinator vendorizadas sin cambios
+- propietario o no redistribuible para los documentos fuente de NVCA gestionados mediante flujos de recipes
 
-## Descargo de responsabilidad
+Consulta el `metadata.yaml` de cada plantilla para detalles específicos de la fuente.
 
-Esta herramienta genera documentos a partir de plantillas estándar. No proporciona asesoría legal. No se implica afiliación ni respaldo por parte de Common Paper, Bonterms, Y Combinator, NVCA ni ninguna fuente de plantillas. Consulta a un abogado para recibir orientación legal.
+Esta herramienta genera documentos a partir de plantillas estándar. No proporciona asesoría legal. Consulta a un abogado para recibir orientación legal.

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ Works with Claude Code, Gemini CLI, Cursor, and local MCP or CLI workflows.
 
 ## Contents
 
-- [Install](#install)
-- [Quick Start](#quick-start)
 - [Available Templates](#available-templates)
 - [Available Skills](#available-skills)
 - [Packages](#packages)
+- [Quick Start](#quick-start)
+- [Install](#install)
 - [Documentation](#documentation)
 - [Privacy](#privacy)
 - [See Also](#see-also)
@@ -38,89 +38,6 @@ Works with Claude Code, Gemini CLI, Cursor, and local MCP or CLI workflows.
 </p>
 
 > *Demo: Claude fills a Common Paper Mutual NDA in under 2 minutes. Sped up for brevity.*
-
-## Install
-
-### Agent Skill (recommended)
-
-```bash
-npx skills add open-agreements/open-agreements
-```
-
-### Remote MCP
-
-Connect any MCP-compatible agent to the hosted server at `https://openagreements.org/api/mcp`.
-
-**Claude Code**
-
-```bash
-claude mcp add --transport http open-agreements https://openagreements.org/api/mcp
-```
-
-**Codex CLI**
-
-```bash
-codex mcp add open-agreements --url https://openagreements.org/api/mcp
-```
-
-**Other agents** — point your client at `https://openagreements.org/api/mcp` (streamable HTTP).
-
-### Gemini CLI Extension
-
-```bash
-gemini extensions install https://github.com/open-agreements/open-agreements
-```
-
-### CLI
-
-```bash
-npm install -g open-agreements
-```
-
-Or run directly with zero install:
-
-```bash
-npx -y open-agreements@latest list
-```
-
-## Quick Start
-
-### With Claude Code
-
-Ask Claude:
-
-```text
-Fill the Common Paper mutual NDA for my company
-```
-
-Claude can discover templates, interview you for field values, and render a signed-ready DOCX.
-
-### With the CLI
-
-```bash
-# See all available templates
-open-agreements list
-
-# Fill a template from a JSON data file
-open-agreements fill common-paper-mutual-nda -d values.json -o my-nda.docx
-
-# Fill with inline values
-open-agreements fill common-paper-mutual-nda --set party_1_name="Acme Corp" --set governing_law="Delaware"
-```
-
-### Example Prompts
-
-- "Draft an NDA for our construction subcontractor"
-- "Create a consulting agreement for our insurance agency"
-- "Fill the independent contractor agreement for a freelance designer"
-- "Generate a SAFE with a $5M valuation cap"
-
-### What Happens
-
-1. The agent runs `list --json` to discover templates and their fields.
-2. It interviews you for field values grouped by section.
-3. It runs `fill <template>` to render a DOCX preserving the source formatting.
-4. You review and sign the output document.
 
 ## Available Templates
 
@@ -352,6 +269,89 @@ This repository includes a Cursor plugin manifest at `.cursor-plugin/plugin.json
 Choose based on document sensitivity and internal policy. See the trust checklist below for the data-flow summary.
 
 </details>
+
+## Quick Start
+
+### With Claude Code
+
+Ask Claude:
+
+```text
+Fill the Common Paper mutual NDA for my company
+```
+
+Claude can discover templates, interview you for field values, and render a signed-ready DOCX.
+
+### With the CLI
+
+```bash
+# See all available templates
+open-agreements list
+
+# Fill a template from a JSON data file
+open-agreements fill common-paper-mutual-nda -d values.json -o my-nda.docx
+
+# Fill with inline values
+open-agreements fill common-paper-mutual-nda --set party_1_name="Acme Corp" --set governing_law="Delaware"
+```
+
+### Example Prompts
+
+- "Draft an NDA for our construction subcontractor"
+- "Create a consulting agreement for our insurance agency"
+- "Fill the independent contractor agreement for a freelance designer"
+- "Generate a SAFE with a $5M valuation cap"
+
+### What Happens
+
+1. The agent runs `list --json` to discover templates and their fields.
+2. It interviews you for field values grouped by section.
+3. It runs `fill <template>` to render a DOCX preserving the source formatting.
+4. You review and sign the output document.
+
+## Install
+
+### Agent Skill (recommended)
+
+```bash
+npx skills add open-agreements/open-agreements
+```
+
+### Remote MCP
+
+Connect any MCP-compatible agent to the hosted server at `https://openagreements.org/api/mcp`.
+
+**Claude Code**
+
+```bash
+claude mcp add --transport http open-agreements https://openagreements.org/api/mcp
+```
+
+**Codex CLI**
+
+```bash
+codex mcp add open-agreements --url https://openagreements.org/api/mcp
+```
+
+**Other agents** — point your client at `https://openagreements.org/api/mcp` (streamable HTTP).
+
+### Gemini CLI Extension
+
+```bash
+gemini extensions install https://github.com/open-agreements/open-agreements
+```
+
+### CLI
+
+```bash
+npm install -g open-agreements
+```
+
+Or run directly with zero install:
+
+```bash
+npx -y open-agreements@latest list
+```
 
 ---
 

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -1,201 +1,214 @@
+<!-- This file is generated from README.template.md by scripts/generate_readme.mjs. Do not edit README.md directly. -->
+
 # OpenAgreements
 
 [![npm version](https://img.shields.io/npm/v/open-agreements)](https://www.npmjs.com/package/open-agreements)
 [![npm downloads](https://img.shields.io/npm/dm/open-agreements.svg)](https://npmjs.org/package/open-agreements)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![Agent Skill](https://img.shields.io/badge/agent--skill-open--agreements-purple)](https://skills.sh)
 [![CI](https://github.com/open-agreements/open-agreements/actions/workflows/ci.yml/badge.svg)](https://github.com/open-agreements/open-agreements/actions/workflows/ci.yml)
-[![MCP Server Status](https://img.shields.io/endpoint?url=https%3A%2F%2Fopenagreements.org%2Fapi%2Fstatus%3Fformat%3Dshields)](https://openagreements.openstatus.dev/)
 [![codecov](https://img.shields.io/codecov/c/github/open-agreements/open-agreements/main)](https://app.codecov.io/gh/open-agreements/open-agreements)
-[![GitHub stargazers](https://img.shields.io/github/stars/open-agreements/open-agreements?style=social)](https://github.com/open-agreements/open-agreements/stargazers)
-[![Tests: Vitest](https://img.shields.io/badge/tests-vitest-6E9F18)](https://vitest.dev/)
-[![OpenSpec Traceability](https://img.shields.io/badge/openspec-traceability%20gate-brightgreen)](./scripts/validate_openspec_coverage.mjs)
 [![Socket Badge](https://socket.dev/api/badge/npm/package/open-agreements)](https://socket.dev/npm/package/open-agreements)
+[![GitHub stargazers](https://img.shields.io/github/stars/open-agreements/open-agreements?style=social)](https://github.com/open-agreements/open-agreements/stargazers)
+[![Agent Skill](https://img.shields.io/badge/agent--skill-open--agreements-purple)](https://skills.sh)
+[![MCP Server Status](https://img.shields.io/endpoint?url=https%3A%2F%2Fopenagreements.org%2Fapi%2Fstatus%3Fformat%3Dshields)](https://openagreements.openstatus.dev/)
 [![install size](https://packagephobia.com/badge?p=open-agreements)](https://packagephobia.com/result?p=open-agreements)
 
-[English](./README.md) | [Español](./README.es.md) | [简体中文](./README.zh.md) | [Português (Brasil)](./README.pt-br.md) | [Deutsch](./README.de.md)
+[English](https://github.com/open-agreements/open-agreements/blob/main/README.md) | [Español](https://github.com/open-agreements/open-agreements/blob/main/README.es.md) | [简体中文](https://github.com/open-agreements/open-agreements/blob/main/README.zh.md) | [Português (Brasil)](https://github.com/open-agreements/open-agreements/blob/main/README.pt-br.md) | [Deutsch](https://github.com/open-agreements/open-agreements/blob/main/README.de.md)
 
 > **Aviso de tradução:** o `README.md` em inglês é a fonte canônica de verdade. Esta tradução pode ter pequeno atraso. Atualizações importantes do README em inglês devem ser propagadas em até 72 horas.
 
-<!-- TODO: Add OpenSSF Scorecard badge once repo is indexed at securityscorecards.dev -->
-<!-- TODO: Add OpenSSF Best Practices badge after registration at bestpractices.dev -->
-<!-- TODO: Re-evaluate Snyk badge — Advisor migrated to security.snyk.io (July 2024) -->
+Preencha modelos padrão de acordos legais e gere arquivos DOCX prontos para assinatura. O OpenAgreements inclui mais de 40 modelos cobrindo NDAs, acordos de serviço em nuvem, documentos de trabalho, acordos com contratados, SAFEs e documentos de financiamento NVCA.
+
+Funciona com Claude Code, Gemini CLI, Cursor e fluxos locais de MCP ou CLI.
+
+## Conteúdo
+
+- [Modelos Disponíveis](#modelos-disponíveis)
+- [Skills Disponíveis](#skills-disponíveis)
+- [Pacotes](#pacotes)
+- [Início Rápido](#início-rápido)
+- [Instalação](#instalação)
+- [Documentação](#documentação)
+- [Privacidade](#privacidade)
+- [Veja Também](#veja-também)
+- [Contribuindo](#contribuindo)
+- [Construído com OpenAgreements](#construído-com-openagreements)
+- [Licença](#licença)
 
 <p align="center">
-  <img src="docs/assets/demo-fill-nda.gif" alt="Fill a Mutual NDA in Claude Code — prompt, answer questions, get a signed-ready DOCX" width="720">
+  <img src="https://raw.githubusercontent.com/open-agreements/open-agreements/main/docs/assets/demo-fill-nda.gif" alt="Fill a Mutual NDA in Claude Code — prompt, answer questions, get a signed-ready DOCX" width="720">
 </p>
 
 > *Demo: Claude preenche um NDA mútuo da Common Paper em menos de 2 minutos. Acelerado para brevidade.*
 
-Preencha modelos padrão de acordos legais e gere arquivos DOCX prontos para assinatura. Os modelos cobrem NDAs, termos de cloud, documentos de trabalho, acordos com contratados, SAFEs e documentos de financiamento NVCA.
+## Modelos Disponíveis
 
-**Open Agreements** por [UseJunior](https://usejunior.com) — parte das [ferramentas para desenvolvedores da UseJunior](https://usejunior.com/developer-tools/open-agreements). Em produção em escritórios Am Law 100.
+A coluna Fonte aponta para o padrão upstream, documento de origem ou página canônica do projeto (varia por editor). A coluna Licença mostra os termos de redistribuição. Os links de Repo apontam para o diretório de conteúdo no GitHub de cada modelo ou recipe.
 
-## Qualidade e sinais de confiança
+### Confidencialidade
 
-- O CI roda em pull requests e em pushes para `main`.
-- A saúde do serviço em produção é publicada via OpenStatus em `openagreements.openstatus.dev`.
-- A cobertura é publicada no Codecov com gates de patch/projeto definidos no repositório em `codecov.yml`.
-- O framework de testes JS ativo é Vitest, com resultados JUnit enviados para analytics de testes no Codecov.
-- A rastreabilidade de cenários OpenSpec é aplicada com `npm run check:spec-coverage`. Para exportar uma matriz local, rode `npm run check:spec-coverage -- --write-matrix integration-tests/OPENSPEC_TRACEABILITY.md`.
-- O canário de source drift de recipes (`npm run check:source-drift`) valida o hash de origem esperado e âncoras estruturais de replace/normalize.
-- Regressões em nível de suposição são rastreadas em `docs/assumptions.md` e validadas por testes de regressão direcionados + gates de CI.
-- A renderização visual de DOCX com LibreOffice usa configuração fixada no macOS (`config/libreoffice-headless.json`); rode `npm run check:libreoffice` antes de testes visuais de evidência do Allure.
-- Maintainer: [Steven Obiajulu](https://www.linkedin.com/in/steven-obiajulu/) (engenheiro mecânico formado no MIT; advogado com formação em Harvard Law).
+| Modelo | Site | Fonte | Licença | Repo |
+|----------|---------|--------|---------|------|
+| Bonterms Mutual NDA | [Site](https://usejunior.com/templates/bonterms-mutual-nda) | [Bonterms](https://bonterms.com/resources/mutual-nda-cover-page-example) | [CC0-1.0](https://creativecommons.org/publicdomain/zero/1.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/bonterms-mutual-nda) |
+| Common Paper Mutual NDA | [Site](https://usejunior.com/templates/common-paper-mutual-nda) | [Common Paper](https://commonpaper.com/standards/mutual-nda/1.0) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-mutual-nda) |
+| One Way NDA | [Site](https://usejunior.com/templates/common-paper-one-way-nda) | [Common Paper](https://commonpaper.com/standards/one-way-nda) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-one-way-nda) |
 
-## Como funciona
+### Vendas e Licenciamento
 
-1. Etapa 1: escolha um modelo (36 acordos padrão)
-2. Etapa 2: preencha seus dados (prompts interativos ou MCP)
-3. Etapa 3: receba um DOCX com formatação profissional
+| Modelo | Site | Fonte | Licença | Repo |
+|----------|---------|--------|---------|------|
+| Cloud Service Agreement | [Site](https://usejunior.com/templates/common-paper-cloud-service-agreement) | [Common Paper](https://commonpaper.com/standards/cloud-service-agreement/2.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-cloud-service-agreement) |
+| CSA Click Through | [Site](https://usejunior.com/templates/common-paper-csa-click-through) | [Common Paper](https://commonpaper.com/standards/cloud-service-agreement/2.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-csa-click-through) |
+| CSA With AI | [Site](https://usejunior.com/templates/common-paper-csa-with-ai) | [Common Paper](https://commonpaper.com/standards/cloud-service-agreement/2.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-csa-with-ai) |
+| CSA With SLA | [Site](https://usejunior.com/templates/common-paper-csa-with-sla) | [Common Paper](https://commonpaper.com/standards/cloud-service-agreement/2.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-csa-with-sla) |
+| CSA Without SLA | [Site](https://usejunior.com/templates/common-paper-csa-without-sla) | [Common Paper](https://commonpaper.com/standards/cloud-service-agreement/2.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-csa-without-sla) |
+| Order Form | [Site](https://usejunior.com/templates/common-paper-order-form) | [Common Paper](https://commonpaper.com/standards/cloud-service-agreement/2.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-order-form) |
+| Order Form With SLA | [Site](https://usejunior.com/templates/common-paper-order-form-with-sla) | [Common Paper](https://commonpaper.com/standards/cloud-service-agreement/2.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-order-form-with-sla) |
+| Software License Agreement | [Site](https://usejunior.com/templates/common-paper-software-license-agreement) | [Common Paper](https://commonpaper.com/standards/software-license-agreement/1.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-software-license-agreement) |
 
-O OpenAgreements oferece dois modos de execução com limites de confiança diferentes:
+### Dados e Conformidade
 
-- Conector MCP remoto hospedado (`https://openagreements.org/api/mcp`) para setup rápido no Claude.
-- Execução totalmente local do pacote (`npx`, instalação global ou pacote MCP local por stdio) para fluxos de trabalho na própria máquina.
+| Modelo | Site | Fonte | Licença | Repo |
+|----------|---------|--------|---------|------|
+| AI Addendum | [Site](https://usejunior.com/templates/common-paper-ai-addendum) | [Common Paper](https://commonpaper.com/standards/ai-addendum/1.0) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-ai-addendum) |
+| AI Addendum In App | [Site](https://usejunior.com/templates/common-paper-ai-addendum-in-app) | [Common Paper](https://commonpaper.com/standards/ai-addendum/1.0) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-ai-addendum-in-app) |
+| Business Associate Agreement | [Site](https://usejunior.com/templates/common-paper-business-associate-agreement) | [Common Paper](https://commonpaper.com/standards/business-associate-agreement/1.0) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-business-associate-agreement) |
+| Data Processing Agreement | [Site](https://usejunior.com/templates/common-paper-data-processing-agreement) | [Common Paper](https://commonpaper.com/standards/data-processing-agreement/1.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-data-processing-agreement) |
 
-Não há recomendação global de modo padrão. Escolha com base na sensibilidade do documento, política interna e velocidade desejada no fluxo de trabalho. Veja `docs/trust-checklist.md` para um resumo de fluxo de dados em 60 segundos.
+### Serviços Profissionais
 
-### Decisão rápida
+| Modelo | Site | Fonte | Licença | Repo |
+|----------|---------|--------|---------|------|
+| Bonterms Professional Services Agreement | [Site](https://usejunior.com/templates/bonterms-professional-services-agreement) | [Bonterms](https://bonterms.com/resources/psa-cover-page-example) | [CC0-1.0](https://creativecommons.org/publicdomain/zero/1.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/bonterms-professional-services-agreement) |
+| Independent Contractor Agreement | [Site](https://usejunior.com/templates/common-paper-independent-contractor-agreement) | [Common Paper](https://commonpaper.com/standards/independent-contractor-agreement) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-independent-contractor-agreement) |
+| Common Paper Professional Services Agreement | [Site](https://usejunior.com/templates/common-paper-professional-services-agreement) | [Common Paper](https://commonpaper.com/standards/professional-services-agreement/1.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-professional-services-agreement) |
+| Statement Of Work | [Site](https://usejunior.com/templates/common-paper-statement-of-work) | [Common Paper](https://commonpaper.com/standards/statement-of-work) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-statement-of-work) |
 
-- Se seu documento é sensível, use execução totalmente local do pacote.
-- Se você prioriza conveniência, use o conector MCP remoto hospedado.
+### Negócios e Parcerias
 
-## Uso com Claude Code
+| Modelo | Site | Fonte | Licença | Repo |
+|----------|---------|--------|---------|------|
+| Amendment | [Site](https://usejunior.com/templates/common-paper-amendment) | [Common Paper](https://commonpaper.com/standards/amendment) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-amendment) |
+| Design Partner Agreement | [Site](https://usejunior.com/templates/common-paper-design-partner-agreement) | [Common Paper](https://commonpaper.com/standards/design-partner-agreement/1.3) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-design-partner-agreement) |
+| Letter Of Intent | [Site](https://usejunior.com/templates/common-paper-letter-of-intent) | [Common Paper](https://commonpaper.com/standards/letter-of-intent) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-letter-of-intent) |
+| Partnership Agreement | [Site](https://usejunior.com/templates/common-paper-partnership-agreement) | [Common Paper](https://commonpaper.com/standards/partnership-agreement/1.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-partnership-agreement) |
+| Pilot Agreement | [Site](https://usejunior.com/templates/common-paper-pilot-agreement) | [Common Paper](https://commonpaper.com/standards/pilot-agreement/1.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-pilot-agreement) |
+| Term Sheet | [Site](https://usejunior.com/templates/common-paper-term-sheet) | [Common Paper](https://commonpaper.com/standards/term-sheet) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-term-sheet) |
 
-OpenAgreements funciona como [plugin do Claude Code](https://docs.anthropic.com/en/docs/claude-code/plugins) e [Agent Skill](https://agentskills.io). Não é necessária pré-instalação: o Claude baixa e executa o CLI sob demanda via `npx`.
+### Emprego
 
-### Opção 1: Agent Skill (recomendado)
+| Modelo | Site | Fonte | Licença | Repo |
+|----------|---------|--------|---------|------|
+| Employee IP Inventions Assignment | [Site](https://usejunior.com/templates/openagreements-employee-ip-inventions-assignment) | [OpenAgreements](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-employee-ip-inventions-assignment) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-employee-ip-inventions-assignment) |
+| Employment Confidentiality Acknowledgement | [Site](https://usejunior.com/templates/openagreements-employment-confidentiality-acknowledgement) | [OpenAgreements](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-employment-confidentiality-acknowledgement) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-employment-confidentiality-acknowledgement) |
+| Employment Offer Letter | [Site](https://usejunior.com/templates/openagreements-employment-offer-letter) | [OpenAgreements](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-employment-offer-letter) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-employment-offer-letter) |
+| Restrictive Covenant Wyoming | [Site](https://usejunior.com/templates/openagreements-restrictive-covenant-wyoming) | [OpenAgreements](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-restrictive-covenant-wyoming) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-restrictive-covenant-wyoming) |
 
-```bash
-npx skills add open-agreements/open-agreements
+### SAFEs
+
+| Modelo | Site | Fonte | Licença | Repo |
+|----------|---------|--------|---------|------|
+| Discount | [Site](https://usejunior.com/templates/yc-safe-discount) | [Y Combinator](https://www.ycombinator.com/documents) | [CC-BY-ND-4.0](https://creativecommons.org/licenses/by-nd/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/external/yc-safe-discount) |
+| MFN | [Site](https://usejunior.com/templates/yc-safe-mfn) | [Y Combinator](https://www.ycombinator.com/documents) | [CC-BY-ND-4.0](https://creativecommons.org/licenses/by-nd/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/external/yc-safe-mfn) |
+| Pro Rata Side Letter | [Site](https://usejunior.com/templates/yc-safe-pro-rata-side-letter) | [Y Combinator](https://www.ycombinator.com/documents) | [CC-BY-ND-4.0](https://creativecommons.org/licenses/by-nd/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/external/yc-safe-pro-rata-side-letter) |
+| Valuation Cap | [Site](https://usejunior.com/templates/yc-safe-valuation-cap) | [Y Combinator](https://www.ycombinator.com/documents) | [CC-BY-ND-4.0](https://creativecommons.org/licenses/by-nd/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/external/yc-safe-valuation-cap) |
+
+### Financiamento de Venture Capital
+
+| Modelo | Site | Fonte | Licença | Repo |
+|----------|---------|--------|---------|------|
+| Certificate Of Incorporation | [Site](https://usejunior.com/templates/nvca-certificate-of-incorporation) | [NVCA](https://nvca.org/wp-content/uploads/2025/10/NVCA-Model-COI-10-1-2025.docx) | Recipe | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/recipes/nvca-certificate-of-incorporation) |
+| Indemnification Agreement | [Site](https://usejunior.com/templates/nvca-indemnification-agreement) | [NVCA](https://nvca.org/wp-content/uploads/2021/12/NVCA-2020-Indemnification-Agreement.docx) | Recipe | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/recipes/nvca-indemnification-agreement) |
+| Investors Rights Agreement | [Site](https://usejunior.com/templates/nvca-investors-rights-agreement) | [NVCA](https://nvca.org/wp-content/uploads/2025/10/NVCA-Model-IRA-10-1-2025-2-1.docx) | Recipe | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/recipes/nvca-investors-rights-agreement) |
+| Management Rights Letter | [Site](https://usejunior.com/templates/nvca-management-rights-letter) | [NVCA](https://nvca.org/wp-content/uploads/2025/12/NVCA-2020-Management-Rights-Letter-1-1.docx) | Recipe | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/recipes/nvca-management-rights-letter) |
+| ROFR Co Sale Agreement | [Site](https://usejunior.com/templates/nvca-rofr-co-sale-agreement) | [NVCA](https://nvca.org/wp-content/uploads/2025/10/NVCA-Model-ROFRA-10-1-2025.docx) | Recipe | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/recipes/nvca-rofr-co-sale-agreement) |
+| Stock Purchase Agreement | [Site](https://usejunior.com/templates/nvca-stock-purchase-agreement) | [NVCA](https://nvca.org/wp-content/uploads/2025/10/NVCA-Model-SPA-10-28-2025-1.docx) | Recipe | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/recipes/nvca-stock-purchase-agreement) |
+| Voting Agreement | [Site](https://usejunior.com/templates/nvca-voting-agreement) | [NVCA](https://nvca.org/wp-content/uploads/2024/10/NVCA-Model-VA-10-1-2025.docx) | Recipe | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/recipes/nvca-voting-agreement) |
+
+### Outros
+
+| Modelo | Site | Fonte | Licença | Repo |
+|----------|---------|--------|---------|------|
+| Closing Checklist | [Site](https://usejunior.com/templates/closing-checklist) | [OpenAgreements](https://github.com/open-agreements/open-agreements) | [CC0-1.0](https://creativecommons.org/publicdomain/zero/1.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/closing-checklist) |
+| Board Consent SAFE | [Site](https://usejunior.com/templates/openagreements-board-consent-safe) | [OpenAgreements](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-board-consent-safe) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-board-consent-safe) |
+| Due Diligence Request List | [Site](https://usejunior.com/templates/openagreements-due-diligence-request-list) | [OpenAgreements](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-due-diligence-request-list) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-due-diligence-request-list) |
+| Stockholder Consent SAFE | [Site](https://usejunior.com/templates/openagreements-stockholder-consent-safe) | [OpenAgreements](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-stockholder-consent-safe) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-stockholder-consent-safe) |
+| Working Group List | [Site](https://usejunior.com/templates/working-group-list) | [OpenAgreements](https://github.com/open-agreements/open-agreements) | [CC0-1.0](https://creativecommons.org/publicdomain/zero/1.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/working-group-list) |
+
+## Skills Disponíveis
+
+### Redação e Preenchimento de Acordos
+
+| Skill | Descrição |
+|-------|-------------|
+| [open-agreements](https://github.com/open-agreements/open-agreements/tree/main/skills/open-agreements) | Preencha modelos padrão de acordos legais (NDAs, acordos de serviço em nuvem, SAFEs) e gere arquivos DOCX prontos para assinatura. Suporta modelos da Common Paper, Bonterms e Y Combinator. Use quando o usuário precisar redigir um acordo legal, criar um NDA, preencher um modelo de contrato ou gerar um SAFE. Também pode enviar acordos para assinatura eletrônica via DocuSign. |
+| [nda](https://github.com/open-agreements/open-agreements/tree/main/skills/nda) | Redija e preencha modelos de NDA — NDA mútuo, NDA unilateral, acordo de confidencialidade. Gera arquivos DOCX prontos para assinatura a partir de formulários padrão da Common Paper e Bonterms. Use quando o usuário disser "NDA", "acordo de não divulgação", "acordo de confidencialidade", "NDA mútuo" ou "NDA unilateral". |
+| [cloud-service-agreement](https://github.com/open-agreements/open-agreements/tree/main/skills/cloud-service-agreement) | Redija e preencha modelos de acordo SaaS — contrato de nuvem, MSA, formulário de pedido, licença de software, acordo piloto, acordo de parceiro de design. Inclui variantes com SLAs e termos de IA. Gera DOCX pronto para assinatura a partir de formulários padrão da Common Paper. Use quando o usuário disser "acordo SaaS", "contrato de nuvem", "MSA", "formulário de pedido", "licença de software", "acordo piloto" ou "acordo de parceiro de design". |
+| [services-agreement](https://github.com/open-agreements/open-agreements/tree/main/skills/services-agreement) | Redija e preencha modelos de acordo de serviços — contrato de consultoria, acordo de contratado, SOW, statement of work, acordo de serviços profissionais. Gera arquivos DOCX prontos para assinatura a partir de formulários padrão da Common Paper e Bonterms. Use quando o usuário disser "contrato de consultoria", "acordo de contratado", "SOW", "statement of work", "acordo de serviços" ou "contrato de freelancer". |
+| [employment-contract](https://github.com/open-agreements/open-agreements/tree/main/skills/employment-contract) | Redija e preencha modelos de acordo de trabalho — carta-proposta, cessão de PI, PIIA, declaração de confidencialidade. Gera arquivos DOCX prontos para assinatura a partir de formulários padrão do OpenAgreements para contratação de funcionários. Use quando o usuário disser "carta-proposta", "acordo de trabalho", "PIIA", "cessão de PI", "contratar alguém" ou "documentação de onboarding". |
+| [data-privacy-agreement](https://github.com/open-agreements/open-agreements/tree/main/skills/data-privacy-agreement) | Redija e preencha modelos de acordo de privacidade de dados — DPA, acordo de processamento de dados, GDPR, HIPAA BAA, acordo de associado comercial, adendo de IA. Gera arquivos DOCX prontos para assinatura a partir de formulários padrão da Common Paper. Use quando o usuário disser "DPA", "acordo de processamento de dados", "HIPAA BAA", "acordo de associado comercial" ou "adendo de IA". |
+| [safe](https://github.com/open-agreements/open-agreements/tree/main/skills/safe) | Redija e preencha modelos de SAFE do Y Combinator — valuation cap, discount, MFN, pro rata side letter. Documentos padrão de captação para startups, voltados para equity conversível. Gera arquivos DOCX prontos para assinatura. Use quando o usuário disser "SAFE", "simple agreement for future equity", "YC SAFE", "valuation cap", "documentos de seed round" ou "papelada de fundraising". |
+| [venture-financing](https://github.com/open-agreements/open-agreements/tree/main/skills/venture-financing) | Redija e preencha documentos modelo da NVCA — stock purchase agreement, certificate of incorporation, investors rights agreement, voting agreement, ROFR, co-sale, indenização, management rights letter. Modelos de Series A e financiamento de venture capital. Gera arquivos DOCX prontos para assinatura. Use quando o usuário disser "documentos de Series A", "NVCA", "stock purchase agreement", "investors rights agreement", "voting agreement" ou "documentos de financiamento de venture". |
+
+### Edição e Fluxos com Clientes
+
+| Skill | Descrição |
+|-------|-------------|
+| [edit-docx-agreement](https://github.com/open-agreements/open-agreements/tree/main/skills/edit-docx-agreement) | Faça edições sob medida em um acordo DOCX gerado pelo OpenAgreements (ou qualquer DOCX existente), usando ferramentas MCP do Safe Docx para edições cirúrgicas que preservam a formatação e saídas com track changes. Use quando o usuário disser "editar este contrato", "alterar uma cláusula", "modificar o acordo", "edições personalizadas no docx" ou "alterações sob medida no documento". |
+| [client-email](https://github.com/open-agreements/open-agreements/tree/main/skills/client-email) | Redija e-mails voltados ao cliente para serviços jurídicos — cover notes para entregas de contratos, resumos de redlines, atualizações de status do deal e follow-ups. Use ao compor ou revisar e-mails de saída para clientes sobre trabalho jurídico. Disparado por "redigir resposta", "e-mail para cliente", "cover note", "responder para" ou qualquer e-mail de saída acompanhando uma entrega jurídica. |
+| [delaware-franchise-tax](https://github.com/open-agreements/open-agreements/tree/main/skills/delaware-franchise-tax) | Faça a declaração anual do Delaware franchise tax e do annual report. Orienta no cálculo do imposto (métodos Authorized Shares e Assumed Par Value Capital), no processo de submissão pelo portal eCorp e no pagamento. Para Delaware C-Corps (prazo 1 de março) e LLCs/LPs/GPs (prazo 1 de junho). Use quando o usuário disser "Delaware franchise tax", "annual report Delaware", "declarar franchise tax" ou "portal eCorp". |
+
+### Conformidade e Auditoria
+
+| Skill | Descrição |
+|-------|-------------|
+| [soc2-readiness](https://github.com/open-agreements/open-agreements/tree/main/skills/soc2-readiness) | Avalie a prontidão para SOC 2 Type II. Mapeie Trust Services Criteria para controles, identifique gaps e construa um plano de remediação. Usa NIST SP 800-53 (domínio público) como referência canônica com mapeamento cruzado para critérios SOC 2. Use quando o usuário disser "prontidão para SOC 2", "preparação para SOC 2", "análise de gaps SOC 2" ou "preparar para auditoria SOC 2". |
+| [iso-27001-internal-audit](https://github.com/open-agreements/open-agreements/tree/main/skills/iso-27001-internal-audit) | Conduza uma auditoria interna ISO 27001. Percorra controles por domínio, identifique gaps, colete evidências e gere achados com recomendações de ações corretivas. Usa NIST SP 800-53 (domínio público) como referência canônica. Use quando o usuário disser "rodar auditoria interna", "auditoria ISO 27001", "avaliação de controles", "achados de auditoria" ou "avaliação de ISMS". |
+| [iso-27001-evidence-collection](https://github.com/open-agreements/open-agreements/tree/main/skills/iso-27001-evidence-collection) | Colete, organize e valide evidências para auditorias ISO 27001 e SOC 2. Abordagem API-first com comandos CLI para grandes plataformas em nuvem. Gera pacotes de evidência com timestamp prontos para auditor. Use quando o usuário disser "coletar evidências de auditoria", "preparar pacote de evidências", "evidências para o auditor", "atualizar evidências" ou "análise de gaps de evidências". |
+
+### Fluxos para Desenvolvedores
+
+| Skill | Descrição |
+|-------|-------------|
+| [recipe-quality-audit](https://github.com/open-agreements/open-agreements/tree/main/skills/recipe-quality-audit) | Audite a qualidade de recipes da NVCA: verifique o inventário de arquivos, o schema de metadados, a cobertura de campos para substituições, chaves ambíguas, smart quotes, fixtures de teste e qualidade de preenchimento. Gera um scorecard estruturado por recipe com classificação de nível de maturidade. Use quando o usuário disser "auditar qualidade de recipe", "verificar cobertura de recipe", "scorecard de recipe" ou "qualidade de recipe NVCA". |
+| [unit-test-philosophy](https://github.com/open-agreements/open-agreements/tree/main/skills/unit-test-philosophy) | Testes unitários baseados em risco e estilo de spec comportamental legível pelo Allure para o open-agreements. Use quando o usuário disser "adicionar testes", "qualidade dos testes", "expansão de cobertura", "estilo de teste unitário" ou "spec de teste Allure". Aplica-se ao adicionar/atualizar testes, expandir cobertura ou revisar a qualidade de testes em src, integration-tests e pacotes do workspace. |
+
+### Autoria de Modelos
+
+| Skill | Descrição |
+|-------|-------------|
+| [canonical-markdown-authoring](https://github.com/open-agreements/open-agreements/tree/main/skills/canonical-markdown-authoring) | Converta rascunhos de contratos em markdown comum para o formato canônico template.md do OpenAgreements — frontmatter YAML, tabelas de termos da capa Kind|Label|Value|Show When, diretivas oa:clause, parágrafos com [[Termo Definido]] e diretivas oa:signer que compilam para JSON specs validados e artefatos DOCX. Use quando o usuário disser "converter isto para markdown canônico", "criar um novo modelo OpenAgreements", "migrar modelo para template.md" ou "escrever um contrato em formato canônico". |
+
+## Pacotes
+
+| Pacote | Descrição |
+|---------|-------------|
+| [open-agreements](https://www.npmjs.com/package/open-agreements) | CLI e biblioteca open-source para preenchimento de modelos legais |
+| [@open-agreements/contract-templates-mcp](https://github.com/open-agreements/open-agreements/blob/main/packages/contract-templates-mcp/README.md) | Servidor MCP local por stdio para descoberta e preenchimento de modelos do OpenAgreements |
+| [@open-agreements/contracts-workspace](https://github.com/open-agreements/open-agreements/blob/main/packages/contracts-workspace/README.md) | CLI orientado a workspace para organizar e acompanhar repositórios de contratos |
+| [@open-agreements/contracts-workspace-mcp](https://github.com/open-agreements/open-agreements/blob/main/packages/contracts-workspace-mcp/README.md) | Servidor MCP local por stdio para operações de contracts workspace |
+| [@open-agreements/checklist-mcp](https://github.com/open-agreements/open-agreements/blob/main/packages/checklist-mcp/README.md) | Servidor MCP local por stdio para operações de memória de checklist do OpenAgreements |
+
+### O Que É Instalado
+
+```text
+open-agreements/
+  bin/                    # CLI entry point
+  dist/                   # Compiled TypeScript
+  content/
+    templates/            # Fillable DOCX templates with {tag} placeholders
+    external/             # YC SAFE templates vendored unchanged
+    recipes/              # Recipe instructions for non-redistributable sources
+  skills/                 # Agent skill definitions
+  server.json             # MCP server manifest
+  gemini-extension.json   # Gemini CLI extension config
+  README.md, LICENSE
 ```
 
-Depois, peça ao Claude para redigir um acordo:
+Os modelos de recipe da NVCA são baixados em tempo de execução e não são empacotados no pacote.
 
-```
-> Draft an NDA between Acme Corp and Beta Inc
-```
-
-O Claude descobre os modelos disponíveis, entrevista você para coletar valores de campos e gera um DOCX pronto para assinatura.
-
-### Opção 2: Extensão Gemini CLI
-
-```bash
-gemini extensions install https://github.com/open-agreements/open-agreements
-```
-
-Depois, peça ao Gemini para redigir um acordo. A extensão fornece ferramentas MCP, arquivos de contexto e skills para descoberta e preenchimento de modelos.
-
-### Opção 3: Direto com Claude Code
-
-Se você tiver Node.js >= 20, basta pedir ao Claude:
-
-```
-> Fill the Common Paper mutual NDA for my company
-```
-
-O Claude executa `npx -y open-agreements@latest list --json` para descobrir modelos e depois `npx -y open-agreements@latest fill <template>` para gerar a saída. Sem instalação.
-
-### Opção 4: CLI
-
-```bash
-# Install globally
-npm install -g open-agreements
-
-# List available templates
-open-agreements list
-
-# Fill a template
-open-agreements fill common-paper-mutual-nda -d values.json -o my-nda.docx
-```
-
-### O que acontece
-
-1. O Claude executa `list --json` para descobrir modelos disponíveis e seus campos
-2. O Claude entrevista você para coletar valores de campos (agrupados por seção, até 4 perguntas por rodada)
-3. O Claude executa `fill <template>` para gerar um DOCX preservando toda a formatação original
-4. Você revisa e assina o documento de saída
-
-## Uso com Cursor
-
-Este repositório inclui um manifesto de plugin do Cursor com integração MCP:
-
-- Plugin manifest: `.cursor-plugin/plugin.json`
-- MCP config: `mcp.json`
-- Skill: `skills/open-agreements/SKILL.md`
-
-A configuração MCP padrão em `mcp.json` inclui:
-
-- Conector MCP OpenAgreements hospedado (`https://openagreements.org/api/mcp`)
-- Servidor MCP local de workspace (`npx -y @open-agreements/contracts-workspace-mcp`)
-- Servidor MCP local para drafting de modelos (`npx -y @open-agreements/contract-templates-mcp`)
-
-Para publicar este plugin no Cursor Marketplace, envie este repositório em:
-
-- https://cursor.com/marketplace/publish
-
-## Modelos
-
-28 modelos em três níveis. Rode `open-agreements list` para ver o inventário completo.
-
-| Nível | Quantidade | Fonte | Como funciona |
-|------|-------|--------|--------------|
-| Modelos internos | 17 | [Common Paper](https://commonpaper.com), [Bonterms](https://bonterms.com), OpenAgreements | Empacotados no pacote, CC BY 4.0 |
-| Modelos externos | 4 | [Y Combinator](https://www.ycombinator.com/documents) | Vendorizados sem alterações, CC BY-ND 4.0 |
-| Recipes | 7 | [NVCA](https://nvca.org/model-legal-documents/) | Baixados sob demanda (não redistribuíveis) |
-
-**Modelos internos** (NDAs, termos cloud, formulários de trabalho, acordos com contratados etc.) são CC BY 4.0 — enviamos o DOCX com placeholders `{tag}`.
-
-**Modelos externos** (YC SAFEs) são CC BY-ND 4.0 — vendorizamos o original sem alterações. A saída preenchida é um derivado transitório na sua máquina.
-
-**Recipes** (documentos de financiamento NVCA) são livremente baixáveis, mas não redistribuíveis — enviamos apenas instruções de transformação e baixamos o DOCX de origem de nvca.org em tempo de execução.
-
-### Extração de guidance
-
-Documentos de origem contêm comentários especializados — notas de rodapé, notas de redação, blocos `[Comment: ...]` — escritos por especialistas de domínio (por exemplo, advogados de mercado de capitais). O limpador de recipes remove esse conteúdo para produzir um documento preenchível, mas também pode extraí-lo como JSON estruturado:
-
-```bash
-open-agreements recipe clean source.docx -o cleaned.docx \
-  --recipe nvca-indemnification-agreement \
-  --extract-guidance guidance.json
-```
-
-Isso produz um `guidance.json` com cada nota de rodapé, comentário e nota de redação removidos, marcados por tipo de fonte e posição no documento. O guidance é um artefato somente local (não é commitado nem distribuído) que agentes de IA ou autores humanos podem consultar ao preencher o formulário. Veja [Adding Recipes — Guidance Extraction](docs/adding-recipes.md#guidance-extraction) para detalhes de formato.
-
-**Por que extração programática?** O documento de origem é a única fonte de verdade. Reexecutar a extração após uma atualização do editor gera guidance atualizado sem esforço manual, preserva a linguagem exata de especialistas e captura tudo — uma IA pode resumir em tempo real, mas não pode recuperar conteúdo descartado.
-
-Cada modelo é um diretório autocontido:
-
-```
-content/templates/<name>/
-├── template.docx     # DOCX with {tag} placeholders
-├── metadata.yaml     # Fields, license, source, attribution
-└── README.md         # Template-specific documentation
-```
-
-## Comandos CLI
-
-### `fill <template>`
-
-Renderiza um DOCX preenchido a partir de um modelo.
-
-```bash
-# Using a JSON data file
-open-agreements fill common-paper-mutual-nda -d data.json -o output.docx
-
-# Using inline --set flags
-open-agreements fill common-paper-mutual-nda --set party_1_name="Acme Corp" --set governing_law="Delaware"
-```
-
-### `validate [template]`
-
-Executa o pipeline de validação em um ou todos os modelos.
-
-```bash
-open-agreements validate                          # All templates
-open-agreements validate common-paper-mutual-nda  # One template
-```
+<details>
+<summary><strong>Referência da CLI</strong></summary>
 
 ### `list`
 
@@ -204,174 +217,201 @@ Mostra modelos disponíveis com informações de licença e contagem de campos.
 ```bash
 open-agreements list
 
-# Machine-readable JSON output (for agent skills and automation)
+# Machine-readable JSON for agent skills and automation
 open-agreements list --json
 ```
 
-## Contracts Workspace CLI (pacote separado)
+### `fill <template>`
 
-O OpenAgreements agora inclui um pacote irmão para operações de repositório/workspace:
-
-- Package: `@open-agreements/contracts-workspace`
-- Binary: `open-agreements-workspace`
-- Docs: `docs/contracts-workspace.md`
-
-Este pacote é propositalmente separado de `open-agreements`, permitindo que equipes adotem:
-
-- apenas preenchimento de modelos
-- apenas gerenciamento de workspace
-- ou ambos juntos
-
-Recursos principais de workspace:
-
-- planejamento `init` orientado por tópicos (estrutura mínima sugerida com domínios de nível superior)
-- catálogo de formulários com validação de URL + SHA-256
-- indexação e lint de status YAML com status `_executed` orientado por nome de arquivo
-
-O modelo v1 é apenas filesystem e funciona em pastas de nuvem sincronizadas localmente (por exemplo, sync do Google Drive). Não requer integração com Drive API/OAuth.
-
-## MCP local para demo de workspace
-
-Para demos de conectores locais, há um pacote MCP local por stdio:
-
-- Package: `@open-agreements/contracts-workspace-mcp`
-- Binary: `open-agreements-workspace-mcp`
-- Docs: `docs/contracts-workspace.md`
-
-Início rápido:
+Renderiza um DOCX preenchido a partir de um modelo.
 
 ```bash
-npm run build:workspace-mcp
-node packages/contracts-workspace-mcp/bin/open-agreements-workspace-mcp.js
+# From a JSON data file
+open-agreements fill common-paper-mutual-nda -d data.json -o output.docx
+
+# With inline --set flags
+open-agreements fill common-paper-mutual-nda --set party_1_name="Acme Corp" --set governing_law="Delaware"
 ```
 
-## MCP local para drafting de modelos
+### `validate [template]`
 
-Para fluxos locais de drafting de modelos em Gemini/Cursor, use:
-
-- Package: `@open-agreements/contract-templates-mcp`
-- Binary: `open-agreements-contract-templates-mcp`
-
-Início rápido:
+Executa o pipeline de validação em um ou todos os modelos.
 
 ```bash
-npm run build:contract-templates-mcp
-node packages/contract-templates-mcp/bin/open-agreements-contract-templates-mcp.js
+open-agreements validate
+open-agreements validate common-paper-mutual-nda
 ```
 
-## Website (Vercel)
+</details>
 
-`site/` é um protocol host enxuto construído com Eleventy.
+<details>
+<summary><strong>Detalhes de Configuração do Agente</strong></summary>
 
-- Metadados de discovery: `site/.well-known/`
-- JSON Schemas publicados: `site/schemas/`
-- Downloads estáticos de DOCX em branco: `site/downloads/`
-- Assets de preview: `site/assets/previews/`
-- Handlers serverless da API: `api/`
-- Discovery outputs (generated during `npm run build:site`): `_site/llms.txt`, `_site/llms-full.txt`, `_site/sitemap.xml`, `_site/robots.txt`
-
-Pré-visualização local:
+### Claude Code
 
 ```bash
-npm run build:site
-python3 -m http.server 8080 --directory _site
+npx skills add open-agreements/open-agreements
 ```
 
-Depois verifique, por exemplo, `http://localhost:8080/.well-known/mcp-server-card`, `http://localhost:8080/llms.txt` ou os arquivos gerados dentro de `_site/`.
+### Gemini CLI
 
-Notas de deploy na Vercel:
+```bash
+gemini extensions install https://github.com/open-agreements/open-agreements
+```
 
-- Importe este repositório na Vercel
-- Mantenha a raiz do projeto como a raiz do repositório
-- O `vercel.json` incluído publica `_site/` como saída estática
+### Cursor
 
-## Raízes opcionais de conteúdo (preparação para o futuro)
+Este repositório inclui um manifesto de plugin do Cursor em `.cursor-plugin/plugin.json` com integração MCP em `mcp.json`.
 
-Para suportar desacoplamento lógico conforme bibliotecas de formulários crescem, `open-agreements` pode carregar conteúdo de raízes adicionais via:
+### Execução Local vs Hospedada
 
-- env var: `OPEN_AGREEMENTS_CONTENT_ROOTS`
-- format: lista delimitada por separador de caminho de diretórios absolutos/relativos (por exemplo, `dirA:dirB` em macOS/Linux)
-- estrutura esperada em cada raiz: `templates/`, `external/` e/ou `recipes/` (ou aninhados em `content/`)
+- **Local**: `npx`, instalação global ou MCP por stdio. O processamento acontece na sua máquina.
+- **Hospedado**: `https://openagreements.org/api/mcp`. O preenchimento de modelos roda do lado do servidor para um setup mais rápido.
 
-A precedência de busca é:
+Escolha com base na sensibilidade do documento e na política interna. Veja a trust checklist abaixo para um resumo do fluxo de dados.
 
-1. raízes em `OPEN_AGREEMENTS_CONTENT_ROOTS` (na ordem listada)
-2. conteúdo empacotado padrão (fallback)
+</details>
 
-Isso mantém instalações padrão simples e permite que usuários avançados movam bibliotecas de conteúdo grandes para fora do pacote principal.
+## Início Rápido
 
-## Veja também
+### Com Claude Code
 
-- [safe-docx](https://github.com/UseJunior/safe-docx) — edição cirúrgica de documentos Word existentes com agentes de código (servidor MCP)
-- [UseJunior Developer Tools](https://usejunior.com/developer-tools/open-agreements) — página do produto com opções de instalação e catálogo de modelos
+Peça ao Claude:
+
+```text
+Fill the Common Paper mutual NDA for my company
+```
+
+O Claude pode descobrir modelos, entrevistar você para valores de campos e gerar um DOCX pronto para assinatura.
+
+### Com a CLI
+
+```bash
+# See all available templates
+open-agreements list
+
+# Fill a template from a JSON data file
+open-agreements fill common-paper-mutual-nda -d values.json -o my-nda.docx
+
+# Fill with inline values
+open-agreements fill common-paper-mutual-nda --set party_1_name="Acme Corp" --set governing_law="Delaware"
+```
+
+### Exemplos de Prompts
+
+- "Redija um NDA para nosso subcontratado de construção"
+- "Crie um acordo de consultoria para nossa agência de seguros"
+- "Preencha o acordo de contratado independente para um designer freelancer"
+- "Gere um SAFE com valuation cap de $5M"
+
+### O Que Acontece
+
+1. O agente roda `list --json` para descobrir modelos e seus campos.
+2. Ele entrevista você para coletar valores de campos agrupados por seção.
+3. Ele roda `fill <template>` para gerar um DOCX preservando a formatação de origem.
+4. Você revisa e assina o documento de saída.
+
+## Instalação
+
+### Agent Skill (recomendado)
+
+```bash
+npx skills add open-agreements/open-agreements
+```
+
+### MCP Remoto
+
+Conecte qualquer agente compatível com MCP ao servidor hospedado em `https://openagreements.org/api/mcp`.
+
+**Claude Code**
+
+```bash
+claude mcp add --transport http open-agreements https://openagreements.org/api/mcp
+```
+
+**Codex CLI**
+
+```bash
+codex mcp add open-agreements --url https://openagreements.org/api/mcp
+```
+
+**Outros agentes** — aponte seu cliente para `https://openagreements.org/api/mcp` (streamable HTTP).
+
+### Extensão Gemini CLI
+
+```bash
+gemini extensions install https://github.com/open-agreements/open-agreements
+```
+
+### CLI
+
+```bash
+npm install -g open-agreements
+```
+
+Ou rode diretamente sem instalar nada:
+
+```bash
+npx -y open-agreements@latest list
+```
+
+---
+
+## Documentação
+
+### Comece Aqui
+
+- [Getting Started](https://github.com/open-agreements/open-agreements/blob/main/docs/getting-started.md)
+
+### Guias
+
+- [Adding Templates](https://github.com/open-agreements/open-agreements/blob/main/docs/adding-templates.md)
+- [Adding Recipes](https://github.com/open-agreements/open-agreements/blob/main/docs/adding-recipes.md)
+
+### Outros Pacotes
+
+- [Contracts Workspace CLI](https://github.com/open-agreements/open-agreements/blob/main/docs/contracts-workspace.md)
+
+### Referência
+
+- [Licensing](https://github.com/open-agreements/open-agreements/blob/main/docs/licensing.md)
+- [Changelog & Release Process](https://github.com/open-agreements/open-agreements/blob/main/docs/changelog-release-process.md)
+- [Trust Checklist](https://github.com/open-agreements/open-agreements/blob/main/docs/trust-checklist.md)
+- [Supported Tools](https://github.com/open-agreements/open-agreements/blob/main/docs/supported-tools.md)
+- [Assumptions](https://github.com/open-agreements/open-agreements/blob/main/docs/assumptions.md)
+- [Employment Source Policy](https://github.com/open-agreements/open-agreements/blob/main/docs/employment-source-policy.md)
+
+**Links:** [Site](https://usejunior.com) | [Catálogo de Modelos](https://usejunior.com/templates) | [Docs](https://github.com/open-agreements/open-agreements/tree/main/docs) | [Trust](https://usejunior.com/security) | [npm](https://www.npmjs.com/package/open-agreements)
+
+## Privacidade
+
+- **Modo local** (`npx`, instalação global, MCP por stdio): todo o processamento acontece na sua máquina. Nenhum conteúdo de documento é enviado para fora.
+- **Modo hospedado** (`https://openagreements.org/api/mcp`): o preenchimento de modelos roda do lado do servidor. Nenhum documento preenchido é armazenado depois que a resposta é retornada.
+
+Veja a [Política de Privacidade](https://usejunior.com/privacy_policy) para detalhes.
+
+## Veja Também
+
+- [safe-docx](https://github.com/UseJunior/safe-docx) — edição cirúrgica de documentos Word existentes com agentes de código
 
 ## Contribuindo
 
-Veja [CONTRIBUTING.md](CONTRIBUTING.md) para saber como adicionar modelos, recipes e outras melhorias.
+Veja [CONTRIBUTING.md](https://github.com/open-agreements/open-agreements/blob/main/CONTRIBUTING.md) para saber como adicionar modelos, recipes e outras melhorias.
 
-- [Adding templates](docs/adding-templates.md) (fontes CC BY 4.0 / CC0)
-- [Adding recipes](docs/adding-recipes.md) (fontes não redistribuíveis)
-- [Employment source policy](docs/employment-source-policy.md) (classificações de confiança e termos)
-- [Code of Conduct](CODE_OF_CONDUCT.md) (expectativas da comunidade e aplicação)
+## Construído com OpenAgreements
 
-## Releases
+- [Safe Clause](https://safeclause.deltaxy.ai) — plataforma de contratos com IA para startups. [#1 no vibecode.law, março de 2026](https://vibecode.law/showcase/safe-clause-317416).
 
-Releases são automatados via GitHub Actions usando publicação confiável da npm (OIDC) com provenance habilitada.
-
-1. Atualize versões no pacote raiz + pacotes MCP publicáveis.
-2. Faça push do commit + tag com `git push origin main --tags`
-3. Rode o gate local da extensão Gemini (copiar/symlink para `~/.gemini/extensions/open-agreements` e verificar que ambos servidores MCP locais iniciam/respondem).
-4. O workflow `Release` publica a partir da tag após rodar build, validação, testes, smoke de runtime isolado e checks de pacote.
-
-Guardrails do workflow:
-
-- a tag deve corresponder às versões do pacote raiz + pacotes publicáveis
-- o commit de release deve estar contido em `origin/main`
-- a publicação falha se qualquer versão alvo na npm já existir
-
-## Arquitetura
-
-- **Language**: TypeScript
-- **DOCX Engine**: [docx-templates](https://www.npmjs.com/package/docx-templates) (MIT)
-- **CLI**: [Commander.js](https://www.npmjs.com/package/commander)
-- **Validation**: [Zod](https://www.npmjs.com/package/zod) schemas
-- **Skill Pattern**: Agent-agnostic `ToolCommandAdapter` interface
-
-```
-content/                    # All content directories
-├── templates/              # Internal templates (CC BY 4.0)
-├── external/               # External templates (CC BY-ND 4.0)
-└── recipes/                # Recipes (downloaded at runtime)
-
-src/                        # TypeScript source + collocated unit tests
-├── cli/                    # Commander.js CLI
-├── commands/               # fill, validate, list, recipe, scan
-├── core/
-│   ├── engine.ts           # docx-templates wrapper
-│   ├── metadata.ts         # Zod schemas + loader
-│   ├── recipe/             # Recipe pipeline (clean → patch → fill → verify)
-│   ├── external/           # External template support
-│   ├── validation/         # template, license, output, recipe
-│   └── command-generation/
-│       ├── types.ts        # ToolCommandAdapter interface
-│       └── adapters/       # Claude Code adapter
-└── index.ts                # Public API
-
-integration-tests/          # Integration and end-to-end tests
-```
-
-## Recursos
-
-- [Claude Code Documentation](https://docs.anthropic.com/en/docs/claude-code)
-- [Claude Code Plugins Guide](https://docs.anthropic.com/en/docs/claude-code/plugins)
-- [Agent Skills Specification](https://agentskills.io)
+Está construindo algo sobre o OpenAgreements? Abra um PR para adicionar seu projeto.
 
 ## Licença
 
-MIT
+MIT. O conteúdo dos modelos é licenciado por seus respectivos autores:
 
-O conteúdo dos modelos é licenciado por seus respectivos autores — CC BY 4.0 (Common Paper, Bonterms), CC BY-ND 4.0 (Y Combinator) ou proprietário (NVCA, baixado em tempo de execução). Veja `metadata.yaml` de cada modelo para detalhes.
+- CC BY 4.0 para modelos da Common Paper, Bonterms e modelos autorais do OpenAgreements
+- CC BY-ND 4.0 para modelos de SAFE do Y Combinator vendorizados sem alterações
+- proprietário ou não redistribuível para documentos de origem da NVCA tratados via recipes
 
-## Aviso legal
+Veja o `metadata.yaml` de cada modelo para detalhes específicos da fonte.
 
-Esta ferramenta gera documentos a partir de modelos padrão. Ela não fornece assessoria jurídica. Não há afiliação com ou endosso por Common Paper, Bonterms, Y Combinator, NVCA ou qualquer fonte de modelo. Consulte um advogado para orientação jurídica.
+Esta ferramenta gera documentos a partir de modelos padrão. Ela não fornece assessoria jurídica. Consulte um advogado para orientação jurídica.

--- a/README.template.md
+++ b/README.template.md
@@ -27,89 +27,6 @@ Works with Claude Code, Gemini CLI, Cursor, and local MCP or CLI workflows.
 
 > *Demo: Claude fills a Common Paper Mutual NDA in under 2 minutes. Sped up for brevity.*
 
-## Install
-
-### Agent Skill (recommended)
-
-```bash
-npx skills add open-agreements/open-agreements
-```
-
-### Remote MCP
-
-Connect any MCP-compatible agent to the hosted server at `https://openagreements.org/api/mcp`.
-
-**Claude Code**
-
-```bash
-claude mcp add --transport http open-agreements https://openagreements.org/api/mcp
-```
-
-**Codex CLI**
-
-```bash
-codex mcp add open-agreements --url https://openagreements.org/api/mcp
-```
-
-**Other agents** — point your client at `https://openagreements.org/api/mcp` (streamable HTTP).
-
-### Gemini CLI Extension
-
-```bash
-gemini extensions install https://github.com/open-agreements/open-agreements
-```
-
-### CLI
-
-```bash
-npm install -g open-agreements
-```
-
-Or run directly with zero install:
-
-```bash
-npx -y open-agreements@latest list
-```
-
-## Quick Start
-
-### With Claude Code
-
-Ask Claude:
-
-```text
-Fill the Common Paper mutual NDA for my company
-```
-
-Claude can discover templates, interview you for field values, and render a signed-ready DOCX.
-
-### With the CLI
-
-```bash
-# See all available templates
-open-agreements list
-
-# Fill a template from a JSON data file
-open-agreements fill common-paper-mutual-nda -d values.json -o my-nda.docx
-
-# Fill with inline values
-open-agreements fill common-paper-mutual-nda --set party_1_name="Acme Corp" --set governing_law="Delaware"
-```
-
-### Example Prompts
-
-- "Draft an NDA for our construction subcontractor"
-- "Create a consulting agreement for our insurance agency"
-- "Fill the independent contractor agreement for a freelance designer"
-- "Generate a SAFE with a $5M valuation cap"
-
-### What Happens
-
-1. The agent runs `list --json` to discover templates and their fields.
-2. It interviews you for field values grouped by section.
-3. It runs `fill <template>` to render a DOCX preserving the source formatting.
-4. You review and sign the output document.
-
 ## Available Templates
 
 The Source column links to the upstream standard, source document, or canonical project page (varies by publisher). The License column shows redistribution terms. Repo links point to the GitHub content directory for each template or recipe.
@@ -206,6 +123,89 @@ This repository includes a Cursor plugin manifest at `.cursor-plugin/plugin.json
 Choose based on document sensitivity and internal policy. See the trust checklist below for the data-flow summary.
 
 </details>
+
+## Quick Start
+
+### With Claude Code
+
+Ask Claude:
+
+```text
+Fill the Common Paper mutual NDA for my company
+```
+
+Claude can discover templates, interview you for field values, and render a signed-ready DOCX.
+
+### With the CLI
+
+```bash
+# See all available templates
+open-agreements list
+
+# Fill a template from a JSON data file
+open-agreements fill common-paper-mutual-nda -d values.json -o my-nda.docx
+
+# Fill with inline values
+open-agreements fill common-paper-mutual-nda --set party_1_name="Acme Corp" --set governing_law="Delaware"
+```
+
+### Example Prompts
+
+- "Draft an NDA for our construction subcontractor"
+- "Create a consulting agreement for our insurance agency"
+- "Fill the independent contractor agreement for a freelance designer"
+- "Generate a SAFE with a $5M valuation cap"
+
+### What Happens
+
+1. The agent runs `list --json` to discover templates and their fields.
+2. It interviews you for field values grouped by section.
+3. It runs `fill <template>` to render a DOCX preserving the source formatting.
+4. You review and sign the output document.
+
+## Install
+
+### Agent Skill (recommended)
+
+```bash
+npx skills add open-agreements/open-agreements
+```
+
+### Remote MCP
+
+Connect any MCP-compatible agent to the hosted server at `https://openagreements.org/api/mcp`.
+
+**Claude Code**
+
+```bash
+claude mcp add --transport http open-agreements https://openagreements.org/api/mcp
+```
+
+**Codex CLI**
+
+```bash
+codex mcp add open-agreements --url https://openagreements.org/api/mcp
+```
+
+**Other agents** — point your client at `https://openagreements.org/api/mcp` (streamable HTTP).
+
+### Gemini CLI Extension
+
+```bash
+gemini extensions install https://github.com/open-agreements/open-agreements
+```
+
+### CLI
+
+```bash
+npm install -g open-agreements
+```
+
+Or run directly with zero install:
+
+```bash
+npx -y open-agreements@latest list
+```
 
 ---
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,201 +1,214 @@
+<!-- This file is generated from README.template.md by scripts/generate_readme.mjs. Do not edit README.md directly. -->
+
 # OpenAgreements
 
 [![npm version](https://img.shields.io/npm/v/open-agreements)](https://www.npmjs.com/package/open-agreements)
 [![npm downloads](https://img.shields.io/npm/dm/open-agreements.svg)](https://npmjs.org/package/open-agreements)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![Agent Skill](https://img.shields.io/badge/agent--skill-open--agreements-purple)](https://skills.sh)
 [![CI](https://github.com/open-agreements/open-agreements/actions/workflows/ci.yml/badge.svg)](https://github.com/open-agreements/open-agreements/actions/workflows/ci.yml)
-[![MCP Server Status](https://img.shields.io/endpoint?url=https%3A%2F%2Fopenagreements.org%2Fapi%2Fstatus%3Fformat%3Dshields)](https://openagreements.openstatus.dev/)
 [![codecov](https://img.shields.io/codecov/c/github/open-agreements/open-agreements/main)](https://app.codecov.io/gh/open-agreements/open-agreements)
-[![GitHub stargazers](https://img.shields.io/github/stars/open-agreements/open-agreements?style=social)](https://github.com/open-agreements/open-agreements/stargazers)
-[![Tests: Vitest](https://img.shields.io/badge/tests-vitest-6E9F18)](https://vitest.dev/)
-[![OpenSpec Traceability](https://img.shields.io/badge/openspec-traceability%20gate-brightgreen)](./scripts/validate_openspec_coverage.mjs)
 [![Socket Badge](https://socket.dev/api/badge/npm/package/open-agreements)](https://socket.dev/npm/package/open-agreements)
+[![GitHub stargazers](https://img.shields.io/github/stars/open-agreements/open-agreements?style=social)](https://github.com/open-agreements/open-agreements/stargazers)
+[![Agent Skill](https://img.shields.io/badge/agent--skill-open--agreements-purple)](https://skills.sh)
+[![MCP Server Status](https://img.shields.io/endpoint?url=https%3A%2F%2Fopenagreements.org%2Fapi%2Fstatus%3Fformat%3Dshields)](https://openagreements.openstatus.dev/)
 [![install size](https://packagephobia.com/badge?p=open-agreements)](https://packagephobia.com/result?p=open-agreements)
 
-[English](./README.md) | [Español](./README.es.md) | [简体中文](./README.zh.md) | [Português (Brasil)](./README.pt-br.md) | [Deutsch](./README.de.md)
+[English](https://github.com/open-agreements/open-agreements/blob/main/README.md) | [Español](https://github.com/open-agreements/open-agreements/blob/main/README.es.md) | [简体中文](https://github.com/open-agreements/open-agreements/blob/main/README.zh.md) | [Português (Brasil)](https://github.com/open-agreements/open-agreements/blob/main/README.pt-br.md) | [Deutsch](https://github.com/open-agreements/open-agreements/blob/main/README.de.md)
 
 > **翻译说明：** 英文版 `README.md` 是规范的事实来源。此翻译可能会有短暂滞后。英文 README 的重大更新应在 72 小时内同步到本文件。
 
-<!-- TODO: Add OpenSSF Scorecard badge once repo is indexed at securityscorecards.dev -->
-<!-- TODO: Add OpenSSF Best Practices badge after registration at bestpractices.dev -->
-<!-- TODO: Re-evaluate Snyk badge — Advisor migrated to security.snyk.io (July 2024) -->
+填写标准法律协议模板并生成可签署的 DOCX 文件。OpenAgreements 提供 40 多份模板，涵盖 NDA、云服务协议、雇佣文档、承包商协议、SAFE 以及 NVCA 融资文件。
+
+可与 Claude Code、Gemini CLI、Cursor 以及本地 MCP 或 CLI 工作流配合使用。
+
+## 目录
+
+- [模板](#模板)
+- [可用技能](#可用技能)
+- [软件包](#软件包)
+- [快速开始](#快速开始)
+- [安装](#安装)
+- [文档](#文档)
+- [隐私](#隐私)
+- [另请参阅](#另请参阅)
+- [贡献](#贡献)
+- [基于 OpenAgreements 构建](#基于-openagreements-构建)
+- [许可](#许可)
 
 <p align="center">
-  <img src="docs/assets/demo-fill-nda.gif" alt="Fill a Mutual NDA in Claude Code — prompt, answer questions, get a signed-ready DOCX" width="720">
+  <img src="https://raw.githubusercontent.com/open-agreements/open-agreements/main/docs/assets/demo-fill-nda.gif" alt="Fill a Mutual NDA in Claude Code — prompt, answer questions, get a signed-ready DOCX" width="720">
 </p>
 
 > *演示：Claude 在 2 分钟内完成一份 Common Paper 双向 NDA。为简洁起见已加速。*
 
-填写标准法律协议模板并生成可签署的 DOCX 文件。模板涵盖 NDA、云服务条款、雇佣文档、承包商协议、SAFE 以及 NVCA 融资文件。
-
-**Open Agreements** 由 [UseJunior](https://usejunior.com) 构建，属于 [UseJunior 开发者工具](https://usejunior.com/developer-tools/open-agreements)的一部分。已在 Am Law 100 律所中投入生产使用。
-
-## 质量与可信信号
-
-- CI 会在 pull request 以及推送到 `main` 时运行。
-- 实时服务健康状态通过 OpenStatus 在 `openagreements.openstatus.dev` 发布。
-- 覆盖率发布到 Codecov，并在 `codecov.yml` 中使用仓库定义的 patch/project 门禁。
-- 当前 JS 测试框架是 Vitest，JUnit 测试结果会上传到 Codecov 进行测试分析。
-- OpenSpec 场景可追溯性通过 `npm run check:spec-coverage` 强制执行。若要导出本地矩阵，请运行 `npm run check:spec-coverage -- --write-matrix integration-tests/OPENSPEC_TRACEABILITY.md`。
-- 配方源漂移 canary（`npm run check:source-drift`）会校验预期源哈希，以及结构化替换/规范化锚点。
-- 假设级回归在 `docs/assumptions.md` 中跟踪，并通过定向回归测试与 CI 门禁进行验证。
-- 基于 LibreOffice 的 DOCX 视觉渲染在 macOS 使用固定构建配置（`config/libreoffice-headless.json`）；运行视觉 Allure 证据测试前请先执行 `npm run check:libreoffice`。
-- Maintainer: [Steven Obiajulu](https://www.linkedin.com/in/steven-obiajulu/)（MIT 机械工程背景；哈佛法学院法律训练）。
-
-## 工作方式
-
-1. 第 1 步：选择模板（36 份标准协议）
-2. 第 2 步：填写你的信息（交互式提示或 MCP）
-3. 第 3 步：获得专业排版的 DOCX
-
-OpenAgreements 支持两种执行模式，信任边界不同：
-
-- 托管远程 MCP 连接器（`https://openagreements.org/api/mcp`），便于在 Claude 中快速配置。
-- 完全本地包执行（`npx`、全局安装或本地 stdio MCP 包），用于本机本地工作流。
-
-没有全局默认模式推荐。请根据文档敏感度、内部策略和工作流速度需求进行选择。参见 `docs/trust-checklist.md` 获取 60 秒数据流概览。
-
-### 快速决策
-
-- 如果文档敏感，请使用完全本地包执行。
-- 如果更优先便捷性，请使用托管远程 MCP 连接器。
-
-## 与 Claude Code 一起使用
-
-OpenAgreements 可作为 [Claude Code 插件](https://docs.anthropic.com/en/docs/claude-code/plugins) 和 [Agent Skill](https://agentskills.io) 使用。无需预安装，Claude 会通过 `npx` 按需下载并运行 CLI。
-
-### 选项 1：Agent Skill（推荐）
-
-```bash
-npx skills add open-agreements/open-agreements
-```
-
-然后让 Claude 起草协议：
-
-```
-> Draft an NDA between Acme Corp and Beta Inc
-```
-
-Claude 会发现可用模板、向你提问获取字段值，并生成可签署的 DOCX。
-
-### 选项 2：Gemini CLI 扩展
-
-```bash
-gemini extensions install https://github.com/open-agreements/open-agreements
-```
-
-然后让 Gemini 起草协议。该扩展提供 MCP 工具、上下文文件和用于模板发现与填写的技能。
-
-### 选项 3：直接配合 Claude Code
-
-如果你有 Node.js >= 20，直接向 Claude 提示：
-
-```
-> Fill the Common Paper mutual NDA for my company
-```
-
-Claude 会运行 `npx -y open-agreements@latest list --json` 来发现模板，然后运行 `npx -y open-agreements@latest fill <template>` 生成输出。零安装。
-
-### 选项 4：CLI
-
-```bash
-# Install globally
-npm install -g open-agreements
-
-# List available templates
-open-agreements list
-
-# Fill a template
-open-agreements fill common-paper-mutual-nda -d values.json -o my-nda.docx
-```
-
-### 执行过程
-
-1. Claude 运行 `list --json` 来发现可用模板及其字段
-2. Claude 询问字段值（按章节分组，每轮最多 4 个问题）
-3. Claude 运行 `fill <template>` 生成 DOCX，并保留原始格式
-4. 你审核并签署输出文档
-
-## 与 Cursor 一起使用
-
-本仓库包含带 MCP 接线的 Cursor 插件清单：
-
-- Plugin manifest: `.cursor-plugin/plugin.json`
-- MCP config: `mcp.json`
-- Skill: `skills/open-agreements/SKILL.md`
-
-`mcp.json` 中的默认 MCP 配置包含：
-
-- 托管 OpenAgreements MCP 连接器（`https://openagreements.org/api/mcp`）
-- 本地 workspace MCP 服务器（`npx -y @open-agreements/contracts-workspace-mcp`）
-- 本地模板起草 MCP 服务器（`npx -y @open-agreements/contract-templates-mcp`）
-
-要将该插件发布到 Cursor Marketplace，请在以下地址提交此仓库：
-
-- https://cursor.com/marketplace/publish
-
 ## 模板
 
-共 28 个模板，分为三个层级。运行 `open-agreements list` 查看完整清单。
+Source 列指向上游标准、源文档或规范项目页面（因发布方而异）。License 列显示再分发条款。Repo 链接指向每个模板或配方的 GitHub 内容目录。
 
-| 层级 | 数量 | 来源 | 工作方式 |
-|------|-------|--------|--------------|
-| 内部模板 | 17 | [Common Paper](https://commonpaper.com), [Bonterms](https://bonterms.com), OpenAgreements | 随包发布，CC BY 4.0 |
-| 外部模板 | 4 | [Y Combinator](https://www.ycombinator.com/documents) | 原样 vendor，CC BY-ND 4.0 |
-| Recipes | 7 | [NVCA](https://nvca.org/model-legal-documents/) | 按需下载（不可再分发） |
+### 保密协议
 
-**内部模板**（NDA、云条款、雇佣表单、承包商协议等）采用 CC BY 4.0，我们随包提供带 `{tag}` 占位符的 DOCX。
+| 模板 | 网站 | 来源 | 许可 | 仓库 |
+|----------|---------|--------|---------|------|
+| Bonterms Mutual NDA | [Website](https://usejunior.com/templates/bonterms-mutual-nda) | [Bonterms](https://bonterms.com/resources/mutual-nda-cover-page-example) | [CC0-1.0](https://creativecommons.org/publicdomain/zero/1.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/bonterms-mutual-nda) |
+| Common Paper Mutual NDA | [Website](https://usejunior.com/templates/common-paper-mutual-nda) | [Common Paper](https://commonpaper.com/standards/mutual-nda/1.0) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-mutual-nda) |
+| One Way NDA | [Website](https://usejunior.com/templates/common-paper-one-way-nda) | [Common Paper](https://commonpaper.com/standards/one-way-nda) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-one-way-nda) |
 
-**外部模板**（YC SAFE）采用 CC BY-ND 4.0，我们原样 vendor。填写后的输出是在你机器上的临时衍生结果。
+### 销售与授权
 
-**Recipes**（NVCA 融资文件）可自由下载但不可再分发，我们仅提供转换指令，并在运行时从 nvca.org 下载源 DOCX。
+| 模板 | 网站 | 来源 | 许可 | 仓库 |
+|----------|---------|--------|---------|------|
+| Cloud Service Agreement | [Website](https://usejunior.com/templates/common-paper-cloud-service-agreement) | [Common Paper](https://commonpaper.com/standards/cloud-service-agreement/2.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-cloud-service-agreement) |
+| CSA Click Through | [Website](https://usejunior.com/templates/common-paper-csa-click-through) | [Common Paper](https://commonpaper.com/standards/cloud-service-agreement/2.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-csa-click-through) |
+| CSA With AI | [Website](https://usejunior.com/templates/common-paper-csa-with-ai) | [Common Paper](https://commonpaper.com/standards/cloud-service-agreement/2.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-csa-with-ai) |
+| CSA With SLA | [Website](https://usejunior.com/templates/common-paper-csa-with-sla) | [Common Paper](https://commonpaper.com/standards/cloud-service-agreement/2.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-csa-with-sla) |
+| CSA Without SLA | [Website](https://usejunior.com/templates/common-paper-csa-without-sla) | [Common Paper](https://commonpaper.com/standards/cloud-service-agreement/2.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-csa-without-sla) |
+| Order Form | [Website](https://usejunior.com/templates/common-paper-order-form) | [Common Paper](https://commonpaper.com/standards/cloud-service-agreement/2.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-order-form) |
+| Order Form With SLA | [Website](https://usejunior.com/templates/common-paper-order-form-with-sla) | [Common Paper](https://commonpaper.com/standards/cloud-service-agreement/2.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-order-form-with-sla) |
+| Software License Agreement | [Website](https://usejunior.com/templates/common-paper-software-license-agreement) | [Common Paper](https://commonpaper.com/standards/software-license-agreement/1.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-software-license-agreement) |
 
-### Guidance 提取
+### 数据与合规
 
-源文档包含专家评论，例如脚注、起草说明、`[Comment: ...]` 块，这些内容由领域专家（如证券律师）撰写。配方清理器会移除这些内容以生成可填写文档，也可以将其提取为结构化 JSON：
+| 模板 | 网站 | 来源 | 许可 | 仓库 |
+|----------|---------|--------|---------|------|
+| AI Addendum | [Website](https://usejunior.com/templates/common-paper-ai-addendum) | [Common Paper](https://commonpaper.com/standards/ai-addendum/1.0) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-ai-addendum) |
+| AI Addendum In App | [Website](https://usejunior.com/templates/common-paper-ai-addendum-in-app) | [Common Paper](https://commonpaper.com/standards/ai-addendum/1.0) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-ai-addendum-in-app) |
+| Business Associate Agreement | [Website](https://usejunior.com/templates/common-paper-business-associate-agreement) | [Common Paper](https://commonpaper.com/standards/business-associate-agreement/1.0) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-business-associate-agreement) |
+| Data Processing Agreement | [Website](https://usejunior.com/templates/common-paper-data-processing-agreement) | [Common Paper](https://commonpaper.com/standards/data-processing-agreement/1.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-data-processing-agreement) |
 
-```bash
-open-agreements recipe clean source.docx -o cleaned.docx \
-  --recipe nvca-indemnification-agreement \
-  --extract-guidance guidance.json
+### 专业服务
+
+| 模板 | 网站 | 来源 | 许可 | 仓库 |
+|----------|---------|--------|---------|------|
+| Bonterms Professional Services Agreement | [Website](https://usejunior.com/templates/bonterms-professional-services-agreement) | [Bonterms](https://bonterms.com/resources/psa-cover-page-example) | [CC0-1.0](https://creativecommons.org/publicdomain/zero/1.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/bonterms-professional-services-agreement) |
+| Independent Contractor Agreement | [Website](https://usejunior.com/templates/common-paper-independent-contractor-agreement) | [Common Paper](https://commonpaper.com/standards/independent-contractor-agreement) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-independent-contractor-agreement) |
+| Common Paper Professional Services Agreement | [Website](https://usejunior.com/templates/common-paper-professional-services-agreement) | [Common Paper](https://commonpaper.com/standards/professional-services-agreement/1.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-professional-services-agreement) |
+| Statement Of Work | [Website](https://usejunior.com/templates/common-paper-statement-of-work) | [Common Paper](https://commonpaper.com/standards/statement-of-work) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-statement-of-work) |
+
+### 交易与合作
+
+| 模板 | 网站 | 来源 | 许可 | 仓库 |
+|----------|---------|--------|---------|------|
+| Amendment | [Website](https://usejunior.com/templates/common-paper-amendment) | [Common Paper](https://commonpaper.com/standards/amendment) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-amendment) |
+| Design Partner Agreement | [Website](https://usejunior.com/templates/common-paper-design-partner-agreement) | [Common Paper](https://commonpaper.com/standards/design-partner-agreement/1.3) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-design-partner-agreement) |
+| Letter Of Intent | [Website](https://usejunior.com/templates/common-paper-letter-of-intent) | [Common Paper](https://commonpaper.com/standards/letter-of-intent) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-letter-of-intent) |
+| Partnership Agreement | [Website](https://usejunior.com/templates/common-paper-partnership-agreement) | [Common Paper](https://commonpaper.com/standards/partnership-agreement/1.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-partnership-agreement) |
+| Pilot Agreement | [Website](https://usejunior.com/templates/common-paper-pilot-agreement) | [Common Paper](https://commonpaper.com/standards/pilot-agreement/1.1) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-pilot-agreement) |
+| Term Sheet | [Website](https://usejunior.com/templates/common-paper-term-sheet) | [Common Paper](https://commonpaper.com/standards/term-sheet) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/common-paper-term-sheet) |
+
+### 雇佣
+
+| 模板 | 网站 | 来源 | 许可 | 仓库 |
+|----------|---------|--------|---------|------|
+| Employee IP Inventions Assignment | [Website](https://usejunior.com/templates/openagreements-employee-ip-inventions-assignment) | [OpenAgreements](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-employee-ip-inventions-assignment) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-employee-ip-inventions-assignment) |
+| Employment Confidentiality Acknowledgement | [Website](https://usejunior.com/templates/openagreements-employment-confidentiality-acknowledgement) | [OpenAgreements](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-employment-confidentiality-acknowledgement) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-employment-confidentiality-acknowledgement) |
+| Employment Offer Letter | [Website](https://usejunior.com/templates/openagreements-employment-offer-letter) | [OpenAgreements](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-employment-offer-letter) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-employment-offer-letter) |
+| Restrictive Covenant Wyoming | [Website](https://usejunior.com/templates/openagreements-restrictive-covenant-wyoming) | [OpenAgreements](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-restrictive-covenant-wyoming) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-restrictive-covenant-wyoming) |
+
+### SAFEs
+
+| 模板 | 网站 | 来源 | 许可 | 仓库 |
+|----------|---------|--------|---------|------|
+| Discount | [Website](https://usejunior.com/templates/yc-safe-discount) | [Y Combinator](https://www.ycombinator.com/documents) | [CC-BY-ND-4.0](https://creativecommons.org/licenses/by-nd/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/external/yc-safe-discount) |
+| MFN | [Website](https://usejunior.com/templates/yc-safe-mfn) | [Y Combinator](https://www.ycombinator.com/documents) | [CC-BY-ND-4.0](https://creativecommons.org/licenses/by-nd/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/external/yc-safe-mfn) |
+| Pro Rata Side Letter | [Website](https://usejunior.com/templates/yc-safe-pro-rata-side-letter) | [Y Combinator](https://www.ycombinator.com/documents) | [CC-BY-ND-4.0](https://creativecommons.org/licenses/by-nd/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/external/yc-safe-pro-rata-side-letter) |
+| Valuation Cap | [Website](https://usejunior.com/templates/yc-safe-valuation-cap) | [Y Combinator](https://www.ycombinator.com/documents) | [CC-BY-ND-4.0](https://creativecommons.org/licenses/by-nd/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/external/yc-safe-valuation-cap) |
+
+### 风险融资
+
+| 模板 | 网站 | 来源 | 许可 | 仓库 |
+|----------|---------|--------|---------|------|
+| Certificate Of Incorporation | [Website](https://usejunior.com/templates/nvca-certificate-of-incorporation) | [NVCA](https://nvca.org/wp-content/uploads/2025/10/NVCA-Model-COI-10-1-2025.docx) | Recipe | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/recipes/nvca-certificate-of-incorporation) |
+| Indemnification Agreement | [Website](https://usejunior.com/templates/nvca-indemnification-agreement) | [NVCA](https://nvca.org/wp-content/uploads/2021/12/NVCA-2020-Indemnification-Agreement.docx) | Recipe | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/recipes/nvca-indemnification-agreement) |
+| Investors Rights Agreement | [Website](https://usejunior.com/templates/nvca-investors-rights-agreement) | [NVCA](https://nvca.org/wp-content/uploads/2025/10/NVCA-Model-IRA-10-1-2025-2-1.docx) | Recipe | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/recipes/nvca-investors-rights-agreement) |
+| Management Rights Letter | [Website](https://usejunior.com/templates/nvca-management-rights-letter) | [NVCA](https://nvca.org/wp-content/uploads/2025/12/NVCA-2020-Management-Rights-Letter-1-1.docx) | Recipe | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/recipes/nvca-management-rights-letter) |
+| ROFR Co Sale Agreement | [Website](https://usejunior.com/templates/nvca-rofr-co-sale-agreement) | [NVCA](https://nvca.org/wp-content/uploads/2025/10/NVCA-Model-ROFRA-10-1-2025.docx) | Recipe | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/recipes/nvca-rofr-co-sale-agreement) |
+| Stock Purchase Agreement | [Website](https://usejunior.com/templates/nvca-stock-purchase-agreement) | [NVCA](https://nvca.org/wp-content/uploads/2025/10/NVCA-Model-SPA-10-28-2025-1.docx) | Recipe | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/recipes/nvca-stock-purchase-agreement) |
+| Voting Agreement | [Website](https://usejunior.com/templates/nvca-voting-agreement) | [NVCA](https://nvca.org/wp-content/uploads/2024/10/NVCA-Model-VA-10-1-2025.docx) | Recipe | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/recipes/nvca-voting-agreement) |
+
+### 其他
+
+| 模板 | 网站 | 来源 | 许可 | 仓库 |
+|----------|---------|--------|---------|------|
+| Closing Checklist | [Website](https://usejunior.com/templates/closing-checklist) | [OpenAgreements](https://github.com/open-agreements/open-agreements) | [CC0-1.0](https://creativecommons.org/publicdomain/zero/1.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/closing-checklist) |
+| Board Consent SAFE | [Website](https://usejunior.com/templates/openagreements-board-consent-safe) | [OpenAgreements](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-board-consent-safe) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-board-consent-safe) |
+| Due Diligence Request List | [Website](https://usejunior.com/templates/openagreements-due-diligence-request-list) | [OpenAgreements](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-due-diligence-request-list) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-due-diligence-request-list) |
+| Stockholder Consent SAFE | [Website](https://usejunior.com/templates/openagreements-stockholder-consent-safe) | [OpenAgreements](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-stockholder-consent-safe) | [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/openagreements-stockholder-consent-safe) |
+| Working Group List | [Website](https://usejunior.com/templates/working-group-list) | [OpenAgreements](https://github.com/open-agreements/open-agreements) | [CC0-1.0](https://creativecommons.org/publicdomain/zero/1.0/) | [Repo](https://github.com/open-agreements/open-agreements/tree/main/content/templates/working-group-list) |
+
+## 可用技能
+
+### 协议起草与填写
+
+| 技能 | 描述 |
+|-------|-------------|
+| [open-agreements](https://github.com/open-agreements/open-agreements/tree/main/skills/open-agreements) | 填写标准法律协议模板（NDA、云服务协议、SAFE）并生成可签署的 DOCX 文件。支持 Common Paper、Bonterms 和 Y Combinator 模板。在用户需要起草法律协议、生成 NDA、填写合同模板或生成 SAFE 时使用。也可通过 DocuSign 发送协议进行电子签署。 |
+| [nda](https://github.com/open-agreements/open-agreements/tree/main/skills/nda) | 起草并填写 NDA 模板 — 双向 NDA、单向 NDA、保密协议。从 Common Paper 和 Bonterms 标准表单生成可签署的 DOCX 文件。当用户提到 "NDA"、"保密协议"、"双向 NDA" 或 "单向 NDA" 时使用。 |
+| [cloud-service-agreement](https://github.com/open-agreements/open-agreements/tree/main/skills/cloud-service-agreement) | 起草并填写 SaaS 协议模板 — 云合同、MSA、订单表、软件许可、试点协议、设计合作伙伴协议。包含带 SLA 和 AI 条款的变体。从 Common Paper 标准表单生成可签署的 DOCX。当用户提到 "SaaS 协议"、"云合同"、"MSA"、"订单表"、"软件许可"、"试点协议" 或 "设计合作伙伴协议" 时使用。 |
+| [services-agreement](https://github.com/open-agreements/open-agreements/tree/main/skills/services-agreement) | 起草并填写服务协议模板 — 咨询合同、承包商协议、SOW、工作说明书、专业服务协议。从 Common Paper 和 Bonterms 标准表单生成可签署的 DOCX 文件。当用户提到 "咨询合同"、"承包商协议"、"SOW"、"工作说明书"、"服务协议" 或 "自由职业者合同" 时使用。 |
+| [employment-contract](https://github.com/open-agreements/open-agreements/tree/main/skills/employment-contract) | 起草并填写雇佣协议模板 — 录用函、IP 转让、PIIA、保密承诺书。从 OpenAgreements 标准表单生成可签署的 DOCX 文件，用于雇佣员工。当用户提到 "录用函"、"雇佣协议"、"PIIA"、"IP 转让"、"招人" 或 "入职文件" 时使用。 |
+| [data-privacy-agreement](https://github.com/open-agreements/open-agreements/tree/main/skills/data-privacy-agreement) | 起草并填写数据隐私协议模板 — DPA、数据处理协议、GDPR、HIPAA BAA、业务伙伴协议、AI 附录。从 Common Paper 标准表单生成可签署的 DOCX 文件。当用户提到 "DPA"、"数据处理协议"、"HIPAA BAA"、"业务伙伴协议" 或 "AI 附录" 时使用。 |
+| [safe](https://github.com/open-agreements/open-agreements/tree/main/skills/safe) | 起草并填写 Y Combinator SAFE 模板 — 估值上限、折扣、MFN、pro rata 边信。可转换股权的标准创业融资文件。生成可签署的 DOCX 文件。当用户提到 "SAFE"、"未来股权简单协议"、"YC SAFE"、"估值上限"、"种子轮文件" 或 "融资文件" 时使用。 |
+| [venture-financing](https://github.com/open-agreements/open-agreements/tree/main/skills/venture-financing) | 起草并填写 NVCA 模型文件 — 股票认购协议、公司章程、投资者权利协议、投票协议、ROFR、共售、补偿、管理权利信。Series A 和风险融资模板。生成可签署的 DOCX 文件。当用户提到 "Series A 文件"、"NVCA"、"股票认购协议"、"投资者权利协议"、"投票协议" 或 "风险融资文件" 时使用。 |
+
+### 编辑与客户工作流
+
+| 技能 | 描述 |
+|-------|-------------|
+| [edit-docx-agreement](https://github.com/open-agreements/open-agreements/tree/main/skills/edit-docx-agreement) | 使用 Safe Docx MCP 工具对由 OpenAgreements 生成的（或任何已有的）DOCX 协议进行定制编辑，实现精准、保留格式的编辑和带修订标记的输出。当用户提到 "编辑此合同"、"修改条款"、"修改协议"、"对 docx 做自定义编辑" 或 "对文档做定制更改" 时使用。 |
+| [client-email](https://github.com/open-agreements/open-agreements/tree/main/skills/client-email) | 为法律服务起草面向客户的邮件 — 合同交付件附信、redline 摘要、交易进度更新和跟进。在撰写或修改与法律工作产物相关的对外邮件时使用。触发关键词包括 "起草回复"、"给客户邮件"、"附信"、"回复给"，或任何随法律交付件一同发出的邮件。 |
+| [delaware-franchise-tax](https://github.com/open-agreements/open-agreements/tree/main/skills/delaware-franchise-tax) | 申报 Delaware 年度特许经营税和年度报告。引导完成税额计算（授权股份法和假定面值资本法）、eCorp 门户申报流程及付款。适用于 Delaware C-Corp（3 月 1 日截止）和 LLC/LP/GP（6 月 1 日截止）。当用户提到 "Delaware 特许经营税"、"Delaware 年度报告"、"申报特许经营税" 或 "eCorp 门户" 时使用。 |
+
+### 合规与审计
+
+| 技能 | 描述 |
+|-------|-------------|
+| [soc2-readiness](https://github.com/open-agreements/open-agreements/tree/main/skills/soc2-readiness) | 评估 SOC 2 Type II 准备情况。将信任服务标准映射到控制项，识别差距，并制定整改计划。以 NIST SP 800-53（公有领域）作为规范参考，并与 SOC 2 标准交叉映射。当用户提到 "SOC 2 准备"、"SOC 2 准备工作"、"SOC 2 差距分析" 或 "为 SOC 2 审计做准备" 时使用。 |
+| [iso-27001-internal-audit](https://github.com/open-agreements/open-agreements/tree/main/skills/iso-27001-internal-audit) | 运行 ISO 27001 内部审计。按领域逐一审阅控制项，识别差距，收集证据，并生成包含纠正措施建议的发现。以 NIST SP 800-53（公有领域）作为规范参考。当用户提到 "运行内部审计"、"ISO 27001 审计"、"控制评估"、"审计发现" 或 "ISMS 评估" 时使用。 |
+| [iso-27001-evidence-collection](https://github.com/open-agreements/open-agreements/tree/main/skills/iso-27001-evidence-collection) | 收集、组织并验证用于 ISO 27001 和 SOC 2 审计的证据。采用 API 优先方式，并为主流云平台提供 CLI 命令。生成带时间戳、审计师可直接使用的证据包。当用户提到 "收集审计证据"、"准备证据包"、"给审计师的证据"、"刷新证据" 或 "证据差距分析" 时使用。 |
+
+### 开发者工作流
+
+| 技能 | 描述 |
+|-------|-------------|
+| [recipe-quality-audit](https://github.com/open-agreements/open-agreements/tree/main/skills/recipe-quality-audit) | 审计 NVCA 配方质量：检查文件清单、元数据 schema、字段-替换覆盖率、模糊键、智能引号、测试 fixtures 以及填写质量。为每个配方生成带成熟度分级的结构化评分卡。当用户提到 "审计配方质量"、"检查配方覆盖率"、"配方评分卡" 或 "NVCA 配方质量" 时使用。 |
+| [unit-test-philosophy](https://github.com/open-agreements/open-agreements/tree/main/skills/unit-test-philosophy) | 面向 open-agreements 的基于风险的单元测试以及 Allure 可读的行为规范风格。当用户提到 "添加测试"、"测试质量"、"扩展覆盖率"、"单元测试风格" 或 "Allure 测试规范" 时使用。适用于在 src、integration-tests 和 workspace 包中添加/更新测试、扩展覆盖率或审查测试质量的场景。 |
+
+### 模板撰写
+
+| 技能 | 描述 |
+|-------|-------------|
+| [canonical-markdown-authoring](https://github.com/open-agreements/open-agreements/tree/main/skills/canonical-markdown-authoring) | 将普通 markdown 合同草稿转换为 OpenAgreements 的规范 template.md 撰写格式 — YAML frontmatter、Kind\|Label\|Value\|Show When 封面术语表、oa:clause 指令、[[Defined Term]] 段落以及 oa:signer 指令，编译为经过验证的 JSON spec 和 DOCX 产物。当用户提到 "把这个转换为 canonical markdown"、"撰写新的 OpenAgreements 模板"、"将模板迁移到 template.md" 或 "撰写规范形式的合同" 时使用。 |
+
+## 软件包
+
+| 软件包 | 描述 |
+|---------|-------------|
+| [open-agreements](https://www.npmjs.com/package/open-agreements) | 开源法律模板填写 CLI 和库 |
+| [@open-agreements/contract-templates-mcp](https://github.com/open-agreements/open-agreements/blob/main/packages/contract-templates-mcp/README.md) | 用于 OpenAgreements 模板发现与填写的本地 stdio MCP 服务器 |
+| [@open-agreements/contracts-workspace](https://github.com/open-agreements/open-agreements/blob/main/packages/contracts-workspace/README.md) | 面向工作区的 CLI，用于组织和跟踪合同仓库 |
+| [@open-agreements/contracts-workspace-mcp](https://github.com/open-agreements/open-agreements/blob/main/packages/contracts-workspace-mcp/README.md) | 用于合同工作区操作的本地 stdio MCP 服务器 |
+| [@open-agreements/checklist-mcp](https://github.com/open-agreements/open-agreements/blob/main/packages/checklist-mcp/README.md) | 用于 OpenAgreements 清单内存操作的本地 stdio MCP 服务器 |
+
+### 安装包含的内容
+
+```text
+open-agreements/
+  bin/                    # CLI entry point
+  dist/                   # Compiled TypeScript
+  content/
+    templates/            # Fillable DOCX templates with {tag} placeholders
+    external/             # YC SAFE templates vendored unchanged
+    recipes/              # Recipe instructions for non-redistributable sources
+  skills/                 # Agent skill definitions
+  server.json             # MCP server manifest
+  gemini-extension.json   # Gemini CLI extension config
+  README.md, LICENSE
 ```
 
-这会生成 `guidance.json`，其中包含每条被移除的脚注、评论和起草说明，并按来源类型和文档位置打标。该 guidance 仅为本地产物（不会提交或发布），可供 AI 代理或人工作者在填写表单时参考。格式细节见 [Adding Recipes — Guidance Extraction](docs/adding-recipes.md#guidance-extraction)。
+NVCA 配方模板在运行时下载，不随包一起打包。
 
-**为什么要程序化提取？** 源文档是唯一事实来源。发布方更新后重新提取即可零人工获取最新 guidance，保留领域专家原文，并且覆盖全部内容。AI 可以即时总结，但无法恢复已经丢弃的内容。
-
-每个模板都是自包含目录：
-
-```
-content/templates/<name>/
-├── template.docx     # DOCX with {tag} placeholders
-├── metadata.yaml     # Fields, license, source, attribution
-└── README.md         # Template-specific documentation
-```
-
-## CLI 命令
-
-### `fill <template>`
-
-基于模板渲染已填写 DOCX。
-
-```bash
-# Using a JSON data file
-open-agreements fill common-paper-mutual-nda -d data.json -o output.docx
-
-# Using inline --set flags
-open-agreements fill common-paper-mutual-nda --set party_1_name="Acme Corp" --set governing_law="Delaware"
-```
-
-### `validate [template]`
-
-对单个或全部模板运行验证流水线。
-
-```bash
-open-agreements validate                          # All templates
-open-agreements validate common-paper-mutual-nda  # One template
-```
+<details>
+<summary><strong>CLI 参考</strong></summary>
 
 ### `list`
 
@@ -204,174 +217,201 @@ open-agreements validate common-paper-mutual-nda  # One template
 ```bash
 open-agreements list
 
-# Machine-readable JSON output (for agent skills and automation)
+# Machine-readable JSON for agent skills and automation
 open-agreements list --json
 ```
 
-## Contracts Workspace CLI（独立包）
+### `fill <template>`
 
-OpenAgreements 现在包含一个用于仓库/workspace 操作的同级包：
-
-- Package: `@open-agreements/contracts-workspace`
-- Binary: `open-agreements-workspace`
-- Docs: `docs/contracts-workspace.md`
-
-该包刻意与 `open-agreements` 分离，团队可以选择：
-
-- 仅采用模板填写
-- 仅采用 workspace 管理
-- 或两者一起采用
-
-workspace 核心能力：
-
-- 面向主题的 `init` 规划（建议最小结构，含顶层域）
-- 带 URL + SHA-256 校验的表单目录
-- 通过文件名驱动 `_executed` 状态的 YAML 状态索引与 lint
-
-v1 模型仅依赖文件系统，可在本地同步的云盘目录中工作（例如 Google Drive 同步）。无需 Drive API/OAuth 集成。
-
-## 本地 MCP（Workspace 演示）
-
-用于本地连接器演示时，可使用本地 stdio MCP 包：
-
-- Package: `@open-agreements/contracts-workspace-mcp`
-- Binary: `open-agreements-workspace-mcp`
-- Docs: `docs/contracts-workspace.md`
-
-快速开始：
+基于模板渲染已填写的 DOCX。
 
 ```bash
-npm run build:workspace-mcp
-node packages/contracts-workspace-mcp/bin/open-agreements-workspace-mcp.js
+# From a JSON data file
+open-agreements fill common-paper-mutual-nda -d data.json -o output.docx
+
+# With inline --set flags
+open-agreements fill common-paper-mutual-nda --set party_1_name="Acme Corp" --set governing_law="Delaware"
 ```
 
-## 本地 MCP（模板起草）
+### `validate [template]`
 
-用于本地 Gemini/Cursor 模板起草流程，请使用：
-
-- Package: `@open-agreements/contract-templates-mcp`
-- Binary: `open-agreements-contract-templates-mcp`
-
-快速开始：
+对单个或全部模板运行验证流水线。
 
 ```bash
-npm run build:contract-templates-mcp
-node packages/contract-templates-mcp/bin/open-agreements-contract-templates-mcp.js
+open-agreements validate
+open-agreements validate common-paper-mutual-nda
 ```
 
-## 网站（Vercel）
+</details>
 
-`site/` 是一个通过 Eleventy 构建的精简协议托管层。
+<details>
+<summary><strong>代理设置详情</strong></summary>
 
-- 发现元数据：`site/.well-known/`
-- 发布的 JSON Schema：`site/schemas/`
-- 静态空白 DOCX 下载：`site/downloads/`
-- 预览资源：`site/assets/previews/`
-- Serverless API 处理器：`api/`
-- Discovery outputs (generated during `npm run build:site`): `_site/llms.txt`, `_site/llms-full.txt`, `_site/sitemap.xml`, `_site/robots.txt`
-
-本地预览：
+### Claude Code
 
 ```bash
-npm run build:site
-python3 -m http.server 8080 --directory _site
+npx skills add open-agreements/open-agreements
 ```
 
-然后检查例如 `http://localhost:8080/.well-known/mcp-server-card`、`http://localhost:8080/llms.txt`，或 `_site/` 中生成的文件。
+### Gemini CLI
 
-Vercel 部署说明：
+```bash
+gemini extensions install https://github.com/open-agreements/open-agreements
+```
 
-- 在 Vercel 中导入此仓库
-- 保持项目根目录为仓库根目录
-- 随仓提供的 `vercel.json` 会将 `_site/` 作为静态输出部署
+### Cursor
 
-## 可选内容根目录（面向未来）
+本仓库包含位于 `.cursor-plugin/plugin.json` 的 Cursor 插件清单，并在 `mcp.json` 中配置了 MCP 接线。
 
-为了在表单库增长时支持逻辑解耦，`open-agreements` 可以通过以下方式从额外根目录加载内容：
+### 本地与托管执行
 
-- env var: `OPEN_AGREEMENTS_CONTENT_ROOTS`
-- format: 由路径分隔符连接的绝对/相对目录列表（例如 macOS/Linux 上的 `dirA:dirB`）
-- 每个根目录下预期结构：`templates/`、`external/` 和/或 `recipes/`（或嵌套在 `content/` 下）
+- **本地**：`npx`、全局安装或 stdio MCP。所有处理都在你的机器上完成。
+- **托管**：`https://openagreements.org/api/mcp`。模板填写在服务器端运行，配置更快。
 
-查找优先级：
+请根据文档敏感度和内部策略进行选择。数据流概览见下文的信任清单。
 
-1. `OPEN_AGREEMENTS_CONTENT_ROOTS` 中的根目录（按列出顺序）
-2. 包内自带内容（默认回退）
+</details>
 
-这既保持默认安装简单，也允许高级用户将大型内容库移出核心包。
+## 快速开始
+
+### 与 Claude Code 配合
+
+向 Claude 提问：
+
+```text
+Fill the Common Paper mutual NDA for my company
+```
+
+Claude 可以发现模板、向你询问字段值，并生成可签署的 DOCX。
+
+### 与 CLI 配合
+
+```bash
+# See all available templates
+open-agreements list
+
+# Fill a template from a JSON data file
+open-agreements fill common-paper-mutual-nda -d values.json -o my-nda.docx
+
+# Fill with inline values
+open-agreements fill common-paper-mutual-nda --set party_1_name="Acme Corp" --set governing_law="Delaware"
+```
+
+### 示例提示词
+
+- "为我们的建筑分包商起草一份 NDA"
+- "为我们的保险代理公司起草一份咨询协议"
+- "为一位自由设计师填写独立承包商协议"
+- "生成一份估值上限为 500 万美元的 SAFE"
+
+### 执行过程
+
+1. 代理运行 `list --json` 发现模板及其字段。
+2. 按章节分组向你询问字段值。
+3. 运行 `fill <template>` 渲染 DOCX，并保留原始格式。
+4. 你审核并签署输出文档。
+
+## 安装
+
+### Agent Skill（推荐）
+
+```bash
+npx skills add open-agreements/open-agreements
+```
+
+### 远程 MCP
+
+将任何兼容 MCP 的代理连接到托管服务器 `https://openagreements.org/api/mcp`。
+
+**Claude Code**
+
+```bash
+claude mcp add --transport http open-agreements https://openagreements.org/api/mcp
+```
+
+**Codex CLI**
+
+```bash
+codex mcp add open-agreements --url https://openagreements.org/api/mcp
+```
+
+**其他代理** — 将你的客户端指向 `https://openagreements.org/api/mcp`（streamable HTTP）。
+
+### Gemini CLI 扩展
+
+```bash
+gemini extensions install https://github.com/open-agreements/open-agreements
+```
+
+### CLI
+
+```bash
+npm install -g open-agreements
+```
+
+或零安装直接运行：
+
+```bash
+npx -y open-agreements@latest list
+```
+
+---
+
+## 文档
+
+### 从这里开始
+
+- [Getting Started](https://github.com/open-agreements/open-agreements/blob/main/docs/getting-started.md)
+
+### 指南
+
+- [Adding Templates](https://github.com/open-agreements/open-agreements/blob/main/docs/adding-templates.md)
+- [Adding Recipes](https://github.com/open-agreements/open-agreements/blob/main/docs/adding-recipes.md)
+
+### 其他软件包
+
+- [Contracts Workspace CLI](https://github.com/open-agreements/open-agreements/blob/main/docs/contracts-workspace.md)
+
+### 参考
+
+- [Licensing](https://github.com/open-agreements/open-agreements/blob/main/docs/licensing.md)
+- [Changelog & Release Process](https://github.com/open-agreements/open-agreements/blob/main/docs/changelog-release-process.md)
+- [Trust Checklist](https://github.com/open-agreements/open-agreements/blob/main/docs/trust-checklist.md)
+- [Supported Tools](https://github.com/open-agreements/open-agreements/blob/main/docs/supported-tools.md)
+- [Assumptions](https://github.com/open-agreements/open-agreements/blob/main/docs/assumptions.md)
+- [Employment Source Policy](https://github.com/open-agreements/open-agreements/blob/main/docs/employment-source-policy.md)
+
+**链接：** [Website](https://usejunior.com) | [Template Catalog](https://usejunior.com/templates) | [Docs](https://github.com/open-agreements/open-agreements/tree/main/docs) | [Trust](https://usejunior.com/security) | [npm](https://www.npmjs.com/package/open-agreements)
+
+## 隐私
+
+- **本地模式**（`npx`、全局安装、stdio MCP）：所有处理都在你的机器上完成，不会向外部发送任何文档内容。
+- **托管模式**（`https://openagreements.org/api/mcp`）：模板填写在服务器端运行，响应返回后不会存储已填写的文档。
+
+详见 [Privacy Policy](https://usejunior.com/privacy_policy)。
 
 ## 另请参阅
 
-- [safe-docx](https://github.com/UseJunior/safe-docx) — 使用编程代理对现有 Word 文档进行精准编辑（MCP 服务器）
-- [UseJunior Developer Tools](https://usejunior.com/developer-tools/open-agreements) — 产品页面，含安装选项和模板目录
+- [safe-docx](https://github.com/UseJunior/safe-docx) — 使用编程代理对现有 Word 文档进行精准编辑
 
 ## 贡献
 
-参见 [CONTRIBUTING.md](CONTRIBUTING.md) 了解如何添加模板、recipes 及其他改进。
+参见 [CONTRIBUTING.md](https://github.com/open-agreements/open-agreements/blob/main/CONTRIBUTING.md) 了解如何添加模板、配方及其他改进。
 
-- [Adding templates](docs/adding-templates.md)（CC BY 4.0 / CC0 来源）
-- [Adding recipes](docs/adding-recipes.md)（不可再分发来源）
-- [Employment source policy](docs/employment-source-policy.md)（信任与条款分类）
-- [Code of Conduct](CODE_OF_CONDUCT.md)（社区规范与执行）
+## 基于 OpenAgreements 构建
 
-## 发布
+- [Safe Clause](https://safeclause.deltaxy.ai) — 面向创业公司的 AI 驱动合同平台。[2026 年 3 月 vibecode.law 第 1 名](https://vibecode.law/showcase/safe-clause-317416)。
 
-发布通过 GitHub Actions 自动完成，使用 npm 可信发布（OIDC）并启用 provenance。
-
-1. 在根包和可发布 MCP 包中更新版本。
-2. 提交并打标签后执行 `git push origin main --tags`
-3. 运行本地 Gemini 扩展门禁（复制/软链接到 `~/.gemini/extensions/open-agreements`，并验证两个本地 MCP 服务器可启动/响应）。
-4. `Release` workflow 会在标签上运行 build、验证、测试、隔离运行时 smoke 和包检查后发布。
-
-workflow 防护规则：
-
-- 标签必须与根包和可发布包版本一致
-- 发布提交必须包含在 `origin/main` 中
-- 若任一目标 npm 版本已存在，发布将失败
-
-## 架构
-
-- **Language**: TypeScript
-- **DOCX Engine**: [docx-templates](https://www.npmjs.com/package/docx-templates) (MIT)
-- **CLI**: [Commander.js](https://www.npmjs.com/package/commander)
-- **Validation**: [Zod](https://www.npmjs.com/package/zod) schemas
-- **Skill Pattern**: Agent-agnostic `ToolCommandAdapter` interface
-
-```
-content/                    # All content directories
-├── templates/              # Internal templates (CC BY 4.0)
-├── external/               # External templates (CC BY-ND 4.0)
-└── recipes/                # Recipes (downloaded at runtime)
-
-src/                        # TypeScript source + collocated unit tests
-├── cli/                    # Commander.js CLI
-├── commands/               # fill, validate, list, recipe, scan
-├── core/
-│   ├── engine.ts           # docx-templates wrapper
-│   ├── metadata.ts         # Zod schemas + loader
-│   ├── recipe/             # Recipe pipeline (clean → patch → fill → verify)
-│   ├── external/           # External template support
-│   ├── validation/         # template, license, output, recipe
-│   └── command-generation/
-│       ├── types.ts        # ToolCommandAdapter interface
-│       └── adapters/       # Claude Code adapter
-└── index.ts                # Public API
-
-integration-tests/          # Integration and end-to-end tests
-```
-
-## 资源
-
-- [Claude Code Documentation](https://docs.anthropic.com/en/docs/claude-code)
-- [Claude Code Plugins Guide](https://docs.anthropic.com/en/docs/claude-code/plugins)
-- [Agent Skills Specification](https://agentskills.io)
+正在基于 OpenAgreements 进行构建？提交 PR 添加你的项目。
 
 ## 许可
 
-MIT
+MIT。模板内容按各自作者授权：
 
-模板内容按各自作者授权：CC BY 4.0（Common Paper、Bonterms）、CC BY-ND 4.0（Y Combinator）或专有（NVCA，运行时下载）。详见每个模板的 `metadata.yaml`。
+- Common Paper、Bonterms 以及 OpenAgreements 撰写的模板采用 CC BY 4.0
+- Y Combinator SAFE 模板原样 vendor，采用 CC BY-ND 4.0
+- NVCA 源文档通过 recipe 工作流处理，采用专有或不可再分发许可
 
-## 免责声明
+具体来源详情见每个模板的 `metadata.yaml`。
 
-本工具基于标准模板生成文档，不构成法律建议。与 Common Paper、Bonterms、Y Combinator、NVCA 或任何模板来源不存在附属关系或背书关系。请咨询律师获取法律建议。
+本工具基于标准模板生成文档，不构成法律建议。请咨询律师以获取法律意见。

--- a/scripts/generate_readme.mjs
+++ b/scripts/generate_readme.mjs
@@ -43,11 +43,11 @@ function normalizeUrl(value, key) {
 }
 
 const CONTENTS = [
-  ["Install", "#install"],
-  ["Quick Start", "#quick-start"],
   ["Available Templates", "#available-templates"],
   ["Available Skills", "#available-skills"],
   ["Packages", "#packages"],
+  ["Quick Start", "#quick-start"],
+  ["Install", "#install"],
   ["Documentation", "#documentation"],
   ["Privacy", "#privacy"],
   ["See Also", "#see-also"],


### PR DESCRIPTION
## Summary

- Reorders the main README to lead with **Available Templates**, putting the catalog up top where most readers expect it.
- New section order: Available Templates → Available Skills → Packages → Quick Start → Install → Documentation → Privacy → See Also → Contributing → Built With OpenAgreements → License.
- Updates English (`README.md` via `README.template.md` + `scripts/generate_readme.mjs`) and re-syncs all four translations (es / de / zh / pt-br) — translations were structurally drifted from English, so they were rewritten to mirror the new structure while preserving existing translated terminology.

## Test plan

- [x] `npm run generate:readme` regenerates `README.md` cleanly
- [x] Section order verified across all 5 READMEs (en/es/de/zh/pt-br)
- [x] Tables, code blocks, badges, and URLs preserved verbatim in translations
- [ ] CI green (covers `check:readme` drift gate)