### PR TITLE
fix(ci): surface LLM-gate WARN diagnostics + compact PR_LABELS (closes #342)

### DIFF
--- a/.github/actions/llm-gate-check/action.yml
+++ b/.github/actions/llm-gate-check/action.yml
@@ -119,11 +119,17 @@ runs:
         PARSED=""
         ATTEMPTS=0
         MAX_ATTEMPTS=3
+        LAST_RAW=""
+        LAST_ERR=""
+        DIAG_LOG="$RUNNER_TEMP/diag-${CHECK_ID}.log"
+        : > "$DIAG_LOG"
 
         for attempt in 1 2 3; do
           ATTEMPTS=$attempt
           RAW="$RUNNER_TEMP/raw-${CHECK_ID}-${attempt}.json"
           ERR="$RUNNER_TEMP/err-${CHECK_ID}-${attempt}.log"
+          LAST_RAW="$RAW"
+          LAST_ERR="$ERR"
 
           # Direct CLI invocation: we control logging, retries, and what
           # ends up in $GITHUB_STEP_SUMMARY. The official action would
@@ -134,7 +140,12 @@ runs:
               --output-format json \
               --prompt "$(cat "$PROMPT_FILE")" \
               > "$RAW" 2> "$ERR"; then
+            GEMINI_EXIT=0
+          else
+            GEMINI_EXIT=$?
+          fi
 
+          if [ "$GEMINI_EXIT" -eq 0 ]; then
             # The CLI returns {"response": "<model text>", "stats": {...}}.
             # Extract response, then parse it as our {status, justification} JSON.
             if MODEL_TEXT=$(jq -er '.response' "$RAW" 2>/dev/null) && \
@@ -143,8 +154,12 @@ runs:
                    and (.justification | type == "string")
                    and (.justification | length > 0))
                ' 2>/dev/null); then
+              printf 'attempt %d: ok (CLI exit 0, parsed)\n' "$attempt" >> "$DIAG_LOG"
               break
             fi
+            printf 'attempt %d: CLI exit 0 but response JSON did not match {status,justification} contract\n' "$attempt" >> "$DIAG_LOG"
+          else
+            printf 'attempt %d: CLI exit %d (no parse attempted)\n' "$attempt" "$GEMINI_EXIT" >> "$DIAG_LOG"
           fi
 
           if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
@@ -163,6 +178,33 @@ runs:
         if [ -z "$PARSED" ]; then
           echo "::warning::Check ${CHECK_ID} fell back to WARN after $MAX_ATTEMPTS malformed attempts"
           PARSED=$(jq -n '{status: "WARN", justification: "Unable to verify: the LLM produced malformed output across all retry attempts. Review this question manually."}')
+
+          # Surface the last-attempt diagnostic so we can root-cause why all
+          # retries failed (auth/quota, model availability, CLI/model
+          # incompatibility, response-envelope change, etc.). Bounded leak
+          # risk: only the model's error envelope and response head, never
+          # the prompt or PR diff.
+          if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+            {
+              printf '### Check %s — WARN fallback diagnostics\n\n' "$CHECK_ID"
+              printf 'All %d retry attempts failed. Per-attempt outcome:\n\n' "$MAX_ATTEMPTS"
+              printf '```\n'
+              cat "$DIAG_LOG"
+              printf '```\n\n'
+              if [ -s "$LAST_ERR" ]; then
+                printf '<details><summary>Last attempt stderr (head 4096 bytes)</summary>\n\n'
+                printf '```\n'
+                head -c 4096 "$LAST_ERR"
+                printf '\n```\n\n</details>\n\n'
+              fi
+              if [ -s "$LAST_RAW" ]; then
+                printf '<details><summary>Last attempt raw response (head 4096 bytes)</summary>\n\n'
+                printf '```\n'
+                head -c 4096 "$LAST_RAW"
+                printf '\n```\n\n</details>\n'
+              fi
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
         fi
 
         # Char-count cost estimation. Token counts aren't exposed by the

--- a/.github/workflows/llm-based-quality-gate.yml
+++ b/.github/workflows/llm-based-quality-gate.yml
@@ -96,7 +96,11 @@ jobs:
               echo "head_sha=$PR_HEAD_SHA"
               echo "head_ref=$PR_HEAD_REF"
               echo "base_ref=$PR_BASE_REF"
-              echo "labels=$PR_LABELS"
+              # `toJSON()` emits pretty-printed (multi-line) JSON, which
+              # $GITHUB_OUTPUT rejects without heredoc syntax. Collapse to
+              # single-line so the downstream `JSON.parse(PR_LABELS)` keeps
+              # working and the override label can be evaluated.
+              echo "labels=$(printf '%s' "$PR_LABELS" | jq -c .)"
             } >> "$GITHUB_OUTPUT"
           fi
 


### PR DESCRIPTION
## Summary

Fixes two bugs in `.github/workflows/llm-based-quality-gate.yml` / `.github/actions/llm-gate-check/action.yml` reported in #342. Both were triggered while landing PR #340 (a docs-only README reorder) and together prevented the gate from ever producing a usable verdict.

- **Bug 1 — WARN fallback hid the real failure.** When all 3 retries produced malformed output, the per-check job emitted a generic "Unable to verify…" justification and discarded the actual stderr/response, making it impossible to tell from CI logs whether the issue was auth/quota, model availability, CLI/model incompatibility, or a response-envelope change. Now the retry loop tracks each attempt's outcome (CLI nonzero exit vs. CLI zero exit + parse failure) in a diag log, and on final fallback writes the per-attempt verdicts plus `head -c 4096` of the last attempt's stderr and raw response to `$GITHUB_STEP_SUMMARY`. Bounded leak risk — error envelope and model output snippets only, never the prompt or PR diff.
- **Bug 2 — `PR_LABELS` multi-line broke `$GITHUB_OUTPUT`.** `toJSON(github.event.pull_request.labels.*.name)` in GitHub Actions emits pretty-printed (multi-line) JSON, so `echo "labels=$PR_LABELS" >> "$GITHUB_OUTPUT"` wrote a multi-line value and Parse checklist crashed with `Invalid format '  "llm-gate/override"'`. That meant adding the documented `llm-gate/override` label — the escape hatch for Bug 1 — made the gate fail _harder_ than the WARN it was overriding. Now compacted via `jq -c .` to match what the `workflow_dispatch` branch eight lines above already does, preserving the JSON-array consumer contract at line 264.

The same composite action backs `.github/workflows/llm-based-quality-gate-post-merge.yml`, so the diagnostic improvement automatically benefits both pre-merge and post-merge runs. Post-merge label handling was already correct (it uses `jq -c '[.labels[].name]'`) and is unchanged.

## Test plan

- [x] `actionlint .github/workflows/llm-based-quality-gate.yml .github/workflows/llm-based-quality-gate-post-merge.yml` — clean
- [x] `shellcheck` on the retry-loop step — clean
- [x] Local sanity check for Bug 2: `printf '%s' "$PR_LABELS" | jq -c .` collapses the multi-line `toJSON()` output to a single line
- [ ] On the next gate run against a PR, Parse checklist should resolve PR context cleanly even with `llm-gate/override` set
- [ ] If a check still WARNs, the per-job Actions UI summary should show the last attempt's stderr/raw response so we can finally root-cause #342 Bug 1