### PR TITLE
fix(ci): pass --repo to gh pr view in LLM gate workflow_dispatch path (closes #347)

### DIFF
--- a/.github/workflows/llm-based-quality-gate.yml
+++ b/.github/workflows/llm-based-quality-gate.yml
@@ -82,7 +82,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            gh pr view "$DISPATCH_PR_NUMBER" --json headRefOid,headRefName,baseRefName,labels > "$RUNNER_TEMP/pr.json"
+            gh pr view "$DISPATCH_PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json headRefOid,headRefName,baseRefName,labels > "$RUNNER_TEMP/pr.json"
             {
               echo "pr_number=$DISPATCH_PR_NUMBER"
               echo "head_sha=$(jq -r '.headRefOid' "$RUNNER_TEMP/pr.json")"


### PR DESCRIPTION
## Summary

The LLM-Based Quality Gate workflow's `workflow_dispatch` re-trigger path was silently broken — every manual re-fire crashed in 3-15s with `fatal: not a git repository` before the matrix could parse the checklist. One-line fix: pass `--repo "$GITHUB_REPOSITORY"` to the `gh pr view` call.

## Implementation

`.github/workflows/llm-based-quality-gate.yml:85` (the `Resolve PR context` step's `workflow_dispatch` branch):

```diff
- gh pr view "$DISPATCH_PR_NUMBER" --json headRefOid,headRefName,baseRefName,labels > "$RUNNER_TEMP/pr.json"
+ gh pr view "$DISPATCH_PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json headRefOid,headRefName,baseRefName,labels > "$RUNNER_TEMP/pr.json"
```

`gh pr view` without `--repo` falls back to inferring the target from the current dir's `git remote`. The step runs before any `actions/checkout`, so `$GITHUB_WORKSPACE` is empty and `gh` exits 1. `$GITHUB_REPOSITORY` is a default Actions env var (always set), so no extra wiring is needed.

The `pull_request` else-branch (which uses event payload fields) is untouched.

## Verification

- [x] `actionlint` — no diagnostics
- [x] YAML parses (Python `yaml.safe_load`)
- [x] Codex's pre-commit run: `npm install` + `npm run build` + targeted `npx vitest run integration-tests/api-endpoints.test.ts integration-tests/mcp-contract.test.ts` (89/89 pass)
- [x] Diff scope: 1 file, +1/-1 line, no drift
- [ ] Peer review (Gemini + Codex) — pending; results will be appended below
- [ ] Live `workflow_dispatch` smoke after merge — fire `gh workflow run llm-based-quality-gate.yml -f pr_number=<some-PR>` against main and confirm the matrix actually proceeds past `Resolve PR context`

## Out of scope

- Changing the gate's trigger conditions to add `synchronize` (intentional cost decision per #338's footer comment)
- Refactoring how the step resolves PR context (minimal fix only)
- The mergeability-after-branch-update flow that required `llm-gate/override` label hackery on #338 — separate consideration

## Failed runs that surfaced this

- Run [26450314514](https://github.com/open-agreements/open-agreements/actions/runs/26450314514) — PR #332 manual re-fire, failed in 3s
- Run [26457545833](https://github.com/open-agreements/open-agreements/actions/runs/26457545833) — PR #338 manual re-fire, failed in 14s

## Closes
- #347