### PR TITLE
fix(ci): npm 11 rejects double-loaded user/global config — split paths

### DIFF
--- a/.github/actions/llm-gate-check/action.yml
+++ b/.github/actions/llm-gate-check/action.yml
@@ -45,15 +45,21 @@ runs:
       # runs `gemini` with GEMINI_API_KEY in env — the output sanitizer can't
       # defend against a malicious binary (it can exfil over network or stderr).
       # Install from $RUNNER_TEMP (no .npmrc), force per-user and global config
-      # to a forced-empty file, pin the registry explicitly.
+      # to forced-empty files, pin the registry explicitly.
+      #
+      # NOTE: the user-config and global-config paths must be DIFFERENT files.
+      # npm 11+ rejects loading the same file in both roles with:
+      #   "double-loading config '<path>' as 'global', previously loaded as 'user'"
+      # (Same bug landed in safe-docx then was caught here; the fix is portable.)
       env:
         GEMINI_CLI_VERSION: ${{ inputs.gemini-cli-version }}
-        NPM_CONFIG_USERCONFIG: ${{ runner.temp }}/llm-gate-empty-npmrc
-        NPM_CONFIG_GLOBALCONFIG: ${{ runner.temp }}/llm-gate-empty-npmrc
+        NPM_CONFIG_USERCONFIG: ${{ runner.temp }}/llm-gate-empty-userconfig
+        NPM_CONFIG_GLOBALCONFIG: ${{ runner.temp }}/llm-gate-empty-globalconfig
         NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
       run: |
         set -euo pipefail
         : > "$NPM_CONFIG_USERCONFIG"
+        : > "$NPM_CONFIG_GLOBALCONFIG"
         cd "$RUNNER_TEMP"
         npm install --silent --no-audit --no-fund --global "@google/gemini-cli@${GEMINI_CLI_VERSION}"
         gemini --version


### PR DESCRIPTION
## Summary

One-line fix to the `.npmrc`-poisoning hardening from #334. Same bug as caught in [safe-docx#269 CI logs](https://github.com/UseJunior/safe-docx/pull/269) — npm 11+ rejects loading the same file as both `NPM_CONFIG_USERCONFIG` and `NPM_CONFIG_GLOBALCONFIG`:

```
Exit prior to config file resolving
cause
double-loading config "<path>" as "global", previously loaded as "user"
##[error]Process completed with exit code 1.
```

The bug exists in this repo since #334 merged. Fixing here in parallel with [safe-docx#270](https://github.com/UseJunior/safe-docx/pull/270).

## Fix

Use two separate empty-file paths:

```yaml
NPM_CONFIG_USERCONFIG: ${{ runner.temp }}/llm-gate-empty-userconfig
NPM_CONFIG_GLOBALCONFIG: ${{ runner.temp }}/llm-gate-empty-globalconfig
```

Touch both before install. Security property unchanged — both files forced-empty, registry pinned, install still runs from `\$RUNNER_TEMP`.

## Verification

- [x] `actionlint .github/workflows/llm-based-quality-gate.yml` clean
- [x] Embedded `settings.json` still parses

## Test plan

When this PR opens the gate workflow runs from base-ref source, so it hits the same broken install. **After merge**, future PRs should see the gate install Gemini cleanly and produce per-item verdicts.

## Note on this PR's own gate run

This PR's own gate run is required for merge (per branch protection on this repo). Same bootstrap problem as PR #334 — the workflow on the PR runs from base-ref (broken) → fails at install → no verdicts. Will apply `llm-gate/override` label to bypass, same as the pattern used for #334.