### PR TITLE
feat(issue-template): add Practice-note correction form (closes #356)

### DIFF
--- a/.github/ISSUE_TEMPLATE/practice-note-correction.yml
+++ b/.github/ISSUE_TEMPLATE/practice-note-correction.yml
@@ -1,0 +1,64 @@
+name: Practice-note correction
+description: Report a factual error, broken citation, stale law update, or copy issue on a published practice-note page.
+title: "Practice-note correction: "
+labels:
+  - area/practice-notes
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Triage notes:
+        - Set issue Type to `Bug` for factual errors or broken citations; `Feature` for stale-law updates requiring a content rewrite.
+        - Maintainers assign `area/practice-notes`, `priority/*`, and `status/*` labels during triage.
+        - Keep Assignees, Projects, and Milestone empty unless ownership / scheduling is explicit.
+
+  - type: input
+    id: page_url
+    attributes:
+      label: Page URL
+      placeholder: https://legal-explainer.vercel.app/legal/non-compete/wyoming
+    validations:
+      required: true
+
+  - type: input
+    id: section
+    attributes:
+      label: Question / section
+      placeholder: e.g., "Are employee non-compete agreements enforceable in Wyoming?" or "Authority A.4"
+    validations:
+      required: false
+
+  - type: textarea
+    id: issue
+    attributes:
+      label: What is wrong?
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggested_correction
+    attributes:
+      label: Suggested correction
+    validations:
+      required: false
+
+  - type: textarea
+    id: source_backing
+    attributes:
+      label: Source / authority backing the correction
+      placeholder: Statute citation, case citation, link to law-firm commentary, etc.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - Factual error (legal substance)
+        - Citation is broken or wrong
+        - Stale (law has changed)
+        - Copy / phrasing
+        - Other
+    validations:
+      required: false


### PR DESCRIPTION
## Summary

Closes #356. Adds a guided GitHub issue template at `.github/ISSUE_TEMPLATE/practice-note-correction.yml` so the "Report a correction on GitHub" link in legal-explainer's document-meta block lands on a structured form instead of a blank one.

## Implementation

New file `.github/ISSUE_TEMPLATE/practice-note-correction.yml` matching the form-syntax style of `.github/ISSUE_TEMPLATE/form-source-proposal.yml`:

- `name: Practice-note correction`
- `description: Report a factual error, broken citation, stale law update, or copy issue on a published practice-note page.`
- `title: "Practice-note correction: "`
- `labels: [area/practice-notes]`
- 6 form fields (page URL required, section optional, what-is-wrong required, suggested correction optional, source backing optional, severity dropdown optional)
- Triage notes block at top mirrors `form-source-proposal.yml`

## Verification

- `python3 -c "import yaml; yaml.safe_load(open(...))"` parses cleanly with all 7 body fields (1 markdown block + 6 form fields)
- `git diff origin/main -- .github/ISSUE_TEMPLATE/config.yml` produces no output (config unchanged)
- `git diff --name-only origin/main` outputs exactly `.github/ISSUE_TEMPLATE/practice-note-correction.yml` (one file added)

## Closes
- #356

## Maintainer action needed

The `area/practice-notes` label referenced in the template doesn't exist yet. Please provision it through whatever label-management workflow this repo uses (the codebase has no `.github/labels.yml`, so labels appear to be managed via GitHub UI or a separate automation). Without the label, issues filed with this template will land label-less; triage can still apply it manually.

## Downstream

After this lands, `legal-explainer` `lib/site-constants.ts` will update `feedbackUrl` from `https://github.com/open-agreements/open-agreements/issues/new` to `https://github.com/open-agreements/open-agreements/issues/new?template=practice-note-correction.yml` so the link auto-selects this form.

## Peer review
Pending — Codex CLI to follow before arming auto-merge.