### PR TITLE
docs(readme): add Star History chart badge (closes #363)

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -402,6 +402,10 @@ Siehe [CONTRIBUTING.md](https://github.com/open-agreements/open-agreements/blob/
 
 Baust du auf OpenAgreements auf? Eröffne einen PR, um dein Projekt aufzunehmen.
 
+## Star-Verlauf
+
+[![Star History Chart](https://api.star-history.com/svg?repos=open-agreements/open-agreements&type=Date)](https://star-history.com/#open-agreements/open-agreements&Date)
+
 ## Lizenz
 
 MIT. Vorlageninhalte werden von ihren jeweiligen Autor:innen lizenziert:

--- a/README.es.md
+++ b/README.es.md
@@ -404,6 +404,10 @@ Consulta [CONTRIBUTING.md](https://github.com/open-agreements/open-agreements/bl
 
 ¿Construyes algo con OpenAgreements? Abre un PR para añadir tu proyecto.
 
+## Historial de estrellas
+
+[![Star History Chart](https://api.star-history.com/svg?repos=open-agreements/open-agreements&type=Date)](https://star-history.com/#open-agreements/open-agreements&Date)
+
 ## Licencia
 
 MIT. El contenido de las plantillas está licenciado por sus respectivos autores:

--- a/README.md
+++ b/README.md
@@ -402,6 +402,10 @@ See [CONTRIBUTING.md](https://github.com/open-agreements/open-agreements/blob/ma
 
 Building on OpenAgreements? Open a PR to add your project.
 
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=open-agreements/open-agreements&type=Date)](https://star-history.com/#open-agreements/open-agreements&Date)
+
 ## License
 
 MIT. Template content is licensed by its respective authors:

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -404,6 +404,10 @@ Veja [CONTRIBUTING.md](https://github.com/open-agreements/open-agreements/blob/m
 
 Está construindo algo sobre o OpenAgreements? Abra um PR para adicionar seu projeto.
 
+## Histórico de estrelas
+
+[![Star History Chart](https://api.star-history.com/svg?repos=open-agreements/open-agreements&type=Date)](https://star-history.com/#open-agreements/open-agreements&Date)
+
 ## Licença
 
 MIT. O conteúdo dos modelos é licenciado por seus respectivos autores:

--- a/README.template.md
+++ b/README.template.md
@@ -236,6 +236,10 @@ See [CONTRIBUTING.md](https://github.com/open-agreements/open-agreements/blob/ma
 
 Building on OpenAgreements? Open a PR to add your project.
 
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=open-agreements/open-agreements&type=Date)](https://star-history.com/#open-agreements/open-agreements&Date)
+
 ## License
 
 MIT. Template content is licensed by its respective authors:

--- a/README.zh.md
+++ b/README.zh.md
@@ -404,6 +404,10 @@ npx -y open-agreements@latest list
 
 正在基于 OpenAgreements 进行构建？提交 PR 添加你的项目。
 
+## Star 历史趋势
+
+[![Star History Chart](https://api.star-history.com/svg?repos=open-agreements/open-agreements&type=Date)](https://star-history.com/#open-agreements/open-agreements&Date)
+
 ## 许可
 
 MIT。模板内容按各自作者授权：


### PR DESCRIPTION
## Summary
Adds a [star-history.com](https://star-history.com) chart badge to the README so the project's growth curve is visible inline.

## Implementation
- New `## Star History` section in `README.template.md`, positioned between `## Built With OpenAgreements` and `## License`.
- `README.md` regenerated via `scripts/generate_readme.mjs` (idempotent — no diff after re-run).
- The four language READMEs (`README.es.md`, `README.zh.md`, `README.pt-br.md`, `README.de.md`) hand-edited with translated headings ("Historial de estrellas" / "Star 历史趋势" / "Histórico de estrelas" / "Star-Verlauf"). Badge URL stays in English since it's a star-history.com API call.

## Verification
- [x] Section sits between Built With and License in all 6 variants (built=399, star=405, license=409 in English).
- [x] `grep -c 'star-history' README.md` → 1.
- [x] `node scripts/generate_readme.mjs` runs clean and is idempotent on re-run.
- [ ] Peer review (Gemini + Codex) — pending; will be appended below.

## Closes
- #363