### PR TITLE
docs(readme): add safe-docx-style architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Works with Claude Code, Gemini CLI, Cursor, and local MCP or CLI workflows.
 
 ## Contents
 
+- [How It Works](#how-it-works)
 - [Available Templates](#available-templates)
 - [Available Skills](#available-skills)
 - [Packages](#packages)
@@ -38,6 +39,76 @@ Works with Claude Code, Gemini CLI, Cursor, and local MCP or CLI workflows.
 </p>
 
 > *Demo: Claude fills a Common Paper Mutual NDA in under 2 minutes. Sped up for brevity.*
+
+## How It Works
+
+<!-- SYNC:architecture-diagram BEGIN -->
+```mermaid
+%%{init: {"flowchart": {"htmlLabels": true, "curve": "basis", "nodeSpacing": 30, "rankSpacing": 50}, "themeVariables": {"fontSize": "14px"}} }%%
+flowchart LR
+    InputLeft["<b>Catalog + values</b><br/>Common Paper · Bonterms ·<br/>NVCA · YC SAFE<br/><br/>party info · dates · terms"]
+
+    subgraph Server["open-agreements — local MCP server"]
+        direction LR
+
+        subgraph Discover["<b>1. Discover</b>"]
+            direction TB
+            DiscTool["<code>list_templates(cursor, limit)</code><br/><code>get_template(template_id)</code>"]
+        end
+
+        subgraph Fill["<b>2. Fill</b>"]
+            direction TB
+            FillTool["<code>fill_template(<br/>&nbsp;&nbsp;template, values,<br/>&nbsp;&nbsp;output_path, return_mode)</code>"]
+        end
+
+        subgraph Sign["<b>3. Sign</b>"]
+            direction TB
+            SignTool["<code>send_for_signature(<br/>&nbsp;&nbsp;file_path, signers,<br/>&nbsp;&nbsp;document_name, api_key)</code>"]
+        end
+
+        subgraph Track["<b>4. Track</b>"]
+            direction TB
+            TrackTool["<code>check_signature_status(<br/>&nbsp;&nbsp;envelope_id, api_key)</code>"]
+        end
+
+        Discover --> Fill
+        Fill --> Sign
+        Sign -->|envelope_id| Track
+    end
+
+    OutputRight["<b>Signable .docx</b><br/>then <b>signed .pdf</b><br/>on envelope completion"]
+
+    DocuSign["<b>DocuSign</b><br/>draft · review · signers · artifact"]
+
+    subgraph Client [" "]
+        direction TB
+        Prompt["<b>Prompt</b><br/>'Send a Mutual NDA to acme@example.com'"]
+        Agent["<b>Coding agent / MCP client</b><br/>Claude Code · Cursor · Gemini CLI"]
+        Prompt --> Agent
+    end
+
+    InputLeft --> Discover
+    Track --> OutputRight
+    SignTool <--> DocuSign
+    TrackTool <--> DocuSign
+    Agent <-->|tool call / tool result| Server
+
+    classDef io fill:#f5f5f5,stroke:#888,color:#222
+    classDef server fill:#eff6ff,stroke:#3b82f6,color:#1e3a8a
+    classDef stage fill:#eef2ff,stroke:#6366f1,color:#1e1b4b
+    classDef tools fill:#ecfdf5,stroke:#10b981,color:#064e3b
+    classDef ext fill:#ddd6fe,stroke:#7c3aed,color:#3b0764
+    classDef hidden fill:none,stroke:none
+    class InputLeft,OutputRight io
+    class Server server
+    class Discover,Fill,Sign,Track stage
+    class DiscTool,FillTool,SignTool,TrackTool tools
+    class Prompt,Agent,DocuSign ext
+    class Client hidden
+```
+<!-- SYNC:architecture-diagram END -->
+
+> *Local stdio MCP shown. The hosted HTTP server at `openagreements.org/api/mcp` exposes the same workflow plus a `search_templates` tool, with JWT-based auth replacing the one-time `connect_signing_provider` step.*
 
 ## Available Templates
 

--- a/README.template.md
+++ b/README.template.md
@@ -27,6 +27,76 @@ Works with Claude Code, Gemini CLI, Cursor, and local MCP or CLI workflows.
 
 > *Demo: Claude fills a Common Paper Mutual NDA in under 2 minutes. Sped up for brevity.*
 
+## How It Works
+
+<!-- SYNC:architecture-diagram BEGIN -->
+```mermaid
+%%{init: {"flowchart": {"htmlLabels": true, "curve": "basis", "nodeSpacing": 30, "rankSpacing": 50}, "themeVariables": {"fontSize": "14px"}} }%%
+flowchart LR
+    InputLeft["<b>Catalog + values</b><br/>Common Paper · Bonterms ·<br/>NVCA · YC SAFE<br/><br/>party info · dates · terms"]
+
+    subgraph Server["open-agreements — local MCP server"]
+        direction LR
+
+        subgraph Discover["<b>1. Discover</b>"]
+            direction TB
+            DiscTool["<code>list_templates(cursor, limit)</code><br/><code>get_template(template_id)</code>"]
+        end
+
+        subgraph Fill["<b>2. Fill</b>"]
+            direction TB
+            FillTool["<code>fill_template(<br/>&nbsp;&nbsp;template, values,<br/>&nbsp;&nbsp;output_path, return_mode)</code>"]
+        end
+
+        subgraph Sign["<b>3. Sign</b>"]
+            direction TB
+            SignTool["<code>send_for_signature(<br/>&nbsp;&nbsp;file_path, signers,<br/>&nbsp;&nbsp;document_name, api_key)</code>"]
+        end
+
+        subgraph Track["<b>4. Track</b>"]
+            direction TB
+            TrackTool["<code>check_signature_status(<br/>&nbsp;&nbsp;envelope_id, api_key)</code>"]
+        end
+
+        Discover --> Fill
+        Fill --> Sign
+        Sign -->|envelope_id| Track
+    end
+
+    OutputRight["<b>Signable .docx</b><br/>then <b>signed .pdf</b><br/>on envelope completion"]
+
+    DocuSign["<b>DocuSign</b><br/>draft · review · signers · artifact"]
+
+    subgraph Client [" "]
+        direction TB
+        Prompt["<b>Prompt</b><br/>'Send a Mutual NDA to acme@example.com'"]
+        Agent["<b>Coding agent / MCP client</b><br/>Claude Code · Cursor · Gemini CLI"]
+        Prompt --> Agent
+    end
+
+    InputLeft --> Discover
+    Track --> OutputRight
+    SignTool <--> DocuSign
+    TrackTool <--> DocuSign
+    Agent <-->|tool call / tool result| Server
+
+    classDef io fill:#f5f5f5,stroke:#888,color:#222
+    classDef server fill:#eff6ff,stroke:#3b82f6,color:#1e3a8a
+    classDef stage fill:#eef2ff,stroke:#6366f1,color:#1e1b4b
+    classDef tools fill:#ecfdf5,stroke:#10b981,color:#064e3b
+    classDef ext fill:#ddd6fe,stroke:#7c3aed,color:#3b0764
+    classDef hidden fill:none,stroke:none
+    class InputLeft,OutputRight io
+    class Server server
+    class Discover,Fill,Sign,Track stage
+    class DiscTool,FillTool,SignTool,TrackTool tools
+    class Prompt,Agent,DocuSign ext
+    class Client hidden
+```
+<!-- SYNC:architecture-diagram END -->
+
+> *Local stdio MCP shown. The hosted HTTP server at `openagreements.org/api/mcp` exposes the same workflow plus a `search_templates` tool, with JWT-based auth replacing the one-time `connect_signing_provider` step.*
+
 ## Available Templates
 
 The Source column links to the upstream standard, source document, or canonical project page (varies by publisher). The License column shows redistribution terms. Repo links point to the GitHub content directory for each template or recipe.

--- a/scripts/generate_readme.mjs
+++ b/scripts/generate_readme.mjs
@@ -43,6 +43,7 @@ function normalizeUrl(value, key) {
 }
 
 const CONTENTS = [
+  ["How It Works", "#how-it-works"],
   ["Available Templates", "#available-templates"],
   ["Available Skills", "#available-skills"],
   ["Packages", "#packages"],


### PR DESCRIPTION
## Summary
- Adds a mermaid `flowchart LR` to the README showing the OpenAgreements workflow at a glance: catalog + values → **Discover** → **Fill** → **Sign** → **Track** → signable `.docx` + signed `.pdf`, with DocuSign as the external signing service and the coding-agent MCP client wired in via tool calls.
- Mirrors the visual language of [@usejunior/safe-docx](https://github.com/UseJunior/safe-docx/blob/main/README.md) so the two projects read as siblings.
- Scoped to the **local stdio MCP**; a caption notes that the hosted HTTP server at `openagreements.org/api/mcp` adds `search_templates` and uses JWT auth.
- Adds the new "How It Works" section to the generated TOC via `scripts/generate_readme.mjs`.

## Peer review
Reviewed by Codex and Gemini via the `/peer-review` skill across two passes. Tool signatures verified against the zod schemas in `packages/contract-templates-mcp/src/core/tools.ts` and `packages/signing/src/mcp-tools.ts`. Confirmed localized READMEs (`README.es.md` / `.zh.md` / `.pt-br.md` / `.de.md`) are NOT auto-regenerated — they'll need a follow-up to sync the diagram. Anchor `#how-it-works` resolves under GitHub's standard heading-anchor conventions.

## Test plan
- [x] `npm run generate:readme` — README.md regenerated cleanly from template
- [x] `npm run check:readme` will pass on the merged commit (it fails locally only because of the uncommitted state during review)
- [x] Mermaid block renders via `@mermaid-js/mermaid-cli` (PNG visually compared against safe-docx reference)
- [ ] GitHub-native mermaid renderer parses the block on the PR preview tab — verify here before merging

## Notes
- Localized READMEs intentionally left out of scope (the generator writes only `README.md`); follow-up needed to sync translations.
- `connect_signing_provider` / `disconnect_signing_provider` are intentionally omitted from the diagram (one-time auth setup, not per-document workflow) and mentioned in the caption instead.