### PR TITLE
ci: add publish-gh-runtime workflow for @usejunior/openagreements-runtime

### DIFF
--- a/.github/workflows/publish-gh-runtime.yml
+++ b/.github/workflows/publish-gh-runtime.yml
@@ -68,6 +68,8 @@ jobs:
         working-directory: runtime-pkg
         run: |
           set -euo pipefail
+          # .npmrc so the install resolves @usejunior/* from GitHub Packages
+          echo "@usejunior:registry=https://npm.pkg.github.com" > .npmrc
           npm install "@usejunior/docx-core@${DOCX_CORE_VERSION}" \
             --no-save --ignore-scripts --package-lock=false
           echo "Verifying bundle contents..."
@@ -82,6 +84,7 @@ jobs:
           '
         env:
           DOCX_CORE_VERSION: ${{ inputs.docx_core_version }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish to GitHub Packages
         working-directory: runtime-pkg

--- a/.github/workflows/publish-gh-runtime.yml
+++ b/.github/workflows/publish-gh-runtime.yml
@@ -1,0 +1,90 @@
+name: Publish openagreements-runtime to GitHub Packages
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (for example: 0.7.5)"
+        required: true
+        type: string
+      docx_core_version:
+        description: "Version of @usejunior/docx-core to bundle (must match the version installed in the public repo's node_modules)"
+        required: true
+        type: string
+
+jobs:
+  publish:
+    name: Publish runtime tarball
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          registry-url: https://npm.pkg.github.com
+          scope: "@usejunior"
+          cache: npm
+
+      - name: Install dependencies (retry)
+        uses: ./.github/actions/npm-ci-retry
+
+      - name: Build dist/
+        run: npm run build
+
+      - name: Stage runtime-pkg/
+        run: |
+          set -euo pipefail
+          rm -rf runtime-pkg
+          mkdir -p runtime-pkg
+          cp -r dist runtime-pkg/dist
+          cp -r content runtime-pkg/content
+          node -e '
+            const pkg = {
+              name: "@usejunior/openagreements-runtime",
+              version: process.env.PKG_VERSION,
+              type: "module",
+              main: "./dist/index.js",
+              types: "./dist/index.d.ts",
+              exports: {
+                ".": { "import": "./dist/index.js", "types": "./dist/index.d.ts" },
+                "./dist/*": "./dist/*",
+                "./content/*": "./content/*"
+              },
+              files: ["dist/", "content/"],
+              bundleDependencies: ["@usejunior/docx-core"],
+              publishConfig: { registry: "https://npm.pkg.github.com" },
+              engines: { node: ">=20" }
+            };
+            require("fs").writeFileSync("runtime-pkg/package.json", JSON.stringify(pkg, null, 2));
+          '
+        env:
+          PKG_VERSION: ${{ inputs.version }}
+
+      - name: Install @usejunior/docx-core into runtime-pkg/ (required for bundleDependencies)
+        working-directory: runtime-pkg
+        run: |
+          set -euo pipefail
+          npm install "@usejunior/docx-core@${DOCX_CORE_VERSION}" \
+            --no-save --ignore-scripts --package-lock=false
+          echo "Verifying bundle contents..."
+          npm pack --dry-run --json | node -e '
+            const data = JSON.parse(require("fs").readFileSync(0, "utf8"));
+            const bundled = data[0].bundled || [];
+            if (!bundled.includes("@usejunior/docx-core")) {
+              console.error("FAIL: @usejunior/docx-core not in bundled list:", bundled);
+              process.exit(1);
+            }
+            console.log("OK: @usejunior/docx-core is bundled");
+          '
+        env:
+          DOCX_CORE_VERSION: ${{ inputs.docx_core_version }}
+
+      - name: Publish to GitHub Packages
+        working-directory: runtime-pkg
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/publish-gh-runtime.yml`, a `workflow_dispatch`-only workflow that publishes a slimmed-down runtime package (`@usejunior/openagreements-runtime`) to **GitHub Packages**.
- The runtime package contains only `dist/` + `content/` with subpath exports configured (`./dist/*`, `./content/*`) so consumers can deep-import internal helpers that are not surfaced from the public `dist/index.js`.
- Installs `@usejunior/docx-core` into the staging dir before `npm publish` so `bundleDependencies` actually bundles it (verified via `npm pack --dry-run`).

## Why
The hosted `openagreements.org` Vercel deployment is moving out of this repo into a private repo (`UseJunior/openagreements-org-deploy`). The private deploy needs a `dist/` + `content/` artifact it can pin and bump on its own cadence — faster than the public `open-agreements` npm release cycle.

This workflow is the publisher; the consumer lives in the private deploy repo. No traffic impact from merging this PR alone; the workflow only fires on manual dispatch.

## Trigger inputs
- `version` — semver for the runtime package (recommend starting at `0.7.5` to mirror current `open-agreements`)
- `docx_core_version` — pinned `@usejunior/docx-core` version to bundle (must match the version installed in this repo's `node_modules`)

## Test plan
- [ ] Merge this PR
- [ ] Dispatch the workflow with `version=0.7.5` and the docx-core version from the current `package-lock.json`
- [ ] Verify the package appears at https://github.com/orgs/UseJunior/packages
- [ ] Inspect the published tarball includes `dist/`, `content/`, and bundled `node_modules/@usejunior/docx-core/`