### PR TITLE
fix(ci): @usejunior/docx-core is on public npm, not GH Packages

### DIFF
--- a/.github/workflows/publish-gh-runtime.yml
+++ b/.github/workflows/publish-gh-runtime.yml
@@ -22,11 +22,12 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # No scope/registry on setup-node — we need to talk to BOTH registries:
+      # @usejunior/docx-core lives on public npm; @usejunior/openagreements-runtime
+      # publishes to GitHub Packages. We configure each per-step via .npmrc.
       - uses: actions/setup-node@v5
         with:
           node-version: 22
-          registry-url: https://npm.pkg.github.com
-          scope: "@usejunior"
           cache: npm
 
       - name: Install dependencies (retry)
@@ -64,13 +65,15 @@ jobs:
         env:
           PKG_VERSION: ${{ inputs.version }}
 
-      - name: Install @usejunior/docx-core into runtime-pkg/ (required for bundleDependencies)
+      - name: Install @usejunior/docx-core (public npm) into runtime-pkg/ for bundleDependencies
         working-directory: runtime-pkg
         run: |
           set -euo pipefail
-          # .npmrc so the install resolves @usejunior/* from GitHub Packages
-          echo "@usejunior:registry=https://npm.pkg.github.com" > .npmrc
+          # @usejunior/docx-core is published on public npm, NOT GitHub Packages.
+          # Pin the install registry explicitly so neither setup-node nor the
+          # publishConfig accidentally routes the install to npm.pkg.github.com.
           npm install "@usejunior/docx-core@${DOCX_CORE_VERSION}" \
+            --registry=https://registry.npmjs.org/ \
             --no-save --ignore-scripts --package-lock=false
           echo "Verifying bundle contents..."
           npm pack --dry-run --json | node -e '
@@ -84,10 +87,18 @@ jobs:
           '
         env:
           DOCX_CORE_VERSION: ${{ inputs.docx_core_version }}
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish to GitHub Packages
         working-directory: runtime-pkg
-        run: npm publish
+        run: |
+          set -euo pipefail
+          # .npmrc for the publish step only. publishConfig in package.json
+          # also pins the registry; having both is the documented GH Packages setup.
+          cat > .npmrc <<'EOF'
+          @usejunior:registry=https://npm.pkg.github.com
+          //npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
+          always-auth=true
+          EOF
+          npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
First dispatch of `publish-gh-runtime.yml` failed with `E404 @usejunior/docx-core@0.9.0 is not in this registry` because `setup-node` was configured with `scope: '@usejunior'` + `registry-url: https://npm.pkg.github.com`, which routes ALL `@usejunior/*` installs to GitHub Packages. But `@usejunior/docx-core` lives on public npm.

## Fix
- Drop `scope` / `registry-url` from `setup-node`
- Install step pins `--registry=https://registry.npmjs.org/` explicitly when fetching `@usejunior/docx-core` for the bundleDependencies bundle
- Publish step writes its own `.npmrc` with GH Packages auth right before `npm publish`

## Verification
```
$ npm view @usejunior/docx-core@0.9.0 --registry=https://registry.npmjs.org/ dist.tarball
'https://registry.npmjs.org/@usejunior/docx-core/-/docx-core-0.9.0.tgz'
```

## Test plan
- [ ] Merge, then re-dispatch the workflow with `version=0.7.5`, `docx_core_version=0.9.0`
- [ ] Verify `@usejunior/openagreements-runtime@0.7.5` appears at https://github.com/orgs/UseJunior/packages
