### PR TITLE
fix(ci): rescope runtime package to @open-agreements/

### DIFF
--- a/.github/workflows/publish-gh-runtime.yml
+++ b/.github/workflows/publish-gh-runtime.yml
@@ -1,4 +1,4 @@
-name: Publish openagreements-runtime to GitHub Packages
+name: Publish @open-agreements/openagreements-runtime to GitHub Packages
 
 on:
   workflow_dispatch:
@@ -48,11 +48,15 @@ jobs:
           # the install step run without --no-save, so npm pack sees it as bundled.
           node -e '
             const pkg = {
-              name: "@usejunior/openagreements-runtime",
+              name: "@open-agreements/openagreements-runtime",
               version: process.env.PKG_VERSION,
               type: "module",
               main: "./dist/index.js",
               types: "./dist/index.d.ts",
+              repository: {
+                type: "git",
+                url: "https://github.com/open-agreements/open-agreements.git"
+              },
               exports: {
                 ".": { "import": "./dist/index.js", "types": "./dist/index.d.ts" },
                 "./dist/*": "./dist/*",
@@ -99,7 +103,7 @@ jobs:
           # .npmrc for the publish step only. publishConfig in package.json
           # also pins the registry; having both is the documented GH Packages setup.
           cat > .npmrc <<'EOF'
-          @usejunior:registry=https://npm.pkg.github.com
+          @open-agreements:registry=https://npm.pkg.github.com
           //npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
           always-auth=true
           EOF

--- a/.github/workflows/publish-gh-runtime.yml
+++ b/.github/workflows/publish-gh-runtime.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v5
 
       # No scope/registry on setup-node — we need to talk to BOTH registries:
-      # @usejunior/docx-core lives on public npm; @usejunior/openagreements-runtime
+      # @usejunior/docx-core lives on public npm; @open-agreements/openagreements-runtime
       # publishes to GitHub Packages. We configure each per-step via .npmrc.
       - uses: actions/setup-node@v5
         with:


### PR DESCRIPTION
## Summary
Third `publish-gh-runtime.yml` dispatch got `403 Forbidden permission_denied: The requested installation does not exist.` when trying to publish `@usejunior/openagreements-runtime` to GitHub Packages.

## Root cause
GitHub Packages npm enforces that the package scope matches the OWNER of the repo whose `GITHUB_TOKEN` is publishing. This repo is in the `open-agreements` org, but the package was scoped `@usejunior` (a separate org). The token has no write access to the `UseJunior` org's package namespace.

## Fix
- Rescope to `@open-agreements/openagreements-runtime`
- Add `repository` field to the generated `package.json` (GitHub Packages uses it to bind the package to the source repo on first publish)
- Update workflow's publish-step `.npmrc` to point `@open-agreements` (not `@usejunior`) at `npm.pkg.github.com`

## Consumer impact
The private deploy repo (`UseJunior/openagreements-org-deploy`) needs three trivial updates:
- `package.json` dep: `@usejunior/openagreements-runtime` → `@open-agreements/openagreements-runtime`
- `.npmrc` scope: `@usejunior` → `@open-agreements`
- `vercel.json` `includeFiles` globs: `node_modules/@usejunior/...` → `node_modules/@open-agreements/...`

I'll push a parallel commit to that repo after this PR merges.

## Test plan
- [ ] Merge this PR
- [ ] Re-dispatch the workflow with `version=0.7.5`, `docx_core_version=0.9.0`
- [ ] Verify `@open-agreements/openagreements-runtime@0.7.5` appears at https://github.com/orgs/open-agreements/packages
