### PR TITLE
feat(check-preview-freshness): manifest for byte-identical docx changes

### DIFF
--- a/integration-tests/check-preview-freshness.test.ts
+++ b/integration-tests/check-preview-freshness.test.ts
@@ -9,6 +9,7 @@ import {
   NON_PREFIX_OA_TEMPLATE_IDS,
   SHARED_RENDERER_TEMPLATE_IDS,
   expandTriggers,
+  findManifestSatisfied,
   findMissingFreshness,
   parseChangedFiles,
 } from '../scripts/check_preview_freshness.mjs';
@@ -335,6 +336,42 @@ describe('parseChangedFiles', () => {
   });
 });
 
+// ── Manifest satisfaction ───────────────────────────────────────────────────
+
+describe('manifest satisfaction', () => {
+  it('satisfies a triggered template when the manifest SHA matches template.docx', () => {
+    const result = findManifestSatisfied(['openagreements-employment-offer-letter'], REPO_ROOT, [
+      {
+        templateId: 'openagreements-employment-offer-letter',
+        docxSha256: '2cceb36a2e5a45af97f9bda244b994f44d2290deba97188b2b9a13e99c44595b',
+        reason: 'test byte-identical render claim',
+      },
+    ]);
+
+    expect(result.satisfied).toEqual(new Set(['openagreements-employment-offer-letter']));
+    expect(result.stale).toEqual([]);
+  });
+
+  it('reports stale entries when the manifest SHA no longer matches template.docx', () => {
+    const result = findManifestSatisfied(['openagreements-employment-offer-letter'], REPO_ROOT, [
+      {
+        templateId: 'openagreements-employment-offer-letter',
+        docxSha256: '0000000000000000000000000000000000000000000000000000000000000000',
+        reason: 'test stale claim',
+      },
+    ]);
+
+    expect(result.satisfied.size).toBe(0);
+    expect(result.stale).toEqual([
+      {
+        templateId: 'openagreements-employment-offer-letter',
+        declaredSha: '0000000000000000000000000000000000000000000000000000000000000000',
+        currentSha: '2cceb36a2e5a45af97f9bda244b994f44d2290deba97188b2b9a13e99c44595b',
+      },
+    ]);
+  });
+});
+
 // ── CLI smoke test ───────────────────────────────────────────────────────────
 
 describe('CLI main-guard', () => {
@@ -377,6 +414,26 @@ describe('CLI main-guard', () => {
     });
     expect(result.status).toBe(0);
     expect(result.stdout).toMatch(/PASS preview-freshness/);
+  });
+
+  it('exits 0 on a docx change covered by a matching manifest entry', () => {
+    const result = spawnSync(process.execPath, [SCRIPT_PATH], {
+      cwd: REPO_ROOT,
+      env: {
+        ...process.env,
+        OA_CHANGED_FILES: JSON.stringify([
+          {
+            status: 'modified',
+            path: 'content/templates/openagreements-employment-offer-letter/template.docx',
+            previousPath: null,
+          },
+        ]),
+        OA_GATE_REQUIRE_INPUT: '1',
+      },
+      encoding: 'utf8',
+    });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toMatch(/1 template\(s\) satisfied via manifest/);
   });
 
   it('exits 1 on empty OA_CHANGED_FILES with OA_GATE_REQUIRE_INPUT=1', () => {

--- a/integration-tests/check-preview-freshness.test.ts
+++ b/integration-tests/check-preview-freshness.test.ts
@@ -1,7 +1,9 @@
 import { spawnSync } from 'node:child_process';
-import { resolve } from 'node:path';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import {
   CANONICAL_TEMPLATE_IDS,
@@ -11,6 +13,7 @@ import {
   expandTriggers,
   findManifestSatisfied,
   findMissingFreshness,
+  loadPreviewFreshnessManifest,
   parseChangedFiles,
 } from '../scripts/check_preview_freshness.mjs';
 
@@ -336,6 +339,82 @@ describe('parseChangedFiles', () => {
   });
 });
 
+// ── Manifest loader validation ──────────────────────────────────────────────
+
+describe('loadPreviewFreshnessManifest validation', () => {
+  const tempDirs: string[] = [];
+  afterEach(() => {
+    while (tempDirs.length > 0) rmSync(tempDirs.pop()!, { recursive: true, force: true });
+  });
+
+  function fakeRepo(manifestBody: unknown): string {
+    const dir = mkdtempSync(join(tmpdir(), 'oa-pf-manifest-'));
+    tempDirs.push(dir);
+    mkdirSync(join(dir, 'scripts'), { recursive: true });
+    writeFileSync(
+      join(dir, 'scripts', 'preview-freshness-manifest.json'),
+      typeof manifestBody === 'string' ? manifestBody : JSON.stringify(manifestBody),
+    );
+    return dir;
+  }
+
+  it('rejects non-hex docxSha256 values', () => {
+    const repo = fakeRepo({
+      entries: [{ templateId: 'foo', docxSha256: 'not-a-sha', reason: 'x' }],
+    });
+    expect(() => loadPreviewFreshnessManifest(repo)).toThrow(/invalid docxSha256/);
+  });
+
+  it('rejects the (missing) sentinel as a docxSha256 value', () => {
+    const repo = fakeRepo({
+      entries: [{ templateId: 'foo', docxSha256: '(missing)', reason: 'deletion bypass attempt' }],
+    });
+    expect(() => loadPreviewFreshnessManifest(repo)).toThrow(/invalid docxSha256/);
+  });
+
+  it('rejects SHA values with the wrong length', () => {
+    const repo = fakeRepo({
+      entries: [{ templateId: 'foo', docxSha256: 'aabb', reason: 'too short' }],
+    });
+    expect(() => loadPreviewFreshnessManifest(repo)).toThrow(/invalid docxSha256/);
+  });
+
+  it('rejects duplicate templateId entries', () => {
+    const repo = fakeRepo({
+      entries: [
+        { templateId: 'foo', docxSha256: 'a'.repeat(64), reason: 'first' },
+        { templateId: 'foo', docxSha256: 'b'.repeat(64), reason: 'second hides first' },
+      ],
+    });
+    expect(() => loadPreviewFreshnessManifest(repo)).toThrow(/duplicate templateId/);
+  });
+
+  it('rejects non-object entries (string, array, null)', () => {
+    expect(() => loadPreviewFreshnessManifest(fakeRepo({ entries: ['hello'] }))).toThrow(
+      /must be an object/,
+    );
+    expect(() => loadPreviewFreshnessManifest(fakeRepo({ entries: [['a']] }))).toThrow(
+      /must be an object/,
+    );
+    expect(() => loadPreviewFreshnessManifest(fakeRepo({ entries: [null] }))).toThrow(
+      /must be an object/,
+    );
+  });
+
+  it('accepts a valid 64-char lowercase hex SHA', () => {
+    const repo = fakeRepo({
+      entries: [{ templateId: 'foo', docxSha256: 'a'.repeat(64), reason: 'ok' }],
+    });
+    expect(() => loadPreviewFreshnessManifest(repo)).not.toThrow();
+  });
+
+  it('returns [] when the manifest file is absent', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'oa-pf-manifest-absent-'));
+    tempDirs.push(dir);
+    expect(loadPreviewFreshnessManifest(dir)).toEqual([]);
+  });
+});
+
 // ── Manifest satisfaction ───────────────────────────────────────────────────
 
 describe('manifest satisfaction', () => {
@@ -367,6 +446,24 @@ describe('manifest satisfaction', () => {
         templateId: 'openagreements-employment-offer-letter',
         declaredSha: '0000000000000000000000000000000000000000000000000000000000000000',
         currentSha: '2cceb36a2e5a45af97f9bda244b994f44d2290deba97188b2b9a13e99c44595b',
+      },
+    ]);
+  });
+
+  it('flags a manifest entry as stale (not satisfied) when template.docx is missing on disk', () => {
+    const result = findManifestSatisfied(['template-that-does-not-exist'], REPO_ROOT, [
+      {
+        templateId: 'template-that-does-not-exist',
+        docxSha256: '0000000000000000000000000000000000000000000000000000000000000000',
+        reason: 'deletion-bypass guard',
+      },
+    ]);
+    expect(result.satisfied.size).toBe(0);
+    expect(result.stale).toEqual([
+      {
+        templateId: 'template-that-does-not-exist',
+        declaredSha: '0000000000000000000000000000000000000000000000000000000000000000',
+        currentSha: '(template.docx missing on disk)',
       },
     ]);
   });
@@ -414,6 +511,32 @@ describe('CLI main-guard', () => {
     });
     expect(result.status).toBe(0);
     expect(result.stdout).toMatch(/PASS preview-freshness/);
+  });
+
+  it('exits 1 when docx AND template.md change together (manifest cannot shield source-side change)', () => {
+    const result = spawnSync(process.execPath, [SCRIPT_PATH], {
+      cwd: REPO_ROOT,
+      env: {
+        ...process.env,
+        OA_CHANGED_FILES: JSON.stringify([
+          {
+            status: 'modified',
+            path: 'content/templates/openagreements-employment-offer-letter/template.docx',
+            previousPath: null,
+          },
+          {
+            status: 'modified',
+            path: 'content/templates/openagreements-employment-offer-letter/template.md',
+            previousPath: null,
+          },
+        ]),
+        OA_GATE_REQUIRE_INPUT: '1',
+      },
+      encoding: 'utf8',
+    });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toMatch(/openagreements-employment-offer-letter/);
+    expect(result.stdout).not.toMatch(/satisfied via manifest/);
   });
 
   it('exits 0 on a docx change covered by a matching manifest entry', () => {

--- a/integration-tests/check-preview-freshness.test.ts
+++ b/integration-tests/check-preview-freshness.test.ts
@@ -513,6 +513,49 @@ describe('CLI main-guard', () => {
     expect(result.stdout).toMatch(/PASS preview-freshness/);
   });
 
+  it('exits 1 when template.docx is ADDED (manifest cannot vouch for byte-identity vs nonexistent baseline)', () => {
+    const result = spawnSync(process.execPath, [SCRIPT_PATH], {
+      cwd: REPO_ROOT,
+      env: {
+        ...process.env,
+        OA_CHANGED_FILES: JSON.stringify([
+          {
+            status: 'added',
+            path: 'content/templates/openagreements-employment-offer-letter/template.docx',
+            previousPath: null,
+          },
+        ]),
+        OA_GATE_REQUIRE_INPUT: '1',
+      },
+      encoding: 'utf8',
+    });
+    expect(result.status).toBe(1);
+    expect(result.stdout).not.toMatch(/satisfied via manifest/);
+    expect(result.stderr).toMatch(/openagreements-employment-offer-letter/);
+  });
+
+  it("'freshness/skip' label bypasses the gate even when manifest validation would fail", () => {
+    // A stale manifest entry would normally hard-fail. Asserts the label
+    // short-circuit fires BEFORE manifest loading, so the bypass is total —
+    // not conditional on manifest validity. Documents the precedence policy
+    // for future maintainers.
+    const result = spawnSync(process.execPath, [SCRIPT_PATH], {
+      cwd: REPO_ROOT,
+      env: {
+        ...process.env,
+        OA_PR_LABELS: 'freshness/skip',
+        // Empty OA_CHANGED_FILES would fail with OA_GATE_REQUIRE_INPUT=1, but
+        // the label short-circuit fires before that check too.
+        OA_CHANGED_FILES: '',
+        OA_GATE_REQUIRE_INPUT: '1',
+      },
+      encoding: 'utf8',
+    });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toMatch(/freshness\/skip/);
+    expect(result.stdout).toMatch(/explicitly bypassed/);
+  });
+
   it('exits 1 when docx AND template.md change together (manifest cannot shield source-side change)', () => {
     const result = spawnSync(process.execPath, [SCRIPT_PATH], {
       cwd: REPO_ROOT,

--- a/scripts/check_preview_freshness.mjs
+++ b/scripts/check_preview_freshness.mjs
@@ -390,7 +390,13 @@ export function loadPreviewFreshnessManifest(repoRoot = REPO_ROOT) {
     throw new Error("Preview freshness manifest must contain an entries array");
   }
 
+  const seen = new Set();
   return parsed.entries.map((entry, index) => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      throw new Error(
+        `Preview freshness manifest entry ${index + 1} must be an object`
+      );
+    }
     const templateId = String(entry.templateId ?? "");
     const docxSha256 = String(entry.docxSha256 ?? "").toLowerCase();
     if (!templateId || !docxSha256) {
@@ -398,6 +404,17 @@ export function loadPreviewFreshnessManifest(repoRoot = REPO_ROOT) {
         `Preview freshness manifest entry ${index + 1} must include templateId and docxSha256`
       );
     }
+    if (!/^[a-f0-9]{64}$/.test(docxSha256)) {
+      throw new Error(
+        `Preview freshness manifest entry ${index + 1} has invalid docxSha256 — must be 64 lowercase hex characters (SHA-256), got '${entry.docxSha256}'`
+      );
+    }
+    if (seen.has(templateId)) {
+      throw new Error(
+        `Preview freshness manifest has duplicate templateId '${templateId}' — each template may have at most one entry to preserve audit trail`
+      );
+    }
+    seen.add(templateId);
     return {
       templateId,
       docxSha256,
@@ -436,13 +453,13 @@ export function findManifestSatisfied(
     const currentSha = sha256File(
       path.resolve(repoRoot, "content", "templates", id, TEMPLATE_DOCX_FILE)
     );
-    if (entry.docxSha256 === currentSha) {
+    if (currentSha !== null && entry.docxSha256 === currentSha) {
       satisfied.add(id);
     } else {
       stale.push({
         templateId: id,
         declaredSha: entry.docxSha256,
-        currentSha,
+        currentSha: currentSha ?? "(template.docx missing on disk)",
       });
     }
   }
@@ -450,8 +467,19 @@ export function findManifestSatisfied(
   return { satisfied, stale };
 }
 
+/**
+ * Compute the SHA-256 of a file, or return null if absent.
+ *
+ * Important: null is intentionally NOT a valid SHA value and can never compare
+ * equal to a manifest entry's docxSha256 (which is validated as 64 hex chars).
+ * That closes a deletion-bypass shape where a manifest entry could otherwise
+ * claim a sentinel "(missing)" string and satisfy a removed template.docx.
+ *
+ * @param {string} filePath
+ * @returns {string | null}
+ */
 function sha256File(filePath) {
-  if (!existsSync(filePath)) return "(missing)";
+  if (!existsSync(filePath)) return null;
   return createHash("sha256").update(readFileSync(filePath)).digest("hex");
 }
 
@@ -660,44 +688,64 @@ export async function main(env) {
 
   const manifestEntries = loadPreviewFreshnessManifest(REPO_ROOT);
   const manifestCheck = findManifestSatisfied(
-    docxTriggeredIds(triggered),
+    docxOnlyTriggeredIds(triggered),
     REPO_ROOT,
     manifestEntries
   );
-  if (manifestCheck.stale.length > 0) {
-    console.error(formatManifestStaleMessage(manifestCheck.stale));
-    process.exit(1);
-  }
 
   const missing = findMissingFreshness(input.records, triggered).filter(
     (id) => !manifestCheck.satisfied.has(id)
   );
 
-  if (missing.length === 0) {
-    if (manifestCheck.satisfied.size > 0) {
-      console.log(
-        `PASS preview-freshness gate: ${manifestCheck.satisfied.size} template(s) satisfied via manifest (byte-identical render claim).`
-      );
-      return;
+  // Aggregate failures: emit both stale-manifest and missing-preview errors in
+  // one run so a contributor can fix everything in a single follow-up commit.
+  if (manifestCheck.stale.length > 0 || missing.length > 0) {
+    if (missing.length > 0) {
+      emitGithubAnnotations(triggered, missing);
+      console.error(formatFailureMessage(triggered, missing));
     }
+    if (manifestCheck.stale.length > 0) {
+      if (missing.length > 0) console.error("");
+      console.error(formatManifestStaleMessage(manifestCheck.stale));
+    }
+    process.exit(1);
+  }
+
+  if (manifestCheck.satisfied.size > 0) {
     console.log(
-      `PASS preview-freshness gate: ${triggered.size} template(s) had matching preview updates.`
+      `PASS preview-freshness gate: ${manifestCheck.satisfied.size} template(s) satisfied via manifest (byte-identical render claim).`
     );
     return;
   }
-
-  emitGithubAnnotations(triggered, missing);
-  console.error(formatFailureMessage(triggered, missing));
-  process.exit(1);
+  console.log(
+    `PASS preview-freshness gate: ${triggered.size} template(s) had matching preview updates.`
+  );
 }
 
-function docxTriggeredIds(triggered) {
+/**
+ * Return template IDs whose trigger records are EXCLUSIVELY a modification of
+ * `content/templates/<id>/template.docx`. Manifest satisfaction must not apply
+ * when a source-side trigger (template.md, template.json, renderer, layout,
+ * pipeline, etc.) also fires for the same template — the manifest only
+ * declares "this docx mutation is non-visual," it does NOT cover an
+ * accompanying source change.
+ *
+ * Note `every` over `some`: a PR that touches both template.docx AND
+ * template.md must still ship refreshed previews, even if the manifest's docx
+ * SHA matches.
+ *
+ * @param {Map<string, Array<{ status: string, path: string }>>} triggered
+ * @returns {string[]}
+ */
+function docxOnlyTriggeredIds(triggered) {
   const ids = [];
   for (const [id, records] of triggered) {
+    if (records.length === 0) continue;
     if (
-      records.some(
+      records.every(
         (record) =>
-          record.path === `content/templates/${id}/${TEMPLATE_DOCX_FILE}`
+          record.path === `content/templates/${id}/${TEMPLATE_DOCX_FILE}` &&
+          record.status !== "removed"
       )
     ) {
       ids.push(id);

--- a/scripts/check_preview_freshness.mjs
+++ b/scripts/check_preview_freshness.mjs
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -101,6 +103,8 @@ const PIPELINE_TRIGGER_PATHS = new Set([
 const TEMPLATE_MD_FILE = "template.md";
 const TEMPLATE_JSON_FILE = "template.json";
 const TEMPLATE_DOCX_FILE = "template.docx";
+const PREVIEW_FRESHNESS_MANIFEST_PATH =
+  "scripts/preview-freshness-manifest.json";
 
 // ----- Wire format parsing --------------------------------------------------
 
@@ -356,6 +360,101 @@ export function findMissingFreshness(records, triggered) {
   return missing;
 }
 
+/**
+ * Load SHA-pinned byte-identical render claims from the manifest.
+ *
+ * Audit model: a manifest entry pins the current template.docx SHA so a
+ * reviewer can locally run
+ * `npm run generate:template-previews -- --template <id>` and confirm the
+ * rendered preview bytes are unchanged. If template.docx changes later, the
+ * stale SHA forces the contributor to re-verify that claim before the gate can
+ * pass without preview files in the diff.
+ *
+ * @param {string} repoRoot
+ * @returns {Array<{ templateId: string, docxSha256: string, reason?: string }>}
+ */
+export function loadPreviewFreshnessManifest(repoRoot = REPO_ROOT) {
+  const manifestPath = path.resolve(repoRoot, PREVIEW_FRESHNESS_MANIFEST_PATH);
+  if (!existsSync(manifestPath)) return [];
+
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(manifestPath, "utf8"));
+  } catch (err) {
+    throw new Error(
+      `Preview freshness manifest is not valid JSON: ${err.message}`
+    );
+  }
+
+  if (!parsed || typeof parsed !== "object" || !Array.isArray(parsed.entries)) {
+    throw new Error("Preview freshness manifest must contain an entries array");
+  }
+
+  return parsed.entries.map((entry, index) => {
+    const templateId = String(entry.templateId ?? "");
+    const docxSha256 = String(entry.docxSha256 ?? "").toLowerCase();
+    if (!templateId || !docxSha256) {
+      throw new Error(
+        `Preview freshness manifest entry ${index + 1} must include templateId and docxSha256`
+      );
+    }
+    return {
+      templateId,
+      docxSha256,
+      reason: entry.reason ? String(entry.reason) : "",
+    };
+  });
+}
+
+/**
+ * Match triggered templates against manifest entries whose docx SHA still
+ * matches the on-disk template.docx.
+ *
+ * @param {Iterable<string>} triggeredIds
+ * @param {string} repoRoot
+ * @param {Array<{ templateId: string, docxSha256: string, reason?: string }>} manifestEntries
+ * @returns {{
+ *   satisfied: Set<string>,
+ *   stale: Array<{ templateId: string, declaredSha: string, currentSha: string }>,
+ * }}
+ */
+export function findManifestSatisfied(
+  triggeredIds,
+  repoRoot = REPO_ROOT,
+  manifestEntries = []
+) {
+  const entriesById = new Map(
+    manifestEntries.map((entry) => [entry.templateId, entry])
+  );
+  const satisfied = new Set();
+  const stale = [];
+
+  for (const id of triggeredIds) {
+    const entry = entriesById.get(id);
+    if (!entry) continue;
+
+    const currentSha = sha256File(
+      path.resolve(repoRoot, "content", "templates", id, TEMPLATE_DOCX_FILE)
+    );
+    if (entry.docxSha256 === currentSha) {
+      satisfied.add(id);
+    } else {
+      stale.push({
+        templateId: id,
+        declaredSha: entry.docxSha256,
+        currentSha,
+      });
+    }
+  }
+
+  return { satisfied, stale };
+}
+
+function sha256File(filePath) {
+  if (!existsSync(filePath)) return "(missing)";
+  return createHash("sha256").update(readFileSync(filePath)).digest("hex");
+}
+
 // ----- Input acquisition ----------------------------------------------------
 
 function readChangedFilesFromInput(env) {
@@ -447,6 +546,24 @@ function formatFailureMessage(triggered, missing) {
     "Then commit the updated site/assets/previews/<id>/page-*.png files."
   );
   return lines.join("\n");
+}
+
+function formatManifestStaleMessage(stale) {
+  const lines = [];
+  lines.push(
+    `FAIL preview-freshness gate: ${stale.length} preview freshness manifest entr${stale.length === 1 ? "y is" : "ies are"} stale.`
+  );
+  lines.push("");
+  for (const entry of stale) {
+    lines.push(
+      `Manifest entry for ${entry.templateId} is stale: declares SHA ${entry.declaredSha}, current docx SHA is ${entry.currentSha}.`
+    );
+    lines.push(
+      `Re-verify byte-identical-render claim by re-running \`npm run generate:template-previews -- --template ${entry.templateId}\` and confirming no preview file changes; then update the manifest SHA.`
+    );
+    lines.push("");
+  }
+  return lines.join("\n").trimEnd();
 }
 
 function emitGithubAnnotations(triggered, missing) {
@@ -541,9 +658,28 @@ export async function main(env) {
     return;
   }
 
-  const missing = findMissingFreshness(input.records, triggered);
+  const manifestEntries = loadPreviewFreshnessManifest(REPO_ROOT);
+  const manifestCheck = findManifestSatisfied(
+    docxTriggeredIds(triggered),
+    REPO_ROOT,
+    manifestEntries
+  );
+  if (manifestCheck.stale.length > 0) {
+    console.error(formatManifestStaleMessage(manifestCheck.stale));
+    process.exit(1);
+  }
+
+  const missing = findMissingFreshness(input.records, triggered).filter(
+    (id) => !manifestCheck.satisfied.has(id)
+  );
 
   if (missing.length === 0) {
+    if (manifestCheck.satisfied.size > 0) {
+      console.log(
+        `PASS preview-freshness gate: ${manifestCheck.satisfied.size} template(s) satisfied via manifest (byte-identical render claim).`
+      );
+      return;
+    }
     console.log(
       `PASS preview-freshness gate: ${triggered.size} template(s) had matching preview updates.`
     );
@@ -553,6 +689,21 @@ export async function main(env) {
   emitGithubAnnotations(triggered, missing);
   console.error(formatFailureMessage(triggered, missing));
   process.exit(1);
+}
+
+function docxTriggeredIds(triggered) {
+  const ids = [];
+  for (const [id, records] of triggered) {
+    if (
+      records.some(
+        (record) =>
+          record.path === `content/templates/${id}/${TEMPLATE_DOCX_FILE}`
+      )
+    ) {
+      ids.push(id);
+    }
+  }
+  return ids;
 }
 
 if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {

--- a/scripts/check_preview_freshness.mjs
+++ b/scripts/check_preview_freshness.mjs
@@ -734,6 +734,12 @@ export async function main(env) {
  * template.md must still ship refreshed previews, even if the manifest's docx
  * SHA matches.
  *
+ * Note `status === "modified"`: a manifest entry asserts "byte-identical
+ * against the previously-committed previews." For an `added` template.docx
+ * there are no previously-committed previews to compare against, so the
+ * claim is vacuous; the gate must still require fresh previews to be
+ * committed alongside the new template. Same logic for `removed`.
+ *
  * @param {Map<string, Array<{ status: string, path: string }>>} triggered
  * @returns {string[]}
  */
@@ -745,7 +751,7 @@ function docxOnlyTriggeredIds(triggered) {
       records.every(
         (record) =>
           record.path === `content/templates/${id}/${TEMPLATE_DOCX_FILE}` &&
-          record.status !== "removed"
+          record.status === "modified"
       )
     ) {
       ids.push(id);

--- a/scripts/preview-freshness-manifest.json
+++ b/scripts/preview-freshness-manifest.json
@@ -1,0 +1,46 @@
+{
+  "entries": [
+    {
+      "templateId": "openagreements-board-consent-safe",
+      "docxSha256": "79b92e64648c453f512f2cb013af33e17bd12f61561fc420771a6b2351d51185",
+      "reason": "theme/webSettings injection has no visual effect on traditional consent layout with explicit fonts (PR #378)",
+      "addedInPR": "#378"
+    },
+    {
+      "templateId": "openagreements-employee-ip-inventions-assignment",
+      "docxSha256": "0f4a9a04feaaae737e430c8aa8a3be8adb1c74b48ab32a5da7e5c72cda2dfc3d",
+      "reason": "theme/webSettings injection has no visual effect on cover-standard layout with explicit fonts (PR #378)",
+      "addedInPR": "#378"
+    },
+    {
+      "templateId": "openagreements-employment-confidentiality-acknowledgement",
+      "docxSha256": "98e161a3b6413162f7f41337baf1c8f85a9bd297a8c0891bf48a1c53c8ec9f9f",
+      "reason": "theme/webSettings injection has no visual effect on cover-standard layout with explicit fonts (PR #378)",
+      "addedInPR": "#378"
+    },
+    {
+      "templateId": "openagreements-employment-offer-letter",
+      "docxSha256": "2cceb36a2e5a45af97f9bda244b994f44d2290deba97188b2b9a13e99c44595b",
+      "reason": "theme/webSettings injection has no visual effect on cover-standard layout with explicit fonts (PR #378)",
+      "addedInPR": "#378"
+    },
+    {
+      "templateId": "openagreements-restrictive-covenant-wyoming",
+      "docxSha256": "04991b77311d8a6ded26d7b5c6584dc5803d92b1290080e501b38198b3f3e13c",
+      "reason": "theme/webSettings injection has no visual effect on cover-standard layout with explicit fonts (PR #378)",
+      "addedInPR": "#378"
+    },
+    {
+      "templateId": "openagreements-stockholder-consent-safe",
+      "docxSha256": "6c795ec3060c52b96b22163666ce793abe9da17c942199a115d9f049114b994c",
+      "reason": "theme/webSettings injection has no visual effect on traditional consent layout with explicit fonts (PR #378)",
+      "addedInPR": "#378"
+    },
+    {
+      "templateId": "working-group-list",
+      "docxSha256": "4be6c30efc52b9a5a7b610a765753002382afeb53d10d48705f93b121cf45dc3",
+      "reason": "theme/webSettings injection has no visual effect on working-group list layout with explicit fonts (PR #378)",
+      "addedInPR": "#378"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a SHA-pinned **preview-freshness manifest** that lets a PR declare:
> "This docx changed but produces a byte-identical render against the previously-committed previews — no preview refresh needed for this template."

Fine-grained complement to the `freshness/skip` label landed in `2120dab` (which is a coarse "I know what I'm doing" override). The manifest pins the docx SHA per template so the claim stays auditable.

## Why

PR #378 injects `word/theme/theme1.xml` + `word/webSettings.xml` into 13 templates via the docx post-processor. For 7 of those templates (the cover-standard / traditional-consent / working-group-list layouts use explicit fonts everywhere and `webSettings` has no visual effect), the regenerated previews are byte-identical to what's already committed.

The current gate has no escape hatch for "docx changed but render is identical" and false-positives on all 7. After this PR, those 7 templates are covered by manifest entries and PR #378's `preview-freshness-gate` passes without any preview re-commit.

## Implementation

- **`scripts/preview-freshness-manifest.json`** — per-template entries, each with `templateId`, `docxSha256`, and a human-readable `reason`. Initial set covers the 7 PR #378 templates.
- **`scripts/check_preview_freshness.mjs`** — new exported helpers `loadPreviewFreshnessManifest` and `findManifestSatisfied`. Main flow:
  1. Load manifest.
  2. For each template triggered by a `template.docx` change (only — not source-side triggers like `template.md`), check the manifest.
  3. If a pinned SHA matches the current on-disk docx SHA → satisfied.
  4. If a pinned SHA does NOT match → FAIL with a stale-claim message that names the SHAs and points at the re-verification command.
  5. Satisfied templates are subtracted from the missing-preview set before any annotations fire.
- **`integration-tests/check-preview-freshness.test.ts`** — 3 new test cases covering the manifest match, stale-SHA failure, and CLI smoke test for the satisfied path. 42 tests pass.

## Scope guard

Manifest covers **only** direct `template.docx` triggers. `template.md`, `template.json`, renderer, layout, style, and pipeline changes still require previews — the manifest can't silence a real source change.

## Audit story

Anyone can re-verify a manifest entry locally:
```bash
npm run generate:template-previews -- --template <id>
git status -- site/assets/previews/<id>/
```
If `git status` shows no preview change, the claim holds. If it shows preview changes, the claim was wrong — delete the entry rather than bumping the SHA.

## Verification

- `npx vitest run integration-tests/check-preview-freshness.test.ts` → 42 pass
- `OA_CHANGED_FILES=<PR #378 7-docx diff> npm run check:preview-freshness` → `PASS preview-freshness gate: 7 template(s) satisfied via manifest`
- Tamper one entry's SHA → `FAIL preview-freshness gate: 1 preview freshness manifest entry is stale.` (exit 1)
- ESLint clean

## Test plan

- [x] Vitest gate suite passes (42)
- [x] Lint clean
- [x] Local CLI smoke (PR #378 diff simulation)
- [ ] CI green (build, all gates)
- [ ] Peer review (Gemini + Codex) — pending; supervisor will append

## Stacked on

`fix/issue-373-theme-websettings` (PR #378). Once both PRs merge, PR #378's `preview-freshness-gate` job goes green.

## Related

- #378 — the originating PR (Word for Mac theme/webSettings injection)
- `2120dab` (this branch's parent) — coarse `freshness/skip` label override
- `47bb83c` (this branch's parent) — `UNREGISTERED_PART` defensive linter check