### PR TITLE
ci: replace release-time dispatch with main-push notify workflow

### DIFF
--- a/.github/workflows/notify-dev-website-on-main-push.yml
+++ b/.github/workflows/notify-dev-website-on-main-push.yml
@@ -1,0 +1,42 @@
+name: Notify dev-website of main push
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  # Reduce duplicate dispatches when rapid successive main pushes happen.
+  # Note: cancel-in-progress does NOT undo an HTTP call that has already
+  # fired — receiving-side concurrency + the fixed automation branch in
+  # dev-website are what guarantee idempotency end-to-end.
+  group: notify-dev-website
+  cancel-in-progress: true
+
+jobs:
+  dispatch:
+    name: Dispatch open-agreements-main-push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fire repository_dispatch
+        env:
+          GH_TOKEN: ${{ secrets.DEV_WEBSITE_DISPATCH_TOKEN }}
+          # Env indirection — do NOT interpolate ${{ github.event.head_commit.message }}
+          # directly into the run block. Commit messages are attacker-controlled and an
+          # inline expression would let a crafted message break out of the shell string.
+          HEAD_MESSAGE: ${{ github.event.head_commit.message }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::warning::DEV_WEBSITE_DISPATCH_TOKEN not set; skipping dispatch."
+            exit 0
+          fi
+          gh api --method POST \
+            -H "Accept: application/vnd.github+json" \
+            /repos/UseJunior/dev-website/dispatches \
+            -f event_type=open-agreements-main-push \
+            -f "client_payload[sha]=${GITHUB_SHA}" \
+            -f "client_payload[short_sha]=${GITHUB_SHA:0:7}" \
+            -f "client_payload[message]=${HEAD_MESSAGE}"
+          echo "Dispatched open-agreements-main-push to UseJunior/dev-website for ${GITHUB_SHA:0:7}."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -268,7 +268,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   publish-template-snapshot:
-    name: Publish template snapshot tarball + dispatch dev-website
+    name: Publish template snapshot tarball
     needs: [preflight, publish-suite, publish-github-release]
     if: needs.preflight.result == 'success' && needs.publish-suite.result == 'success' && needs.publish-github-release.result == 'success'
     runs-on: ubuntu-latest
@@ -315,32 +315,6 @@ jobs:
           TAG_REF="${RELEASE_TAG:-$GITHUB_REF_NAME}"
           gh release upload "$TAG_REF" "${{ steps.build_tarball.outputs.tarball }}" --clobber
 
-      - name: Dispatch dev-website snapshot bump
-        env:
-          GH_TOKEN: ${{ secrets.DEV_WEBSITE_DISPATCH_TOKEN }}
-        run: |
-          if [ -z "$GH_TOKEN" ]; then
-            echo "::warning::DEV_WEBSITE_DISPATCH_TOKEN secret is not set. Skipping dev-website dispatch."
-            echo "Provision a fine-grained PAT scoped to UseJunior/dev-website with contents:read and dispatches:write to enable downstream rebuild."
-            exit 0
-          fi
-
-          TAG_REF="${RELEASE_TAG:-$GITHUB_REF_NAME}"
-          VERSION="${{ steps.build_tarball.outputs.version }}"
-          REPO="${{ github.repository }}"
-          TARBALL_URL="https://github.com/${REPO}/releases/download/${TAG_REF}/${{ steps.build_tarball.outputs.tarball }}"
-
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            /repos/UseJunior/dev-website/dispatches \
-            -f event_type=open-agreements-release \
-            -f "client_payload[tag]=${TAG_REF}" \
-            -f "client_payload[version]=${VERSION}" \
-            -f "client_payload[tarball_url]=${TARBALL_URL}"
-
-          echo "Dispatched open-agreements-release to UseJunior/dev-website for ${TAG_REF}."
-
       - name: Snapshot summary
         if: always()
         run: |
@@ -350,10 +324,5 @@ jobs:
           {
             echo "### Template snapshot: ${TAG_REF}"
             echo "- Tarball: \`${TARBALL}\` (${SIZE_BYTES} bytes)"
-            if [ -n "${{ secrets.DEV_WEBSITE_DISPATCH_TOKEN }}" ]; then
-              echo "- dev-website dispatch: SENT (\`open-agreements-release\` event_type)"
-            else
-              echo "- dev-website dispatch: SKIPPED — \`DEV_WEBSITE_DISPATCH_TOKEN\` secret not set"
-            fi
           } >> "$GITHUB_STEP_SUMMARY"
 


### PR DESCRIPTION
## Summary

Switches the OA → dev-website coupling from release-tag-driven to main-push-driven.

- Adds `.github/workflows/notify-dev-website-on-main-push.yml` — fires `repository_dispatch` (`event_type=open-agreements-main-push`) to `UseJunior/dev-website` on every push to main with the new SHA, short SHA, and head commit message.
- Removes the `Dispatch dev-website snapshot bump` step from `release.yml` (previously fired only on release tags — too coarse for keeping a renderer downstream in sync).
- Updates `publish-template-snapshot` job name and `Snapshot summary` step to match (no dangling references to a dispatch that no longer happens).

The tarball build + upload steps stay — the tarball is a release asset that may have other consumers (decision deferred to #388).

## Why

`release.yml`'s dispatch only fires on release tags. For dev-website to track main changes, we'd otherwise either need to cut a release for every main commit, or have dev-website poll OA (burns ~48 free-tier Actions runs/day to catch changes that happen 1–2× per week). Push-on-main-push is the lowest-overhead option and gets the round-trip under a few minutes.

## Security notes

- `notify-dev-website-on-main-push.yml` uses env indirection (`HEAD_MESSAGE: \${{ github.event.head_commit.message }}` exposed to the run block via `env:` rather than inline interpolation). Commit messages are attacker-controlled — inline interpolation in a `run:` block is a documented script injection vector. See GitHub's "Security hardening for GitHub Actions" guide.
- `concurrency: cancel-in-progress` on the notify workflow *reduces* duplicate dispatches but does NOT undo an HTTP call that has already fired. The receiving-side defense (dev-website's listener has its own `cancel-in-progress` + a fixed `automation/bump-open-agreements` branch) is what makes this safe end-to-end.

## Companion PR

dev-website-side listener is a separate PR — both must merge before the end-to-end flow works. Until then, this workflow will fire dispatches that hit a 404 on dev-website (no listener registered yet); that's harmless.

## Test plan

- [ ] CI passes (YAML lint, workflow validators)
- [ ] After merge: push a noop commit to main (e.g., whitespace change) and confirm the notify workflow fires in the Actions tab. Until the dev-website listener is also merged, the `gh api` call will return 404 — that's expected.
- [ ] After both PRs merged: any OA main push opens an automation PR in dev-website pinning the new SHA.