### PR TITLE
ci(notify): add workflow_dispatch trigger to notify-dev-website-on-main-push

### DIFF
--- a/.github/workflows/notify-dev-website-on-main-push.yml
+++ b/.github/workflows/notify-dev-website-on-main-push.yml
@@ -3,6 +3,12 @@ name: Notify dev-website of main push
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: "OA SHA to dispatch (defaults to main HEAD if blank)"
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -20,13 +26,31 @@ jobs:
     name: Dispatch open-agreements-main-push
     runs-on: ubuntu-latest
     steps:
+      - name: Resolve dispatch SHA
+        id: resolve
+        env:
+          INPUT_SHA: ${{ inputs.sha }}
+        run: |
+          # On push events GITHUB_SHA is already the new HEAD. On workflow_dispatch,
+          # the user can override (e.g., for replay-from-a-prior-SHA testing); blank
+          # input falls back to whatever GITHUB_SHA resolves to (main HEAD for the run).
+          if [ -n "$INPUT_SHA" ]; then
+            DISPATCH_SHA="$INPUT_SHA"
+          else
+            DISPATCH_SHA="$GITHUB_SHA"
+          fi
+          echo "sha=${DISPATCH_SHA}" >> "$GITHUB_OUTPUT"
+          echo "short_sha=${DISPATCH_SHA:0:7}" >> "$GITHUB_OUTPUT"
+
       - name: Fire repository_dispatch
         env:
           GH_TOKEN: ${{ secrets.DEV_WEBSITE_DISPATCH_TOKEN }}
           # Env indirection — do NOT interpolate ${{ github.event.head_commit.message }}
           # directly into the run block. Commit messages are attacker-controlled and an
           # inline expression would let a crafted message break out of the shell string.
-          HEAD_MESSAGE: ${{ github.event.head_commit.message }}
+          HEAD_MESSAGE: ${{ github.event.head_commit.message || format('Manual dispatch from {0}', github.actor) }}
+          DISPATCH_SHA: ${{ steps.resolve.outputs.sha }}
+          DISPATCH_SHORT: ${{ steps.resolve.outputs.short_sha }}
         run: |
           if [ -z "$GH_TOKEN" ]; then
             echo "::warning::DEV_WEBSITE_DISPATCH_TOKEN not set; skipping dispatch."
@@ -36,7 +60,7 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             /repos/UseJunior/dev-website/dispatches \
             -f event_type=open-agreements-main-push \
-            -f "client_payload[sha]=${GITHUB_SHA}" \
-            -f "client_payload[short_sha]=${GITHUB_SHA:0:7}" \
+            -f "client_payload[sha]=${DISPATCH_SHA}" \
+            -f "client_payload[short_sha]=${DISPATCH_SHORT}" \
             -f "client_payload[message]=${HEAD_MESSAGE}"
-          echo "Dispatched open-agreements-main-push to UseJunior/dev-website for ${GITHUB_SHA:0:7}."
+          echo "Dispatched open-agreements-main-push to UseJunior/dev-website for ${DISPATCH_SHORT}."


### PR DESCRIPTION
## Summary

Adds a `workflow_dispatch` trigger to the notify workflow so we can re-test the dispatch → dev-website listener loop without pushing a noop commit to main.

- Optional `sha` input — blank falls back to `GITHUB_SHA` (main HEAD on `workflow_dispatch`)
- `HEAD_MESSAGE` uses `format()` fallback for `workflow_dispatch` (no `head_commit` context)
- Env indirection preserved on both interpolations

## Why

Smoke from the original notify PR (#389) caught a stale `DEV_WEBSITE_DISPATCH_TOKEN`. After rotating the PAT, the only retest path was either (a) push a noop commit to main, or (b) wait for an organic main push. This adds (c) — manually fire from the Actions tab.

## Test plan

- [ ] After merge: Actions → "Notify dev-website of main push" → "Run workflow" with no input → confirm the run succeeds and a dispatch lands in `UseJunior/dev-website` Actions tab.