### PR TITLE
ci(publish-gh-runtime): declare runtime's transitive deps (closes #391)

### DIFF
--- a/.github/workflows/publish-gh-runtime.yml
+++ b/.github/workflows/publish-gh-runtime.yml
@@ -69,7 +69,9 @@ jobs:
                 "adm-zip": "^0.5.16",
                 "commander": "^13.1.0",
                 "docx-templates": "^4.13.0",
-                "minisearch": "^7.2.0"
+                "js-yaml": "^4.1.0",
+                "minisearch": "^7.2.0",
+                "zod": "^4.0.0"
               },
               bundleDependencies: ["@usejunior/docx-core"],
               publishConfig: { registry: "https://npm.pkg.github.com" },

--- a/.github/workflows/publish-gh-runtime.yml
+++ b/.github/workflows/publish-gh-runtime.yml
@@ -63,7 +63,14 @@ jobs:
                 "./content/*": "./content/*"
               },
               files: ["dist/", "content/"],
-              dependencies: { "@usejunior/docx-core": process.env.DOCX_CORE_VERSION },
+              dependencies: {
+                "@usejunior/docx-core": process.env.DOCX_CORE_VERSION,
+                "@xmldom/xmldom": "^0.9.9",
+                "adm-zip": "^0.5.16",
+                "commander": "^13.1.0",
+                "docx-templates": "^4.13.0",
+                "minisearch": "^7.2.0"
+              },
               bundleDependencies: ["@usejunior/docx-core"],
               publishConfig: { registry: "https://npm.pkg.github.com" },
               engines: { node: ">=20" }


### PR DESCRIPTION
## Summary
- `@open-agreements/openagreements-runtime` imports 5 packages from `dist/core/*` that the publish workflow doesn't declare in the generated `runtime-pkg/package.json`, so consumers don't install them and hit `ERR_MODULE_NOT_FOUND` at runtime
- Add them as plain `dependencies` (NOT `bundleDependencies`) so `npm ci` resolves them on the consumer side, matching the convention for normal npm deps

## Implementation
Single-file change to `.github/workflows/publish-gh-runtime.yml`. Added `@xmldom/xmldom@^0.9.9`, `adm-zip@^0.5.16`, `commander@^13.1.0`, `docx-templates@^4.13.0`, `minisearch@^7.2.0` to the `dependencies` object inside the inline `node -e` block that writes `runtime-pkg/package.json`. Version specifiers match what the root `package.json` pins today.

`bundleDependencies` stays as `["@usejunior/docx-core"]` only — the five new deps should NOT be bundled, just declared.

## Context
Caught during Phase 1.5 preview smoke on `UseJunior/openagreements-org-deploy`. Band-aid PR https://github.com/UseJunior/openagreements-org-deploy/pull/2 declared these in the deploy's own `package.json` to unblock Phase 2. After this lands + a republish of the runtime + bump of the deploy's pin, the band-aid in the deploy repo can be removed.

## Verification
- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] All 5 version specifiers match `open-agreements/package.json`
- [x] `bundleDependencies` unchanged
- [ ] Peer review (Gemini + Codex) — pending; will be appended

## Out of scope
- Republishing the runtime to GH Packages (separate manual workflow_dispatch after merge — bump to `0.7.6`)
- Updating `openagreements-org-deploy/package.json` to consume the new runtime version (separate PR in that repo)

## Closes
- #391