### PR TITLE
ci(llm-gate): mirror conclusion to PR head SHA on workflow_dispatch

### DIFF
--- a/.github/workflows/llm-based-quality-gate.yml
+++ b/.github/workflows/llm-based-quality-gate.yml
@@ -227,6 +227,11 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      # `checks: write` lets the workflow_dispatch mirror step POST an
+      # explicit check_run to /repos/.../check-runs. Without it, the mirror
+      # POST returns 403 and PRs re-fired via workflow_dispatch stay
+      # `mergeStateStatus: BLOCKED` (the bug this whole step exists to fix).
+      checks: write
     steps:
       - name: Download all per-item results
         uses: actions/download-artifact@v5

--- a/.github/workflows/llm-based-quality-gate.yml
+++ b/.github/workflows/llm-based-quality-gate.yml
@@ -239,6 +239,7 @@ jobs:
         run: ls -la results/ || echo "no results downloaded"
 
       - name: Compose and post checklist comment
+        id: compose
         uses: actions/github-script@v7
         env:
           MODEL: ${{ env.GEMINI_MODEL }}
@@ -382,3 +383,41 @@ jobs:
             if (blockingMode && warns > 0 && !overrideActive) {
               core.setFailed(`LLM-Based Quality Gate found ${warns} WARN row(s). Add the \`llm-gate/override\` label to bypass (with justification in a PR comment).`);
             }
+
+      # When this workflow is re-fired via `workflow_dispatch` (e.g. after a
+      # push that bypassed the `synchronize`-blind PR trigger), the auto-
+      # generated check_run for this job IS attached to the PR's head SHA,
+      # but GitHub's PR `statusCheckRollup` (which branch protection
+      # consults) does NOT include workflow_dispatch-triggered check_runs.
+      # The required check appears green via the Checks API but the PR stays
+      # `mergeStateStatus: BLOCKED`. POST an explicit check_run mirror so
+      # the rollup picks it up.
+      #
+      # `always()` is critical: when the gate finds WARN rows and the
+      # github-script step calls core.setFailed(), the default `if: success()`
+      # would skip this mirror. The mirror's own conclusion is derived from
+      # the prior step's outcome, so a failed gate produces a failed mirror.
+      - name: Mirror conclusion to PR head SHA (workflow_dispatch)
+        if: always() && github.event_name == 'workflow_dispatch' && needs.parse-checklist.outputs.head_sha != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ needs.parse-checklist.outputs.head_sha }}
+          COMPOSE_OUTCOME: ${{ steps.compose.outcome }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          if [ "$COMPOSE_OUTCOME" = "success" ]; then
+            CONCLUSION="success"
+            TITLE="LLM gate passed (re-fired via workflow_dispatch)"
+          else
+            CONCLUSION="failure"
+            TITLE="LLM gate FAILED (re-fired via workflow_dispatch)"
+          fi
+          gh api -X POST "repos/$GITHUB_REPOSITORY/check-runs" \
+            -f "name=Aggregate and post review" \
+            -f "head_sha=$HEAD_SHA" \
+            -f "status=completed" \
+            -f "conclusion=$CONCLUSION" \
+            -f "details_url=$RUN_URL" \
+            -f "output[title]=$TITLE" \
+            -f "output[summary]=Mirrored from workflow_dispatch run. Full output: $RUN_URL"


### PR DESCRIPTION
## Summary
- Fixes the missing-required-check problem we hit on #392 when re-firing the LLM gate via `workflow_dispatch`
- Adds a final step in the `aggregate` job that POSTs an explicit `check_run` to `/repos/.../check-runs` with `head_sha` set to the PR's resolved head SHA, so it shows up in the PR's `statusCheckRollup`
- Conclusion mirrors the compose step's outcome — WARN+blocking still fails the mirror (gate doesn't get bypassed)

## Background
GitHub auto-creates a `check_run` for every job, named after the job. When that job runs via `pull_request`, the check_run lands in the PR's `statusCheckRollup` and branch protection sees it. When the same job runs via `workflow_dispatch -f pr_number=N` (the documented re-trigger path per the workflow's own README), the check_run is created with the correct `head_sha` and `app_id` but **doesn't get linked into `statusCheckRollup`** — so branch protection treats the required check as missing.

Symptom: required check `Aggregate and post review` appears green in `/repos/{}/commits/{sha}/check-runs` but absent from `gh pr view --json statusCheckRollup`. PR sits at `mergeStateStatus: BLOCKED` with no failing checks. We worked around this on #392 by converting the PR to draft and back to ready (firing a `ready_for_review` event); this PR removes the need for that workaround.

## Implementation
Single step added at the end of the aggregate job:

```yaml
- name: Mirror conclusion to PR head SHA (workflow_dispatch)
  if: always() && github.event_name == 'workflow_dispatch' && needs.parse-checklist.outputs.head_sha != ''
```

- `always()` because the prior `core.setFailed()` on WARN+blocking would otherwise skip this step under the default `if: success()` cascade.
- Conclusion derived from `steps.compose.outcome` so a failed gate produces a failed mirror — does not weaken the gate.
- `head_sha` resolved from `parse-checklist` outputs (same source the rest of the workflow uses).

## Verification
- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] No-op for `pull_request` event path (step is gated on `github.event_name == 'workflow_dispatch'`)
- [ ] Live test: after merge, manually re-fire the gate on any open PR — confirm the resulting check appears in `statusCheckRollup`
- [ ] Peer review (Gemini + Codex) — pending; will be appended

## Out of scope
- Changing the gate's blocking semantics
- Modifying any of the per-check matrix jobs
- Refactoring the gate's trigger filter

## Closes
- N/A (no issue filed — surfaced during the #392 merge dance)