### PR TITLE
fix(security): parse URL host instead of substring match (CodeQL #15)

### DIFF
--- a/scripts/lib/template-utils.mjs
+++ b/scripts/lib/template-utils.mjs
@@ -27,16 +27,33 @@ export function loadTemplateMetadata(templateId) {
   return parsed && typeof parsed === "object" ? parsed : {};
 }
 
+function hostMatches(host, domain) {
+  return host === domain || host.endsWith(`.${domain}`);
+}
+
 export function isOpenAgreementsOwned(templateId, metadata) {
   if (templateId.startsWith("openagreements-")) {
     return true;
   }
-  const sourceUrl = String(metadata.source_url || "").toLowerCase();
-  return (
-    sourceUrl.includes("openagreements.org") ||
-    sourceUrl.includes("openagreements.ai") ||
-    sourceUrl.includes("github.com/open-agreements/open-agreements")
-  );
+  const rawUrl = String(metadata.source_url || "").trim();
+  if (!rawUrl) {
+    return false;
+  }
+  let url;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return false;
+  }
+  const host = url.hostname.toLowerCase();
+  if (hostMatches(host, "openagreements.org") || hostMatches(host, "openagreements.ai")) {
+    return true;
+  }
+  if (hostMatches(host, "github.com")) {
+    const path = url.pathname.toLowerCase().replace(/^\/+/, "");
+    return path === "open-agreements/open-agreements" || path.startsWith("open-agreements/open-agreements/");
+  }
+  return false;
 }
 
 export function listOpenAgreementsTemplateIds() {


### PR DESCRIPTION
## What

Fixes [code-scanning alert #15](https://github.com/open-agreements/open-agreements/security/code-scanning/15) — `js/incomplete-url-substring-sanitization` (CWE-20, high severity).

## Why

`isOpenAgreementsOwned` in `scripts/lib/template-utils.mjs` checked ownership with substring `includes()` on the raw `source_url`:

```js
sourceUrl.includes("openagreements.org") || ...
```

This is bypassable — a URL like `https://evil.net/?x=openagreements.org` would match.

## How

Parse `source_url` with the `URL` constructor and check `url.hostname` against an explicit allowlist (exact host or subdomain via `.endsWith("." + domain)`), plus a path check for the `github.com` repo. Malformed/empty URLs return `false`.

## Behavior

Preserved — the same 9 templates resolve as OpenAgreements-owned (verified via `listOpenAgreementsTemplateIds()`).