### PR TITLE
feat(wyo-rc): align metadata with restrictive-covenant spec inputs

### DIFF
--- a/content/templates/openagreements-restrictive-covenant-wyoming/metadata.yaml
+++ b/content/templates/openagreements-restrictive-covenant-wyoming/metadata.yaml
@@ -57,6 +57,12 @@ fields:
       - Professional Staff
       - Physician
       - Other
+    default: Other
+    default_value_rationale: >-
+      Other is the conservative default when worker category cannot be
+      determined from context. The calling LLM may set this explicitly
+      based on title, scope, and duties; absent that signal, Other avoids
+      asserting a statutory pathway that may not apply.
     section: AI Analysis
   - name: restriction_pathways
     type: string
@@ -66,6 +72,23 @@ fields:
       Not shown in the output document. Options: Executive or Management
       Personnel, Trade Secret Protection, None.
     default: None
+    section: AI Analysis
+  - name: restrictive_covenant_entered_after_employment_started
+    type: boolean
+    description: >-
+      Whether the restrictive covenant is signed AFTER the employee already
+      started working (post-hire) vs at or before the first day of employment
+      (at-hire). Wyoming case law (Brown v. Best Home Health & Hospice,
+      2021 WY 83) requires separate consideration beyond continued employment
+      for post-hire restrictive covenants. AI-only field that drives memo
+      warnings and conditional drafting of the separate-consideration recital.
+      Not shown in the output document.
+    default: 'true'
+    default_value_rationale: >-
+      Defaulting to post-hire (true) is the conservative posture: it triggers
+      the separate-consideration recital required by Brown. If the covenant
+      is genuinely at-hire, the calling LLM should set this to false to
+      suppress the recital.
     section: AI Analysis
 
   # --- Confidentiality (on cover page, always visible) ---

--- a/data/templates-snapshot.json
+++ b/data/templates-snapshot.json
@@ -12846,8 +12846,8 @@
           "required": false,
           "section": "AI Analysis",
           "description": "Employee role classification under Wyo. Stat. section 1-23-108. AI-only field that drives memo warnings. Not shown in the output document.",
-          "default": null,
-          "default_value_rationale": null,
+          "default": "Other",
+          "default_value_rationale": "Other is the conservative default when worker category cannot be determined from context. The calling LLM may set this explicitly based on title, scope, and duties; absent that signal, Other avoids asserting a statutory pathway that may not apply.",
           "options": [
             "Executive",
             "Management",
@@ -12864,6 +12864,15 @@
           "description": "Wyoming restriction pathway(s) under Wyo. Stat. section 1-23-108. AI-only field that drives memo warnings and conditional gating. Not shown in the output document. Options: Executive or Management Personnel, Trade Secret Protection, None.",
           "default": "None",
           "default_value_rationale": null
+        },
+        {
+          "name": "restrictive_covenant_entered_after_employment_started",
+          "type": "boolean",
+          "required": false,
+          "section": "AI Analysis",
+          "description": "Whether the restrictive covenant is signed AFTER the employee already started working (post-hire) vs at or before the first day of employment (at-hire). Wyoming case law (Brown v. Best Home Health & Hospice, 2021 WY 83) requires separate consideration beyond continued employment for post-hire restrictive covenants. AI-only field that drives memo warnings and conditional drafting of the separate-consideration recital. Not shown in the output document.",
+          "default": "true",
+          "default_value_rationale": "Defaulting to post-hire (true) is the conservative posture: it triggers the separate-consideration recital required by Brown. If the covenant is genuinely at-hire, the calling LLM should set this to false to suppress the recital."
         },
         {
           "name": "confidentiality_trade_secret_duration",
@@ -12953,7 +12962,7 @@
           "description": "Whether the non-competition covenant is included. Requires a lawful restriction pathway under Wyo. Stat. section 1-23-108.",
           "display_label": "Non-Competition Included",
           "default": "false",
-          "default_value_rationale": "Wyo. Stat. section 1-23-108 voids most non-compete covenants. The drafter must affirmatively include this covenant only when a statutory pathway applies."
+          "default_value_rationale": "Wyo. Stat. section 1-23-108 (SF 107, 2025; effective July 1, 2025) voids covered non-compete covenants unless a statutory exception applies: (1) purchase and sale of a business or business assets, (2) protection of trade secrets as defined by W.S. 6-3-501(a)(xi), (3) recovery of relocation, education, and training expenses within the statute's tenure-based caps, or (4) executive and management personnel and officers / employees who constitute professional staff to executive and management personnel. Physician practice restrictions are separately void under subsection (b), not a permitted pathway. The drafter must include this covenant only after documenting the applicable pathway in the agreement."
         },
         {
           "name": "noncompete_duration",

--- a/src/core/employment/memo.ts
+++ b/src/core/employment/memo.ts
@@ -318,11 +318,15 @@ const CLAUSE_SIGNALS: Record<string, ClauseSignal[]> = {
       field: 'worker_category',
       missingSeverity: 'high',
       missingSummary:
-        'Worker category is blank. Wyoming Stat. section 1-23-108 enforceability depends on whether the employee is executive, management, professional staff, physician, or other.',
+        'Worker category is unclassified. Wyoming Stat. section 1-23-108 enforceability depends on whether the employee is executive, management, professional staff, physician, or other; the "Other" default does not satisfy any subsection (a)(iv) pathway.',
       presentSummary:
         'Worker category is specified.',
       followUpQuestionWhenMissing:
         'Can licensed counsel confirm the employee role classification under Wyoming Stat. section 1-23-108?',
+      isPresent: (value) => {
+        const normalized = normalizeForCompare(value);
+        return normalized.length > 0 && normalized !== 'other';
+      },
     },
     {
       id: 'competitive-business-definition',


### PR DESCRIPTION
## Summary

Mechanical pass to bring the Wyoming restrictive-covenant template's metadata into conformance with the contract-spec input interface (`restrictive-covenant.core@0.7.0` + Wyoming overlay).

Two changes to `content/templates/openagreements-restrictive-covenant-wyoming/metadata.yaml`:

1. **Add `restrictive_covenant_entered_after_employment_started`** (boolean, default `true`). AI-only field. Drives the separate-consideration recital required by *Brown v. Best Home Health & Hospice*, 2021 WY 83 — Wyoming requires consideration beyond continued employment for restrictive covenants signed after the employee already started.
2. **Change `worker_category` default to `Other`**. Conservative default when the worker category cannot be inferred; the calling LLM sets explicit values from title/scope/duties.

Both fields are in the **AI Analysis** section (not rendered to the output document) — the wiring of memo warnings and conditional-clause drafting that consumes these signals is **deferred** to a follow-up.

## Scope

Mechanical-only: just the metadata-field definitions. Out of scope here:
- Wiring `restrictive_covenant_entered_after_employment_started` into `src/core/employment/memo.ts` warnings
- Adding a separate-consideration recital clause to `template.docx` and gating it on the new field
- The broader clause-text refinement pass against `restrictive-covenant.wyoming@0.9.0`'s 6 Requirements

These are tracked in [`UseJunior/legal-context#414`](https://github.com/UseJunior/legal-context/issues/414) (Wyoming template spec-conformance exemplar, subsumes #411).

## Test plan

- [x] `node bin/open-agreements.js validate openagreements-restrictive-covenant-wyoming` → PASS (AI-only-field warnings are expected and match the existing `worker_category` / `restriction_pathways` pattern)
- [x] `npm run build` → PASS
- [x] `npx vitest run packages/contract-templates-mcp` → 29/29 PASS
- [x] `npm run check:spec-coverage` → no new failures
- [x] `node bin/open-agreements.js fill openagreements-restrictive-covenant-wyoming --set ... -o /tmp/wyo-test.docx` → renders successfully with both new defaults applied

## Out of scope (intentional)

The new field surfaces in the renderer's "Fields used" list but does not yet drive any conditional output. That is by design for this PR — the spec declares the input; this PR makes the template accept the input; the next pass wires it through.