### PR TITLE
fix(wyoming-rc): align display copy + metadata enum with applicable_noncompete_exceptions rename

### DIFF
--- a/content/templates/openagreements-restrictive-covenant-wyoming/metadata.yaml
+++ b/content/templates/openagreements-restrictive-covenant-wyoming/metadata.yaml
@@ -67,10 +67,12 @@ fields:
   - name: applicable_noncompete_exceptions
     type: string
     description: >-
-      Wyoming restriction pathway(s) under Wyo. Stat. section 1-23-108.
-      AI-only field that drives memo warnings and conditional gating.
-      Not shown in the output document. Options: Executive or Management
-      Personnel, Trade Secret Protection, None.
+      Applicable statutory exception(s) under Wyo. Stat. section 1-23-108
+      that would permit an otherwise-prohibited non-compete-adjacent
+      covenant. AI-only field that drives memo warnings and conditional
+      gating. Not shown in the output document. Options: Executive or
+      Management Personnel, Trade Secret Protection, Training Cost
+      Recovery, Sale of Business, None.
     default: None
     section: AI Analysis
   - name: restrictive_covenant_entered_after_employment_started

--- a/data/templates-snapshot.json
+++ b/data/templates-snapshot.json
@@ -12861,7 +12861,7 @@
           "type": "string",
           "required": false,
           "section": "AI Analysis",
-          "description": "Wyoming restriction pathway(s) under Wyo. Stat. section 1-23-108. AI-only field that drives memo warnings and conditional gating. Not shown in the output document. Options: Executive or Management Personnel, Trade Secret Protection, None.",
+          "description": "Applicable statutory exception(s) under Wyo. Stat. section 1-23-108 that would permit an otherwise-prohibited non-compete-adjacent covenant. AI-only field that drives memo warnings and conditional gating. Not shown in the output document. Options: Executive or Management Personnel, Trade Secret Protection, Training Cost Recovery, Sale of Business, None.",
           "default": "None",
           "default_value_rationale": null
         },

--- a/src/core/employment/jurisdiction-rules.ts
+++ b/src/core/employment/jurisdiction-rules.ts
@@ -130,7 +130,7 @@ export const EMPLOYMENT_JURISDICTION_RULES: JurisdictionRule[] = [
       },
     },
     message:
-      'Restriction pathway is set to none, but non-compete-adjacent covenants (non-competition, non-dealing, or non-investment) may be included. Under Wyoming Stat. section 1-23-108, these provisions are likely void without a lawful statutory pathway.',
+      'No applicable non-compete exception is selected, but non-compete-adjacent covenants (non-competition, non-dealing, or non-investment) may be included. Under Wyoming Stat. section 1-23-108, these provisions are likely void without an enumerated statutory exception.',
     source_reference:
       'Wyoming Statute section 1-23-108 (Senate File 107, 2025 Session).',
     source_date: '2025-07-01',

--- a/src/core/employment/memo.ts
+++ b/src/core/employment/memo.ts
@@ -303,15 +303,15 @@ const CLAUSE_SIGNALS: Record<string, ClauseSignal[]> = {
   ],
   'openagreements-restrictive-covenant-wyoming': [
     {
-      id: 'restriction-pathways',
+      id: 'applicable-noncompete-exceptions',
       field: 'applicable_noncompete_exceptions',
       missingSeverity: 'high',
       missingSummary:
-        'Restriction pathway is blank. Under Wyoming Stat. section 1-23-108, non-compete-adjacent covenants require a lawful statutory pathway. The template cannot determine enforceability without this field.',
+        'No applicable non-compete exception is specified. Under Wyoming Stat. section 1-23-108, non-compete-adjacent covenants are unenforceable unless they fall within an enumerated statutory exception. The template cannot determine enforceability without this field.',
       presentSummary:
-        'Restriction pathway is specified.',
+        'Applicable non-compete exception is specified.',
       followUpQuestionWhenMissing:
-        'Can licensed counsel confirm which Wyoming Stat. section 1-23-108 pathway applies to this employee?',
+        'Can licensed counsel confirm which Wyoming Stat. section 1-23-108 exception applies to this employee?',
     },
     {
       id: 'worker-category',


### PR DESCRIPTION
## Summary

Follow-up cleanup to #404 (rename `restriction_pathways` → `applicable_noncompete_exceptions`). The earlier PR moved the field name through code, tests, and snapshots but missed:

1. User-visible memo copy in `src/core/employment/memo.ts` (lines 310, 312) and `src/core/employment/jurisdiction-rules.ts` (line 133) still said *"Restriction pathway is blank/specified."*
2. Template metadata description in `metadata.yaml` still listed only 3 of the 5 `applicable_noncompete_exceptions` enum options, omitting **Training Cost Recovery** (§ 1-23-108(a)(iv)) and **Sale of Business** (§ 1-23-108(a)(i)).

## Why both reviewers flagged this

Both Codex and Gemini ran a follow-up sweep against the post-merge state of #404 and converged on the display-copy + missing enum options as `SHOULD-FIX` items.

## Changes

- `src/core/employment/memo.ts:306-314` — rename internal `id: 'restriction-pathways'` → `'applicable-noncompete-exceptions'`; rewrite the three user-visible strings (`missingSummary`, `presentSummary`, `followUpQuestionWhenMissing`) to use "applicable non-compete exception" framing aligned with Wyo. Stat. § 1-23-108's statutory "exceptions to" language.
- `src/core/employment/jurisdiction-rules.ts:133` — same fix to the `emp-jur-wy-pathway-none-noncompete-001` rule message.
- `content/templates/openagreements-restrictive-covenant-wyoming/metadata.yaml:67-74` — reworded description to match new field-name semantics + added the two missing enum options ("Training Cost Recovery", "Sale of Business").
- `data/templates-snapshot.json` — regenerated via `node scripts/export-templates-snapshot.mjs`.

## Verification

- `npm run build` — clean.
- `npm test` — 945/951 passed (6 failures all in `packages/signing/tests/gcloud-storage.test.ts` from pre-existing local GCP-auth issues, unrelated). Notably `integration-tests/employment-memo.test.ts` (11/11) and `packages/contract-templates-mcp/tests/tools.test.ts` (29/29) both pass.
- Snapshot inspection confirms the new description landed in `data/templates-snapshot.json` as expected.

## Out of scope (separate follow-up issues)

- **Multi-value applicability semantics** — `applicable_noncompete_exceptions` is documented as comma-stackable in the Wyoming overlay design, but Wyoming-overlay-spec gates still use `==` equality. Fixing this cleanly requires introducing a `contains` operator in the legal-context spec-format doc and updating affected gates. Will file as a separate issue against legal-context.
- **Cosmetic cleanups in legal-context** (shape.yaml rename, heading-level inconsistency, broken anchor in Wyoming overlay design) are landing in a sibling PR against `UseJunior/legal-context`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)