### PR TITLE
chore(wyoming-rc): drop law-firm name list from footer attribution

### DIFF
--- a/content/templates/openagreements-restrictive-covenant-wyoming/metadata.yaml
+++ b/content/templates/openagreements-restrictive-covenant-wyoming/metadata.yaml
@@ -12,9 +12,8 @@ license: CC-BY-4.0
 allow_derivatives: true
 attribution_text: >-
   Authored by OpenAgreements contributors. Wyoming-specific analysis informed
-  by publicly available commentary from Am Law firms including Ogletree Deakins,
-  Fisher Phillips, Littler Mendelson, Foley & Lardner, Faegre Drinker, and
-  Vinson & Elkins. See practice note for sources. Licensed under CC BY 4.0.
+  by publicly available legal commentary cited in the related practice note.
+  Licensed under CC BY 4.0.
 fields:
   # --- Parties (on cover page) ---
   - name: employer_name


### PR DESCRIPTION
## Summary

The Wyoming restrictive-covenant template's footer attribution currently enumerates the Am Law firms whose public commentary informed the analysis (Ogletree Deakins, Fisher Phillips, Littler Mendelson, Foley & Lardner, Faegre Drinker, Vinson & Elkins). Per maintainer direction, move that list out of the footer and let the cited practice note (\`openagreements.org/legal/non-compete/wyoming\`) carry the full source list as it already does — the named footnoted citations on the practice note are the canonical record.

## Diff

Just \`content/templates/openagreements-restrictive-covenant-wyoming/metadata.yaml#attribution_text\`. Keeps:
- The \"Authored by OpenAgreements contributors\" attribution
- The pointer to the practice note for sources
- The CC BY 4.0 license disclosure

## Downstream effect

- \`usejunior.com/templates/openagreements-restrictive-covenant-wyoming\` (eleventy) picks up on the next site build.
- \`openagreements.org/templates/openagreements-restrictive-covenant-wyoming\` (legal-explainer / Next.js) picks up the next time \`OA_UPSTREAM_REF\` resolves to the post-merge SHA (each \`npm run prebuild\` fetches \`main\`).