### PR TITLE
fix(llm-gate): stagger LLM calls + retry backoff to avoid API bursts

### DIFF
--- a/.github/actions/llm-gate-check/action.yml
+++ b/.github/actions/llm-gate-check/action.yml
@@ -163,6 +163,18 @@ runs:
         DIAG_LOG="$RUNNER_TEMP/diag-${CHECK_ID}.log"
         : > "$DIAG_LOG"
 
+        # Stagger concurrent matrix jobs so they don't fire their first LLM
+        # call at the same instant. With max-parallel > 1 the jobs in a wave
+        # otherwise hit the API simultaneously; a burst of large requests is
+        # what provokes rate-limit / quota / empty-response failures (observed:
+        # all checks returning empty JSON, retries firing ~6ms apart). Sleep a
+        # deterministic 1-5s keyed on the check id (so each wave's jobs are
+        # offset) plus a small random jitter to break any residual alignment.
+        STAGGER_BASE=$(( (10#$CHECK_ID - 1) % 5 + 1 ))
+        STAGGER=$(awk -v b="$STAGGER_BASE" 'BEGIN { srand(); printf "%.1f", b + rand() }')
+        echo "Staggering check ${CHECK_ID} start by ${STAGGER}s (avoid LLM API bursts)"
+        sleep "$STAGGER"
+
         for attempt in 1 2 3; do
           ATTEMPTS=$attempt
           RAW="$RUNNER_TEMP/raw-${CHECK_ID}-${attempt}.json"
@@ -203,6 +215,14 @@ runs:
 
           if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
             echo "::warning::Attempt $attempt for check ${CHECK_ID} produced malformed output; retrying"
+            # Back off before retrying (jittered, escalating: ~2-3s then ~4-5s).
+            # An empty/error CLI response returns near-instantly, so without a
+            # sleep the 3 attempts fire within milliseconds and just re-hit the
+            # same transient rate-limit/quota wall. Spacing the retries lets a
+            # transient condition clear before the next call.
+            BACKOFF=$(awk -v a="$attempt" 'BEGIN { srand(); printf "%.1f", a * 2 + rand() }')
+            echo "Backing off ${BACKOFF}s before retry $((attempt + 1)) for check ${CHECK_ID}"
+            sleep "$BACKOFF"
             # Append a short corrective note for the next attempt so the
             # model knows what went wrong.
             {


### PR DESCRIPTION
## Summary
The LLM-Based Quality Gate intermittently returns **empty JSON for every check** (e.g. on #407 — 14/14 WARN-fallback "malformed output"). Root-cause from the run logs: the 3 retries per check fire **~6ms apart** — too fast to be real LLM round-trips — so the calls are coming back empty/error near-instantly (rate-limit / quota / blocked / oversized-request rejection), made worse by a **burst**: concurrent matrix jobs each instant-retrying hammer the API within milliseconds.

## Fix (in `.github/actions/llm-gate-check/action.yml`)
- **Startup stagger** — each matrix job sleeps a deterministic **1–5s** (keyed on check id so a wave's concurrent jobs offset) + small random jitter, before its first call.
- **Retry backoff** — jittered escalating sleep (~2–3s, then ~4–5s) before each retry instead of the prior instant re-fire.

No change to verdict logic — purely spaces the calls out (what was requested: "1–5s between calls"). `max-parallel` stays configurable via `LLM_GATE_MAX_PARALLEL` (set it to `1` for fully serial + spaced if bursts persist).

## Verification
- [x] `action.yml` parses as YAML (4 steps); extracted run-script passes `bash -n`
- [ ] Live effect only visible **after merge** — the gate executes from the trusted **base ref**, so this PR's own gate run still uses the old un-staggered code (expect the same flakiness here; that's not a regression).

## Context
Diagnosed during the Florida CHOICE Act program; complements the discussion on the gate's degraded behavior.