### PR TITLE
chore(vercel): disable Git deployments for the public repo

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": false
+  }
+}


### PR DESCRIPTION
## Problem

The legacy **`Vercel`** commit-status fails **repo-wide** — including on `main` itself:

```
Deployment has failed … No Output Directory named "_site"
```

`gh pr ... statusCheckRollup` looks all-green; only the legacy combined-status API surfaces it:

```
gh api repos/:owner/:repo/commits/$(git rev-parse main)/status
# → state: failure  ·  context: Vercel
```

### Root cause

#394 ("Phase 3 — remove deployed-API surface") intentionally deleted `vercel.json` and `api/**` because the hosted site/API moved to the private `UseJunior/openagreements-org-deploy` repo. The public repo is now **purely library + content**.

But the `use-junior/open-agreements` Vercel project still has its **Git integration enabled** with **Output Directory = `_site`**. With no `vercel.json` and no build producing `_site`, every push fails — adding a red `Vercel` status to every PR and creating noise/blocking around automerge.

## Fix

Re-add a minimal `vercel.json` that **disables Git deployments** rather than re-introducing a build target (which would contradict #394):

```json
{ "git": { "deploymentEnabled": false } }
```

With `deploymentEnabled: false`, the Git integration creates no deployment and posts no commit status — clearing the failing `Vercel` check going forward.

## Scope / safety

- ✅ `Vercel` is **not** a branch-protection required check — disabling it only removes a perpetually-failing non-required status.
- ✅ The separate **`tests-openagreements`** Allure-report project (deployed via the Vercel CLI in `ci.yml`) is unaffected — different project, different mechanism.
- ✅ No tests assert on `vercel.json` (those were removed in #394).

## Follow-up (dashboard, optional)

For full tidiness the `use-junior/open-agreements` Git integration could also be disconnected in the Vercel dashboard; this committed config is the declarative, reviewable equivalent.