### PR TITLE
feat(skills): non-compete-contract-explainer snapshot 2026-06-08 (59 jurisdictions)

### DIFF
--- a/skills/non-compete-contract-explainer/content/alabama.md
+++ b/skills/non-compete-contract-explainer/content/alabama.md
@@ -1,0 +1,251 @@
+---
+jurisdiction: "Alabama"
+slug: alabama
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-03"
+canonicalUrl: https://openagreements.org/legal/non-compete/alabama
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/alabama · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in Alabama[^about]
+
+A question-by-question summary of Alabama non-compete law under the 2016 Restrictive Covenant Act (Ala. Code § 8-1-190 et seq.), including the void-by-default rule, the six statutory exceptions and their duration presumptions, protectable interests, the all-parties signature requirement after Amanda Howard, judicial reformation, the professional exemption, tolling-during-breach clauses, and choice-of-law limits.
+
+
+## At a glance
+
+| Question | Alabama |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed if reasonable |
+| **Bottom line** | Alabama voids non-competes by default but enforces an employee covenant that fits the Restrictive Covenant Act's narrow safe harbor, protects a statutory interest, and is properly signed. |
+| **Main law or case** | Ala. Code § 8-1-190 et seq. (Restrictive Covenant Act) |
+| **Main exceptions** | Sale of business; current-customer non-solicit (18-mo); employee no-hire for uniquely essential workers; professional exemption (physicians, CPAs, veterinarians, physical therapists) |
+| **Can a court narrow it?** | Yes — rewrites to reasonable |
+| **Applies to contractors?** | Unclear |
+| **Restriction extended during a breach?** | Not addressed by statute or case law |
+| **Maximum length set by law** | 2 years presumed reasonable (employee) |
+
+## Are employee non-compete agreements enforceable in Alabama? {#employee-noncompetes}
+
+**Short answer.** Yes, but only inside a narrow statutory safe harbor. Alabama starts from the rule that every contract restraining a lawful profession, trade, or business is void, and then allows an employee non-compete as one of six listed exceptions; a covenant of two years or less is presumed reasonable [^ala-8-1-190-void][^ala-8-1-190-employee].
+
+Alabama is not a reasonableness state in the usual sense. Restrictive covenants are now governed by the Alabama Restrictive Covenant Act, Ala. Code § 8-1-190 et seq. (enacted as Act 2015-465, effective in 2016), which replaced the older, common-law-driven § 8-1-1. The Act governs covenants entered on or after its effective date; agreements predating it remain governed by the former § 8-1-1, which is why several leading Alabama cases construe that predecessor statute. The Act begins with a presumption of voidness.
+
+"Every contract by which anyone is restrained from exercising a lawful profession, trade, or business of any kind otherwise than is provided by this section is to that extent void."[^ala-8-1-190-void]
+
+An employee non-compete escapes that rule only if it fits the employee exception in § 8-1-190(b)(4), which requires a specified geographic area and a competing business by the employer, and which builds in a durational presumption [^ala-8-1-190-employee]. Fitting a statutory category is necessary but not sufficient: the covenant still has to protect a statutory protectable interest, satisfy the writing-and-signature and consideration rules, and survive the professional exemption and any other defense. So the practical question in Alabama is rarely whether a covenant is generally reasonable; it is whether the covenant fits a statutory category and clears those additional limits.
+
+## Which restrictive covenants does the Alabama Restrictive Covenant Act allow? {#allowed-covenants}
+
+**Short answer.** Six categories, each with its own limits. The Act lists employee no-hire covenants for uniquely essential employees, exclusive-dealing agreements, sale-of-business covenants, employee non-competes, current-customer non-solicitation covenants, and dissolution covenants, with presumptively reasonable durations of one year for sales, two years for employee non-competes, and eighteen months for current-customer non-solicits [^ala-8-1-190-sale][^ala-8-1-190-nonsolicit].
+
+The exceptions are listed in § 8-1-190(b). They are the entire universe of allowed restraints; anything that does not fit one of the six is void. The employee-facing categories carry the most-cited duration presumptions.
+
+For a sale-of-business covenant, a one-year restraint is presumed reasonable [^ala-8-1-190-sale]. The customer non-solicitation exception reaches only *current* customers, not former or merely prospective ones, and for such a covenant the presumed-reasonable period is eighteen months or as long as post-separation consideration is paid, whichever is greater.
+
+"Restraints of 18 months or for as long as post-separation consideration is paid for such agreement, whichever is greater, are presumed to be reasonable."[^ala-8-1-190-nonsolicit]
+
+The employee no-hire category is unusually narrow. A covenant restricting the hiring of another party's workers is allowed only where the worker holds a position uniquely essential to the business [^ala-8-1-190-no-hire], a high bar that few rank-and-file or mid-level employees will meet.
+
+## What is a protectable interest under Alabama law? {#protectable-interest}
+
+**Short answer.** A statutorily listed interest, not ordinary competition. Section 8-1-191 lists trade secrets, confidential information, specific customer relationships and goodwill, and specialized training as protectable interests, and it states that job skills alone are not [^ala-8-1-191-customers][^ala-8-1-191-jobskills].
+
+Fitting a statutory exception is not enough; the party enforcing the covenant must also show it protects a protectable interest defined in § 8-1-191. The list includes trade secrets, which are defined by cross-reference to the Alabama Trade Secrets Act at Ala. Code § 8-27-2, along with confidential information, goodwill, and commercial relationships with specific customers, including prospective ones [^ala-8-1-191-customers].
+
+The statute draws a hard line at general skills. An employer cannot restrain a former employee just to suppress competition.
+
+"Job skills in and of themselves, without more, are not protectable interests."[^ala-8-1-191-jobskills]
+
+Specialized training counts, but only if the employer takes a specific drafting step: the training and its expense must be set out in writing in the agreement itself as consideration for the restraint [^ala-8-1-191-training].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not rely on a generic recital of training to support an Alabama covenant. Section 8-1-191 makes specialized training a protectable interest only when the training and its anticipated expense are specifically set forth in writing in the agreement as consideration for the restraint, so a boilerplate reference will not qualify [^ala-8-1-191-training].
+
+## Must an Alabama non-compete be signed by all parties, including the employer? {#signature-requirement}
+
+**Short answer.** Yes. Section 8-1-192 requires the covenant to be in writing, signed by all parties, and supported by adequate consideration, and the Alabama Supreme Court held in Amanda Howard Real Estate v. Lee that an employer's failure to sign the document containing the covenant makes it void [^ala-8-1-192][^howard-affirm].
+
+Section 8-1-192 sets three formation requirements for any covenant under the Act.
+
+"In order to be valid, any contract or agreement executed pursuant to this article shall be reduced to writing, signed by all parties, and be supported by adequate consideration."[^ala-8-1-192]
+
+In *Amanda Howard Real Estate, LLC v. Lee*, the employee signed the addendum containing the non-compete in 2017, but no representative of the employer signed that document at the time; the employer did not sign it until the day the employee resigned, roughly two years later, after the employment contract had already been formed. The trial court held the covenant void, and the Supreme Court affirmed, reading the signed-by-all-parties requirement strictly.
+
+"We affirm the judgment because none of Howard Real Estate's arguments establish that it satisfied the statutory signatures requirement."[^howard-affirm]
+
+The Court rejected the employer's arguments that mutual assent shown by conduct, or full performance of the employment relationship, could substitute for the missing signature [^howard-thing-signed]. The signature has to be on the document that actually contains the restrictive covenant.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Make sure the company itself signs the exact document that contains the non-compete, while the employment relationship is in place. After *Amanda Howard Real Estate v. Lee*, an employer's failure to timely sign the covenant document defeats enforcement of that covenant, and a much-later signature, payment, or assent shown by conduct will not cure it; a fresh, properly signed covenant going forward must itself satisfy § 8-1-192 [^howard-affirm][^howard-thing-signed].
+
+## When does an Alabama non-compete have to be signed relative to employment? {#timing-of-signing}
+
+**Short answer.** The safer answer is that it must. Under the predecessor statute, the Alabama Supreme Court held in Pitney Bowes v. Berney Office Solutions that a covenant signed before the employer-employee relationship began was void; the current Act's employee exceptions are written the same relationship-first way, though no decision under the 2016 Act has yet addressed the point [^pitney-timing].
+
+This is a timing trap that predates the 2016 Act but remains a live drafting risk. In *Pitney Bowes, Inc. v. Berney Office Solutions*, an employee signed a non-compete before the acquiring company became his employer, and the company tried to enforce it after the acquisition closed about a month later. The Court refused.
+
+"The voidness of the agreement in this case did not disappear when Pitney employed Morris almost a month after the signing."[^pitney-timing]
+
+*Pitney Bowes* construed the former § 8-1-1, but the employee exceptions in the current Act are written the same relationship-first way: § 8-1-190(b)(4) and (b)(5) allow a covenant by an *agent, servant, or employee of a commercial entity* with *such entity*, which presupposes an existing employment relationship at signing. The case also disposes of a common argument that paying for the covenant cures the problem; the Court explained the statute already assumes the covenant is supported by consideration [^pitney-consideration]. That is why Alabama treats continued employment of an existing employee as adequate consideration, while a payment cannot rescue a covenant that is void for a different reason.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not have a new hire sign an Alabama non-compete before the employment relationship actually begins. *Pitney Bowes* held that a covenant signed before employment was void and did not become valid when employment later started, so the safer practice is to execute the covenant once the person is employed and to re-execute it after any acquisition that changes the employing entity [^pitney-timing].
+
+## Will an Alabama court narrow an overbroad non-compete instead of voiding it? {#blue-pencil}
+
+**Short answer.** Sometimes. Section 8-1-193 lets a court reform a covenant that is overly broad in duration, but it also tells the court to void the restraint entirely if it does not fit one of the six statutory exceptions in the first place [^ala-8-1-193-reform][^ala-8-1-193-void].
+
+Alabama gives courts a limited blue-pencil power. If the problem is an unreasonable duration, a court can trim the covenant and enforce the rest.
+
+"If a contractually specified restraint is overly broad or unreasonable in its duration, a court may void the restraint in part and reform it to preserve the protectable interest or interests."[^ala-8-1-193-reform]
+
+But reformation has a hard limit. A court can fix an overbroad term inside a valid category; it cannot rewrite a covenant that never fit a statutory exception to begin with [^ala-8-1-193-void]. For a restraint that is not tethered to a protectable interest, or that falls outside the six categories, the statute authorizes a court to void it in its entirety rather than narrow it.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not treat Alabama's blue-pencil power as a safety net for an overreaching covenant. Section 8-1-193 lets a court reform an overbroad *duration*, but it authorizes the court to void the entire restraint if the covenant does not fit one of the six § 8-1-190(b) exceptions, so a covenant that misses a statutory category should not be treated as salvageable through duration reformation [^ala-8-1-193-void].
+
+## Does Alabama exempt professionals from non-compete agreements? {#professional-exemption}
+
+**Short answer.** Yes, within limits. Section 8-1-196 preserves Alabama's common-law professional exemption, under which a non-compete cannot bar a member of a recognized profession from practicing that profession; Alabama courts have applied it to veterinarians and physical therapists. The exemption protects the practice of the profession, not unrelated business conduct [^ala-8-1-196][^benchmark-scope].
+
+The 2016 Act did not disturb the long-standing rule that professionals are off-limits for non-competes. Section 8-1-196 expressly keeps that exemption in place.
+
+"Nothing in this article shall be construed to eliminate any professional exemption recognized by Alabama law."[^ala-8-1-196]
+
+Alabama courts decide who is a professional using a multi-factor test drawn from cases under the former § 8-1-1, which § 8-1-196 carries forward. In *Friddle v. Raymond*, the Court listed the factors that distinguish a profession from an ordinary trade.
+
+"this Court stated several relevant factors to be considered in resolving the issue as to what constitutes a profession: professional training, skill, and experience required to perform certain services; delicate nature of the services offered; and the ability and need to make instantaneous decisions."[^friddle-factors]
+
+A professional cannot squeeze into the statutory exceptions, so a covenant that bars practicing the profession fails [^friddle-cannot-fall]. Alabama courts have classified physicians, certified public accountants, and veterinarians as professionals, and in *Benchmark Medical Holdings, Inc. v. Barnes* a federal court applying Alabama law extended the exemption to physical therapists [^benchmark-pt].
+
+The exemption is not blanket immunity, though. It protects the professional in the practice of the profession, not in every business activity.
+
+"A doctor is, instead, protected only in his practice of medicine, for the purpose of the protection is the interest of the public in being able to receive the doctor's professional services."[^benchmark-scope]
+
+So a professional cannot be barred from practicing, but conduct outside that practice — *Benchmark* used the example of acquiring competing practices purely as an investment, without managing them — can still be restrained.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not assume a non-compete will keep a licensed professional from practicing in Alabama. Because § 8-1-196 preserves the common-law professional exemption, a covenant cannot bar a physician, accountant, veterinarian, physical therapist, or similar professional from practicing the profession, even when it would otherwise fit a statutory category, though restrictions on business activity outside that practice may still operate [^ala-8-1-196][^benchmark-scope].
+
+## Does a tolling or extension-during-breach clause extend an Alabama non-compete? {#tolling-during-breach}
+
+**Short answer.** Alabama law does not answer this directly. No Alabama appellate decision under the 2016 Act addresses a clause that pauses or extends the restricted period during breach or litigation, and a tolling clause that pushes the effective restraint past the presumptively reasonable window is exposed to reformation as an unreasonable duration [^q8-ala-8-1-190-2yr][^q8-ala-8-1-193-reform].
+
+Many non-compete forms add a tolling or extension clause so the employer gets the full restricted period even if the former employee competes during it. Alabama has no statute or controlling case on whether such a clause is enforceable, so this is an open question that calls for caution rather than confidence.
+
+The statutory text is the best available guide. The employee exception presumes a restraint of two years or less to be reasonable.
+
+"Restraints of two years or less are presumed to be reasonable."[^q8-ala-8-1-190-2yr]
+
+A tolling clause that adds the period of breach plus the time spent in litigation can stretch the effective restraint well beyond two years. Section 8-1-193 lets a court reform a restraint that is overly broad or unreasonable in its duration [^q8-ala-8-1-193-reform], which is the mechanism a court would likely use to cut an open-ended extension back to a reasonable fixed term. Because no Alabama court has ruled on the point, an employer should not assume a drafted tolling clause will add lost time back to the period.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Treat an open-ended tolling-during-breach clause in an Alabama non-compete as unsettled and risky. No Alabama decision enforces one, the statute presumes only restraints of two years or less reasonable, and § 8-1-193 gives a court power to reform an unreasonable duration, so a defined, reasonable fixed term is the safer choice [^q8-ala-8-1-190-2yr][^q8-ala-8-1-193-reform].
+
+## Who has the burden of proof, and what remedies are available in Alabama? {#burden-remedies}
+
+**Short answer.** The party enforcing the covenant bears the burden on every element, while the party resisting must prove undue hardship if it raises that defense; remedies include injunctive relief, damages, and contractual attorneys' fees [^ala-8-1-194][^ala-8-1-195-fees].
+
+The Act allocates the burden of proof against the covenant. The employer must establish each element of enforceability.
+
+"The party seeking enforcement of the covenant has the burden of proof on every element."[^ala-8-1-194]
+
+The employee or other restrained party carries the burden only on undue hardship, and only if it chooses to raise that defense. On remedies, § 8-1-195 makes injunctive relief, actual or liquidated damages, and ordinary contract remedies available, including attorneys' fees where the contract or law provides for them [^ala-8-1-195-fees]. The Act also preserves any other defense available in law or equity [^ala-8-1-195-defenses].
+
+## Can an out-of-state choice-of-law clause bypass Alabama non-compete law? {#choice-of-law}
+
+**Short answer.** Usually not. Section 8-1-197 declares the Act to be fundamental public policy and directs Alabama courts to apply it instead of a foreign law whose application would violate that policy [^ala-8-1-197-govern].
+
+Multi-state employers often designate a more permissive state's law to escape Alabama's professional exemption or its other limits. The Act anticipates that move. It first declares its own status.
+
+"It is hereby declared that this article expresses fundamental public policies of the State of Alabama."[^ala-8-1-197-policy]
+
+It then tells courts to apply Alabama law over a conflicting foreign law.
+
+"Therefore, this article shall govern and shall be applied instead of any foreign laws that might otherwise be applicable in those instances when the application of those foreign laws would violate a fundamental public policy expressed in this article."[^ala-8-1-197-govern]
+
+Because the legislature labeled its restrictive-covenant rules fundamental public policy, an Alabama court, or a federal court applying Alabama conflicts rules, can disregard a foreign choice-of-law clause that would enforce a covenant Alabama treats as void.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not count on a Delaware, Florida, or other foreign choice-of-law clause to make an otherwise void Alabama covenant enforceable. Section 8-1-197 designates the Act as fundamental public policy and directs courts to apply Alabama law instead of a conflicting foreign law, so a choice-of-law workaround is unreliable for covenants Alabama would void [^ala-8-1-197-govern].
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-03. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not Alabama. This article synthesizes Alabama primary law and is not legal advice from a Alabama-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^ala-8-1-190-void]: **Ala. Code § 8-1-190** — "Every contract by which anyone is restrained from exercising a lawful profession, trade, or business of any kind otherwise than is provided by this section is to that extent void." *Ala. Code § 8-1-190(a).* <https://alison.legislature.state.al.us/code-of-alabama/8-1-190>
+
+[^ala-8-1-190-employee]: **Ala. Code § 8-1-190** — "Restraints of two years or less are presumed to be reasonable." *Ala. Code § 8-1-190(b)(4).* <https://alison.legislature.state.al.us/code-of-alabama/8-1-190>
+
+[^ala-8-1-190-sale]: **Ala. Code § 8-1-190** — "Restraints of one year or less are presumed to be reasonable." *Ala. Code § 8-1-190(b)(3).* <https://alison.legislature.state.al.us/code-of-alabama/8-1-190>
+
+[^ala-8-1-190-nonsolicit]: **Ala. Code § 8-1-190** — "Restraints of 18 months or for as long as post-separation consideration is paid for such agreement, whichever is greater, are presumed to be reasonable." *Ala. Code § 8-1-190(b)(5).* <https://alison.legislature.state.al.us/code-of-alabama/8-1-190>
+
+[^ala-8-1-190-no-hire]: **Ala. Code § 8-1-190** — "A contract between two or more persons or businesses or a person and a business limiting their ability to hire or employ the agent, servant, or employees of a party to the contract where the agent, servant, or employee holds a position uniquely essential to the management, organization, or service of the business." *Ala. Code § 8-1-190(b)(1).* <https://alison.legislature.state.al.us/code-of-alabama/8-1-190>
+
+[^ala-8-1-191-customers]: **Ala. Code § 8-1-191** — "Commercial relationships or contacts with specific prospective or existing customers, patients, vendors, or clients." *Ala. Code § 8-1-191(a)(3).* <https://alison.legislature.state.al.us/code-of-alabama/8-1-191>
+
+[^ala-8-1-191-jobskills]: **Ala. Code § 8-1-191** — "Job skills in and of themselves, without more, are not protectable interests." *Ala. Code § 8-1-191(b).* <https://alison.legislature.state.al.us/code-of-alabama/8-1-191>
+
+[^ala-8-1-191-training]: **Ala. Code § 8-1-191** — "Specialized and unique training involving substantial business expenditure specifically directed to a particular agent, servant, or employee; provided that such training is specifically set forth in writing as the consideration for the restraint." *Ala. Code § 8-1-191(a)(5).* <https://alison.legislature.state.al.us/code-of-alabama/8-1-191>
+
+[^ala-8-1-192]: **Ala. Code § 8-1-192** — "In order to be valid, any contract or agreement executed pursuant to this article shall be reduced to writing, signed by all parties, and be supported by adequate consideration." *Ala. Code § 8-1-192.* <https://alison.legislature.state.al.us/code-of-alabama/8-1-192>
+
+[^howard-affirm]: **Amanda Howard Real Estate, LLC v. Lee** — "We affirm the judgment because none of Howard Real Estate's arguments establish that it satisfied the statutory signatures requirement." *Amanda Howard Real Estate, LLC v. Lee, 387 So. 3d 120 (Ala. 2023).* <https://www.cunninghambounds.com/documents/appellate-blog-category-/Howard-Real-Estate-LLC-v-Lee-and-JRHBW-Realty-Inc..pdf>
+
+[^howard-thing-signed]: **Amanda Howard Real Estate, LLC v. Lee** — "Thus, the thing that must be signed by all parties is the ‘contract or agreement’ containing the noncompete provision." *Amanda Howard Real Estate, LLC v. Lee, 387 So. 3d 120 (Ala. 2023).* <https://www.cunninghambounds.com/documents/appellate-blog-category-/Howard-Real-Estate-LLC-v-Lee-and-JRHBW-Realty-Inc..pdf>
+
+[^pitney-timing]: **Pitney Bowes, Inc. v. Berney Office Solutions** — "The voidness of the agreement in this case did not disappear when Pitney employed Morris almost a month after the signing." *Pitney Bowes, Inc. v. Berney Office Solutions, 823 So. 2d 659 (Ala. 2001).* <https://www.courtlistener.com/opinion/1099624/pitney-bowes-inc-v-berney-office-solutions/#:~:text=The%20voidness%20of%20the%20agreement,a%20month%20after%20the%20signing.>
+
+[^pitney-consideration]: **Pitney Bowes, Inc. v. Berney Office Solutions** — "This statute, however, presupposes noncompete agreements supported by consideration." *Pitney Bowes, Inc. v. Berney Office Solutions, 823 So. 2d 659 (Ala. 2001).* <https://www.courtlistener.com/opinion/1099624/pitney-bowes-inc-v-berney-office-solutions/#:~:text=This%20statute%2C%20however%2C%20presupposes%20noncompete%20agreements%20supported%20by%20consideration.>
+
+[^ala-8-1-193-reform]: **Ala. Code § 8-1-193** — "If a contractually specified restraint is overly broad or unreasonable in its duration, a court may void the restraint in part and reform it to preserve the protectable interest or interests." *Ala. Code § 8-1-193.* <https://alison.legislature.state.al.us/code-of-alabama/8-1-193>
+
+[^ala-8-1-193-void]: **Ala. Code § 8-1-193** — "If a contractually specified restraint does not fall within the limited exceptions set out in subsection (b) of Section 8-1-190, a court may void the restraint in its entirety." *Ala. Code § 8-1-193.* <https://alison.legislature.state.al.us/code-of-alabama/8-1-193>
+
+[^ala-8-1-196]: **Ala. Code § 8-1-196** — "Nothing in this article shall be construed to eliminate any professional exemption recognized by Alabama law." *Ala. Code § 8-1-196.* <https://alison.legislature.state.al.us/code-of-alabama/8-1-196>
+
+[^benchmark-scope]: **Benchmark Medical Holdings, Inc. v. Barnes** — "A doctor is, instead, protected only in his practice of medicine, for the purpose of the protection is the interest of the public in being able to receive the doctor's professional services." *Benchmark Med. Holdings, Inc. v. Barnes, 328 F. Supp. 2d 1236 (M.D. Ala. 2004).* <https://www.courtlistener.com/opinion/2438759/benchmark-medical-holdings-inc-v-barnes/#:~:text=A%20doctor%20is%2C%20instead%2C%20protected,receive%20the%20doctor's%20professional%20services.>
+
+[^friddle-factors]: **Friddle v. Raymond** — "this Court stated several relevant factors to be considered in resolving the issue as to what constitutes a profession: professional training, skill, and experience required to perform certain services; delicate nature of the services offered; and the ability and need to make instantaneous decisions." *Friddle v. Raymond, 575 So. 2d 1038 (Ala. 1991).* <https://www.courtlistener.com/opinion/1839261/friddle-v-raymond/#:~:text=this%20Court%20stated%20several%20relevant,need%20to%20make%20instantaneous%20decisions.>
+
+[^friddle-cannot-fall]: **Friddle v. Raymond** — "this Court has stated on numerous occasions that a ‘professional’ cannot fall within these statutory exceptions." *Friddle v. Raymond, 575 So. 2d 1038 (Ala. 1991).* <https://www.courtlistener.com/opinion/1839261/friddle-v-raymond/#:~:text=this%20Court%20has%20stated%20on,fall%20within%20these%20statutory%20exceptions.>
+
+[^benchmark-pt]: **Benchmark Medical Holdings, Inc. v. Barnes** — "Because a physical therapist as a professional cannot fall within either of these statutory exceptions, the general rule that non-compete agreements are invalid applies; therefore, physical therapists are not subject to non-competition agreements." *Benchmark Med. Holdings, Inc. v. Barnes, 328 F. Supp. 2d 1236 (M.D. Ala. 2004).* <https://www.courtlistener.com/opinion/2438759/benchmark-medical-holdings-inc-v-barnes/#:~:text=Because%20a%20physical%20therapist%20as,not%20subject%20to%20non%2Dcompetition%20agreements.>
+
+[^q8-ala-8-1-190-2yr]: **Ala. Code § 8-1-190** — "Restraints of two years or less are presumed to be reasonable." *Ala. Code § 8-1-190(b)(4).* <https://alison.legislature.state.al.us/code-of-alabama/8-1-190>
+
+[^q8-ala-8-1-193-reform]: **Ala. Code § 8-1-193** — "If a contractually specified restraint is overly broad or unreasonable in its duration, a court may void the restraint in part and reform it to preserve the protectable interest or interests." *Ala. Code § 8-1-193.* <https://alison.legislature.state.al.us/code-of-alabama/8-1-193>
+
+[^ala-8-1-194]: **Ala. Code § 8-1-194** — "The party seeking enforcement of the covenant has the burden of proof on every element." *Ala. Code § 8-1-194.* <https://alison.legislature.state.al.us/code-of-alabama/8-1-194>
+
+[^ala-8-1-195-fees]: **Ala. Code § 8-1-195** — "Any remedies available in contract law, including attorneys’ fees or costs, if provided for in the contract or otherwise provided for by law." *Ala. Code § 8-1-195(a)(3).* <https://alison.legislature.state.al.us/code-of-alabama/8-1-195>
+
+[^ala-8-1-195-defenses]: **Ala. Code § 8-1-195** — "Nothing in this article shall limit the availability of any defense otherwise available in law or equity." *Ala. Code § 8-1-195(b).* <https://alison.legislature.state.al.us/code-of-alabama/8-1-195>
+
+[^ala-8-1-197-govern]: **Ala. Code § 8-1-197** — "Therefore, this article shall govern and shall be applied instead of any foreign laws that might otherwise be applicable in those instances when the application of those foreign laws would violate a fundamental public policy expressed in this article." *Ala. Code § 8-1-197.* <https://alison.legislature.state.al.us/code-of-alabama/8-1-197>
+
+[^ala-8-1-197-policy]: **Ala. Code § 8-1-197** — "It is hereby declared that this article expresses fundamental public policies of the State of Alabama." *Ala. Code § 8-1-197.* <https://alison.legislature.state.al.us/code-of-alabama/8-1-197>

--- a/skills/non-compete-contract-explainer/content/alaska.md
+++ b/skills/non-compete-contract-explainer/content/alaska.md
@@ -1,0 +1,160 @@
+---
+jurisdiction: "Alaska"
+slug: alaska
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-01"
+canonicalUrl: https://openagreements.org/legal/non-compete/alaska
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/alaska · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in Alaska[^about]
+
+Alaska uses a common-law reasonableness test for non-competes, led by Alaska Supreme Court cases and AUTSA trade-secret remedies, with no general statutory non-compete ban as of 2026.
+
+
+## At a glance
+
+| Question | Alaska |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed if reasonable |
+| **Bottom line** | Alaska has no non-compete statute; employee covenants are enforceable under common law if reasonably necessary to protect a legitimate business interest and no broader than needed. |
+| **Main law or case** | common law (Data Mgmt., Inc. v. Greene, 757 P.2d 62 (Alaska 1988)) |
+| **Can a court narrow it?** | Yes — rewrites to reasonable |
+| **Applies to contractors?** | Unclear |
+| **Restriction extended during a breach?** | Silent — no Alaska authority |
+| **Maximum length set by law** | No statutory limit |
+
+## Are employee non-compete agreements enforceable in Alaska? {#employee-noncompetes}
+
+**Short answer.** Yes, if they are reasonable, but Alaska courts start from a skeptical posture: employee non-competes are strictly construed[^decristofaro-disfavored-strictly-construed].
+
+Alaska has no general statute banning employee non-competes as of June 2026. The working rule comes from Alaska Supreme Court common law. *DeCristofaro* sets the posture, and *Data Management* supplies the modern enforcement framework for overbroad employment covenants.
+
+The practical answer is that Alaska is neither a ban state nor an automatic-enforcement state. A covenant should be tied to a real protectable interest, such as customer relationships, confidential information, trade secrets, or goodwill, and should avoid cutting off ordinary competition or the worker's livelihood [^data-management-reasonableness-factors][^decristofaro-disfavored-strictly-construed].
+
+## What makes an Alaska non-compete covenant reasonable? {#reasonableness-test}
+
+**Short answer.** Alaska weighs whether the restraint is reasonably necessary to protect a legitimate business interest and no broader than needed, considering duration, geography, customer contact, confidential information, and the hardship to the employee [^data-management-reasonableness-factors-reasonable].
+
+In employment cases, *Data Management* points courts to practical factors: time and space limits, whether the employee was the sole customer contact, whether confidential information or trade secrets are involved, whether the restriction targets unfair competition rather than ordinary competition, and whether the covenant would bar the employee's sole means of support [^data-management-reasonableness-factors-reasonable].
+
+That makes reasonableness fact-bound. A statewide or long covenant is not automatically invalid, and a short covenant is not automatically valid. The drafting question is whether each restraint maps to the business interest at stake.
+
+## Will Alaska courts rewrite an overbroad non-compete? {#court-narrowing}
+
+**Short answer.** Often yes, through reasonable alteration, but only if the covenant can be made enforceable and the employer proves it was drafted in good faith [^data-management-reasonable-alteration].
+
+Alaska does not follow a mechanical blue-pencil rule. *Data Management* rejected word-deletion formalism and adopted a reasonableness-based alteration approach that lets the court tailor a covenant to the facts.
+
+That doctrine is not a drafting license. If the employer willfully overreached, the court should refuse alteration [^data-management-overreach-good-faith]. The safest drafting posture is to write the covenant as narrowly as the evidence will support, then treat reasonable alteration as a backstop for good-faith excess.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not call Alaska a simple blue-pencil state. *Data Management* uses reasonable alteration, and the employer bears the good-faith burden before an overbroad covenant can be rescued [^data-management-reasonable-alteration].
+
+## Must an Alaska non-compete include geographic and time limits? {#time-geography-limits}
+
+**Short answer.** Not always. A customer-focused activity restraint can survive without stated geography or duration when it is narrowly drawn to protect customer-list interests [^metcalfe-no-time-geography-required].
+
+*Metcalfe* is the key Alaska authority. The alleged oral restraint did not bar the worker from operating a competing real estate business nearby. It targeted potential buyers who first contacted the former employer during employment, so the lack of a traditional territory or term did not defeat enforcement.
+
+The same opinion gives the limiting principle. A customer restriction can become unreasonable if the customer set is so broad that it effectively bars the worker from the specialty, or if the worker had no access to confidential information [^metcalfe-specialty-bar][^metcalfe-confidential-info].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Use *Metcalfe* carefully. It supports narrow customer-list restraints, not open-ended bans on working in the same field [^metcalfe-no-time-geography-required][^metcalfe-specialty-bar].
+
+## How are sale-of-business and healthcare covenants treated in Alaska? {#sale-healthcare-covenants}
+
+**Short answer.** Sale-of-business covenants are treated differently from ordinary employment covenants, but Alaska still weighs goodwill, seller hardship, and likely public injury [^wenzell-sale-business-test].
+
+In *Wenzell*, the covenant arose from a dental-practice sale. Alaska recognized the buyer's legitimate interest in purchased goodwill, while also reading the restraint as a covenant against competition, not a ban on all dentistry in any capacity.
+
+Healthcare facts sharpen the public-interest analysis. Because the challenged work was at a federally funded nonprofit provider offering free or low-cost care, the court held that competition would not be presumed and required proof [^wenzell-low-cost-competition-proof]. If competition exists, the court must still consider whether enforcement would harm the public.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Alaska has no published blanket ban on healthcare non-competes, but *Wenzell* makes access-to-care facts important. A provider covenant that affects low-cost services for a population in need should be tested against public injury, not just geographic radius and duration [^wenzell-public-interest-low-cost].
+
+## What role does AUTSA play in Alaska restrictive covenant disputes? {#autsa-trade-secrets}
+
+**Short answer.** AUTSA gives Alaska employers trade-secret remedies that can substitute for, or sit beside, a narrower non-compete, including injunctions for actual or threatened misappropriation [^autsa-injunctive-relief].
+
+Alaska Stat. § 45.50.910 authorizes injunctions, allows continued relief long enough to eliminate commercial advantage, and permits a reasonable royalty where prohibiting future use would be unreasonable [^autsa-injunctive-relief][^autsa-royalty].
+
+Alaska Stat. § 45.50.915 adds damages for actual loss and unjust enrichment, with exemplary damages up to twice the compensatory award for willful and malicious misappropriation [^autsa-damages]. Alaska Stat. § 45.50.930 displaces conflicting tort and restitutionary claims tied to trade-secret misappropriation, but preserves contract claims and other civil claims not based on misappropriation [^autsa-displacement-contracts].
+
+## Must Alaska non-compete obligations be in writing? {#writing-requirement}
+
+**Short answer.** Not always. *Metcalfe* held that an oral customer-list noncompetition agreement was enforceable despite not being in writing [^metcalfe-oral-not-writing].
+
+That holding is narrow but important. The agreement in *Metcalfe* was a promise to refrain from using customer lists in a new business for an unlimited period, and the court treated that kind of negative promise as outside the statute of frauds.
+
+As a drafting matter, a writing is still far safer. Alaska non-compete disputes are fact-intensive, and the court will still need to know what was agreed, what interest it protected, and how narrowly the restriction operated [^metcalfe-oral-not-writing][^data-management-reasonableness-factors-writing].
+
+## What alternatives do Alaska employers have to non-competes? {#alternatives}
+
+**Short answer.** Alaska employers usually have better odds with targeted tools: customer non-solicitation, confidentiality, trade-secret protection, and contract terms that match the actual risk [^metcalfe-customer-list-alternative][^autsa-injunctive-relief-alternatives].
+
+The narrowest option is often a customer-list or customer-contact restriction. *Metcalfe* upheld the basic concept because the agreement left the worker free to compete generally and only barred expropriating customers procured at the employer's expense [^metcalfe-customer-list-alternative].
+
+Confidentiality and trade-secret clauses should be drafted separately from non-competes. AUTSA supplies injunctions, damages, and preservation of contract claims that are not based on trade-secret misappropriation [^autsa-injunctive-relief-alternatives][^autsa-displacement-contracts-alternatives].
+
+Garden leave is a general option rather than an Alaska-specific doctrine; no published Alaska decision squarely addresses it. If used, it should pay the worker during a short transition, be tied to defined customer, confidentiality, or trade-secret risk, and be tested against the same Alaska reasonableness factors that govern other restraints [^data-management-reasonableness-factors-alternatives].
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-01. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not Alaska. This article synthesizes Alaska primary law and is not legal advice from a Alaska-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^decristofaro-disfavored-strictly-construed]: **DeCristofaro v. Security Nat. Bank** — "They are, therefore, strictly construed." *DeCristofaro v. Sec. Nat'l Bank, 664 P.2d 167, 168-69 (Alaska 1983).* <https://www.courtlistener.com/opinion/1234367/decristofaro-v-security-national-bank/#:~:text=They%20are%2C%20therefore%2C%20strictly%20construed.>
+
+[^data-management-reasonableness-factors]: **Data Management, Inc. v. Greene** — "Among the factors properly to be considered are: ‘[t]he absence or presence of limitations as to time and space, * * * whether the employee represents the sole contact with the customer; whether the employee is possessed with confidential information or trade secrets; whether the covenant seeks to eliminate competition which would be unfair to the employer or merely seeks to eliminate ordinary competition; whether the covenant seeks to stifle the inherent skill and experience of the employee; whether the benefit to the employer is disproportional to the detriment to the employee; whether the covenant operates as a bar to the employee’s sole means of support; whether the employee’s talent which the employer seeks to suppress was actually developed during the period of employment; and whether the forbidden employment is merely incidental to the main employment.’" *Data Mgmt., Inc. v. Greene, 757 P.2d 62, 65 (Alaska 1988).* <https://www.courtlistener.com/opinion/1350283/data-management-inc-v-greene/#:~:text=Among%20the%20factors%20properly%20to,incidental%20to%20the%20main%20employment.%E2%80%9D>
+
+[^data-management-reasonableness-factors-reasonable]: **Data Management, Inc. v. Greene** — "Among the factors properly to be considered are: ‘[t]he absence or presence of limitations as to time and space, * * * whether the employee represents the sole contact with the customer; whether the employee is possessed with confidential information or trade secrets; whether the covenant seeks to eliminate competition which would be unfair to the employer or merely seeks to eliminate ordinary competition; whether the covenant seeks to stifle the inherent skill and experience of the employee; whether the benefit to the employer is disproportional to the detriment to the employee; whether the covenant operates as a bar to the employee’s sole means of support; whether the employee’s talent which the employer seeks to suppress was actually developed during the period of employment; and whether the forbidden employment is merely incidental to the main employment.’" *Data Mgmt., Inc. v. Greene, 757 P.2d 62, 65 (Alaska 1988).* <https://www.courtlistener.com/opinion/1350283/data-management-inc-v-greene/#:~:text=Among%20the%20factors%20properly%20to,incidental%20to%20the%20main%20employment.%E2%80%9D>
+
+[^data-management-reasonable-alteration]: **Data Management, Inc. v. Greene** — "The third approach, and the one we adopt, is to hold that if an overbroad covenant not to compete can be reasonably altered to render it enforceable, then the court shall do so unless it determines the covenant was not drafted in good faith. The burden of proving that the covenant was drafted in good faith is on the employer." *Data Mgmt., Inc. v. Greene, 757 P.2d 62, 64 (Alaska 1988).* <https://www.courtlistener.com/opinion/1350283/data-management-inc-v-greene/#:~:text=The%20third%20approach%2C%20and%20the,faith%20is%20on%20the%20employer.>
+
+[^data-management-overreach-good-faith]: **Data Management, Inc. v. Greene** — "The trial court must determine whether an employer has overreached willfully and, if so, the court should refuse to alter the covenant." *Data Mgmt., Inc. v. Greene, 757 P.2d 62, 65 (Alaska 1988).* <https://www.courtlistener.com/opinion/1350283/data-management-inc-v-greene/#:~:text=The%20trial%20court%20must%20determine,refuse%20to%20alter%20the%20covenant.>
+
+[^metcalfe-no-time-geography-required]: **Metcalfe Investments, Inc. v. Garrison** — "We conclude that the noncompetition agreement is not rendered unenforceable by the lack of a geographical or durational limitation." *Metcalfe Invs., Inc. v. Garrison, 919 P.2d 1356, 1361-62 (Alaska 1996).* <https://www.courtlistener.com/opinion/1274957/metcalfe-investments-inc-v-garrison/#:~:text=We%20conclude%20that%20the%20noncompetition,a%20geographical%20or%20durational%20limitation.>
+
+[^metcalfe-specialty-bar]: **Metcalfe Investments, Inc. v. Garrison** — "For instance, if a business is so large that a restraint on contacting former clients would amount to a bar prohibiting the employee from practicing his or her specialty, the court will require the restraint to be drafted more narrowly." *Metcalfe Invs., Inc. v. Garrison, 919 P.2d 1356, 1362 n.5 (Alaska 1996).* <https://www.courtlistener.com/opinion/1274957/metcalfe-investments-inc-v-garrison/#:~:text=For%20instance%2C%20if%20a%20business,to%20be%20drafted%20more%20narrowly.>
+
+[^metcalfe-confidential-info]: **Metcalfe Investments, Inc. v. Garrison** — "A covenant not to contact former customers will also be unreasonable if the former employee did not have access to confidential information." *Metcalfe Invs., Inc. v. Garrison, 919 P.2d 1356, 1362 n.5 (Alaska 1996).* <https://www.courtlistener.com/opinion/1274957/metcalfe-investments-inc-v-garrison/#:~:text=A%20covenant%20not%20to%20contact,have%20access%20to%20confidential%20information.>
+
+[^wenzell-sale-business-test]: **Dominic Wenzell, DMD PC v. Ingrim** — "Under the second prong, the superior court must balance Wen-zell's need to protect the goodwill he purchased with the hardship to Ingrim from enforcing the covenant and the likely injury to the public." *Dominic Wenzell, DMD PC v. Ingrim, 228 P.3d 103, 111 (Alaska 2010).* <https://www.courtlistener.com/opinion/2601652/dominic-wenzell-dmd-pc-v-ingrim/#:~:text=Under%20the%20second%20prong%2C%20the,likely%20injury%20to%20the%20public.>
+
+[^wenzell-low-cost-competition-proof]: **Dominic Wenzell, DMD PC v. Ingrim** — "In such a case, competition will not be presumed and must be proven." *Dominic Wenzell, DMD PC v. Ingrim, 228 P.3d 103, 109 (Alaska 2010).* <https://www.courtlistener.com/opinion/2601652/dominic-wenzell-dmd-pc-v-ingrim/#:~:text=In%20such%20a%20case%2C%20competition,presumed%20and%20must%20be%20proven.>
+
+[^wenzell-public-interest-low-cost]: **Dominic Wenzell, DMD PC v. Ingrim** — "It appears from the record that Ingrim is employed by an organization providing an important, low-cost service to a population in need of such care." *Dominic Wenzell, DMD PC v. Ingrim, 228 P.3d 103, 111 (Alaska 2010).* <https://www.courtlistener.com/opinion/2601652/dominic-wenzell-dmd-pc-v-ingrim/#:~:text=It%20appears%20from%20the%20record,in%20need%20of%20such%20care.>
+
+[^autsa-injunctive-relief]: **AS 45.50.910 / .915 / .930 (AUTSA)** — "A court may enjoin actual or threatened misappropriation of trade secrets." *Alaska Stat. § 45.50.910(a).* <https://www.akleg.gov/pdf/billfiles/SLAs/SLA%201988/CH%20103%20SLA%201988.pdf>
+
+[^autsa-royalty]: **AS 45.50.910 / .915 / .930 (AUTSA)** — "If the court determines that it would be unreasonable to prohibit future use of a trade secret, an injunction may condition future use upon payment of a reasonable royalty for no longer than the period of time the use could have been prohibited." *Alaska Stat. § 45.50.910(b).* <https://www.akleg.gov/pdf/billfiles/SLAs/SLA%201988/CH%20103%20SLA%201988.pdf>
+
+[^autsa-damages]: **AS 45.50.910 / .915 / .930 (AUTSA)** — "If wilful and malicious misappropriation exists, the court may award exemplary damages in an amount not exceeding twice the damages awarded under (a) of this section." *Alaska Stat. § 45.50.915.* <https://www.akleg.gov/pdf/billfiles/SLAs/SLA%201988/CH%20103%20SLA%201988.pdf>
+
+[^autsa-displacement-contracts]: **AS 45.50.910 / .915 / .930 (AUTSA)** — "AS 45.50 . 910 - 45.50.945 do not affect (1) contractual or other civil liability or relief that is not based upon misappropriation of a trade secret; or (2) criminal liability for misappropriation of a trade secret." *Alaska Stat. § 45.50.930(b).* <https://www.akleg.gov/pdf/billfiles/SLAs/SLA%201988/CH%20103%20SLA%201988.pdf>
+
+[^metcalfe-oral-not-writing]: **Metcalfe Investments, Inc. v. Garrison** — "The noncompetition agreement in this case is thus enforceable despite the fact that it was not in writing." *Metcalfe Invs., Inc. v. Garrison, 919 P.2d 1356, 1362 (Alaska 1996).* <https://www.courtlistener.com/opinion/1274957/metcalfe-investments-inc-v-garrison/#:~:text=The%20noncompetition%20agreement%20in%20this,it%20was%20not%20in%20writing.>
+
+[^data-management-reasonableness-factors-writing]: **Data Management, Inc. v. Greene** — "Among the factors properly to be considered are: ‘[t]he absence or presence of limitations as to time and space, * * * whether the employee represents the sole contact with the customer; whether the employee is possessed with confidential information or trade secrets; whether the covenant seeks to eliminate competition which would be unfair to the employer or merely seeks to eliminate ordinary competition; whether the covenant seeks to stifle the inherent skill and experience of the employee; whether the benefit to the employer is disproportional to the detriment to the employee; whether the covenant operates as a bar to the employee’s sole means of support; whether the employee’s talent which the employer seeks to suppress was actually developed during the period of employment; and whether the forbidden employment is merely incidental to the main employment.’" *Data Mgmt., Inc. v. Greene, 757 P.2d 62, 65 (Alaska 1988).* <https://www.courtlistener.com/opinion/1350283/data-management-inc-v-greene/#:~:text=Among%20the%20factors%20properly%20to,incidental%20to%20the%20main%20employment.%E2%80%9D>
+
+[^metcalfe-customer-list-alternative]: **Metcalfe Investments, Inc. v. Garrison** — "The only thing she was prohibited from doing was expropriating information and customers that Metcalfe Investments had procured at its own expense." *Metcalfe Invs., Inc. v. Garrison, 919 P.2d 1356, 1361 (Alaska 1996).* <https://www.courtlistener.com/opinion/1274957/metcalfe-investments-inc-v-garrison/#:~:text=The%20only%20thing%20she%20was,procured%20at%20its%20own%20expense.>
+
+[^autsa-injunctive-relief-alternatives]: **AS 45.50.910 / .915 / .930 (AUTSA)** — "A court may enjoin actual or threatened misappropriation of trade secrets." *Alaska Stat. § 45.50.910(a).* <https://www.akleg.gov/pdf/billfiles/SLAs/SLA%201988/CH%20103%20SLA%201988.pdf>
+
+[^autsa-displacement-contracts-alternatives]: **AS 45.50.910 / .915 / .930 (AUTSA)** — "AS 45.50 . 910 - 45.50.945 do not affect (1) contractual or other civil liability or relief that is not based upon misappropriation of a trade secret; or (2) criminal liability for misappropriation of a trade secret." *Alaska Stat. § 45.50.930(b).* <https://www.akleg.gov/pdf/billfiles/SLAs/SLA%201988/CH%20103%20SLA%201988.pdf>
+
+[^data-management-reasonableness-factors-alternatives]: **Data Management, Inc. v. Greene** — "Among the factors properly to be considered are: ‘[t]he absence or presence of limitations as to time and space, * * * whether the employee represents the sole contact with the customer; whether the employee is possessed with confidential information or trade secrets; whether the covenant seeks to eliminate competition which would be unfair to the employer or merely seeks to eliminate ordinary competition; whether the covenant seeks to stifle the inherent skill and experience of the employee; whether the benefit to the employer is disproportional to the detriment to the employee; whether the covenant operates as a bar to the employee’s sole means of support; whether the employee’s talent which the employer seeks to suppress was actually developed during the period of employment; and whether the forbidden employment is merely incidental to the main employment.’" *Data Mgmt., Inc. v. Greene, 757 P.2d 62, 65 (Alaska 1988).* <https://www.courtlistener.com/opinion/1350283/data-management-inc-v-greene/#:~:text=Among%20the%20factors%20properly%20to,incidental%20to%20the%20main%20employment.%E2%80%9D>

--- a/skills/non-compete-contract-explainer/content/american-samoa.md
+++ b/skills/non-compete-contract-explainer/content/american-samoa.md
@@ -1,0 +1,187 @@
+---
+jurisdiction: "American Samoa"
+slug: american-samoa
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-03"
+canonicalUrl: https://openagreements.org/legal/non-compete/american-samoa
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/american-samoa · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in American Samoa[^about]
+
+American Samoa has no non-compete statute and no on-point case law; its High Court would gap-fill through the imported common law of A.S.C.A. § 1.0201 and the Restatement reasonableness test, while local public policy and a tiny island economy make aggressive covenants hard to enforce.
+
+
+## At a glance
+
+| Question | American Samoa |
+| --- | --- |
+| **Are non-competes enforceable?** | Unsettled |
+| **Bottom line** | No non-compete statute and no on-point case law; a court would likely apply the Restatement reasonableness test, with local public policy disfavoring broad restraints. |
+| **Main law or case** | A.S.C.A. § 1.0201 (imported common law); Restatement (Second) of Contracts § 188 |
+| **Can a court narrow it?** | Unsettled |
+| **Applies to contractors?** | Unclear |
+| **Restriction extended during a breach?** | Silent — no statute or case law |
+| **Maximum length set by law** | No statutory limit |
+
+## Are employee non-compete agreements enforceable in American Samoa? {#employee-noncompetes}
+
+**Short answer.** Probably sometimes, but the law is genuinely unsettled. American Samoa has no statute that governs employee non-competes and no High Court decision that has squarely enforced or struck one down. A covenant would be judged under the common law the High Court imports through A.S.C.A. § 1.0201 [^asca-1-0201], which in practice means the Restatement reasonableness framework.
+
+American Samoa is an unincorporated U.S. territory with no federal district court, so an employment-covenant dispute is decided in the first instance by the High Court of American Samoa applying territorial law. It is not a per se ban jurisdiction like California or North Dakota, and it has no statutory-reasonableness regime either. The starting point is the reception statute: A.S.C.A. § 1.0201 makes effective *so much of the common law of England as is suitable to conditions in American Samoa* [^asca-1-0201], and the High Court has long read that to import modern U.S. common law and the Restatements.
+
+For in-house counsel, the practical consequence is that almost every operating rule below is a *prediction* rather than a holding. There is no code section to cite and no controlling non-compete case, so a covenant that would survive comfortably in a blue-pencil state carries real first-impression risk here.
+
+## What test would the High Court of American Samoa apply to a non-compete? {#governing-test}
+
+**Short answer.** The High Court would most likely apply the reasonableness framework of the Restatement (Second) of Contracts § 188, imported through A.S.C.A. § 1.0201. It has said it should ordinarily follow the Restatement when it construes the common law [^tung-restatement], and that the common law of contracts applies in American Samoa unless a territorial statute or local conditions displace it [^ilalio-common-law].
+
+Two local decisions anchor that prediction. In *Tung v. Ah Sam*, the High Court adopted the Restatement as its default tool for defining the common law [^tung-restatement], and in *Development Bank of American Samoa v. Ilalio* it confirmed that imported contract doctrine governs ordinary contract disputes [^ilalio-common-law]. Restatement § 188 asks whether a restraint is greater than necessary to protect a legitimate interest and whether the employer's need is outweighed by hardship to the worker and injury to the public.
+
+"In defining the common law, and where not bound otherwise by prior decision of this Court, it is ordinarily appropriate that the Restatement of the Law be followed in order to more nearly effect uniformity of decision."[^tung-restatement]
+
+American Samoa is not hostile to restraints as a category. In *Lindgren v. Betham*, the High Court enforced a restrictive covenant in a lease and framed the governing principle as enforcement subject to an equity and public-policy override [^lindgren-covenant]. Translated to employment, an employer would have to show a genuine protectable interest and a scope no broader than necessary, knowing that equity and public policy supply the limits.
+
+"When presented with a violation of a restrictive covenant, courts are obligated to enforce the covenant unless the complaining party can show that enforcement would be inequitable or contrary to public policy."[^lindgren-covenant]
+
+## Does any American Samoa statute address non-competes? {#statutory-silence}
+
+**Short answer.** No. The American Samoa Code Annotated has no chapter on restrictive covenants, employee mobility, or trade secrets, and the restraint-of-trade language that does appear in the code sits in sector-specific statutes, not in any employment provision [^asca-20-0401]. The nearest labor provision is a right-to-work rule about union membership, not competition [^asca-32-0104].
+
+The statute titled *Illegal trade restraints*, A.S.C.A. § 20.0401, regulates only the transportation of passengers and freight by water — deferred rebates and discriminatory shipping contracts [^asca-20-0401]. The territory's other competition provisions are similarly narrow — for example, a separate section bars restraint of trade in the business of insurance. None is a general restraint-of-trade or employment-covenant statute, so none supplies a rule for a worker's covenant.
+
+Title 32's labor chapter confirms the silence. A.S.C.A. § 32.0104 makes it unlawful to condition employment on union membership or dues [^asca-32-0104]; it governs union-security arrangements, not post-employment competition. This legislative vacuum is itself load-bearing: with no statute either authorizing or banning non-competes, the entire question falls to the High Court's imported common law.
+
+## What consideration supports a non-compete, and what is the employment baseline? {#consideration}
+
+**Short answer.** There is no American Samoa authority on what consideration supports a non-compete or on whether continued employment alone suffices. The baseline is at-will employment [^palelei-atwill], and a covenant extracted through an unfair bargaining process is exposed to the High Court's unconscionability doctrine [^ilalio-unconscionability].
+
+American Samoa presumes at-will employment unless the parties contract otherwise. *Palelei v. Star-Kist Samoa, Inc.* states that without a fixed term or a contractual restriction on discharge, employment is at will [^palelei-atwill], and *Velega v. Legislature of American Samoa* repeats that the presumption yields only to an express or implied contractual provision [^velega-atwill].
+
+"In American Samoa, employment is presumed to be at will, and the employee can be fired without just or good cause, unless there exists an express or implied contractual provision restricting the employer's rights to terminate the employee."[^velega-atwill]
+
+What the local cases do *not* settle is whether merely keeping an at-will job is enough to support a covenant signed after hiring. The High Court has, however, signaled skepticism of one-sided bargains: *Ilalio* will refuse to enforce a contract where both its substance and the bargaining process are unconscionable [^ilalio-unconscionability], and *Atofau v. Tuufuli* holds that a bare gratuity cannot be turned into consideration by a later promise [^atofau-consideration].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Because no American Samoa case blesses continued employment as consideration, give a mid-stream covenant its own distinct consideration — a signing bonus, a raise, or a guaranteed term — rather than relying on continued at-will employment. A covenant imposed on a lower-paid worker without new consideration is the fact pattern most exposed to an unconscionability defense [^ilalio-unconscionability][^atofau-consideration].
+
+## Will the High Court narrow an overbroad covenant, or void it? {#court-narrowing}
+
+**Short answer.** The High Court may be open to narrowing it, but no American Samoa case has narrowed an employment covenant. On reconsideration of a defective-lease dispute, the court held that a court can excise illegal portions of a contract and enforce the remainder, or modify an illegal term to conform to law — citing a non-compete case as its authority [^samoa-aviation-excise].
+
+In *American Samoa Gov't v. Samoa Aviation, Inc.*, the High Court refused to void a defective lease and instead endorsed broad equitable power to sever or modify unlawful terms [^samoa-aviation-excise]. Tellingly, it anchored that power in *Alston Studios*, a federal covenant-not-to-compete case — which suggests the court might be receptive to reforming an overbroad employment restraint rather than discarding it.
+
+"Finally, it is well settled that a court can excise the illegal portions of a contract and enforce the remainder, with or without other compensating adjustments in the contractual obligations of the parties; or may modify an illegal term to make it conform to the law."[^samoa-aviation-excise]
+
+That tendency is reinforced by *Ilalio*'s reliance on Restatement § 208, which lets a court enforce the remainder of a contract or limit an unconscionable term rather than strike everything [^ilalio-partial]. Still, reformation here is a prediction: no American Samoa decision has blue-penciled an employee non-compete, so an employer should draft to a defensible scope rather than count on judicial rescue.
+
+## Does the restricted period toll or extend if the employee breaches? {#tolling}
+
+**Short answer.** American Samoa law is silent. No statute or High Court decision addresses whether a non-compete clock pauses during a breach, during litigation, or during an injunction application — and the deep-research record finds no local authority on either contractual or equitable tolling. The prudent assumption is that a court will not pause the clock unless the contract says so, so any extension-on-breach must be drafted expressly [^asca-1-0201-tolling].
+
+Because the territory imports common-law contract principles through A.S.C.A. § 1.0201 [^asca-1-0201-tolling], a clearly drafted contractual tolling clause — extending the restricted period for any time the employee is in breach — preserves the employer's best argument, though no American Samoa authority confirms such a clause will be enforced. Judicial or equitable tolling is a weaker bet still: there is no local authority granting it, and nothing suggests the High Court would rewrite a covenant to add time a party did not bargain for.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not assume the High Court will equitably extend a covenant while litigation runs. Write the tolling mechanism into the agreement expressly, keep the base term short enough to be reasonable on its own, and treat tolling as an open question of first impression in the territory [^asca-1-0201-tolling].
+
+## What remedies can an employer obtain for a breach? {#remedies}
+
+**Short answer.** Injunctive relief is available but hard-won. American Samoa's injunction statutes require a substantial likelihood of success plus great or irreparable injury for a preliminary injunction [^asca-43-1301], and a permanent injunction issues only after trial and only where money damages are inadequate [^asca-43-1302].
+
+The statutory standard is exacting, and the case law enforces it. In *Drabble v. Mikaele*, the High Court restated the two-part preliminary-injunction test — substantial likelihood of success and great or irreparable harm before trial [^drabble-standard].
+
+"For a preliminary injunction to issue, the applicant must show a substantial likelihood that he will prevail at trial on the merits and obtain a permanent injunction, and that he will suffer great or irreparable harm before a full and final trial can be fairly held on the requested permanent injunction."[^drabble-standard]
+
+Two further limits matter for a covenant plaintiff. The High Court will not issue an injunction that merely punishes a breach: in *Leaana v. Laban* it refused relief that would serve no purpose but punishment [^leaana-punishment]. And *Thompson v. Toluao* makes inadequacy of a legal remedy the defining prerequisite of an injunction [^thompson-inadequacy], so an employer whose loss is quantifiable as money damages may be left to those damages alone.
+
+"Punishment is not the purpose behind injunctive relief."[^leaana-punishment]
+
+Damages are correspondingly constrained. *Moea'i v. Reid* declined to apply a wage statute's punitive-damages provision to a contractual wage claim above the statutory minimum [^moeai-punitive], a reminder that territorial punitive damages are creatures of specific statutes; the local non-compete corpus identifies no special damages remedy, so a covenant plaintiff should expect to prove ordinary compensatory damages.
+
+## How are confidentiality clauses, non-solicits, physician, and sale-of-business covenants treated? {#other-covenants}
+
+**Short answer.** There is no American Samoa authority drawing distinct rules for non-solicitation, confidentiality, physician, or sale-of-business covenants. Each would be analyzed under the same imported reasonableness framework, with trade-secret confidentiality recognized in a limited agency-records regulation [^asac-24-0109] and sale-of-business covenants likely treated more leniently than employee restraints.
+
+American Samoa has not adopted the Uniform Trade Secrets Act. The closest territorial recognition of trade secrets is narrow: an administrative-code provision shields trade secrets in environmental-agency records from public disclosure [^asac-24-0109]. There is no general trade-secret statute and no authority on employee confidentiality covenants, so the enforceability of an NDA remains a common-law prediction. A non-solicitation or confidentiality clause that operates as a *de facto* bar on competing would be analyzed as a non-compete under the same Restatement § 188 reasonableness test.
+
+A physician or other scarce-professional covenant is likely to be especially vulnerable. Under Restatement § 188's injury-to-the-public prong, removing a single doctor, technician, or other scarce professional from a remote island economy is a strong public-interest argument against enforcement — the kind of *likely injury to the public* that the High Court's equity-and-public-policy override in *Lindgren* could weigh heavily [^lindgren-covenant-2]. Sale-of-business covenants, where bargaining power is more even and goodwill is being purchased, would likely be enforced more readily than an employee restraint.
+
+## Why might enforcement be harder in American Samoa than on the mainland? {#island-economy-public-policy}
+
+**Short answer.** Two territorial features cut against aggressive covenants: a public policy that prioritizes the Samoan way of life [^tavai-policy], and a tiny island economy in which a territory-wide restraint can amount to banishment from the worker's profession. A.S.C.A. § 1.0201 imports only common law *suitable to conditions in American Samoa*, and § 1.0202 preserves Samoan custom [^asca-1-0202].
+
+The High Court has described the protection of the Samoan way of life as its primary responsibility [^tavai-policy], and § 1.0202 preserves the customs of the Samoan people where they do not conflict with law [^asca-1-0202]. Those commitments give a worker a territory-specific public-policy argument: a covenant that meaningfully limits a local person's ability to earn a livelihood may be *unsuitable to conditions* in the territory in a way the suitability and custom provisions invite a court to weigh.
+
+Geography compounds the point. American Samoa is roughly 76 square miles, so a territory-wide non-compete does not merely limit where a worker competes — it can force the worker to leave the territory entirely. Under the Restatement reasonableness test the High Court would import, that scale makes overbreadth and undue-hardship objections far easier to sustain than a comparable restraint in a large mainland market.
+
+## What recent developments should employers monitor? {#recent-developments}
+
+**Short answer.** As of June 3, 2026, nothing has displaced the imported-common-law framework. American Samoa's Fono has not enacted a non-compete statute, so A.S.C.A. § 1.0201 gap-filling still controls [^asca-1-0201-current], and the vacated federal FTC Non-Compete Rule supplies no operative territorial rule.
+
+Two background developments matter only for monitoring. The FTC's 2024 Non-Compete Rule was struck down in litigation and the agency has abandoned it, so there is no federal ban to apply in American Samoa. And no targeted non-compete enactment was located in the public Fono legislative materials reviewed for this note. The framework therefore remains entirely judicial, which means the most reliable signal of change would be a first High Court decision on an employee non-compete rather than a statute [^asca-1-0201-current].
+
+The practical takeaway is stability layered on uncertainty: the rules will not move by legislation soon, but because no court has yet decided an employee non-compete, the first case to reach the High Court could set the baseline in either direction.
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-03. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not American Samoa. This article synthesizes American Samoa primary law and is not legal advice from a American Samoa-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^asca-1-0201]: **A.S.C.A. § 1.0201 — Laws applicable in American Samoa** — "so much of the common law of England as is suitable to conditions in American Samoa and not inconsistent with this section." *A.S.C.A. § 1.0201.* <https://asbar.org/code-annotated/1-0201-laws-applicable-in-american-samoa/>
+
+[^tung-restatement]: **Tung v. Ah Sam** — "In defining the common law, and where not bound otherwise by prior decision of this Court, it is ordinarily appropriate that the Restatement of the Law be followed in order to more nearly effect uniformity of decision." *Tung v. Ah Sam, 4 A.S.R. 764 (Trial Div. 1971).* <https://asbar.org/case-law/ah-sam-tung-v/>
+
+[^ilalio-common-law]: **Development Bank of American Samoa v. Ilalio** — "The common law of contracts applies in American Samoa unless it conflicts with a territorial statute or is unsuitable to local conditions." *Development Bank of American Samoa v. Ilalio, 5 A.S.R.2d 1 (Trial Div. 1987).* <https://asbar.org/case-law/development-bank-v-ilalio/>
+
+[^lindgren-covenant]: **Lindgren v. Betham** — "When presented with a violation of a restrictive covenant, courts are obligated to enforce the covenant unless the complaining party can show that enforcement would be inequitable or contrary to public policy." *Lindgren v. Betham, 20 A.S.R.2d 98 (App. Div. 1992).* <https://asbar.org/case-law/lindgren-v-betham/>
+
+[^asca-20-0401]: **A.S.C.A. § 20.0401 — Illegal trade restraints** — "No person may directly or indirectly, in respect to the transportation by water of passengers or freight between a port or landing of American Samoa or between islands of American Samoa or between a port of American Samoa and a port of another country:" *A.S.C.A. § 20.0401.* <https://asbar.org/code-annotated/20-0401-illegal-trade-restraints/>
+
+[^asca-32-0104]: **A.S.C.A. § 32.0104 — Unlawful acts of employer** — "It is unlawful for any employer to: (1) require an employee, as a condition or employment or of continuance of employment, to be or become or remain a member or affiliate of a labor organization;" *A.S.C.A. § 32.0104.* <https://asbar.org/code-annotated/32-0104-unlawful-acts-of-employer/>
+
+[^palelei-atwill]: **Palelei v. Star-Kist Samoa, Inc.** — "If the parties to an employment contract have neither fixed a definite term of employment nor created any contractual obstacle to the right of discretionary discharge, then the contract is for employment at will and the employer may discharge the employee without incurring liability." *Palelei v. Star-Kist Samoa, Inc., 5 A.S.R.2d 162 (Trial Div. 1987).* <https://asbar.org/case-law/5asr2d162/>
+
+[^ilalio-unconscionability]: **Development Bank of American Samoa v. Ilalio** — "A contract is ordinarily rendered unenforceable on the ground of unconscionability only when both its substance and the bargaining process leading up to it are unconscionable." *Development Bank of American Samoa v. Ilalio, 5 A.S.R.2d 1 (Trial Div. 1987).* <https://asbar.org/case-law/development-bank-v-ilalio/>
+
+[^velega-atwill]: **Velega v. Legislature of American Samoa** — "In American Samoa, employment is presumed to be at will, and the employee can be fired without just or good cause, unless there exists an express or implied contractual provision restricting the employer's rights to terminate the employee." *Velega v. Legislature of American Samoa, 4 A.S.R.3d 145 (Trial Div. 2000).* <https://asbar.org/case-law/4asr3d145/>
+
+[^atofau-consideration]: **Atofau v. Tuufuli** — "Gratuity cannot be turned into consideration by subsequent promise to pay therefor so as to make valid contract, and promise to give land after receipt of gratuity is not enforceable." *Atofau v. Tuufuli, 2 A.S.R. 414 (1948).* <https://asbar.org/case-law/atofau-v-tuufuli/>
+
+[^samoa-aviation-excise]: **American Samoa Gov't v. Samoa Aviation, Inc.** — "Finally, it is well settled that a court can excise the illegal portions of a contract and enforce the remainder, with or without other compensating adjustments in the contractual obligations of the parties; or may modify an illegal term to make it conform to the law." *American Samoa Gov't v. Samoa Aviation, Inc., 13 A.S.R.2d 65 (Trial Div. 1989) (on motions for new trial and modification).* <https://asbar.org/case-law/american-samoa-govt-v-samoa-aviation-inc-d96/>
+
+[^ilalio-partial]: **Development Bank of American Samoa v. Ilalio** — "A contract is ordinarily rendered unenforceable on the ground of unconscionability only when both its substance and the bargaining process leading up to it are unconscionable." *Development Bank of American Samoa v. Ilalio, 5 A.S.R.2d 1 (Trial Div. 1987).* <https://asbar.org/case-law/development-bank-v-ilalio/>
+
+[^asca-1-0201-tolling]: **A.S.C.A. § 1.0201 — Laws applicable in American Samoa** — "so much of the common law of England as is suitable to conditions in American Samoa and not inconsistent with this section." *A.S.C.A. § 1.0201.* <https://asbar.org/code-annotated/1-0201-laws-applicable-in-american-samoa/>
+
+[^asca-43-1301]: **A.S.C.A. § 43.1301 — Injunctions: Definitions** — "there is a substantial likelihood that the applicant will prevail at trial on the merits and that a permanent injunction will be issued against the opposing party; and (2) great or irreparable injury will result to the applicant before a full and final trial can be fairly held on whether a permanent injunction should issue." *A.S.C.A. § 43.1301(j).* <https://asbar.org/code-annotated/43-1301-definitions/>
+
+[^asca-43-1302]: **A.S.C.A. § 43.1302 — Issuance of permanent injunction** — "A permanent injunction may be issued by a court having subject matter jurisdiction of the case and personal jurisdiction of the opposing party only after a full and final trial on the merits of the applicant's claim and determination that a judgment for money damages will inadequately remedy the complained of wrong." *A.S.C.A. § 43.1302.* <https://asbar.org/code-annotated/43-1302-issuance-of-permanent-injunction/>
+
+[^drabble-standard]: **Drabble v. Mikaele** — "For a preliminary injunction to issue, the applicant must show a substantial likelihood that he will prevail at trial on the merits and obtain a permanent injunction, and that he will suffer great or irreparable harm before a full and final trial can be fairly held on the requested permanent injunction." *Drabble v. Mikaele (Land & Titles Div. 2004).* <https://asbar.org/case-law/drabble-v-mikaele/>
+
+[^leaana-punishment]: **Leaana v. Laban** — "Punishment is not the purpose behind injunctive relief." *Leaana v. Laban, 12 A.S.R.2d 93 (Land & Titles Div. 1989).* <https://asbar.org/case-law/laban-leaana-v/>
+
+[^thompson-inadequacy]: **Thompson v. Toluao** — "As an equitable remedy, the most distinguishing prerequisite of permanent injunctive relief is the inadequacy of a remedy at law, usually money damages." *Thompson v. Toluao, 24 A.S.R.2d 127 (Land & Titles Div. 1993).* <https://asbar.org/case-law/24asr2d127/>
+
+[^moeai-punitive]: **Moea'i v. Reid** — "this provision does not apply to an action for breach of contract where, although the employee has not been paid, his contractual wage was higher than the statutory minimum." *Moea'i v. Reid, 9 A.S.R.2d 48 (Trial Div. 1988).* <https://asbar.org/case-law/9asr2d48/>
+
+[^asac-24-0109]: **A.S.A.C. § 24.0109 — Confidentiality of records (trade secrets)** — "would otherwise tend to affect adversely the competitive position of such person by revealing trade secrets, the Commission shall consider such record, report, information, or particular portion thereof confidential." *A.S.A.C. § 24.0109.* <https://asbar.org/code-annotated/24-0109-confidentiality-of-records-exceptions-in-government-usage/>
+
+[^lindgren-covenant-2]: **Lindgren v. Betham** — "When presented with a violation of a restrictive covenant, courts are obligated to enforce the covenant unless the complaining party can show that enforcement would be inequitable or contrary to public policy." *Lindgren v. Betham, 20 A.S.R.2d 98 (App. Div. 1992).* <https://asbar.org/case-law/lindgren-v-betham/>
+
+[^tavai-policy]: **Tavai v. Silao** — "the protection of the Samoan way of life is the court's primary responsibility." *Tavai v. Silao, 2 A.S.R.2d 1 (Land & Titles Div. 1981).* <https://asbar.org/case-law/2asr2d1/>
+
+[^asca-1-0202]: **A.S.C.A. § 1.0202 — Preservation of Samoan customs** — "The customs of the Samoan people not in conflict with the laws of American Samoa or the laws of the United States concerning American Samoa shall be preserved." *A.S.C.A. § 1.0202.* <https://asbar.org/code-annotated/1-0202-preservation-of-samoan-customs/>
+
+[^asca-1-0201-current]: **A.S.C.A. § 1.0201 — Laws applicable in American Samoa** — "so much of the common law of England as is suitable to conditions in American Samoa and not inconsistent with this section." *A.S.C.A. § 1.0201.* <https://asbar.org/code-annotated/1-0201-laws-applicable-in-american-samoa/>

--- a/skills/non-compete-contract-explainer/content/arizona.md
+++ b/skills/non-compete-contract-explainer/content/arizona.md
@@ -1,0 +1,293 @@
+---
+jurisdiction: "Arizona"
+slug: arizona
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-03"
+canonicalUrl: https://openagreements.org/legal/non-compete/arizona
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/arizona · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in Arizona[^about]
+
+A question-by-question summary of Arizona non-compete law, including the common-law reasonableness test, the strict no-rewrite (blue-pencil) rule, physician covenants under Valley Medical Specialists v. Farber, the broadcast-employee ban in A.R.S. § 23-494, continued-employment consideration, confidentiality covenants treated as de facto non-competes, the Arizona Uniform Trade Secrets Act, sale-of-business covenants, tolling, attorney fees, and the failed HB 2361 statewide-ban bill.
+
+
+## At a glance
+
+| Question | Arizona |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed if reasonable |
+| **Bottom line** | Arizona has no general non-compete statute; an employee covenant is enforceable under common law only if reasonable and no broader than necessary to protect a legitimate business interest. |
+| **Main law or case** | common law (Valley Medical Specialists v. Farber, 982 P.2d 1277 (Ariz. 1999)) |
+| **Main exceptions** | Broadcast-employee ban (A.R.S. § 23-494); physicians enforceable only under heightened scrutiny |
+| **Can a court narrow it?** | Only strikes wording |
+| **Applies to contractors?** | Unclear |
+| **Restriction extended during a breach?** | Not addressed |
+| **Maximum length set by law** | No statutory limit |
+
+## Are employee non-compete agreements enforceable in Arizona? {#enforceability}
+
+**Short answer.** Sometimes. Arizona has no general statute banning or governing employee non-competes, so the question is decided under common law: a covenant not to compete is enforceable only if it is reasonable. Arizona courts treat these restraints as disfavored[^q1-amex-disfavored] and will refuse to enforce one that sweeps further than the employer's legitimate interest requires [^q1-farber-reasonableness].
+
+Unlike California, North Dakota, or Oklahoma, Arizona does not void employee non-competes by statute. The governing framework comes from the Arizona Supreme Court's decision in *Valley Medical Specialists v. Farber* and a line of Court of Appeals cases applying a fact-intensive reasonableness analysis.
+
+"A restriction is unreasonable and thus will not be enforced: (1) if the restraint is greater than necessary to protect the employer's legitimate interest; or (2) if that interest is outweighed by the hardship to the employee and the likely injury to the public."[^q1-farber-reasonableness]
+
+Because the analysis turns on the facts of each restraint, an employer cannot assume a covenant is enforceable just because the employee signed it. The sections below walk through the reasonableness test, the unusually strict rule against judicial rewriting, and the profession- and context-specific rules.
+
+## What makes a non-compete reasonable under Arizona law? {#reasonableness-test}
+
+**Short answer.** A restraint that is no broader than necessary to protect a legitimate business interest. The employer must identify a protectable interest — such as trade secrets, confidential information, or customer goodwill — and the restriction's duration, geography, and scope of prohibited activity must be tailored to that interest. The employee's hardship is one of the factors weighed in the analysis [^q2-amex-reasonable][^q2-amex-hardship].
+
+The threshold question is always whether the employer has an interest worth protecting. Without one, the covenant fails no matter how narrowly it is drawn.
+
+"A restrictive covenant - whether a covenant not to compete or an anti-piracy agreement - is enforceable as long as it is no broader than necessary to protect the employer's legitimate business interest."[^q2-hilb-protectable]
+
+In *Hilb, Rogal & Hamilton Co. of Arizona v. McKinney*, the Court of Appeals refused to enforce an anti-piracy covenant because the employer had no protectable interest in the particular account at issue.
+
+"We hold that HRH had no protectable interest in the Bell Ford account."[^q2-hilb-holding]
+
+Even where an interest exists, reasonableness is measured against the burden on the employee.
+
+"Hardship to the employee, however, is one of the factors to be considered in determining reasonableness."[^q2-amex-hardship]
+
+## Will an Arizona court narrow or rewrite an overbroad non-compete? {#court-narrowing}
+
+**Short answer.** No — not by rewriting it. Arizona follows a strict blue-pencil rule: a court may eliminate a grammatically severable unreasonable term, but it may not add language or rewrite the covenant to make it reasonable. If the unreasonable portion is not severable, the whole restraint falls [^q3-varsity-bluepencil][^q3-bryceland-severable].
+
+This is the single most important drafting fact about Arizona non-competes. In *Varsity Gold, Inc. v. Porzio*, the Court of Appeals reversed a trial court that had narrowed an overbroad covenant to save it.
+
+"The court explained that, while Arizona courts may ‘blue pencil’ a restrictive covenant by eliminating grammatically sever-able, unreasonable terms, the court cannot add provisions or rewrite them."[^q3-varsity-bluepencil]
+
+"In summary, we decide that the trial court erred by rewriting the restrictive covenant to render it reasonable and enforceable."[^q3-varsity-norewrite]
+
+Where the unreasonable language cannot be cleanly struck, the covenant is unenforceable as a whole. In *Bryceland v. Northey*, the court found the restraint unreasonably broad and not severable.
+
+"Neither the contract itself nor other evidence in the record indicates that this unreasonable portion of the contract was severable."[^q3-bryceland-severable]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Because an Arizona court will strike — not narrow — an overbroad covenant, draft duration, geography, and prohibited activity to the minimum the legitimate business interest actually requires, and use distinct, grammatically severable clauses so a single defect does not void the entire restraint. An overbroad covenant is more likely to fall entirely than to be trimmed by the court [^q3-varsity-bluepencil][^q3-bryceland-severable].
+
+## What non-compete rules apply to physicians in Arizona? {#physician-rules}
+
+**Short answer.** Physician non-competes are not categorically void, but they face heightened scrutiny. In *Farber*, the Arizona Supreme Court held that physician covenants must be strictly construed for reasonableness because of the public interest in patients' ability to choose their doctor, and it refused to enforce the covenant before it on public-policy grounds [^q4-farber-strict][^q4-farber-publicpolicy].
+
+A reasonable physician covenant can still be enforced. The Court of Appeals in *Phoenix Orthopaedic Surgeons, Ltd. v. Peairs* rejected the argument that all physician non-competes are void as against public policy.
+
+"We reject, however, Dr. Peairs' suggestion that all such covenants not to compete are unenforceable as against public policy."[^q4-phoenix-notvoid]
+
+But *Farber* makes clear that the public's interest weighs heavily, and that close calls go against enforcement.
+
+"In light of the great public policy interest involved in covenants not to compete between physicians, each agreement will be strictly construed for reasonableness."[^q4-farber-strict]
+
+> [!NOTE]
+> **Practice note.**
+>
+> Treat a physician non-compete as enforceable only when it is narrowly tailored. Even a covenant that protects a real interest can fail if the restriction on the physician's practice harms patient access; in *Farber* the public-policy interest outweighed the employer's protectable interest [^q4-farber-publicpolicy][^q4-farber-strict].
+
+## Can Arizona broadcast employees be required to sign non-competes? {#broadcast-employees}
+
+**Short answer.** No. Arizona has one statutory non-compete ban, and it covers broadcast employees. Under A.R.S. § 23-494, it is unlawful for a television or radio station or network to require a current or prospective employee to agree to a noncompete clause as a condition of employment [^q5-ars-23-494-prohibition].
+
+This is a categorical prohibition, not a reasonableness test. The statute defines both who is covered and what counts as a prohibited clause.
+
+"As a condition of employment, it is unlawful for a broadcast employer to require a current or prospective employee to agree to a noncompete clause."[^q5-ars-23-494-prohibition]
+
+"‘Noncompete clause’ means a clause in an employment contract with a broadcast employer that prohibits an employee from working in a specific geographic area for a specific period of time after leaving employment with the broadcast employer."[^q5-ars-23-494-definition]
+
+## Is continued employment enough consideration for an Arizona non-compete? {#consideration}
+
+**Short answer.** Yes. Arizona follows the majority rule that continued at-will employment is sufficient consideration to support a covenant, even one signed after employment has already begun. An employer does not have to give a raise, bonus, or promotion to satisfy consideration for a mid-employment covenant — though the covenant still must clear Arizona's reasonableness and no-rewrite rules to be enforceable [^q6-mattison-consideration].
+
+The leading statement is in *Mattison v. Johnston*, where the Court of Appeals upheld a covenant signed during an at-will relationship.
+
+"Although there is authority to the contrary, most jurisdictions which have considered the issue have found that continued employment is sufficient consideration to support a restrictive covenant executed after employment has commenced even where employment continues to be on an at-will basis."[^q6-mattison-consideration]
+
+A federal court applying Arizona law reached the same result in *Compass Bank v. Hartley*.
+
+"In addition, the promise of continued employment validates a covenant executed after the employment relationship has commenced, even where it continues to be on an at-will basis."[^q6-compass-continued]
+
+## Are confidentiality and non-solicitation covenants treated as non-competes in Arizona? {#nonsolicitation-confidentiality}
+
+**Short answer.** They can be. Arizona looks at the functional effect of a restraint, not its label. A confidentiality or non-solicitation covenant that is broad enough to operate as a practical bar on competition is analyzed as a non-compete and judged for reasonableness. In *Orca Communications Unlimited, LLC v. Noder*, the Court of Appeals held that an unlimited confidentiality covenant was unenforceable as the equivalent of a geographically unrestricted non-compete [^q7-orca-defacto].
+
+The risk is greatest where a confidentiality clause has no time or geographic limit and reaches information that is not a trade secret.
+
+"Thus, the trial court did not err in finding that the confidentiality covenant is unenforceable as the equivalent of a geographically unrestricted non-competition agreement."[^q7-orca-defacto]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Scope confidentiality and non-solicitation covenants to actual trade secrets and confidential information, with reasonable limits, rather than broadly restricting a former employee's use of general skills or knowledge. An open-ended confidentiality clause can be struck as a disguised non-compete and is subject to the same strict no-rewrite rule [^q7-orca-defacto][^q7-hilb-antipiracy].
+
+## How does the Arizona Uniform Trade Secrets Act interact with non-competes? {#trade-secrets}
+
+**Short answer.** The Arizona Uniform Trade Secrets Act (AUTSA), A.R.S. §§ 44-401 to 44-407, protects trade secrets independently of any covenant, so an employer often has a remedy even without an enforceable non-compete. AUTSA displaces conflicting common-law claims for trade-secret misappropriation, but it expressly preserves contractual remedies and other civil remedies not based on misappropriation [^q8-ars-44-407-displacement][^q8-ars-44-407-contract].
+
+AUTSA defines a trade secret by the familiar two-part test of independent economic value plus reasonable secrecy efforts.
+
+"‘Trade secret’ means information, including a formula, pattern, compilation, program, device, method, technique or process, that both: (a) Derives independent economic value, actual or potential, from not being generally known to, and not being readily ascertainable by proper means by, other persons who can obtain economic value from its disclosure or use. (b) Is the subject of efforts that are reasonable under the circumstances to maintain its secrecy."[^q8-ars-44-401-definition]
+
+Crucially, the Arizona Supreme Court held in the *Orca* appeal that AUTSA does not wipe out common-law claims based on confidential information that does not rise to the level of a trade secret.
+
+"We hold that AUTSA does not displace common-law claims based on alleged misappropriation of confidential information that is not a trade secret."[^q8-orca2014-nondisplacement]
+
+A misappropriation claim has a three-year limitations period.
+
+"An action for misappropriation must be brought within three years after the misappropriation is discovered or by the exercise of reasonable diligence should have been discovered."[^q8-ars-44-406-sol]
+
+## Are sale-of-business non-competes treated differently in Arizona? {#sale-of-business}
+
+**Short answer.** Yes, somewhat more leniently. A covenant given as part of the sale of a business protects the goodwill the buyer paid for, so Arizona courts will ordinarily uphold one that is limited in time and geographic scope. The covenant still must be reasonable and cannot bar the seller from all business whatsoever [^q9-gann-validity][^q9-gann-goodwill].
+
+In *Gann v. Morris*, the Court of Appeals explained why sale-of-business covenants get more latitude than employment covenants.
+
+"Where limited as to time and space, the covenant is ordinarily valid unless it is to refrain from all business whatsoever."[^q9-gann-validity]
+
+"The sale of such a business necessarily includes the sale of good will and the purchaser has the right to assure himself as best he can of the transfer of the good will."[^q9-gann-goodwill]
+
+More latitude is not a free pass. In *Berkadia Real Estate Advisors LLC v. Wadlund* (D. Ariz. 2024), a federal court applying Arizona law refused to enforce a sale-of-business covenant whose activity, geographic, and duration limits swept further than the goodwill the buyer had acquired.
+
+"The Court finds that the scope of activity, the geographic scope, and the duration of the TCRA restrictive covenants, singularly and in combination, are unreasonable."[^q9-berkadia-unreasonable]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Tie a sale-of-business covenant's geography, duration, and scope of restricted activity to the goodwill actually being transferred. In *Berkadia* a nationwide covenant binding a seller who had only ever worked in Tucson was struck as unreasonable, and Arizona's no-rewrite rule meant the court would not pare it back [^q9-berkadia-unreasonable][^q9-gann-validity].
+
+## Does an Arizona non-compete period extend while the employee is in breach or litigation is pending? {#tolling}
+
+**Short answer.** Arizona law does not squarely answer this. No Arizona appellate decision appears to have decided whether a non-compete period tolls — pauses and extends — while the former employee is violating the covenant or while enforcement litigation is pending. Because Arizona judges covenants for reasonableness and will not rewrite an overbroad term, a contractual extension-on-breach clause is best analyzed as part of the covenant's overall duration and drafted conservatively [^q10-farber-reasonableness][^q10-varsity-norewrite].
+
+The uncertainty is structural. Arizona has no statute on point and no controlling case directly addressing judicial or contractual tolling of restrictive covenants. Two general rules shape the risk. First, the covenant's total effective duration — including any extension — is measured for reasonableness [^q10-farber-reasonableness]. Second, because an Arizona court will strike rather than narrow an unreasonable term, an aggressive extension clause that makes the effective period unreasonable risks taking the covenant down with it rather than being trimmed [^q10-varsity-norewrite].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> If you include a clause extending the restricted period for the time the employee is in breach, draft the base period and the extension so that the combined duration is still reasonable on its own terms. Under Arizona's strict no-rewrite rule, a court that finds the extended period unreasonable is more likely to void the covenant than to shorten it [^q10-varsity-norewrite][^q10-farber-reasonableness].
+
+## Can a non-signatory enforce a forum-selection clause in an Arizona contract dispute? {#non-signatory-forum-clause}
+
+**Short answer.** Generally no, based only on a close relationship to a party. In 2025 the Arizona Supreme Court declined to adopt the closely-related-party doctrine for forum-selection clauses, holding that the provisions of the contract control. A person or company that did not sign the contract — an affiliate, a founder, or a related entity — cannot enforce its forum-selection clause against a signatory merely because it is closely related to a party [^q11-henderson-forum].
+
+This matters for covenant disputes, where a party often tries to invoke a contract's forum-selection clause for the benefit of someone who never signed the agreement.
+
+"We decline to adopt that doctrine with regard to forum selection clauses, holding that the provisions of the contract control and that other established doctrines providing non-signatories with benefits under a contract are ample."[^q11-henderson-forum]
+
+## Can an employer use another state's law to make an Arizona non-compete easier to enforce? {#out-of-state-law}
+
+**Short answer.** Often not, when Arizona has the strongest connection to the employment. A federal court in Arizona declined to apply a Washington choice-of-law clause that would have imported Washington's more employer-friendly approach to non-competes, reasoning that doing so would be contrary to a fundamental policy of Arizona law [^qcol-pathway-policy][^qcol-pathway-187].
+
+In *Pathway Medical Technologies, Inc. v. Nelson*, the employer's agreement selected Washington law, which is friendlier to non-competes — including allowing courts to rewrite an overbroad covenant. Applying the Restatement (Second) of Conflict of Laws § 187, the court treated that as an attempt to escape Arizona's policy.
+
+"Arizona law does not approve of broad non-compete provisions."[^qcol-pathway-policy]
+
+"the Agreement's choice of Washington law likely is not enforceable under Restatement section 187(2)(b)."[^qcol-pathway-187]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not rely on a sister-state choice-of-law clause to obtain a more lenient non-compete rule or judicial reformation for an Arizona-centered employment relationship. Where Arizona has the most significant relationship, a court may apply Arizona law — including its strict no-rewrite rule — regardless of the contract's chosen law [^qcol-pathway-187][^qcol-pathway-policy].
+
+## Who pays attorney fees in an Arizona non-compete lawsuit? {#attorney-fees}
+
+**Short answer.** Either side can be ordered to. A non-compete dispute arises out of a contract, so A.R.S. § 12-341.01 lets the court award reasonable attorney fees to the successful party. The award is discretionary, but the fee-shifting risk runs both ways: an employer that loses an overreaching enforcement action can be ordered to pay the former employee's fees [^q12-ars-12-341-fees].
+
+"In any contested action arising out of a contract, express or implied, the court may award the successful party reasonable attorney fees."[^q12-ars-12-341-fees]
+
+## What are the recent developments in Arizona non-compete law? {#recent-developments}
+
+**Short answer.** Arizona remains a common-law reasonableness state, and recent efforts to change that by statute have not been enacted. In 2026, HB 2361 proposed adding a new statute, A.R.S. § 23-207, to bar any public or private employer from requiring a noncompete clause; a near-identical 2025 bill, HB 2589, proposed the same ban. Neither has become law, so Arizona still has no general non-compete statute outside the broadcast-employee context [^q13-hb2361][^q13-hb2589].
+
+Both bills used the same operative language, which would have replaced Arizona's case-by-case reasonableness analysis with a flat prohibition for most employees.
+
+"As a condition of employment, it is unlawful for a public or private employer to require a current or prospective employee to agree to a noncompete clause."[^q13-hb2361]
+
+Key developments:
+
+- 
+- 
+
+Because neither ban has become law, an Arizona non-compete is still governed by the reasonableness and strict no-rewrite rules described above, not by any statutory ban outside the broadcast-employee context.
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-03. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not Arizona. This article synthesizes Arizona primary law and is not legal advice from a Arizona-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^q1-amex-disfavored]: **Amex Distributing Co. v. Mascari** — "Restrictive covenants which tend to prevent an employee from pursuing a similar vocation after termination of employment are disfavored." *Amex Distributing Co. v. Mascari, 150 Ariz. 510, 724 P.2d 596 (Ct. App. 1986).* <https://www.courtlistener.com/opinion/1211495/amex-distributing-co-inc-v-mascari/#:~:text=Restrictive%20covenants%20which%20tend%20to,termination%20of%20employment%20are%20disfavored.>
+
+[^q1-farber-reasonableness]: **Valley Medical Specialists v. Farber** — "A restriction is unreasonable and thus will not be enforced: (1) if the restraint is greater than necessary to protect the employer's legitimate interest; or (2) if that interest is outweighed by the hardship to the employee and the likely injury to the public." *Valley Medical Specialists v. Farber, 194 Ariz. 363, 982 P.2d 1277 (1999).* <https://www.courtlistener.com/opinion/1253291/valley-medical-specialists-v-farber/#:~:text=A%20restriction%20is%20unreasonable%20and,likely%20injury%20to%20the%20public.>
+
+[^q2-amex-reasonable]: **Amex Distributing Co. v. Mascari** — "Reasonable restraints-those no broader than the employer's legitimately protectable interests-will be enforced in Arizona." *Amex Distributing Co. v. Mascari, 150 Ariz. 510, 724 P.2d 596 (Ct. App. 1986).* <https://www.courtlistener.com/opinion/1211495/amex-distributing-co-inc-v-mascari/#:~:text=Reasonable%20restraints%2Dthose%20no%20broader%20than,interests%2Dwill%20be%20enforced%20in%20Arizona.>
+
+[^q2-amex-hardship]: **Amex Distributing Co. v. Mascari** — "Hardship to the employee, however, is one of the factors to be considered in determining reasonableness." *Amex Distributing Co. v. Mascari, 150 Ariz. 510, 724 P.2d 596 (Ct. App. 1986).* <https://www.courtlistener.com/opinion/1211495/amex-distributing-co-inc-v-mascari/#:~:text=Hardship%20to%20the%20employee%2C%20however%2C,be%20considered%20in%20determining%20reasonableness.>
+
+[^q2-hilb-protectable]: **Hilb, Rogal & Hamilton Co. of Arizona v. McKinney** — "A restrictive covenant - whether a covenant not to compete or an anti-piracy agreement - is enforceable as long as it is no broader than necessary to protect the employer's legitimate business interest." *Hilb, Rogal & Hamilton Co. of Arizona v. McKinney, 190 Ariz. 213, 946 P.2d 464 (Ct. App. 1997).* <https://www.courtlistener.com/opinion/1124526/hilb-rogal-hamilton-co-of-arizona-inc-v-mckinney/#:~:text=A%20restrictive%20covenant%20%2D%20whether,the%20employer's%20legitimate%20business%20interest.>
+
+[^q2-hilb-holding]: **Hilb, Rogal & Hamilton Co. of Arizona v. McKinney** — "We hold that HRH had no protectable interest in the Bell Ford account." *Hilb, Rogal & Hamilton Co. of Arizona v. McKinney, 190 Ariz. 213, 946 P.2d 464 (Ct. App. 1997).* <https://www.courtlistener.com/opinion/1124526/hilb-rogal-hamilton-co-of-arizona-inc-v-mckinney/#:~:text=We%20hold%20that%20HRH%20had,in%20the%20Bell%20Ford%20account.>
+
+[^q3-varsity-bluepencil]: **Varsity Gold, Inc. v. Porzio** — "The court explained that, while Arizona courts may ‘blue pencil’ a restrictive covenant by eliminating grammatically sever-able, unreasonable terms, the court cannot add provisions or rewrite them." *Varsity Gold, Inc. v. Porzio, 202 Ariz. 355, 45 P.3d 352 (Ct. App. 2002).* <https://www.courtlistener.com/opinion/2638678/varsity-gold-inc-v-porzio/#:~:text=The%20court%20explained%20that%2C%20while,add%20provisions%20or%20rewrite%20them.>
+
+[^q3-bryceland-severable]: **Bryceland v. Northey** — "Neither the contract itself nor other evidence in the record indicates that this unreasonable portion of the contract was severable." *Bryceland v. Northey, 160 Ariz. 213, 772 P.2d 36 (Ct. App. 1989).* <https://www.courtlistener.com/opinion/1414072/bryceland-v-northey/#:~:text=Neither%20the%20contract%20itself%20nor,of%20the%20contract%20was%20severable.>
+
+[^q3-varsity-norewrite]: **Varsity Gold, Inc. v. Porzio** — "In summary, we decide that the trial court erred by rewriting the restrictive covenant to render it reasonable and enforceable." *Varsity Gold, Inc. v. Porzio, 202 Ariz. 355, 45 P.3d 352 (Ct. App. 2002).* <https://www.courtlistener.com/opinion/2638678/varsity-gold-inc-v-porzio/#:~:text=In%20summary%2C%20we%20decide%20that,render%20it%20reasonable%20and%20enforceable.>
+
+[^q4-farber-strict]: **Valley Medical Specialists v. Farber** — "In light of the great public policy interest involved in covenants not to compete between physicians, each agreement will be strictly construed for reasonableness." *Valley Medical Specialists v. Farber, 194 Ariz. 363, 982 P.2d 1277 (1999).* <https://www.courtlistener.com/opinion/1253291/valley-medical-specialists-v-farber/#:~:text=In%20light%20of%20the%20great,be%20strictly%20construed%20for%20reasonableness.>
+
+[^q4-farber-publicpolicy]: **Valley Medical Specialists v. Farber** — "Public policy concerns in this case outweigh Valley Medical's protectable interests in enforcing the agreement." *Valley Medical Specialists v. Farber, 194 Ariz. 363, 982 P.2d 1277 (1999).* <https://www.courtlistener.com/opinion/1253291/valley-medical-specialists-v-farber/#:~:text=Public%20policy%20concerns%20in%20this,interests%20in%20enforcing%20the%20agreement.>
+
+[^q4-phoenix-notvoid]: **Phoenix Orthopaedic Surgeons, Ltd. v. Peairs** — "We reject, however, Dr. Peairs' suggestion that all such covenants not to compete are unenforceable as against public policy." *Phoenix Orthopaedic Surgeons, Ltd. v. Peairs, 164 Ariz. 54, 790 P.2d 752 (Ct. App. 1989).* <https://www.courtlistener.com/opinion/1425574/phoenix-orthopaedic-surgeons-ltd-v-peairs/#:~:text=We%20reject%2C%20however%2C%20Dr.%20Peairs',unenforceable%20as%20against%20public%20policy.>
+
+[^q5-ars-23-494-prohibition]: **A.R.S. § 23-494** — "As a condition of employment, it is unlawful for a broadcast employer to require a current or prospective employee to agree to a noncompete clause." *A.R.S. § 23-494(A).* <https://www.azleg.gov/ars/23/00494.htm>
+
+[^q5-ars-23-494-definition]: **A.R.S. § 23-494** — "‘Noncompete clause’ means a clause in an employment contract with a broadcast employer that prohibits an employee from working in a specific geographic area for a specific period of time after leaving employment with the broadcast employer." *A.R.S. § 23-494(B)(2).* <https://www.azleg.gov/ars/23/00494.htm>
+
+[^q6-mattison-consideration]: **Mattison v. Johnston** — "Although there is authority to the contrary, most jurisdictions which have considered the issue have found that continued employment is sufficient consideration to support a restrictive covenant executed after employment has commenced even where employment continues to be on an at-will basis." *Mattison v. Johnston, 152 Ariz. 109, 730 P.2d 286 (Ct. App. 1986).* <https://www.courtlistener.com/opinion/1118936/mattison-v-johnston/#:~:text=Although%20there%20is%20authority%20to,be%20on%20an%20at%2Dwill%20basis.>
+
+[^q6-compass-continued]: **Compass Bank v. Hartley** — "In addition, the promise of continued employment validates a covenant executed after the employment relationship has commenced, even where it continues to be on an at-will basis." *Compass Bank v. Hartley, 430 F. Supp. 2d 989 (D. Ariz. 2006).* <https://www.courtlistener.com/opinion/2317852/compass-bank-v-hartley/#:~:text=In%20addition%2C%20the%20promise%20of,be%20on%20an%20at%2Dwill%20basis.>
+
+[^q7-orca-defacto]: **Orca Communications Unlimited, LLC v. Noder** — "Thus, the trial court did not err in finding that the confidentiality covenant is unenforceable as the equivalent of a geographically unrestricted non-competition agreement." *Orca Communications Unlimited, LLC v. Noder, 233 Ariz. 411 (Ct. App. 2013).* <https://www.courtlistener.com/opinion/6604207/orca-communications-unlimited-llc-v-noder/#:~:text=Thus%2C%20the%20trial%20court%20did,a%20geographically%20unrestricted%20non%2Dcompetition%20agreement.>
+
+[^q7-hilb-antipiracy]: **Hilb, Rogal & Hamilton Co. of Arizona v. McKinney** — "A restrictive covenant - whether a covenant not to compete or an anti-piracy agreement - is enforceable as long as it is no broader than necessary to protect the employer's legitimate business interest." *Hilb, Rogal & Hamilton Co. of Arizona v. McKinney, 190 Ariz. 213, 946 P.2d 464 (Ct. App. 1997).* <https://www.courtlistener.com/opinion/1124526/hilb-rogal-hamilton-co-of-arizona-inc-v-mckinney/#:~:text=A%20restrictive%20covenant%20%2D%20whether,the%20employer's%20legitimate%20business%20interest.>
+
+[^q8-ars-44-407-displacement]: **A.R.S. § 44-407** — "Except as provided in subsection B, this chapter displaces conflicting tort, restitutionary and other laws of this state providing civil remedies for misappropriation of a trade secret." *A.R.S. § 44-407(A).* <https://www.azleg.gov/ars/44/00407.htm>
+
+[^q8-ars-44-407-contract]: **A.R.S. § 44-407** — "Contractual remedies, whether or not based on misappropriation of a trade secret." *A.R.S. § 44-407(B)(1).* <https://www.azleg.gov/ars/44/00407.htm>
+
+[^q8-ars-44-401-definition]: **A.R.S. § 44-401** — "‘Trade secret’ means information, including a formula, pattern, compilation, program, device, method, technique or process, that both: (a) Derives independent economic value, actual or potential, from not being generally known to, and not being readily ascertainable by proper means by, other persons who can obtain economic value from its disclosure or use. (b) Is the subject of efforts that are reasonable under the circumstances to maintain its secrecy." *A.R.S. § 44-401(4).* <https://www.azleg.gov/ars/44/00401.htm>
+
+[^q8-orca2014-nondisplacement]: **Orca Communications Unlimited, LLC v. Noder** — "We hold that AUTSA does not displace common-law claims based on alleged misappropriation of confidential information that is not a trade secret." *Orca Communications Unlimited, LLC v. Noder, 236 Ariz. 180, 337 P.3d 545 (2014).* <https://www.courtlistener.com/opinion/2752976/orca-communications-v-ann-noder-et-virpitch-public/#:~:text=We%20hold%20that%20AUTSA%20does,is%20not%20a%20trade%20secret.>
+
+[^q8-ars-44-406-sol]: **A.R.S. § 44-406** — "An action for misappropriation must be brought within three years after the misappropriation is discovered or by the exercise of reasonable diligence should have been discovered." *A.R.S. § 44-406.* <https://www.azleg.gov/ars/44/00406.htm>
+
+[^q9-gann-validity]: **Gann v. Morris** — "Where limited as to time and space, the covenant is ordinarily valid unless it is to refrain from all business whatsoever." *Gann v. Morris, 122 Ariz. 517, 596 P.2d 43 (Ct. App. 1979).* <https://www.courtlistener.com/opinion/1362794/gann-v-morris/#:~:text=Where%20limited%20as%20to%20time,refrain%20from%20all%20business%20whatsoever.>
+
+[^q9-gann-goodwill]: **Gann v. Morris** — "The sale of such a business necessarily includes the sale of good will and the purchaser has the right to assure himself as best he can of the transfer of the good will." *Gann v. Morris, 122 Ariz. 517, 596 P.2d 43 (Ct. App. 1979).* <https://www.courtlistener.com/opinion/1362794/gann-v-morris/#:~:text=The%20sale%20of%20such%20a,transfer%20of%20the%20good%20will.>
+
+[^q9-berkadia-unreasonable]: **Berkadia Real Estate Advisors LLC v. Wadlund** — "The Court finds that the scope of activity, the geographic scope, and the duration of the TCRA restrictive covenants, singularly and in combination, are unreasonable." *Berkadia Real Estate Advisors LLC v. Wadlund, No. CV-22-00049-TUC-CKJ, 2024 WL 4125533 (D. Ariz. June 27, 2024).* <https://www.govinfo.gov/app/details/USCOURTS-azd-4_22-cv-00049/USCOURTS-azd-4_22-cv-00049-10>
+
+[^q10-farber-reasonableness]: **Valley Medical Specialists v. Farber** — "A restriction is unreasonable and thus will not be enforced: (1) if the restraint is greater than necessary to protect the employer's legitimate interest; or (2) if that interest is outweighed by the hardship to the employee and the likely injury to the public." *Valley Medical Specialists v. Farber, 194 Ariz. 363, 982 P.2d 1277 (1999).* <https://www.courtlistener.com/opinion/1253291/valley-medical-specialists-v-farber/#:~:text=A%20restriction%20is%20unreasonable%20and,likely%20injury%20to%20the%20public.>
+
+[^q10-varsity-norewrite]: **Varsity Gold, Inc. v. Porzio** — "The court explained that, while Arizona courts may ‘blue pencil’ a restrictive covenant by eliminating grammatically sever-able, unreasonable terms, the court cannot add provisions or rewrite them." *Varsity Gold, Inc. v. Porzio, 202 Ariz. 355, 45 P.3d 352 (Ct. App. 2002).* <https://www.courtlistener.com/opinion/2638678/varsity-gold-inc-v-porzio/#:~:text=The%20court%20explained%20that%2C%20while,add%20provisions%20or%20rewrite%20them.>
+
+[^q11-henderson-forum]: **Henderson v. Moskowitz** — "We decline to adopt that doctrine with regard to forum selection clauses, holding that the provisions of the contract control and that other established doctrines providing non-signatories with benefits under a contract are ample." *Henderson v. Moskowitz (Ariz. Nov. 28, 2025).* <https://www.courtlistener.com/opinion/10743771/henderson-v-hon-moskowitzsullivan/#:~:text=We%20decline%20to%20adopt%20that,under%20a%20contract%20are%20ample.>
+
+[^qcol-pathway-policy]: **Pathway Medical Technologies, Inc. v. Nelson** — "Arizona law does not approve of broad non-compete provisions." *Pathway Medical Technologies, Inc. v. Nelson, No. CV11-0857-PHX-DGC, 2011 WL 4543928 (D. Ariz. Sept. 30, 2011).* <https://scholar.google.com/scholar_case?case=17995886739076358627>
+
+[^qcol-pathway-187]: **Pathway Medical Technologies, Inc. v. Nelson** — "the Agreement's choice of Washington law likely is not enforceable under Restatement section 187(2)(b)." *Pathway Medical Technologies, Inc. v. Nelson, No. CV11-0857-PHX-DGC, 2011 WL 4543928 (D. Ariz. Sept. 30, 2011).* <https://scholar.google.com/scholar_case?case=17995886739076358627>
+
+[^q12-ars-12-341-fees]: **A.R.S. § 12-341.01** — "In any contested action arising out of a contract, express or implied, the court may award the successful party reasonable attorney fees." *A.R.S. § 12-341.01(A).* <https://www.azleg.gov/ars/12/00341-01.htm>
+
+[^q13-hb2361]: **Arizona HB 2361 (2026)** — "As a condition of employment, it is unlawful for a public or private employer to require a current or prospective employee to agree to a noncompete clause." *Ariz. H.B. 2361, 57th Leg., 2d Reg. Sess. (2026).* <https://www.azleg.gov/legtext/57leg/2R/bills/HB2361P.htm>
+
+[^q13-hb2589]: **Arizona HB 2589 (2025)** — "As a condition of employment, it is unlawful for a public or private employer to require a current or prospective employee to agree to a noncompete clause." *Ariz. H.B. 2589, 57th Leg., 1st Reg. Sess. (2025).* <https://www.azleg.gov/legtext/57leg/1R/bills/HB2589P.htm>

--- a/skills/non-compete-contract-explainer/content/arkansas.md
+++ b/skills/non-compete-contract-explainer/content/arkansas.md
@@ -1,0 +1,235 @@
+---
+jurisdiction: "Arkansas"
+slug: arkansas
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-02"
+canonicalUrl: https://openagreements.org/legal/non-compete/arkansas
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/arkansas · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in Arkansas[^about]
+
+Arkansas non-compete law under Ark. Code Ann. § 4-75-101, enacted by Act 921 of 2015, includes mandatory reformation, continued-employment consideration, a two-year presumption, a physician ban, and judicial tolling risk.
+
+
+## At a glance
+
+| Question | Arkansas |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed if reasonable |
+| **Bottom line** | Arkansas enforces an employee non-compete that is ancillary, protects a statutory business interest, and is no broader in time and scope than necessary, with overbroad covenants reformed by the court. |
+| **Main law or case** | Ark. Code Ann. § 4-75-101 (Act 921 of 2015; amended by Act 232 of 2025) |
+| **Main exceptions** | Physician practice restrictions void (§ 4-75-101(k), 2025); Title 17 Subtitle 3 licensees excluded; non-solicits/NDAs excluded |
+| **Can a court narrow it?** | Yes — rewrites to reasonable |
+| **Applies to contractors?** | Unclear |
+| **Restriction extended during a breach?** | Open question — prospective injunctions allowed, contractual tolling unsettled |
+| **Maximum length set by law** | 2 years presumptively reasonable |
+
+## Are employee non-compete agreements enforceable in Arkansas? {#employee-noncompetes}
+
+**Short answer.** Yes, if the covenant is ancillary to employment, protects a statutory business interest, and is no broader in time and scope than necessary to defend that interest [^q1-aca-enforceable].
+
+For agreements governed by the current statute, Arkansas is a permissible, enforce-if-reasonable state rather than a ban state. Ark. Code Ann. § 4-75-101 lists protectable interests, supplies a two-year duration presumption, allows no defined geographic restriction in some cases, and requires reformation of overbroad covenants [^q1-aca-enforceable][^q1-aca-protectable][^q1-aca-reformation].
+
+The effective-date line matters. *Box* treated Act 921 as effective July 22, 2015, and said the statute only arguably applied to the agreement executed after that date, while older agreements remained on the pre-Act common-law track [^q1-box-effective-date].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not cite pre-2015 Arkansas cases as if they still supply the whole remedial rule. They remain useful for the old common-law framework and reasonableness concepts, but current covered employment covenants start with § 4-75-101 [^q1-box-effective-date][^q1-aca-reformation].
+
+## What makes an Arkansas non-compete reasonable or enforceable? {#reasonableness-test}
+
+**Short answer.** The covenant must be tied to a protectable business interest and limited in time and scope no more than necessary to defend that interest [^q2-aca-enforceable].
+
+The statute supplies the protectable-interest categories. They include trade secrets, intellectual property, customer lists, customer goodwill, business practices, methods, margins, costs, confidential business information, employee training and education, and other valuable employer data reasonably safeguarded from competitors [^q2-aca-protectable].
+
+Reasonableness is still contextual. The statute tells courts to consider the nature of the employer's protectable interest, the geographic scope of the business, whether a geographic limit is feasible, whether the restriction is limited to a specific customer or business group, and the nature of the employer's business [^q2-aca-factors].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Ordinary competition is not enough. Even before Act 921, Arkansas cases required a real protectable interest rather than a covenant designed only to eliminate competition, and the current statute keeps that interest requirement at the center [^q2-mercy-no-ordinary-competition][^q2-aca-enforceable].
+
+## Does an Arkansas non-compete need a geographic limit? {#geographic-limit}
+
+**Short answer.** Not always. The current statute says the lack of a specific or defined geographic restriction does not make a covenant overbroad if the restraint is otherwise reasonable as to time and scope [^q3-aca-no-geography].
+
+"The lack of a specific or defined geographic descriptive restriction in a covenant not to compete agreement does not make the covenant not to compete agreement overly broad under subdivision (a)(2) of this section if the covenant not to compete agreement is limited with respect to time and scope in a manner that is not greater than necessary to defend the protectable business interest of the employer."[^q3-aca-no-geography]
+
+That is a major statutory shift from the old common-law risk. In *Bendinger*, the Arkansas Supreme Court rejected a covenant with no geographic limit because the facts did not justify it; in *NanoMech*, the Eighth Circuit applied pre-Act Arkansas law to invalidate a no-geography, any-capacity covenant [^q3-bendinger-geography][^q3-nanomech-geography].
+
+The current drafting point is practical rather than formalistic. If there is no geography, the covenant needs another limiting mechanism, such as customer scope, activity scope, or business-scope limits tied to the employer's protectable interest [^q3-aca-no-geography][^q3-aca-factors].
+
+## How long can an Arkansas non-compete last? {#duration}
+
+**Short answer.** Two years is presumptively reasonable under the statute, unless the particular facts clearly show that two years is unreasonable compared with the employer's protectable interest [^q4-aca-two-years].
+
+"A post-termination restriction of two (2) years is presumptively reasonable as to length of time under subdivision (a)(2) of this section unless the facts and circumstances of a particular case clearly demonstrate that two (2) years is unreasonable compared to the employer's protectable business interest."[^q4-aca-two-years]
+
+The presumption is not a safe harbor for every two-year clause. The statute ties duration back to the employer's protectable business interest, and *Bud Anderson* noted the older Arkansas damages treatise summary that one- and two-year limits had been upheld while three- and five-year limits had been unreasonable or invalid [^q4-aca-two-years][^q4-bud-duration].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Avoid treating two years as automatic. The presumption can be overcome by case-specific facts, especially if the protected interest is narrow or the work restriction is broad [^q4-aca-two-years].
+
+## Will an Arkansas court reform an overbroad non-compete? {#court-reformation}
+
+**Short answer.** Yes, for a covered employment non-compete under § 4-75-101. If the restrictions are unreasonable, the court must reform the covenant as needed and enforce it under the reformed terms [^q5-aca-reformation].
+
+"The court shall enforce the covenant not to compete agreement under the reformed terms and conditions."[^q5-aca-reformation-enforce]
+
+That mandatory reformation rule is the watershed change from pre-Act Arkansas law. Under the old regime, the contract had to be valid as written, and the court would not narrow it to a reasonable version [^q5-bendinger-no-rewrite][^q5-nanomech-no-narrow].
+
+The temporal framing is important. *Bendinger* and *NanoMech* remain useful for the old all-or-nothing rule, and *Box* confirms Act 921's effective-date line; they should not be cited as current authority against mandatory statutory reformation for a covered post-Act employment covenant [^q5-box-effective-date][^q5-aca-reformation].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Reformation does not remove the need to draft narrowly. The statute tells courts to reform only to the extent necessary to make the limitations reasonable and no greater than needed to protect the business interest [^q5-aca-reformation].
+
+## Is continued employment enough consideration for an Arkansas non-compete? {#consideration}
+
+**Short answer.** Yes. The statute says continued employment is sufficient consideration for a covenant not to compete [^q6-aca-consideration].
+
+"An employee's continued employment is sufficient consideration for a covenant not to compete agreement."[^q6-aca-consideration]
+
+That means Arkansas does not require a separate bonus, promotion, equity grant, or new job offer for consideration when the statutory rule applies. The covenant still must satisfy the other statutory requirements, including protectable interest and reasonable time and scope [^q6-aca-consideration][^q6-aca-enforceable].
+
+## Are physician and professional non-competes enforceable in Arkansas? {#physicians-professionals}
+
+**Short answer.** Physician practice restrictions are void under the current statute, and § 4-75-101 otherwise does not apply to covered Title 17 professional licensees except for that physician rule [^q7-aca-physician-void][^q7-aca-title-17].
+
+"A covenant not to compete agreement that restricts the right of a physician to practice within the physician's scope of practice is void."[^q7-aca-physician-void]
+
+The physician ban was added by the 2025 amendment. The statute defines physician by reference to the Arkansas Medical Practices Act and osteopathy licensing provisions [^q7-aca-physician-definition].
+
+Older physician cases should be framed as pre-2025 public-policy and common-law context, not as the current statutory text. In *Mercy v. Bicak*, the Court of Appeals emphasized public access to physicians and affirmed summary judgment against enforcement of the physician non-compete [^q7-mercy-public-policy][^q7-mercy-affirm].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not generalize the physician void rule to every licensed professional. The statute voids covered physician practice restrictions, while separately saying § 4-75-101 does not apply to people holding a professional license under Arkansas Code Title 17, Subtitle 3, except as provided in subsection k [^q7-aca-physician-void][^q7-aca-title-17].
+
+## Does an Arkansas non-compete period toll or extend during breach or litigation? {#tolling-extension}
+
+**Short answer.** Sometimes by equitable injunction, but drafted contractual tolling clauses remain an open question. *Bud Anderson* treated a prospective injunction beyond the nominal one-year period as legally possible, while § 4-75-101 does not expressly validate tolling-on-breach clauses [^q8-bud-prospective][^q8-aca-remedies].
+
+The practical lesson is that Arkansas courts may keep a non-compete injunction dispute alive even after the stated period expires. *Bud Anderson* rejected a mootness dismissal where the employer sought an injunction running one year from the order and the record did not show that relief was impossible [^q8-bud-prospective].
+
+That is different from saying every contract clause that automatically extends the restricted period during breach is enforceable. The Arkansas statute speaks to damages, injunctive relief, irreparable harm, reformation, and enforcement under reformed terms, but it does not contain an express contractual tolling rule [^q8-aca-remedies][^q8-aca-reformation].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Draft tolling language as a risk allocation, not as settled Arkansas law. *Bud Anderson* supports judicially fashioned prospective relief in the injunction posture; it does not squarely decide whether a private extension-on-breach clause is independently enforceable under § 4-75-101 [^q8-bud-prospective][^q8-aca-remedies].
+
+## What remedies are available for breach of an Arkansas non-compete? {#injunction-remedies}
+
+**Short answer.** A court may award damages, appropriate injunctive relief, or both, and immediate harm from breach is statutorily treated as irreparable for preliminary-injunction purposes [^q9-aca-remedies][^q9-aca-irreparable].
+
+"The immediate harm associated with the breach of a covenant not to compete agreement shall be considered irreparable to establish the appropriateness of a preliminary injunction."[^q9-aca-irreparable]
+
+*Porter's* applied that current statutory rule. The Court of Appeals reversed because the circuit court used only the common-law definition of irreparable harm and failed to apply § 4-75-101 in a case involving non-compete agreements executed after 2015 [^q9-porters-after-2015][^q9-porters-statutory-harm].
+
+The statutory irreparable-harm rule does not eliminate every injunction defense. Subsection e says the remedies language does not limit defenses to preliminary injunctive relief or the employer's right to monetary damages [^q9-aca-savings].
+
+## How does Arkansas treat non-solicitation, confidentiality, and trade-secret agreements? {#related-covenants}
+
+**Short answer.** Section 4-75-101 does not apply to employee agreements that do not concern competition or competitive work, including employee non-solicits, confidentiality agreements, and nondisclosure agreements; existing common-law standards remain in effect for those agreements [^q10-aca-related-covenants].
+
+The statute also preserves Arkansas Trade Secrets Act protections and rights. That means a trade-secret claim may be analyzed separately from a non-compete claim, and the statute should not be read to impair, limit, or change ATSA protections [^q10-aca-atsa].
+
+Pre-Act cases show the difference in practice. *Bendinger* rejected the non-compete as overbroad but separately affirmed denial of a permanent trade-secret injunction because the evidence did not prove actual, threatened, or inevitable misappropriation [^q10-bendinger-trade-secrets].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not label every customer, employee, confidentiality, or NDA restriction as a non-compete. Arkansas separates covered competition restraints from other agreements, and the governing standards can differ [^q10-aca-related-covenants].
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-02. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not Arkansas. This article synthesizes Arkansas primary law and is not legal advice from a Arkansas-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^q1-aca-enforceable]: **Ark. Code Ann. § 4-75-101** — "A covenant not to compete agreement is enforceable if the agreement is ancillary to an employment relationship or part of an otherwise enforceable employment agreement or contract to the extent that: (1) The employer has a protectable business interest; and (2) The covenant not to compete agreement is limited with respect to time and scope in a manner that is not greater than necessary to defend the protectable business interest of the employer." *Ark. Code Ann. § 4-75-101(a).* <https://advance.lexis.com/document/?pdmfid=1000516&pddocfullpath=/shared/document/statutes-legislation/urn:contentItem:6F8J-XPN0-R03K-P3X3-00008-00>
+
+[^q1-aca-protectable]: **Ark. Code Ann. § 4-75-101** — "For the purposes of subsection (a) of this section, the protectable business interest of the employer includes the employer's: (1) Trade secrets; (2) Intellectual property; (3) Customer lists; (4) Goodwill with customers; (5) Knowledge of his or her business practices; (6) Methods; (7) Profit margins; (8) Costs; (9) Other confidential business information that is confidential, proprietary, and increases in value from not being known by a competitor; (10) Training and education of the employer's employees; and (11) Other valuable employer data that the employer has provided to an employee that an employer would reasonably seek to protect or safeguard from a competitor in the interest of fairness." *Ark. Code Ann. § 4-75-101(b).* <https://advance.lexis.com/document/?pdmfid=1000516&pddocfullpath=/shared/document/statutes-legislation/urn:contentItem:6F8J-XPN0-R03K-P3X3-00008-00>
+
+[^q1-aca-reformation]: **Ark. Code Ann. § 4-75-101** — "The court shall enforce the covenant not to compete agreement under the reformed terms and conditions." *Ark. Code Ann. § 4-75-101(f).* <https://advance.lexis.com/document/?pdmfid=1000516&pddocfullpath=/shared/document/statutes-legislation/urn:contentItem:6F8J-XPN0-R03K-P3X3-00008-00>
+
+[^q1-box-effective-date]: **Box v. J.B. Hunt Transport, Inc.** — "Arkansas Code Annotated section 4-75-101 (Supp. 2015), which became effective on July 22, 2015, pursuant to the enactment of Act 921 of 2015." *Box v. J.B. Hunt Transp., Inc., 2017 Ark. App. 605, 533 S.W.3d 603.* <https://www.courtlistener.com/opinion/4441363/box-v-jb-hunt-transport-inc/#:~:text=Arkansas%20Code%20Annotated%20section%204%2D75%2D101,of%20Act%20921%20of%202015.>
+
+[^q2-aca-enforceable]: **Ark. Code Ann. § 4-75-101** — "The covenant not to compete agreement is limited with respect to time and scope in a manner that is not greater than necessary to defend the protectable business interest of the employer." *Ark. Code Ann. § 4-75-101(a).* <https://advance.lexis.com/document/?pdmfid=1000516&pddocfullpath=/shared/document/statutes-legislation/urn:contentItem:6F8J-XPN0-R03K-P3X3-00008-00>
+
+[^q2-aca-protectable]: **Ark. Code Ann. § 4-75-101** — "For the purposes of subsection (a) of this section, the protectable business interest of the employer includes the employer's: (1) Trade secrets; (2) Intellectual property; (3) Customer lists; (4) Goodwill with customers; (5) Knowledge of his or her business practices; (6) Methods; (7) Profit margins; (8) Costs; (9) Other confidential business information that is confidential, proprietary, and increases in value from not being known by a competitor; (10) Training and education of the employer's employees; and (11) Other valuable employer data that the employer has provided to an employee that an employer would reasonably seek to protect or safeguard from a competitor in the interest of fairness." *Ark. Code Ann. § 4-75-101(b).* <https://advance.lexis.com/document/?pdmfid=1000516&pddocfullpath=/shared/document/statutes-legislation/urn:contentItem:6F8J-XPN0-R03K-P3X3-00008-00>
+
+[^q2-aca-factors]: **Ark. Code Ann. § 4-75-101** — "The reasonableness of a covenant not to compete agreement shall be determined after considering: (A) The nature of the employer's protectable business interest; (B) The geographic scope of the employer's business and whether or not a geographic limitation is feasible under the circumstances; (C) Whether or not the restriction placed on the employee is limited to a specific group of customers or other individuals or entities associated with the employer's business; and (D) The nature of the employer's business." *Ark. Code Ann. § 4-75-101(c).* <https://advance.lexis.com/document/?pdmfid=1000516&pddocfullpath=/shared/document/statutes-legislation/urn:contentItem:6F8J-XPN0-R03K-P3X3-00008-00>
+
+[^q2-mercy-no-ordinary-competition]: **Mercy Health Sys. of Nw. Ark., Inc. v. Bicak** — "Unless the covenantee has a legitimate interest to be protected by the agreement, the law will not enforce such a contract, as this would merely prohibit ordinary competition." *Mercy Health Sys. of Nw. Ark., Inc. v. Bicak, 2011 Ark. App. 341, 383 S.W.3d 869.* <https://www.courtlistener.com/opinion/5283436/mercy-health-system-of-northwest-arkansas-inc-v-bicak/#:~:text=Unless%20the%20covenantee%20has%20a,would%20merely%20prohibit%20ordinary%20competition.>
+
+[^q3-aca-no-geography]: **Ark. Code Ann. § 4-75-101** — "The lack of a specific or defined geographic descriptive restriction in a covenant not to compete agreement does not make the covenant not to compete agreement overly broad under subdivision (a)(2) of this section if the covenant not to compete agreement is limited with respect to time and scope in a manner that is not greater than necessary to defend the protectable business interest of the employer." *Ark. Code Ann. § 4-75-101(c).* <https://advance.lexis.com/document/?pdmfid=1000516&pddocfullpath=/shared/document/statutes-legislation/urn:contentItem:6F8J-XPN0-R03K-P3X3-00008-00>
+
+[^q3-bendinger-geography]: **Bendinger v. Marshalltown Trowel Co.** — "We hold that the failure of the covenant to contain a geographic restriction in this case renders it overbroad." *Bendinger v. Marshalltown Trowel Co., 338 Ark. 410, 994 S.W.2d 468 (1999).* <https://www.courtlistener.com/opinion/2454655/bendinger-v-marshalltown-trowell-co/#:~:text=We%20hold%20that%20the%20failure,this%20case%20renders%20it%20overbroad.>
+
+[^q3-nanomech-geography]: **NanoMech, Inc. v. Suresh** — "Under Arkansas law, a noncompete agreement must be valid as written; a court may not narrow it." *NanoMech, Inc. v. Suresh, 777 F.3d 1020 (8th Cir. 2015).* <https://www.courtlistener.com/opinion/2777573/nanomech-inc-v-arunya-suresh/#:~:text=Under%20Arkansas%20law%2C%20a%20noncompete,court%20may%20not%20narrow%20it.>
+
+[^q3-aca-factors]: **Ark. Code Ann. § 4-75-101** — "The reasonableness of a covenant not to compete agreement shall be determined after considering: (A) The nature of the employer's protectable business interest; (B) The geographic scope of the employer's business and whether or not a geographic limitation is feasible under the circumstances; (C) Whether or not the restriction placed on the employee is limited to a specific group of customers or other individuals or entities associated with the employer's business; and (D) The nature of the employer's business." *Ark. Code Ann. § 4-75-101(c).* <https://advance.lexis.com/document/?pdmfid=1000516&pddocfullpath=/shared/document/statutes-legislation/urn:contentItem:6F8J-XPN0-R03K-P3X3-00008-00>
+
+[^q4-aca-two-years]: **Ark. Code Ann. § 4-75-101** — "A post-termination restriction of two (2) years is presumptively reasonable as to length of time under subdivision (a)(2) of this section unless the facts and circumstances of a particular case clearly demonstrate that two (2) years is unreasonable compared to the employer's protectable business interest." *Ark. Code Ann. § 4-75-101(d).* <https://advance.lexis.com/document/?pdmfid=1000516&pddocfullpath=/shared/document/statutes-legislation/urn:contentItem:6F8J-XPN0-R03K-P3X3-00008-00>
+
+[^q4-bud-duration]: **Bud Anderson Heating & Cooling, Inc. v. Neil** — "[W]hile the courts have upheld time limits of one year and two years, restrictions of three years and five years were unreasonable and invalid." *Bud Anderson Heating & Cooling, Inc. v. Neil, 2018 Ark. App. 183, 545 S.W.3d 819.* <https://www.courtlistener.com/opinion/6241502/bud-anderson-heating-cooling-inc-v-mike-neil-absolute-hvac-llc/#:~:text=%5BW%5Dhile%20the%20courts%20have%20upheld,years%20were%20unreasonable%20and%20invalid.>
+
+[^q5-aca-reformation]: **Ark. Code Ann. § 4-75-101** — "If restrictions in a covenant not to compete agreement are found to be unreasonable and impose a greater restraint than is necessary to protect the protectable business interest of the employer under subdivision (a)(1) of this section, the court shall reform the covenant not to compete agreement to the extent necessary to: (A) Cause the limitations contained in the covenant not to compete agreement to be reasonable; and (B) Impose a restraint that is not greater than necessary to protect the protectable business interest." *Ark. Code Ann. § 4-75-101(f).* <https://advance.lexis.com/document/?pdmfid=1000516&pddocfullpath=/shared/document/statutes-legislation/urn:contentItem:6F8J-XPN0-R03K-P3X3-00008-00>
+
+[^q5-aca-reformation-enforce]: **Ark. Code Ann. § 4-75-101** — "The court shall enforce the covenant not to compete agreement under the reformed terms and conditions." *Ark. Code Ann. § 4-75-101(f).* <https://advance.lexis.com/document/?pdmfid=1000516&pddocfullpath=/shared/document/statutes-legislation/urn:contentItem:6F8J-XPN0-R03K-P3X3-00008-00>
+
+[^q5-bendinger-no-rewrite]: **Bendinger v. Marshalltown Trowel Co.** — "The court has held that the contract must be valid as written, and the court will not apportion or enforce a contract to the extent that it might be considered reasonable." *Bendinger v. Marshalltown Trowel Co., 338 Ark. 410, 994 S.W.2d 468 (1999).* <https://www.courtlistener.com/opinion/2454655/bendinger-v-marshalltown-trowell-co/#:~:text=The%20court%20has%20held%20that,it%20might%20be%20considered%20reasonable.>
+
+[^q5-nanomech-no-narrow]: **NanoMech, Inc. v. Suresh** — "Under Arkansas law, a noncompete agreement must be valid as written; a court may not narrow it." *NanoMech, Inc. v. Suresh, 777 F.3d 1020 (8th Cir. 2015).* <https://www.courtlistener.com/opinion/2777573/nanomech-inc-v-arunya-suresh/#:~:text=Under%20Arkansas%20law%2C%20a%20noncompete,court%20may%20not%20narrow%20it.>
+
+[^q5-box-effective-date]: **Box v. J.B. Hunt Transport, Inc.** — "However, in the present case the statutory law arguably applies only to the parties’ third restricted stock agreement executed in October 2015 after Act 921 became effective." *Box v. J.B. Hunt Transp., Inc., 2017 Ark. App. 605, 533 S.W.3d 603.* <https://www.courtlistener.com/opinion/4441363/box-v-jb-hunt-transport-inc/#:~:text=However%2C%20in%20the%20present%20case,after%20Act%20921%20became%20effective.>
+
+[^q6-aca-consideration]: **Ark. Code Ann. § 4-75-101** — "An employee's continued employment is sufficient consideration for a covenant not to compete agreement." *Ark. Code Ann. § 4-75-101(g).* <https://advance.lexis.com/document/?pdmfid=1000516&pddocfullpath=/shared/document/statutes-legislation/urn:contentItem:6F8J-XPN0-R03K-P3X3-00008-00>
+
+[^q6-aca-enforceable]: **Ark. Code Ann. § 4-75-101** — "The employer has a protectable business interest; and (2) The covenant not to compete agreement is limited with respect to time and scope in a manner that is not greater than necessary to defend the protectable business interest of the employer." *Ark. Code Ann. § 4-75-101(a).* <https://advance.lexis.com/document/?pdmfid=1000516&pddocfullpath=/shared/document/statutes-legislation/urn:contentItem:6F8J-XPN0-R03K-P3X3-00008-00>
+
+[^q7-aca-physician-void]: **Ark. Code Ann. § 4-75-101** — "A covenant not to compete agreement that restricts the right of a physician to practice within the physician's scope of practice is void." *Ark. Code Ann. § 4-75-101(k).* <https://advance.lexis.com/document/?pdmfid=1000516&pddocfullpath=/shared/document/statutes-legislation/urn:contentItem:6F8J-XPN0-R03K-P3X3-00008-00>
+
+[^q7-aca-title-17]: **Ark. Code Ann. § 4-75-101** — "Except as provided under subsection (k) of this section, this section shall not: (1) Be read to impair, limit, or change a party's protections and rights under the Arkansas Trade Secrets Act, § 4-75-601 et seq.; or (2) Apply to a person holding a professional license under Arkansas Code Title 17, Subtitle 3." *Ark. Code Ann. § 4-75-101(j).* <https://advance.lexis.com/document/?pdmfid=1000516&pddocfullpath=/shared/document/statutes-legislation/urn:contentItem:6F8J-XPN0-R03K-P3X3-00008-00>
+
+[^q7-aca-physician-definition]: **Ark. Code Ann. § 4-75-101** — "As used in subdivision (k)(1) of this section, ‘physician’ means a person authorized or licensed to practice medicine under the Arkansas Medical Practices Act, § 17-95-201 et seq., § 17-95-301 et seq., and § 17-95-401 et seq., and a person authorized to practice osteopathy under § 17-91-101 et seq." *Ark. Code Ann. § 4-75-101(k).* <https://advance.lexis.com/document/?pdmfid=1000516&pddocfullpath=/shared/document/statutes-legislation/urn:contentItem:6F8J-XPN0-R03K-P3X3-00008-00>
+
+[^q7-mercy-public-policy]: **Mercy Health Sys. of Nw. Ark., Inc. v. Bicak** — "Covenants not to compete are not looked upon with favor by the law; in fact, it is contrary to public policy to unduly restrict the [spublic’s right of access to the physicians of their choice." *Mercy Health Sys. of Nw. Ark., Inc. v. Bicak, 2011 Ark. App. 341, 383 S.W.3d 869.* <https://www.courtlistener.com/opinion/5283436/mercy-health-system-of-northwest-arkansas-inc-v-bicak/#:~:text=Covenants%20not%20to%20compete%20are,the%20physicians%20of%20their%20choice.>
+
+[^q7-mercy-affirm]: **Mercy Health Sys. of Nw. Ark., Inc. v. Bicak** — "The circuit court did not err in granting partial summary judgment to Dr. Bicak on the eovenant-not-to-compete claim because Mercy did not counter the evidence demonstrating that it had no interest sufficient to warrant its enforcement; that it was designed only to eliminate competition; and that it would unreasonably interfere with the public’s right of access to the physicians of their choice and Dr. Bicak’s ability to earn a living." *Mercy Health Sys. of Nw. Ark., Inc. v. Bicak, 2011 Ark. App. 341, 383 S.W.3d 869.* <https://www.courtlistener.com/opinion/5283436/mercy-health-system-of-northwest-arkansas-inc-v-bicak/#:~:text=The%20circuit%20court%20did%20not,ability%20to%20earn%20a%20living.>
+
+[^q8-bud-prospective]: **Bud Anderson Heating & Cooling, Inc. v. Neil** — "Therefore, it is not clear and obvious on the record before us that BAHC could not obtain the relief it seeks on appeal, a one-year prospective injunction." *Bud Anderson Heating & Cooling, Inc. v. Neil, 2018 Ark. App. 183, 545 S.W.3d 819.* <https://www.courtlistener.com/opinion/6241502/bud-anderson-heating-cooling-inc-v-mike-neil-absolute-hvac-llc/#:~:text=Therefore%2C%20it%20is%20not%20clear,appeal%2C%20a%20one%2Dyear%20prospective%20injunction.>
+
+[^q8-aca-remedies]: **Ark. Code Ann. § 4-75-101** — "In a private court action, a court may award the employer damages for a breach of a covenant not to compete agreement, appropriate injunctive relief, or both, if appropriate." *Ark. Code Ann. § 4-75-101(e).* <https://advance.lexis.com/document/?pdmfid=1000516&pddocfullpath=/shared/document/statutes-legislation/urn:contentItem:6F8J-XPN0-R03K-P3X3-00008-00>
+
+[^q8-aca-reformation]: **Ark. Code Ann. § 4-75-101** — "The court shall enforce the covenant not to compete agreement under the reformed terms and conditions." *Ark. Code Ann. § 4-75-101(f).* <https://advance.lexis.com/document/?pdmfid=1000516&pddocfullpath=/shared/document/statutes-legislation/urn:contentItem:6F8J-XPN0-R03K-P3X3-00008-00>
+
+[^q9-aca-remedies]: **Ark. Code Ann. § 4-75-101** — "In a private court action, a court may award the employer damages for a breach of a covenant not to compete agreement, appropriate injunctive relief, or both, if appropriate." *Ark. Code Ann. § 4-75-101(e).* <https://advance.lexis.com/document/?pdmfid=1000516&pddocfullpath=/shared/document/statutes-legislation/urn:contentItem:6F8J-XPN0-R03K-P3X3-00008-00>
+
+[^q9-aca-irreparable]: **Ark. Code Ann. § 4-75-101** — "The immediate harm associated with the breach of a covenant not to compete agreement shall be considered irreparable to establish the appropriateness of a preliminary injunction." *Ark. Code Ann. § 4-75-101(e).* <https://advance.lexis.com/document/?pdmfid=1000516&pddocfullpath=/shared/document/statutes-legislation/urn:contentItem:6F8J-XPN0-R03K-P3X3-00008-00>
+
+[^q9-porters-after-2015]: **Porter's Commercial Refrigeration, Inc. v. Brewer** — "The grounds for establishing the right to an injunction are straightforward, but the analysis becomes layered in the context of allegations regarding breaches of noncompete agreements executed after 2015." *Porter's Com. Refrigeration, Inc. v. Brewer, 2024 Ark. App. 232, 688 S.W.3d 145.* <https://www.courtlistener.com/opinion/9490284/porters-commercial-refrigeration-inc-v-danny-a-brewer-jason-spears/#:~:text=The%20grounds%20for%20establishing%20the,noncompete%20agreements%20executed%20after%202015.>
+
+[^q9-porters-statutory-harm]: **Porter's Commercial Refrigeration, Inc. v. Brewer** — "This means that a party seeking a preliminary injunction concerning a noncompete agreement executed after 2015 can establish irreparable harm by establishing immediate harm associated with a breach of the noncompete." *Porter's Com. Refrigeration, Inc. v. Brewer, 2024 Ark. App. 232, 688 S.W.3d 145.* <https://www.courtlistener.com/opinion/9490284/porters-commercial-refrigeration-inc-v-danny-a-brewer-jason-spears/#:~:text=This%20means%20that%20a%20party,a%20breach%20of%20the%20noncompete.>
+
+[^q9-aca-savings]: **Ark. Code Ann. § 4-75-101** — "This subsection does not limit: (A) Any other defense available to a party against a claim for preliminary injunctive relief; or (B) An employer's right to monetary damages for breach of a covenant not to compete agreement." *Ark. Code Ann. § 4-75-101(e).* <https://advance.lexis.com/document/?pdmfid=1000516&pddocfullpath=/shared/document/statutes-legislation/urn:contentItem:6F8J-XPN0-R03K-P3X3-00008-00>
+
+[^q10-aca-related-covenants]: **Ark. Code Ann. § 4-75-101** — "This section shall not apply to other types of agreements between employers and employees that do not concern competition or competitive work, including: (A) Agreements not to solicit, recruit, or hire employees; (B) Confidentiality agreements; (C) Nondisclosure agreements; and (D) The terms and conditions of an employment or employment agreement." *Ark. Code Ann. § 4-75-101(i).* <https://advance.lexis.com/document/?pdmfid=1000516&pddocfullpath=/shared/document/statutes-legislation/urn:contentItem:6F8J-XPN0-R03K-P3X3-00008-00>
+
+[^q10-aca-atsa]: **Ark. Code Ann. § 4-75-101** — "Except as provided under subsection (k) of this section, this section shall not: (1) Be read to impair, limit, or change a party's protections and rights under the Arkansas Trade Secrets Act, § 4-75-601 et seq.; or (2) Apply to a person holding a professional license under Arkansas Code Title 17, Subtitle 3." *Ark. Code Ann. § 4-75-101(j).* <https://advance.lexis.com/document/?pdmfid=1000516&pddocfullpath=/shared/document/statutes-legislation/urn:contentItem:6F8J-XPN0-R03K-P3X3-00008-00>
+
+[^q10-bendinger-trade-secrets]: **Bendinger v. Marshalltown Trowel Co.** — "We next turn to Marshalltown’s cross-appeal where it challenges the chancellor’s denial of injunctive relief under the Arkansas Trade Secrets Act, since this issue may have merit independent from our decision not to enforce the restrictive covenant." *Bendinger v. Marshalltown Trowel Co., 338 Ark. 410, 994 S.W.2d 468 (1999).* <https://www.courtlistener.com/opinion/2454655/bendinger-v-marshalltown-trowell-co/#:~:text=We%20next%20turn%20to%20Marshalltown%E2%80%99s,to%20enforce%20the%20restrictive%20covenant.>

--- a/skills/non-compete-contract-explainer/content/california.md
+++ b/skills/non-compete-contract-explainer/content/california.md
@@ -1,0 +1,270 @@
+---
+jurisdiction: "California"
+slug: california
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-03"
+canonicalUrl: https://openagreements.org/legal/non-compete/california
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/california · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in California[^about]
+
+California voids employee non-compete agreements by statute and treats customer non-solicitation clauses as the same kind of void restraint, and its 2024 laws make entering or enforcing one a civil violation with a private right of action — leaving only narrow sale-of-business exceptions.
+
+
+## At a glance
+
+| Question | California |
+| --- | --- |
+| **Are non-competes enforceable?** | Banned |
+| **Bottom line** | Employee non-competes and customer non-solicits are void by statute, and since 2024 entering or enforcing one is a civil violation with a private right of action. |
+| **Main law or case** | Cal. Bus. & Prof. Code § 16600 |
+| **Main exceptions** | Sale of a business or ownership interest (§§ 16601–16602.5) |
+| **When the ban took effect** | Longstanding (§ 16600); 2024 enforcement laws SB 699 / AB 1076 effective Jan 1, 2024 |
+| **Can a court narrow it?** | No |
+| **Applies to contractors?** | Yes |
+| **Restriction extended during a breach?** | No (covenant is void) |
+| **Maximum length set by law** | Not applicable — void |
+
+## Are employee non-compete agreements enforceable in California? {#employee-noncompetes}
+
+**Short answer.** No. California voids employee non-compete agreements by statute. Business and Professions Code section 16600 makes any contract that restrains someone from engaging in a lawful profession, trade, or business void to that extent, and the Legislature has directed courts to read the ban *broadly* — voiding any noncompete in employment *no matter how narrowly tailored* — unless it fits a specific statutory exception [^stat-16600-void][^stat-16600-broadly].
+
+This makes California the most employee-protective non-compete jurisdiction in the country. Unlike a reasonableness state, California does not weigh a covenant's duration or geography — a clause that restrains a former employee from competing is simply outside the statute and therefore void. The California Supreme Court settled this in *Edwards v. Arthur Andersen LLP*, where it struck a customer non-solicitation covenant and refused to adopt the Ninth Circuit's *narrow-restraint* exception [^edwards-reject-narrow].
+
+"We reject Andersen's contention that we should adopt a narrow-restraint exception to section 16600 and leave it to the Legislature, if it chooses, either to relax the statutory restrictions or adopt additional exceptions to the prohibition-against-restraint rule under section 16600."[^edwards-reject-narrow]
+
+The 2024 amendment to section 16600 wrote that holding into the statute, removing any argument that a short or geographically modest non-compete might survive [^stat-16600-broadly].
+
+"This section shall be read broadly, in accordance with Edwards v. Arthur Andersen LLP (2008) 44 Cal.4th 937, to void the application of any noncompete agreement in an employment context, or any noncompete clause in an employment contract, no matter how narrowly tailored, that does not satisfy an exception in this chapter."[^stat-16600-broadly]
+
+What a California employer can protect instead is a narrow set of interests — the goodwill it buys when it acquires a business, and its trade secrets and confidential information. Each is addressed in its own question below.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not paper a California employee with an out-of-state non-compete form and assume a court will narrow it to something enforceable. California treats a conventional employee non-compete as void rather than reforming it. As the questions below explain, merely *including* or *attempting to enforce* one now carries its own statutory exposure [^stat-16600-void][^edwards-reject-narrow].
+
+## Are customer non-solicitation clauses enforceable in California? {#customer-nonsolicitation}
+
+**Short answer.** No, not in the employment context. California treats a clause barring a former employee from soliciting or servicing the employer's customers as a restraint on trade that is void under section 16600 — the same rule that voids a non-compete. *Edwards* itself struck a customer non-solicitation covenant [^q2-edwards-reject-narrow][^fillpoint-void].
+
+Because *Edwards* rejected any reasonableness or narrow-restraint analysis in employment, a customer non-solicitation clause does not become enforceable just because it is limited to a handful of accounts or a short period. If it forecloses any part of the former employee's ability to compete for business, it is void [^q2-edwards-reject-narrow].
+
+The one place a customer non-solicitation covenant can survive is where it is genuinely part of the sale of a business rather than an employment relationship — and even then courts read the exception narrowly. In *Fillpoint, LLC v. Maas*, the Court of Appeal refused to let a buyer enforce a noncompetition-and-nonsolicitation covenant that sat in the *employment* agreement rather than the purchase agreement [^fillpoint-void].
+
+"In this case, when we read the two noncompetition covenants together, we hold that the noncompetition and nonsolicitation covenant contained in the employment agreement is void and unenforceable under California law."[^fillpoint-void]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not rely on a customer non-solicitation or *non-dealing* clause as a softer substitute for a non-compete in a California employment agreement. Courts analyze it as the same kind of restraint and void it; the durable protection for customer relationships is a properly scoped trade-secret and confidentiality program, addressed below [^q2-edwards-reject-narrow][^fillpoint-void].
+
+## Can a California employer restrict soliciting its employees? {#employee-nonsolicitation}
+
+**Short answer.** It is high-risk and probably void. An older decision, *Loral Corp. v. Moyes*, upheld an employee anti-raiding covenant as only a *slight* restraint, but the more recent appellate decision in *AMN Healthcare v. Aya Healthcare* held an employee non-solicitation clause void under section 16600 because it restrained the recruiters' chosen profession, and questioned whether *Loral* survives *Edwards*. The California Supreme Court has not resolved the split [^amn-void][^loral-slight].
+
+For decades employers relied on *Loral*, where the court treated a clause barring a departing executive from *raiding* his former employer's staff as a minor restriction that did not foreclose anyone's livelihood [^loral-slight].
+
+"This does not appear to be any more of a significant restraint on his engaging in his profession, trade or business than a restraint on solicitation of customers or on disclosure of confidential information."[^loral-slight]
+
+In 2018 the Court of Appeal in *AMN Healthcare* invalidated an employee non-solicitation clause imposed on nurse recruiters and openly questioned whether *Loral* survives *Edwards* [^amn-void].
+
+"Turning to the instant case, we independently conclude that the nonsolicitation of employee provision in the CNDA is void under section 16600."[^amn-void]
+
+Federal district courts applying California law have largely followed *AMN* and extended it beyond the recruiting industry. Until the California Supreme Court speaks, treat a standard employee non-solicitation or *no-hire* clause as carrying a high risk of invalidation — and, as the next question explains, including a void clause now carries its own statutory exposure.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not assume *Loral* still protects a no-hire or anti-raiding clause. After *AMN Healthcare*, an employee non-solicitation provision is more likely void than enforceable, and a clause that bars *hiring* a former colleague who applies on their own initiative is weaker still. Protect the workforce through trade-secret and confidentiality measures rather than a raiding ban [^amn-void][^loral-slight].
+
+## What is an employer's exposure for including or enforcing a void non-compete? {#employer-exposure}
+
+**Short answer.** Substantial. Since January 1, 2024, two laws turned California's ban from a defense into an offensive weapon. Senate Bill 699 (section 16600.5) makes *entering into* or *attempting to enforce* a void non-compete a civil violation with a private right of action and mandatory attorney's fees, reaching contracts signed anywhere. Assembly Bill 1076 (section 16600.1) made *including* such a clause unlawful, required employers to notify affected workers by February 14, 2024, and made a violation an act of unfair competition [^stat-16600-5-violation][^stat-16600-1-unlawful].
+
+The private right of action is what ended the old practice of leaving an unenforceable *scarecrow* covenant in a contract to deter departures. Entering or enforcing a void clause is now itself the violation [^stat-16600-5-violation].
+
+"An employer that enters into a contract that is void under this chapter or attempts to enforce a contract that is void under this chapter commits a civil violation."[^stat-16600-5-violation]
+
+A prevailing worker recovers fees on top of any damages or injunction, which makes even a low-value case worth bringing [^stat-16600-5-fees].
+
+"In addition to the remedies described in paragraph (1), a prevailing employee, former employee, or prospective employee in an action based on a violation of this chapter shall be entitled to recover reasonable attorney's fees and costs."[^stat-16600-5-fees]
+
+AB 1076 layered on a compliance duty: it is unlawful to include the clause at all, and a violation is folded into the Unfair Competition Law [^stat-16600-1-unlawful][^stat-16600-1-ucl].
+
+"It shall be unlawful to include a noncompete clause in an employment contract, or to require an employee to enter a noncompete agreement, that does not satisfy an exception in this chapter."[^stat-16600-1-unlawful]
+
+There is a further trap for employers who present void terms. Labor Code section 432.5 forbids requiring an employee to agree in writing to any term the employer knows to be prohibited by law — which a void non-compete now plainly is — exposing the employer to representative penalty claims [^stat-432-5]. California's Attorney General has publicly reinforced that noncompetes are generally illegal and that workers can act on these rights [^ag-alert].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Audit California employment agreements and remove void non-compete, customer-non-solicit, and overbroad confidentiality clauses now — do not leave them in as a deterrent. Under section 16600.5, entering into or attempting to enforce a void clause is a civil violation with fee-shifting; separately, under section 16600.1 the inclusion of the clause is itself unlawful, and the unmet AB 1076 notice obligation (due February 14, 2024) remains an unfair-competition exposure for employers who never sent it [^stat-16600-5-violation][^stat-16600-1-ucl].
+
+## Can a choice-of-law or forum-selection clause escape California's non-compete ban? {#choice-of-law}
+
+**Short answer.** Usually not for a California employee. Labor Code section 925 lets an employee who primarily resides and works in California void an out-of-state choice-of-law or forum-selection clause imposed as a condition of employment, and section 16600.5 says a void non-compete is unenforceable regardless of where it was signed. But California's extraterritorial reach has limits: federal courts have applied another state's law to enforce a non-compete where that state's interest was greater [^stat-925][^stat-16600-5-anywhere][^draftkings-stand].
+
+Section 925 is the core anti-circumvention rule. A California-based employee can void a clause that forces litigation elsewhere or strips California law, unless the employee was individually represented by counsel in negotiating it [^stat-925].
+
+"An employer shall not require an employee who primarily resides and works in California, as a condition of employment, to agree to a provision that would do either of the following: (1) Require the employee to adjudicate outside of California a claim arising in California. (2) Deprive the employee of the substantive protection of California law with respect to a controversy arising in California."[^stat-925]
+
+Section 925 reaches contracts entered into, modified, or extended on or after January 1, 2017, so it does not retroactively void an older choice-of-law or forum clause [^stat-925]. Section 16600.5 reinforces the rule for newer disputes by declaring void non-competes unenforceable no matter where they were signed [^stat-16600-5-anywhere].
+
+"Any contract that is void under this chapter is unenforceable regardless of where and when the contract was signed."[^stat-16600-5-anywhere]
+
+The limit appears when the dispute lands outside California. In *DraftKings Inc. v. Hermalyn*, the First Circuit applied Massachusetts law, enforced a Massachusetts non-compete against an executive who had moved to California, and let the injunction stand — declining to treat California's policy as overriding [^draftkings-stand].
+
+"Having considered the matter on an expedited basis, we let the challenged order stand."[^draftkings-stand]
+
+> [!NOTE]
+> **Practice note.**
+>
+> A California employee who primarily works in California should treat section 925 as the strongest tool against an out-of-state forum or governing-law clause — but recognize that section 16600.5 is not a guaranteed shield in another state's courts. An employee who never worked in California cannot reliably invoke the ban by relocating after the fact [^stat-925][^draftkings-stand].
+
+## Are non-competes tied to the sale of a business or ownership interest enforceable in California? {#sale-of-business}
+
+**Short answer.** Yes, within narrow statutory limits. A person who sells the goodwill of a business or disposes of an ownership interest may agree not to compete within the geographic area where the business operated (section 16601), and parallel rules cover partners (section 16602) and LLC members (section 16602.5). Courts read these exceptions strictly and tie them to the goodwill actually transferred [^stat-16601][^stat-16602][^stat-16602-5].
+
+The sale-of-business exception exists so a buyer can protect the goodwill it pays for; without it, a seller could reopen next door and take back the customer base just sold. But the covenant must be tied to a genuine sale and limited to the area where the business was carried on [^stat-16601].
+
+A covenant that is really an employment restraint dressed up as a sale term will not qualify. In *Fillpoint*, the court read the purchase and employment agreements together and voided the employment-agreement covenant as outside the exception [^q6-fillpoint-void]. Where the transaction is a real disposition of an ownership interest, the exception applies — in *Blue Mountain Enterprises, LLC v. Owen*, the court enforced a customer non-solicitation covenant tied to an owner's sale of his entire interest [^blue-mountain-16601].
+
+"Here, the trial court correctly found that section 16601 applies as a matter of law because Owen ‘dispos[ed] of all of his . . . ownership interest’ under the Contribution Agreement while concurrently agreeing under the Employment Agreement to ‘refrain from carrying on a similar business within a specified geographic area in which the business so sold.’"[^blue-mountain-16601]
+
+For a *partial* sale — where the owner sells some interest but stays involved — the California Supreme Court's decision in *Ixchel Pharma, LLC v. Biogen, Inc.* supplies the analytical frame: outside the employment and full-sale contexts, a restraint on business dealings is judged under a rule of reason rather than treated as void per se [^ixchel-rule-of-reason]. The Court of Appeal applied that frame to a partial sale in *Samuelian v. Life Generations Healthcare, LLC* [^samuelian-reasonableness].
+
+"In context, section 16600 is best read not to render void per se all contractual restraints on business dealings, but rather to subject such restraints to a rule of reason."[^ixchel-rule-of-reason]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Tie a sale-of-business covenant to the goodwill actually sold and to the geographic area where the business operated, and keep it in the purchase agreement — not the employee's employment agreement. A covenant bootstrapped onto employment, or scoped beyond the acquired goodwill, falls outside sections 16601–16602.5 and is void [^stat-16601][^q6-fillpoint-void].
+
+## Can private equity or hedge funds impose non-competes on California physicians and dentists? {#healthcare-private-equity}
+
+**Short answer.** No — for contracts under the new healthcare law that takes effect January 1, 2026. Senate Bill 351 (Health and Safety Code section 1191) bars a private equity group or hedge fund involved with a physician or dental practice from using a management or asset-sale contract to stop a provider from competing with the practice after leaving, and voids any such clause [^stat-hsc-1191-ban].
+
+SB 351 targets the contractual structures private equity uses to manage medical and dental practices. A management or asset-sale agreement with a PE- or hedge-fund-controlled entity cannot include a clause barring a provider from competing with the practice after a termination or resignation [^stat-hsc-1191-ban].
+
+The law preserves a genuine sale-of-business non-compete but draws a sharp line: a management or asset-sale contract cannot operate as an *employee* non-compete against the provider [^stat-hsc-1191-sale-exception].
+
+"However, a contract described in this subdivision shall not operate as an employee noncompete agreement."[^stat-hsc-1191-sale-exception]
+
+> [!NOTE]
+> **Practice note.**
+>
+> This restriction applies to contracts under the SB 351 framework taking effect January 1, 2026. Private equity and hedge-fund sponsors structuring management services organization (MSO) arrangements with California medical or dental practices should remove provider non-compete clauses from those management and asset-sale contracts and confirm that any retained sale-of-business covenant does not function as an employee non-compete [^stat-hsc-1191-ban].
+
+## Are stay-or-pay and training-repayment (TRAP) clauses enforceable in California? {#stay-or-pay}
+
+**Short answer.** Increasingly not. For contracts entered into on or after January 1, 2026, Assembly Bill 692 (Business and Professions Code section 16608) makes most terms that impose a debt, penalty, or fee on a worker who leaves unlawful, and treats such a contract as void under section 16600. Labor Code section 926 gives the worker a civil action with statutory damages of $5,000 per worker [^stat-16608-void][^stat-926-damages].
+
+Section 16608 reaches the *stay-or-pay* structures — replacement-hire fees, training-repayment provisions (TRAPs), quit fees, and similar termination-triggered charges — that impose a penalty, fee, or cost on a worker who leaves and so function as financial deterrents to departure [^stat-16608-penalty].
+
+A contract that runs afoul of the section is itself a restraint of trade and void under section 16600 — but only prospectively, for contracts entered on or after the January 1, 2026 effective date [^stat-16608-void].
+
+"A contract that is unlawful under subdivision (b) is a contract restraining a person from engaging in a lawful profession, trade, or business, and is void under Section 16600 only if the contract was entered into on or after January 1, 2026."[^stat-16608-void]
+
+The remedy is meaningful: a worker or worker representative can recover actual damages or $5,000 per worker, whichever is greater, plus injunctive relief and fees [^stat-926-damages].
+
+"Any person found liable for a violation of this section shall be liable for actual damages sustained by the worker or workers on whose behalf the case is brought, or five thousand dollars ($5,000) per worker, whichever is greater, in addition to injunctive relief, and reasonable attorney's fees and costs."[^stat-926-damages]
+
+> [!NOTE]
+> **Practice note.**
+>
+> The stay-or-pay rules apply to contracts entered into on or after January 1, 2026, and the statute carves out specific arrangements — for example, a genuine sign-on bonus with separate terms and a retention period of no more than two years, and tuition for a transferable credential offered apart from the employment contract. Review any training-repayment or retention-bonus program against the section 16608 exceptions before using it in California [^stat-16608-void][^stat-926-damages].
+
+## What can a California employer protect instead of a non-compete? {#trade-secrets}
+
+**Short answer.** Trade secrets and narrowly drawn confidentiality. The California Uniform Trade Secrets Act lets an employer enjoin the actual or threatened misappropriation of a trade secret (Civil Code section 3426.2), and that protection operates whether or not any restrictive covenant exists. But a confidentiality clause written so broadly that it bars the employee from working in their field is treated as a *de facto* non-compete and is void [^stat-cuts-injunction][^brown-de-facto].
+
+Because the Trade Secrets Act protects the *information* rather than the employment relationship, it is the most durable tool a California employer has for guarding competitively sensitive material [^stat-cuts-injunction].
+
+"Actual or threatened misappropriation may be enjoined."[^stat-cuts-injunction]
+
+The discipline a California employer must accept is precision. In *Brown v. TGS Management Co.*, the Court of Appeal held that confidentiality provisions defined so expansively that they effectively barred the employee from his profession operated as a *de facto* non-compete and were void [^brown-de-facto].
+
+"Collectively, these overly restrictive provisions operate as a de facto noncompete provision; they plainly bar Brown in perpetuity from doing any work in the securities field, much less in his chosen profession of statistical arbitrage."[^brown-de-facto]
+
+A trade-secret claim also comes with a procedural gate that shapes litigation: before taking discovery, the party alleging misappropriation must identify the trade secret with reasonable particularity [^stat-2019-210].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not define *confidential information* so broadly that it sweeps in the employee's general skills, knowledge, and industry experience — a confidentiality clause that effectively prevents the worker from practicing their profession is a *de facto* non-compete and void under *Brown v. TGS*. Tie confidentiality to genuine, identifiable trade secrets, and rely on the Trade Secrets Act for enforcement [^brown-de-facto][^stat-cuts-injunction].
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-03. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not California. This article synthesizes California primary law and is not legal advice from a California-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^stat-16600-void]: **Cal. Bus. & Prof. Code § 16600** — "Except as provided in this chapter, every contract by which anyone is restrained from engaging in a lawful profession, trade, or business of any kind is to that extent void." *Cal. Bus. & Prof. Code § 16600(a).* <https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=BPC&sectionNum=16600>
+
+[^stat-16600-broadly]: **Cal. Bus. & Prof. Code § 16600** — "This section shall be read broadly, in accordance with Edwards v. Arthur Andersen LLP (2008) 44 Cal.4th 937, to void the application of any noncompete agreement in an employment context, or any noncompete clause in an employment contract, no matter how narrowly tailored, that does not satisfy an exception in this chapter." *Cal. Bus. & Prof. Code § 16600(b)(1).* <https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=BPC&sectionNum=16600>
+
+[^edwards-reject-narrow]: **Edwards v. Arthur Andersen LLP** — "We reject Andersen's contention that we should adopt a narrow-restraint exception to section 16600 and leave it to the Legislature, if it chooses, either to relax the statutory restrictions or adopt additional exceptions to the prohibition-against-restraint rule under section 16600." *Edwards v. Arthur Andersen LLP, 44 Cal. 4th 937 (2008).* <https://www.courtlistener.com/opinion/5608069/edwards-v-arthur-andersen-llp/#:~:text=We%20reject%20Andersen's%20contention%20that,prohibition%2Dagainst%2Drestraint%20rule%20under%20section%2016600.>
+
+[^q2-edwards-reject-narrow]: **Edwards v. Arthur Andersen LLP** — "We reject Andersen's contention that we should adopt a narrow-restraint exception to section 16600 and leave it to the Legislature, if it chooses, either to relax the statutory restrictions or adopt additional exceptions to the prohibition-against-restraint rule under section 16600." *Edwards v. Arthur Andersen LLP, 44 Cal. 4th 937 (2008).* <https://www.courtlistener.com/opinion/5608069/edwards-v-arthur-andersen-llp/#:~:text=We%20reject%20Andersen's%20contention%20that,prohibition%2Dagainst%2Drestraint%20rule%20under%20section%2016600.>
+
+[^fillpoint-void]: **Fillpoint, LLC v. Maas** — "In this case, when we read the two noncompetition covenants together, we hold that the noncompetition and nonsolicitation covenant contained in the employment agreement is void and unenforceable under California law." *Fillpoint, LLC v. Maas, 208 Cal. App. 4th 1170 (2012).* <https://www.courtlistener.com/opinion/5811287/fillpoint-llc-v-maas/#:~:text=In%20this%20case%2C%20when%20we,and%20unenforceable%20under%20California%20law.>
+
+[^amn-void]: **AMN Healthcare, Inc. v. Aya Healthcare Services, Inc.** — "Turning to the instant case, we independently conclude that the nonsolicitation of employee provision in the CNDA is void under section 16600." *AMN Healthcare, Inc. v. Aya Healthcare Servs., Inc., 28 Cal. App. 5th 923 (2018).* <https://www.courtlistener.com/opinion/4549721/amn-healthcare-inc-v-aya-healthcare-services-inc/#:~:text=Turning%20to%20the%20instant%20case%2C,is%20void%20under%20section%2016600.>
+
+[^loral-slight]: **Loral Corp. v. Moyes** — "This does not appear to be any more of a significant restraint on his engaging in his profession, trade or business than a restraint on solicitation of customers or on disclosure of confidential information." *Loral Corp. v. Moyes, 174 Cal. App. 3d 268 (1985).* <https://www.courtlistener.com/opinion/2140771/loral-corp-v-moyes/#:~:text=This%20does%20not%20appear%20to,on%20disclosure%20of%20confidential%20information.>
+
+[^stat-16600-5-violation]: **Cal. Bus. & Prof. Code § 16600.5** — "An employer that enters into a contract that is void under this chapter or attempts to enforce a contract that is void under this chapter commits a civil violation." *Cal. Bus. & Prof. Code § 16600.5(d).* <https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=BPC&sectionNum=16600.5>
+
+[^stat-16600-1-unlawful]: **Cal. Bus. & Prof. Code § 16600.1** — "It shall be unlawful to include a noncompete clause in an employment contract, or to require an employee to enter a noncompete agreement, that does not satisfy an exception in this chapter." *Cal. Bus. & Prof. Code § 16600.1(a).* <https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=BPC&sectionNum=16600.1>
+
+[^stat-16600-5-fees]: **Cal. Bus. & Prof. Code § 16600.5** — "In addition to the remedies described in paragraph (1), a prevailing employee, former employee, or prospective employee in an action based on a violation of this chapter shall be entitled to recover reasonable attorney's fees and costs." *Cal. Bus. & Prof. Code § 16600.5(e)(2).* <https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=BPC&sectionNum=16600.5>
+
+[^stat-16600-1-ucl]: **Cal. Bus. & Prof. Code § 16600.1** — "A violation of this section constitutes an act of unfair competition within the meaning of Chapter 5 (commencing with Section 17200)." *Cal. Bus. & Prof. Code § 16600.1(c).* <https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=BPC&sectionNum=16600.1>
+
+[^stat-432-5]: **Cal. Lab. Code § 432.5** — "No employer, or agent, manager, superintendent, or officer thereof, shall require any employee or applicant for employment to agree, in writing, to any term or condition which is known by such employer, or agent, manager, superintendent, or officer thereof to be prohibited by law." *Cal. Lab. Code § 432.5.* <https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=LAB&sectionNum=432.5>
+
+[^ag-alert]: **California Attorney General — Consumer Alert on Noncompete Agreements** — "Effective January 1, 2024, Senate Bill (SB) 699 makes it generally illegal for employers to enter into noncompete agreements with California employees." *Cal. Att'y Gen., Consumer Alert: Noncompete Agreements (Oct. 15, 2024).* <https://oag.ca.gov/news/press-releases/attorney-general-bonta-issues-consumer-alert-reminding-california-workers-their>
+
+[^stat-925]: **Cal. Lab. Code § 925** — "An employer shall not require an employee who primarily resides and works in California, as a condition of employment, to agree to a provision that would do either of the following: (1) Require the employee to adjudicate outside of California a claim arising in California. (2) Deprive the employee of the substantive protection of California law with respect to a controversy arising in California." *Cal. Lab. Code § 925(a).* <https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=LAB&sectionNum=925>
+
+[^stat-16600-5-anywhere]: **Cal. Bus. & Prof. Code § 16600.5** — "Any contract that is void under this chapter is unenforceable regardless of where and when the contract was signed." *Cal. Bus. & Prof. Code § 16600.5(a).* <https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=BPC&sectionNum=16600.5>
+
+[^draftkings-stand]: **DraftKings Inc. v. Hermalyn** — "Having considered the matter on an expedited basis, we let the challenged order stand." *DraftKings Inc. v. Hermalyn, 118 F.4th 416 (1st Cir. 2024).* <https://www.courtlistener.com/opinion/10125471/draftkings-inc-v-hermalyn/#:~:text=Having%20considered%20the%20matter%20on,let%20the%20challenged%20order%20stand.>
+
+[^stat-16601]: **Cal. Bus. & Prof. Code § 16601** — "Any person who sells the goodwill of a business, or any owner of a business entity selling or otherwise disposing of all of his or her ownership interest in the business entity, or any owner of a business entity that sells (a) all or substantially all of its operating assets together with the goodwill of the business entity, (b) all or substantially all of the operating assets of a division or a subsidiary of the business entity together with the goodwill of that division or subsidiary, or (c) all of the ownership interest of any subsidiary, may agree with the buyer to refrain from carrying on a similar business within a specified geographic area in which the business so sold, or that of the business entity, division, or subsidiary has been carried on, so long as the buyer, or any person deriving title to the goodwill or ownership interest from the buyer, carries on a like business therein." *Cal. Bus. & Prof. Code § 16601.* <https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=BPC&sectionNum=16601>
+
+[^stat-16602]: **Cal. Bus. & Prof. Code § 16602** — "Any partner may, upon or in anticipation of any of the circumstances described in subdivision (b), agree that he or she will not carry on a similar business within a specified geographic area where the partnership business has been transacted, so long as any other member of the partnership, or any person deriving title to the business or its goodwill from any such other member of the partnership, carries on a like business therein." *Cal. Bus. & Prof. Code § 16602(a).* <https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=BPC&sectionNum=16602>
+
+[^stat-16602-5]: **Cal. Bus. & Prof. Code § 16602.5** — "Any member may, upon or in anticipation of a dissolution of, or the termination of his or her interest in, a limited liability company (including a series of a limited liability company formed under the laws of a jurisdiction recognizing such a series), agree that he or she or it will not carry on a similar business within a specified geographic area where the limited liability company business has been transacted, so long as any other member of the limited liability company, or any person deriving title to the business or its goodwill from any such other member of the limited liability company, carries on a like business therein." *Cal. Bus. & Prof. Code § 16602.5.* <https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=BPC&sectionNum=16602.5>
+
+[^q6-fillpoint-void]: **Fillpoint, LLC v. Maas** — "In this case, when we read the two noncompetition covenants together, we hold that the noncompetition and nonsolicitation covenant contained in the employment agreement is void and unenforceable under California law." *Fillpoint, LLC v. Maas, 208 Cal. App. 4th 1170 (2012).* <https://www.courtlistener.com/opinion/5811287/fillpoint-llc-v-maas/#:~:text=In%20this%20case%2C%20when%20we,and%20unenforceable%20under%20California%20law.>
+
+[^blue-mountain-16601]: **Blue Mountain Enterprises, LLC v. Owen** — "Here, the trial court correctly found that section 16601 applies as a matter of law because Owen ‘dispos[ed] of all of his . . . ownership interest’ under the Contribution Agreement while concurrently agreeing under the Employment Agreement to ‘refrain from carrying on a similar business within a specified geographic area in which the business so sold.’" *Blue Mountain Enters., LLC v. Owen, 74 Cal. App. 5th 537 (2022).* <https://www.courtlistener.com/opinion/6246635/blue-mountain-enterprises-llc-v-owen/#:~:text=Here%2C%20the%20trial%20court%20correctly,which%20the%20business%20so%20sold.%E2%80%9D>
+
+[^ixchel-rule-of-reason]: **Ixchel Pharma, LLC v. Biogen, Inc.** — "In context, section 16600 is best read not to render void per se all contractual restraints on business dealings, but rather to subject such restraints to a rule of reason." *Ixchel Pharma, LLC v. Biogen, Inc., 9 Cal. 5th 1130 (2020).* <https://www.courtlistener.com/opinion/4772471/ixchel-pharma-llc-v-biogen-inc/#:~:text=In%20context%2C%20section%2016600%20is,to%20a%20rule%20of%20reason.>
+
+[^samuelian-reasonableness]: **Samuelian v. Life Generations Healthcare, LLC** — "We agree the reasonableness standard applies to partial sales." *Samuelian v. Life Generations Healthcare, LLC (Cal. Ct. App. 2024).* <https://www.courtlistener.com/opinion/10118817/samuelian-v-life-generations-healthcare-llc/#:~:text=We%20agree%20the%20reasonableness%20standard%20applies%20to%20partial%20sales.>
+
+[^stat-hsc-1191-ban]: **Cal. Health & Safety Code § 1191 (SB 351)** — "shall not include any clause barring any provider in that practice from doing either of the following: (A) Competing with that practice in the event of a termination or resignation of that provider from that practice." *Cal. Health & Safety Code § 1191(d)(1).* <https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=HSC&sectionNum=1191>
+
+[^stat-hsc-1191-sale-exception]: **Cal. Health & Safety Code § 1191 (SB 351)** — "An otherwise enforceable sale of business noncompete agreement. However, a contract described in this subdivision shall not operate as an employee noncompete agreement." *Cal. Health & Safety Code § 1191(d)(3)(A).* <https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=HSC&sectionNum=1191>
+
+[^stat-16608-void]: **Cal. Bus. & Prof. Code § 16608 (AB 692)** — "A contract that is unlawful under subdivision (b) is a contract restraining a person from engaging in a lawful profession, trade, or business, and is void under Section 16600 only if the contract was entered into on or after January 1, 2026." *Cal. Bus. & Prof. Code § 16608(c).* <https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=BPC&sectionNum=16608>
+
+[^stat-926-damages]: **Cal. Lab. Code § 926 (AB 692)** — "Any person found liable for a violation of this section shall be liable for actual damages sustained by the worker or workers on whose behalf the case is brought, or five thousand dollars ($5,000) per worker, whichever is greater, in addition to injunctive relief, and reasonable attorney's fees and costs." *Cal. Lab. Code § 926(c).* <https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=LAB&sectionNum=926>
+
+[^stat-16608-penalty]: **Cal. Bus. & Prof. Code § 16608 (AB 692)** — "Imposes any penalty, fee, or cost on a worker if the worker's employment or work relationship with a specific employer terminates." *Cal. Bus. & Prof. Code § 16608(b)(1)(C).* <https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=BPC&sectionNum=16608>
+
+[^stat-cuts-injunction]: **Cal. Civ. Code § 3426.2** — "Actual or threatened misappropriation may be enjoined." *Cal. Civ. Code § 3426.2(a).* <https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=CIV&sectionNum=3426.2>
+
+[^brown-de-facto]: **Brown v. TGS Management Co., LLC** — "Collectively, these overly restrictive provisions operate as a de facto noncompete provision; they plainly bar Brown in perpetuity from doing any work in the securities field, much less in his chosen profession of statistical arbitrage." *Brown v. TGS Mgmt. Co., 57 Cal. App. 5th 303 (2020).* <https://www.courtlistener.com/opinion/4805583/brown-v-tgs-management-co-llc/#:~:text=Collectively%2C%20these%20overly%20restrictive%20provisions,chosen%20profession%20of%20statistical%20arbitrage.>
+
+[^stat-2019-210]: **Cal. Civ. Proc. Code § 2019.210** — "before commencing discovery relating to the trade secret, the party alleging the misappropriation shall identify the trade secret with reasonable particularity" *Cal. Civ. Proc. Code § 2019.210.* <https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=CCP&sectionNum=2019.210>

--- a/skills/non-compete-contract-explainer/content/cnmi.md
+++ b/skills/non-compete-contract-explainer/content/cnmi.md
@@ -1,0 +1,168 @@
+---
+jurisdiction: "Northern Mariana Islands"
+slug: cnmi
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-03"
+canonicalUrl: https://openagreements.org/legal/non-compete/cnmi
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/cnmi · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in the Northern Mariana Islands[^about]
+
+The CNMI has no non-compete statute; post-employment covenants are enforceable only if they are reasonable under Restatement (Second) of Contracts § 188, which the rules-of-decision statute 7 CMC § 3401 imports as Commonwealth law, and the one on-point decision denied a preliminary injunction against two former medical-transport employees on Saipan.
+
+
+## At a glance
+
+| Question | Northern Mariana Islands |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed if reasonable |
+| **Bottom line** | The CNMI has no non-compete statute; a post-employment covenant is enforceable only if reasonable under Restatement (Second) of Contracts § 188, which 7 CMC § 3401 imports as Commonwealth law, and the one on-point federal order denied an injunction in a small-island healthcare context. |
+| **Main law or case** | 7 CMC § 3401 (importing Restatement (Second) of Contracts § 188); August Healthcare Grp., LLC v. Manglona |
+| **Main exceptions** | No statutory carve-outs; small-island public-interest and hardship factors weigh heavily against healthcare/specialist covenants |
+| **Can a court narrow it?** | Unsettled |
+| **Applies to contractors?** | Unclear |
+| **Restriction extended during a breach?** | Silent — rely on an explicit tolling clause kept within § 188 reasonableness |
+| **Maximum length set by law** | No statutory limit |
+
+## Are employee non-compete agreements enforceable in the CNMI? {#employee-noncompetes}
+
+**Short answer.** Sometimes. The Commonwealth of the Northern Mariana Islands has no statute that governs non-competes. When local written law is silent, the Commonwealth's rules-of-decision statute makes the Restatements the rules of decision [^cmc-3401], so a post-employment covenant is enforceable only if it is reasonable under Restatement (Second) of Contracts § 188.
+
+The CNMI is not a per se ban jurisdiction like California or North Dakota, and it is not a statutory-reasonableness jurisdiction either. There is no Commonwealth Code provision that regulates, restricts, or bans employee non-competes. The only court to address one said so directly and routed the analysis to the Restatement [^aug-no-statute].
+
+"There is no specific law, statute, or custom in the CNMI governing covenants not to compete."[^aug-no-statute]
+
+That statutory silence is load-bearing. Under 7 CMC § 3401, the rules of the common law as expressed in the Restatements of the Law are the rules of decision in Commonwealth courts whenever written law and local customary law are silent. The federal court applying CNMI law in *August Healthcare Group, LLC v. Manglona* therefore treated the Restatement (Second) of Contracts as controlling and decided the covenant under it [^aug-restatements].
+
+One caveat frames everything below: *August Healthcare* is a federal district-court order denying a preliminary injunction, and no CNMI Supreme Court decision has yet resolved a private employee non-compete on the merits. The governing framework is thus a statutory directive applied by one federal court, not a body of settled Commonwealth appellate precedent.
+
+## What test must a CNMI non-compete satisfy? {#reasonableness-test}
+
+**Short answer.** The Restatement (Second) of Contracts § 188 rule of reason. A covenant is unreasonable, and unenforceable, if it is greater than is needed to protect a legitimate employer interest, or if that need is outweighed by the hardship to the employee and the likely injury to the public [^aug-188].
+
+This is a two-sided balancing test, not a checklist of fixed limits. An employer must first identify a legitimate interest and tailor the restraint to it; even a narrowly tailored restraint can still fail if the burden on the employee and the harm to the public outweigh the employer's need. The court in *August Healthcare* quoted the black-letter text of § 188 and applied it as Commonwealth law.
+
+"A promise to refrain from competition that imposes a restraint that is ancillary to an otherwise valid transaction or relationship is unreasonably in restraint of trade if (a) the restraint is greater than is needed to protect the promisee's legitimate interest, or (b) the promisee's need is outweighed by the hardship to the promisor and the likely injury to the public."[^aug-188]
+
+Because the limits are judge-made through the Restatement rather than set by a code section, there is no statutory ceiling on duration or geography to anchor a covenant. Reasonableness is decided case by case, which makes the CNMI's small-island context, addressed in the sections below, central to the analysis.
+
+## What consideration supports a CNMI non-compete? {#consideration}
+
+**Short answer.** This is unsettled. The only CNMI covenant decision expressly declined to decide whether continued employment alone is sufficient consideration for a non-compete, so no CNMI authority answers the question [^aug-saves].
+
+In *August Healthcare*, an employee argued, relying on Washington case law, that a non-compete signed months after employment begins is invalid without fresh, independent consideration. The federal court acknowledged the dispute but resolved the motion on reasonableness grounds alone and left consideration for a future case.
+
+"At this stage of the proceedings, this Court finds that the application of Section 188 of the Restatement is sufficient to address St. Michael's request for a preliminary injunction and saves the issue of consideration for another day."[^aug-saves]
+
+Mainland courts are split: many treat continued at-will employment as sufficient consideration, while a substantial minority require something more, such as a bonus, a promotion, or specialized training. Because the CNMI has not chosen a side, the conservative course is to provide independent, bargained-for consideration when a covenant is imposed on a current employee.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not assume continued employment will support a mid-employment covenant. The CNMI has not decided the consideration question, so give independent, bargained-for consideration, such as a promotion or a bonus, when an existing employee signs a non-compete [^aug-saves].
+
+## Will CNMI courts narrow an overbroad non-compete? {#court-narrowing}
+
+**Short answer.** There is no direct CNMI authority. Whether a Commonwealth court would blue-pencil or equitably reform an overbroad employment covenant, rather than void it, is a question of first impression [^pang-gapfill].
+
+The probable doctrinal path runs through the Restatement. Section 3401 directs courts to fill gaps with the common law as expressed in the Restatements, and the CNMI Supreme Court has described that cascade: courts first look to local written law, and where it is lacking, the Restatement fills the gaps. The likely argument from there is Restatement (Second) of Contracts § 184, which lets a court enforce the reasonable remainder of an otherwise overbroad agreement — but that is the route an employer would have to urge, not a rule any CNMI court has adopted.
+
+"To the extent local written law is lacking, the Restatement fills the gaps."[^pang-gapfill]
+
+But no CNMI court has applied § 184 to reform an employment non-compete, and *August Healthcare* did not reach the question because it denied relief on reasonableness grounds. An employer therefore cannot count on judicial salvage of an aggressive covenant.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Draft to a reasonable scope from the outset. Because reformation of an overbroad employment covenant is an unresolved question in the CNMI, a court may void a covenant that reaches too far rather than narrow it [^pang-gapfill].
+
+## How does the CNMI treat NDAs, non-solicits, and customer lists? {#trade-secrets-nonsolicit}
+
+**Short answer.** It depends on the restraint. A non-solicitation covenant restrains competition and is judged by the same Restatement § 188 reasonableness standard as a non-compete. Confidentiality and trade-secret protection instead run through common-law trade-secret principles: in *August Healthcare* the court analyzed the employer's customer list under common-law trade-secret factors and found it was not necessarily a protectable trade secret, because Saipan is a small market where the relevant customers are readily observable [^aug-not-trade-secret].
+
+The protectable-interest analysis is where the employer's claim failed in *August Healthcare*. The court reasoned that on Saipan the names of those needing the employer's services would be public knowledge, so a confidentiality or non-solicitation restraint built around that list could not protect a genuine secret.
+
+"While a customer list and data can be considered trade secrets, Defendants make a convincing argument that Saipan is such a small community that the names of those needing healthcare transportation services would be public knowledge."[^aug-customer-list]
+
+A non-solicitation clause is generally easier to justify than a flat non-compete because it restrains less, but it still must protect a real interest. Where the customer base is common knowledge on a small island, even a narrowly framed non-solicit may not survive § 188.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not assume a customer list is a trade secret in a small island market. The court in *August Healthcare* found the employer's list was not necessarily a trade secret because the customers were readily observable on Saipan [^aug-not-trade-secret].
+
+## Are healthcare and specialist non-competes harder to enforce? {#healthcare-public-interest}
+
+**Short answer.** Likely, though the law is thin. The only CNMI covenant decision shows both limbs of § 188 — the hardship to the employee and the injury to the public — weighing heavily against enforcement in a small island economy. In *August Healthcare* the court declined to preliminarily enjoin two former emergency medical-transport employees from joining a competitor, finding there were no other private medical providers on Saipan and that an injunction would deprive them of their livelihood [^aug-no-providers].
+
+A preliminary injunction is the usual enforcement tool, and in federal court it is an extraordinary remedy measured against a four-factor test of likelihood of success, irreparable harm, the balance of equities, and the public interest [^aug-extraordinary][^aug-four-prong]. On the facts of *August Healthcare* those factors cut against the employer: enjoining the workers would deprive skilled employees of their livelihood and remove the employer's only competitor from the market, while the lost-customer harm was small and calculable [^aug-deprive].
+
+"There are no other private medical service providers on Saipan to hire employees with their specialized skills."[^aug-no-providers]
+
+That outcome is narrow in two respects. The court found the employer had produced a signed non-compete for only one of the two employees and none for the other, so the denial did not rest solely on covenant reasonableness. And it is a single fact-specific federal order, not a CNMI appellate rule. Even so, the same public-interest logic would likely make a physician, nurse, or other specialist non-compete hard to enforce where the restraint would remove the only local provider — a strong inference to plan around, not settled law.
+
+## Does the restricted period toll or extend if the employee breaches? {#tolling}
+
+**Short answer.** CNMI primary law is silent. No Commonwealth statute or decision approves or rejects pausing or extending a non-compete during a period of breach or pending litigation, so the question is genuinely open. A contractual tolling clause is the safer route, but any extension must still leave the total restraint reasonable under § 188 [^tolling-188].
+
+Because there is no CNMI authority on point, an employer should not assume a court will pause the clock while litigation runs. The nearest guidance is persuasive only. In *EMC Corp. v. Arturi*, the First Circuit, applying Massachusetts law, refused to equitably extend a covenant after its term expired and observed that the employer could have contracted for tolling instead.
+
+"Being forewarned, EMC could have contracted, as the district judge noted, for tolling the term of the restriction during litigation, or for a period of restriction to commence upon preliminary finding of breach."[^emc-tolling]
+
+*EMC* is not CNMI law, and it cuts in two directions: it supports drafting an explicit tolling clause, but it also shows courts are reluctant to rewrite the calendar themselves. Under § 188, even a contractual extension is vulnerable if it pushes the effective duration past what is reasonable to protect the employer.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> If you want the clock to pause during a breach, say so in the contract. CNMI courts have not decided whether they will extend a covenant equitably, so rely on an explicit tolling clause, and keep the maximum extended duration reasonable so the extension itself does not make the covenant unenforceable under § 188 [^emc-tolling][^tolling-188].
+
+## What recent developments should employers monitor? {#recent-developments}
+
+**Short answer.** As of June 3, 2026, the framework is stable. No CNMI statute has displaced the analysis that runs from 7 CMC § 3401 to Restatement § 188, and the CNMI Supreme Court reaffirmed that the Restatements are the Commonwealth's rules of decision in 2024 [^pang-current].
+
+Two widely publicized changes do not reach the CNMI on their own force. The federal FTC Non-Compete Rule is not in effect, so it does not displace the Commonwealth analysis. And mainland state bans, such as California's and Washington's, have no jurisdictional reach in the CNMI on their own force; they matter only if a contract's choice-of-law clause imports another state's law.
+
+The practical takeaway is stability with a thin margin. Because the framework is judge-made, the most reliable signal of change would be a new CNMI Supreme Court or federal decision deciding one of the open questions, consideration, reformation, or tolling, rather than a bill.
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-03. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not Northern Mariana Islands. This article synthesizes Northern Mariana Islands primary law and is not legal advice from a Northern Mariana Islands-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^cmc-3401]: **7 CMC § 3401** — "In all proceedings, the rules of the common law, as expressed in the restatements of the law approved by the American Law Institute and, to the extent not so expressed as generally understood and applied in the United States, shall be the rules of decision in the courts of the Commonwealth, in the absence of written law or local customary law to the contrary" *7 CMC § 3401.* <https://cnmilaw.org/pdf/cmc_section/T7/3401.pdf>
+
+[^aug-no-statute]: **August Healthcare Group, LLC v. Manglona** — "There is no specific law, statute, or custom in the CNMI governing covenants not to compete." *August Healthcare Grp., LLC v. Manglona, No. 1:12-cv-00008, 2012 WL 12926085 (D. N. Mar. I. Oct. 12, 2012).* <https://www.govinfo.gov/app/details/USCOURTS-nmid-1_12-cv-00008>
+
+[^aug-restatements]: **August Healthcare Group, LLC v. Manglona** — "In the absence of written law or local customary law, the CNMI looks to the United States common law as expressed in the Restatements." *August Healthcare Grp., LLC v. Manglona, No. 1:12-cv-00008, 2012 WL 12926085 (D. N. Mar. I. Oct. 12, 2012).* <https://www.govinfo.gov/app/details/USCOURTS-nmid-1_12-cv-00008>
+
+[^aug-188]: **August Healthcare Group, LLC v. Manglona** — "A promise to refrain from competition that imposes a restraint that is ancillary to an otherwise valid transaction or relationship is unreasonably in restraint of trade if (a) the restraint is greater than is needed to protect the promisee's legitimate interest, or (b) the promisee's need is outweighed by the hardship to the promisor and the likely injury to the public." *August Healthcare Grp., LLC v. Manglona, No. 1:12-cv-00008, 2012 WL 12926085 (D. N. Mar. I. Oct. 12, 2012).* <https://www.govinfo.gov/app/details/USCOURTS-nmid-1_12-cv-00008>
+
+[^aug-saves]: **August Healthcare Group, LLC v. Manglona** — "At this stage of the proceedings, this Court finds that the application of Section 188 of the Restatement is sufficient to address St. Michael's request for a preliminary injunction and saves the issue of consideration for another day." *August Healthcare Grp., LLC v. Manglona, No. 1:12-cv-00008, 2012 WL 12926085 (D. N. Mar. I. Oct. 12, 2012).* <https://www.govinfo.gov/app/details/USCOURTS-nmid-1_12-cv-00008>
+
+[^pang-gapfill]: **Pangelinan v. Pangelinan** — "first look to local written law, which includes our case law adopting and/or adapting Restatement provisions. To the extent local written law is lacking, the Restatement fills the gaps." *Pangelinan v. Pangelinan, 2024 MP 5.* <https://www.courtlistener.com/opinion/10124676/pangelinan-v-pangelinan/#:~:text=first%20look%20to%20local%20written,the%20Restatement%20fills%20the%20gaps.>
+
+[^aug-not-trade-secret]: **August Healthcare Group, LLC v. Manglona** — "Therefore, the list of customers is not necessarily a trade secret in the industry." *August Healthcare Grp., LLC v. Manglona, No. 1:12-cv-00008, 2012 WL 12926085 (D. N. Mar. I. Oct. 12, 2012).* <https://www.govinfo.gov/app/details/USCOURTS-nmid-1_12-cv-00008>
+
+[^aug-customer-list]: **August Healthcare Group, LLC v. Manglona** — "While a customer list and data can be considered trade secrets, Defendants make a convincing argument that Saipan is such a small community that the names of those needing healthcare transportation services would be public knowledge." *August Healthcare Grp., LLC v. Manglona, No. 1:12-cv-00008, 2012 WL 12926085 (D. N. Mar. I. Oct. 12, 2012).* <https://www.govinfo.gov/app/details/USCOURTS-nmid-1_12-cv-00008>
+
+[^aug-no-providers]: **August Healthcare Group, LLC v. Manglona** — "There are no other private medical service providers on Saipan to hire employees with their specialized skills." *August Healthcare Grp., LLC v. Manglona, No. 1:12-cv-00008, 2012 WL 12926085 (D. N. Mar. I. Oct. 12, 2012).* <https://www.govinfo.gov/app/details/USCOURTS-nmid-1_12-cv-00008>
+
+[^aug-extraordinary]: **August Healthcare Group, LLC v. Manglona** — "A preliminary injunction is an extraordinary remedy never awarded as of right." *August Healthcare Grp., LLC v. Manglona, No. 1:12-cv-00008, 2012 WL 12926085 (D. N. Mar. I. Oct. 12, 2012).* <https://www.govinfo.gov/app/details/USCOURTS-nmid-1_12-cv-00008>
+
+[^aug-four-prong]: **August Healthcare Group, LLC v. Manglona** — "The plaintiff must establish that (1) plaintiff is likely to succeed on the merits, (2) plaintiff is likely to suffer irreparable harm in the absence of a preliminary injunction, (3) the balance of equities tips in plaintiff's favor, and (4) a preliminary injunction is in the public interest." *August Healthcare Grp., LLC v. Manglona, No. 1:12-cv-00008, 2012 WL 12926085 (D. N. Mar. I. Oct. 12, 2012).* <https://www.govinfo.gov/app/details/USCOURTS-nmid-1_12-cv-00008>
+
+[^aug-deprive]: **August Healthcare Group, LLC v. Manglona** — "An injunction that bars Pelisamen and Takai from working for Priority Care would deprive the men of the ability to earn their livelihood in a highly specialized sector of health care on Saipan." *August Healthcare Grp., LLC v. Manglona, No. 1:12-cv-00008, 2012 WL 12926085 (D. N. Mar. I. Oct. 12, 2012).* <https://www.govinfo.gov/app/details/USCOURTS-nmid-1_12-cv-00008>
+
+[^tolling-188]: **August Healthcare Group, LLC v. Manglona** — "A promise to refrain from competition that imposes a restraint that is ancillary to an otherwise valid transaction or relationship is unreasonably in restraint of trade if (a) the restraint is greater than is needed to protect the promisee's legitimate interest, or (b) the promisee's need is outweighed by the hardship to the promisor and the likely injury to the public." *August Healthcare Grp., LLC v. Manglona, No. 1:12-cv-00008, 2012 WL 12926085 (D. N. Mar. I. Oct. 12, 2012).* <https://www.govinfo.gov/app/details/USCOURTS-nmid-1_12-cv-00008>
+
+[^emc-tolling]: **EMC Corp. v. Arturi** — "Being forewarned, EMC could have contracted, as the district judge noted, for tolling the term of the restriction during litigation, or for a period of restriction to commence upon preliminary finding of breach." *EMC Corp. v. Arturi, 655 F.3d 75 (1st Cir. 2011).* <https://www.courtlistener.com/opinion/612666/emc-corp-v-arturi/#:~:text=Being%20forewarned%2C%20EMC%20could%20have,upon%20preliminary%20finding%20of%20breach.>
+
+[^pang-current]: **Pangelinan v. Pangelinan** — "shall be the rules of decision in the courts of the Commonwealth, in the absence of written law or local customary law to the contrary." *Pangelinan v. Pangelinan, 2024 MP 5.* <https://www.courtlistener.com/opinion/10124676/pangelinan-v-pangelinan/#:~:text=shall%20be%20the%20rules%20of,customary%20law%20to%20the%20contrary.>

--- a/skills/non-compete-contract-explainer/content/colorado.md
+++ b/skills/non-compete-contract-explainer/content/colorado.md
@@ -1,0 +1,277 @@
+---
+jurisdiction: "Colorado"
+slug: colorado
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-03"
+canonicalUrl: https://openagreements.org/legal/non-compete/colorado
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/colorado · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in Colorado[^about]
+
+Colorado makes most employee non-competes and customer non-solicits void by statute, allowing them only for highly compensated workers protecting trade secrets and banning them outright for health-care providers.
+
+
+## At a glance
+
+| Question | Colorado |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed above a pay level |
+| **Bottom line** | Colorado voids most employee non-competes and customer non-solicits, allowing a non-compete only against a highly compensated worker ($130,014 in 2026) to protect trade secrets, and banning them entirely for health-care providers. |
+| **Main law or case** | C.R.S. § 8-2-113 |
+| **Main exceptions** | Health-care provider ban (eff. Aug 6, 2025, SB 25-083); sale-of-business; reasonable confidentiality; capped training-repayment |
+| **When the ban took effect** | Aug 10, 2022 (covenants entered or renewed on/after; HB 22-1317) |
+| **Can a court narrow it?** | Unsettled |
+| **Applies to contractors?** | Unclear |
+| **Restriction extended during a breach?** | Open question — threshold must be met at enforcement, cutting against extension |
+| **Maximum length set by law** | No general duration limit |
+
+## Are employee non-compete agreements enforceable in Colorado? {#enforceability}
+
+**Short answer.** Usually no. For covenants entered into or renewed on or after August 10, 2022, Colorado law makes any covenant not to compete that restricts a person's right to earn compensation for labor void unless it fits a narrow statutory exception [^crs-void-rule][^crs-training-exception].
+
+The governing statute is C.R.S. § 8-2-113. Subsection (2)(a) voids covenants not to compete as the baseline rule, and the enforcing employer bears the burden of fitting the covenant into an exception [^crs-void-rule][^phoenix-employer-burden].
+
+The statute leaves a limited set of covenants in play: non-competes and customer non-solicits for highly compensated workers tailored to protect trade secrets, sale-of-business covenants, reasonable confidentiality provisions, and capped training-repayment provisions [^crs-hcw-exception][^crs-training-exception].
+
+A covenant that fits a statutory exception is not automatically enforceable. It still must be for the protection of trade secrets and no broader than reasonably necessary, and the separate-notice rule and the other limits described below still apply [^crs-hcw-exception].
+
+"Except as provided in subsections (2)(b) and (3) of this section, any covenant not to compete that restricts the right of any person to receive compensation for performance of labor for any employer is void."[^crs-void-rule]
+
+## When can a Colorado employer use a non-compete or customer non-solicit agreement? {#highly-compensated-threshold}
+
+**Short answer.** Only for a highly compensated worker, to protect trade secrets. A non-compete is permitted only against a worker whose annualized cash compensation meets the highly compensated worker threshold — $130,014 in 2026 — and a customer non-solicit needs at least 60% of that threshold, $78,008.40 in 2026 [^crs-hcw-threshold][^crs-customer-nonsolicit-threshold][^paycalc-hcw-threshold][^ebg-2026-thresholds].
+
+The worker must meet the threshold both when the covenant is signed and when it is enforced, and the covenant must protect trade secrets and be no broader than reasonably necessary [^crs-hcw-threshold]. The controlling figure is the greater of the August 10, 2022 amount or the amount in effect when the covenant is executed, so a covenant is tested against its execution-year threshold, not necessarily the current year [^crs-threshold-execution-year]. The threshold is reset annually by the Colorado Department of Labor and Employment's PAY CALC Order, which sets the 2026 highly compensated employee figure at $130,014 [^paycalc-hcw-threshold]. The customer-non-solicit threshold is then derived as 60% of that figure [^ebg-2026-thresholds].
+
+The customer non-solicit threshold is pegged to 60% of the same number, and a customer non-solicit must likewise be no broader than reasonably necessary to protect trade secrets [^crs-customer-nonsolicit-threshold].
+
+These thresholds do not help with health-care providers. Senate Bill 25-083 added the same carve-out to both the non-compete and the customer-non-solicit exceptions, so a covenant restricting the practice of medicine, advanced practice registered nursing, or dentistry is void regardless of compensation [^threshold-health-care-exclusion].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Earning above the threshold is necessary but not sufficient. Even for a worker far above $130,014, a Colorado non-compete must still be tied to the protection of specific trade secrets and drafted no broader than reasonably necessary — general goodwill or ordinary customer relationships will not support it [^crs-hcw-threshold][^crs-customer-nonsolicit-threshold].
+
+## What notice must a Colorado employer give before a non-compete? {#notice-requirements}
+
+**Short answer.** A separate, signed written notice, on a strict timeline. Even a covenant that fits an exception is void unless the employer gives the worker a separate written notice — before a prospective worker accepts the job, or at least fourteen days before the covenant or new consideration takes effect for a current worker [^crs-notice-timing][^crs-notice-separate-document].
+
+The notice must be a standalone document, written in clear and conspicuous terms in the language the parties use, identify the agreement by name, point the worker to the covenant, and be signed by the worker [^crs-notice-separate-document].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not bury a Colorado non-compete inside an offer letter or omnibus agreement presented for immediate signature. For a current employee, deliver the separate, signed notice at least fourteen days before the covenant's effective date or before any raise or change that serves as consideration — a defect in the notice voids the covenant on its own [^crs-notice-timing][^crs-notice-separate-document].
+
+## Are non-competes enforceable against Colorado physicians and other health-care providers? {#health-care-providers}
+
+**Short answer.** No, for agreements entered into or renewed on or after August 6, 2025. Senate Bill 25-083 makes non-competes and customer non-solicits void for health-care providers — physicians, advanced practice registered nurses, certified midwives, and dentists — regardless of compensation [^sb25083-health-care-carveout][^sb25083-health-care-provider-definition].
+
+The highly compensated worker exception no longer rescues a covenant that restricts the practice of medicine, advanced practice registered nursing, or dentistry, so these providers cannot be bound even if they earn well above the wage threshold [^sb25083-health-care-carveout].
+
+Colorado previously allowed physician agreements to require liquidated damages tied to a competitive departure, even though an outright practice restraint was void. SB 25-083 removed that path for the listed providers and added patient-communication protections, so a covenant is void if it prevents a departing provider from telling patients about the provider's continuing practice, new contact information, or the patient's right to choose their provider [^sb25083-health-care-carveout][^sb25083-patient-communication].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not rely on the older physician rule that allowed liquidated-damages clauses in place of a non-compete. For health-care providers under agreements entered into or renewed on or after August 6, 2025, the covenant is void regardless of compensation, and a clause restricting patient communications is separately void [^sb25083-health-care-carveout][^sb25083-patient-communication].
+
+## Are sale-of-business non-competes enforceable in Colorado, including for minority owners? {#sale-of-business}
+
+**Short answer.** Yes, with a new cap for minority owners. A covenant tied to the purchase and sale of a business or its assets is a statutory exception, but for an owner who holds a minority share received as equity compensation, SB 25-083 caps the non-compete's duration by a formula [^crs-sale-of-business][^sb25083-minority-owner-formula].
+
+The cap applies to a minority owner who received the ownership share as equity compensation or otherwise in connection with services rendered. For such an owner, the maximum duration in years equals the total consideration the owner received from the sale divided by the owner's average annualized cash compensation from the business over the preceding two years (or the owner's tenure, if shorter) [^sb25083-minority-owner-formula]. So a qualifying minority owner who received $50,000 from the sale and averaged $100,000 in annual compensation could be bound for at most half a year.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not reuse a flat multi-year sale-of-business term for a minority owner who took equity as compensation for services. Calculate the maximum duration from the statutory ratio of sale consideration to average annual compensation, and size the covenant to that cap [^sb25083-minority-owner-formula].
+
+## Can a Colorado employer recover training costs through a repayment agreement (TRAP)? {#training-repayment}
+
+**Short answer.** Only within strict limits. A training-repayment provision is permitted only when the training is distinct from normal on-the-job training and meets the attorney general's rules on transferability of the training or credential, and the recoverable amount is capped at reasonable costs that decrease over two years [^crs-traps].
+
+If the employer overreaches, the attorney general can recover three times the amount of any recovery or attempted recovery on an unlawful training-repayment provision [^crs-traps-treble].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not treat ordinary onboarding or routine skills training as recoverable. A Colorado training-repayment provision is enforceable only for training distinct from normal on-the-job training that satisfies the attorney general's transferability rules, and an unlawful attempt to recover exposes the employer to treble damages [^crs-traps][^crs-traps-treble].
+
+## Are confidentiality and nondisclosure covenants still allowed in Colorado? {#confidentiality-covenants}
+
+**Short answer.** Yes. A reasonable confidentiality provision relevant to the employer's business is expressly permitted and is not treated as a void non-compete [^crs-confidentiality].
+
+The carve-out has limits built in: a confidentiality provision cannot bar the worker from disclosing information that arises from the worker's general training, knowledge, skill, or experience, information readily ascertainable to the public, or information the worker has a right to disclose as legally protected conduct [^crs-confidentiality].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not draft a confidentiality clause so broadly that it functions as a non-compete. Keep it to genuine confidential information and trade secrets, and preserve the worker's right to use general skills and knowledge and to make legally protected disclosures, or the clause risks being treated as a void restraint [^crs-confidentiality].
+
+## What are the penalties for presenting or enforcing a void Colorado non-compete? {#penalties}
+
+**Short answer.** Significant. An employer that enters into, presents, or tries to enforce a void covenant is liable for actual damages plus a penalty of $5,000 per worker or prospective worker harmed, and faces enforcement by both private plaintiffs and the attorney general [^crs-prohibited-conduct][^crs-penalty].
+
+A harmed worker can recover actual damages, reasonable costs, and attorney fees, and the attorney general can seek injunctive relief and penalties [^crs-penalty]. Separately, using force, threats, or intimidation to keep a person from a lawful occupation is a class 2 misdemeanor [^crs-misdemeanor].
+
+> [!NOTE]
+> **Practice note.**
+>
+> The penalty attaches to merely presenting a void covenant, not just to suing on one. Before asking a Colorado worker to sign, confirm the worker meets the compensation threshold, the covenant protects trade secrets, the worker is not a covered health-care provider, and the notice rule is satisfied — because an unlawful presentation alone can trigger the $5,000-per-worker penalty [^crs-prohibited-conduct][^crs-penalty].
+
+## Can another state's law or court govern a Colorado worker's non-compete? {#choice-of-law}
+
+**Short answer.** No, for a Colorado-based worker. If the worker primarily resided and worked in Colorado at termination, Colorado law governs the covenant's enforceability and the worker cannot be required to litigate enforceability outside Colorado, regardless of any contrary contract clause [^crs-choice-of-law][^crs-venue].
+
+This forecloses the common strategy of using a Delaware or New York choice-of-law clause and an out-of-state forum to escape Colorado's limits for a Colorado employee [^crs-choice-of-law].
+
+## Is continued at-will employment enough consideration for a Colorado non-compete? {#continued-employment-consideration}
+
+**Short answer.** Yes. Under *Lucht's Concrete Pumping, Inc. v. Horner*, an employer that forbears from terminating an existing at-will employee gives adequate consideration for a non-compete signed after employment begins [^luchts-continued-employment].
+
+That common-law rule survives the statute, but it now operates alongside the procedural rules: for a current worker, the employer still must give the separate fourteen-day notice before the covenant or its consideration takes effect [^luchts-continued-employment][^crs-consideration-notice].
+
+## Will a Colorado court blue-pencil or narrow an overbroad non-compete? {#court-narrowing}
+
+**Short answer.** Do not count on it. Colorado courts have discretion to blue-pencil an overbroad covenant but are not required to, and parties cannot contractually force a court to rewrite one [^twentythree-ltd-discretion][^twentythree-ltd-no-contractual-compulsion].
+
+In *23 LTD v. Herman*, the court explained that it is not a court's function to rewrite a contract to enable enforcement of terms that violate Colorado public policy, and a severability clause cannot compel the court to do so [^twentythree-ltd-no-rewrite][^twentythree-ltd-no-contractual-compulsion]. The risk is compounded by the penalty regime: because merely presenting a void covenant is unlawful, an employer cannot safely assume a court will trim an overbroad covenant into a lawful one [^crs-present-void-narrowing].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Draft scope, duration, and geography to the minimum the trade-secret interest actually requires, and use separable tiers rather than an aggressive savings clause. A Colorado court may decline to narrow an overbroad covenant, and presenting a void covenant carries its own penalty [^twentythree-ltd-no-rewrite][^crs-present-void-narrowing].
+
+## Are employee non-solicitation (no-hire) clauses enforceable in Colorado? {#employee-nonsolicitation}
+
+**Short answer.** Unsettled, but better supported than customer non-solicits. The statute pegs customer non-solicits to the 60% threshold but is silent on agreements not to solicit a former employer's employees, and *Phoenix Capital, Inc. v. Dowell* treated an employee non-solicit as a lesser restraint that can survive even when the non-compete is invalid [^phoenix-employee-nonsolicit][^phoenix-livelihood-distinction].
+
+*Phoenix* reasoned that, unlike a customer non-solicit, an agreement not to solicit a former employer's employees does not impair the worker's own ability to make a living, so it can be enforceable despite an invalid non-compete [^phoenix-livelihood-distinction][^phoenix-conclusion-distinction].
+
+> [!NOTE]
+> **Practice note.**
+>
+> *Phoenix* predates the 2022 overhaul and the attorney general's active scrutiny of no-poach practices. Treat an overbroad employee no-hire clause as a litigation risk if it functions as a de facto restraint on worker mobility, and keep it limited to active solicitation tied to a legitimate interest [^phoenix-employee-nonsolicit][^crs-customer-nonsolicit-silence].
+
+## Does a Colorado non-compete toll or extend during breach or litigation? {#tolling-extension}
+
+**Short answer.** This is an open Colorado question, and the statute's structure cuts against automatic extension. No Colorado statute or appellate decision endorses automatically tolling or extending the restricted period during a breach or while litigation is pending [^phoenix-no-extension][^crs-enforced-time].
+
+The best Colorado authority points toward caution. In *Phoenix Capital, Inc. v. Dowell*, the court found no error in refusing to extend a preliminary injunction beyond the one-year term the parties had specified [^phoenix-no-extension]. And the statute requires the worker to meet the compensation threshold both when the covenant is entered into and when it is enforced, so a covenant whose enforcement is pushed later must still satisfy the statute at that later time [^crs-enforced-time].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Open question: Colorado law is unsettled on whether an extension-on-breach clause is enforceable after the stated restricted period runs. Do not assume a court will toll or extend an expired Colorado covenant, and remember that a covenant must still meet the statutory threshold at the time of enforcement [^phoenix-no-extension][^crs-enforced-time].
+
+## What are the key recent developments in Colorado non-compete law? {#recent-developments}
+
+**Short answer.** Colorado has tightened its non-compete law in four steps since 2022, moving from a title-based exception regime to objective wage thresholds, then to training-repayment and health-care restrictions [^dev-misdemeanor][^dev-hb22-1317][^dev-hb24-1324][^dev-sb25-083].
+
+- 
+- 
+- 
+- 
+
+> [!NOTE]
+> **Practice note.**
+>
+> Because the wage thresholds reset every year and the health-care and minority-owner rules apply to agreements entered into or renewed on or after their effective dates, recheck the current C.R.S. § 8-2-113 text and the latest PAY CALC Order before relying on a Colorado covenant or updating a form [^dev-sb25-083][^ebg-recent-thresholds].
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-03. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not Colorado. This article synthesizes Colorado primary law and is not legal advice from a Colorado-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^crs-void-rule]: **C.R.S. § 8-2-113** — "Except as provided in subsections (2)(b) and (3) of this section, any covenant not to compete that restricts the right of any person to receive compensation for performance of labor for any employer is void." *C.R.S. § 8-2-113(2)(a).* <https://content.leg.colorado.gov/sites/default/files/images/olls/crs2024-title-08.pdf>
+
+[^crs-training-exception]: **C.R.S. § 8-2-113** — "A provision providing for an employer's recovery of the expense of educating and training a worker where the training is distinct from normal, on-the-job training and satisfies any other requirements established by the attorney general, by rule, regarding the transferability of the training or credentialing that is available to the employee as a result of the training." *C.R.S. § 8-2-113(3)(a).* <https://content.leg.colorado.gov/sites/default/files/images/olls/crs2024-title-08.pdf>
+
+[^phoenix-employer-burden]: **Phoenix Capital, Inc. v. Dowell** — "In the preliminary injunction context, the employer has the burden to establish that the covenant not to compete falls within one of those narrow exceptions." *Phoenix Capital, Inc. v. Dowell, 176 P.3d 835 (Colo. App. 2007).* <https://www.courtlistener.com/opinion/2633761/phoenix-capital-inc-v-dowell/#:~:text=In%20the%20preliminary%20injunction%20context%2C,one%20of%20those%20narrow%20exceptions.>
+
+[^crs-hcw-exception]: **C.R.S. § 8-2-113** — "This subsection (2) does not apply to a covenant not to compete governing a person who, at the time the covenant not to compete is entered into and at the time it is enforced, earns an amount of annualized cash compensation equivalent to or greater than the threshold amount for highly compensated workers, if the covenant not to compete is for the protection of trade secrets and is no broader than is reasonably necessary to protect the employer's legitimate interest in protecting trade secrets." *C.R.S. § 8-2-113(2)(b).* <https://content.leg.colorado.gov/sites/default/files/images/olls/crs2024-title-08.pdf>
+
+[^crs-hcw-threshold]: **C.R.S. § 8-2-113** — "This subsection (2) does not apply to a covenant not to compete governing a person who, at the time the covenant not to compete is entered into and at the time it is enforced, earns an amount of annualized cash compensation equivalent to or greater than the threshold amount for highly compensated workers, if the covenant not to compete is for the protection of trade secrets and is no broader than is reasonably necessary to protect the employer's legitimate interest in protecting trade secrets." *C.R.S. § 8-2-113(2)(b).* <https://content.leg.colorado.gov/sites/default/files/images/olls/crs2024-title-08.pdf>
+
+[^crs-customer-nonsolicit-threshold]: **C.R.S. § 8-2-113** — "This subsection (2) does not apply to a covenant not to solicit customers governing a person who, at the time the covenant is entered into and at the time it is enforced, earns an amount of annualized cash compensation equivalent to or greater than sixty percent of the threshold amount for highly compensated workers if the nonsolicitation covenant is no broader than reasonably necessary to protect the employer's legitimate interest in protecting trade secrets." *C.R.S. § 8-2-113(2)(d).* <https://content.leg.colorado.gov/sites/default/files/images/olls/crs2024-title-08.pdf>
+
+[^paycalc-hcw-threshold]: **2026 PAY CALC Order, 7 CCR 1103-14** — "Highly compensated employees (R. 2.2.11) $130,014 annually, and the EAP salary (row E) weekly" *2026 PAY CALC Order, 7 CCR 1103-14, Rule 1.2.1(G) (eff. Feb. 1, 2026).* <https://www.sos.state.co.us/CCR/GenerateRulePdf.do?ruleVersionId=12310&fileName=7+CCR+1103-14>
+
+[^ebg-2026-thresholds]: **Raising the Cost of Noncompetes: 2026 State Noncompete Salary Threshold Changes** — "Effective January 1, 2026, the threshold amount for highly compensated workers is $130,014. Furthermore, an employer cannot subject an employee to a non-solicitation provision where an employee earns less than 60% of the threshold amount for highly compensated workers. Colorado’s 2026 non-solicitation salary threshold is $78,008.40." *Epstein Becker Green, Raising the Cost of Noncompetes: 2026 State Noncompete Salary Threshold Changes (Dec. 10, 2025).* <https://www.tradesecretsandemployeemobility.com/raising-the-cost-of-noncompetes-2026-state-noncompete-salary-threshold-changes>
+
+[^crs-threshold-execution-year]: **C.R.S. § 8-2-113** — "‘Threshold amount for highly compensated workers’ means the greater of the threshold amount for highly compensated workers as determined by the division of labor standards and statistics in the department of labor and employment: (A) As of August 10, 2022; or (B) At the time the covenant not to compete is executed by the parties." *C.R.S. § 8-2-113(2)(c)(II).* <https://content.leg.colorado.gov/sites/default/files/images/olls/crs2024-title-08.pdf>
+
+[^threshold-health-care-exclusion]: **S.B. 25-083 (Limitations on Restrictive Employment Agreements)** — "EXCEPT FOR A COVENANT NOT TO COMPETE THAT RESTRICTS THE PRACTICE OF MEDICINE, THE PRACTICE OF ADVANCED PRACTICE REGISTERED NURSING, OR THE PRACTICE OF DENTISTRY IN THIS STATE, this subsection (2) does not apply to a covenant not to solicit customers" *S.B. 25-083, 75th Gen. Assemb., Reg. Sess. (Colo. 2025) (amending C.R.S. § 8-2-113(2)(d)).* <https://leg.colorado.gov/bills/sb25-083>
+
+[^crs-notice-timing]: **C.R.S. § 8-2-113** — "A current worker at least fourteen days before the earlier of: (A) The effective date of the covenant; or (B) The effective date of any additional compensation or change in the terms or conditions of employment that provides consideration for the covenant." *C.R.S. § 8-2-113(4)(a)(II).* <https://content.leg.colorado.gov/sites/default/files/images/olls/crs2024-title-08.pdf>
+
+[^crs-notice-separate-document]: **C.R.S. § 8-2-113** — "An employer shall provide the notice required in subsection (4)(a) of this section in a separate document from any other covenants between the worker and employer and in clear and conspicuous terms in the language in which the worker and employer communicate about the worker's performance. The notice must be signed by the worker." *C.R.S. § 8-2-113(4)(b).* <https://content.leg.colorado.gov/sites/default/files/images/olls/crs2024-title-08.pdf>
+
+[^sb25083-health-care-carveout]: **S.B. 25-083 (Limitations on Restrictive Employment Agreements)** — "EXCEPT FOR A COVENANT NOT TO COMPETE THAT RESTRICTS THE PRACTICE OF MEDICINE, THE PRACTICE OF ADVANCED PRACTICE REGISTERED NURSING, OR THE PRACTICE OF DENTISTRY IN THIS STATE, this subsection (2) does not apply to a covenant not to compete" *S.B. 25-083, 75th Gen. Assemb., Reg. Sess. (Colo. 2025) (amending C.R.S. § 8-2-113(2)(b)).* <https://leg.colorado.gov/bills/sb25-083>
+
+[^sb25083-health-care-provider-definition]: **S.B. 25-083 (Limitations on Restrictive Employment Agreements)** — "‘HEALTH-CARE PROVIDER’ MEANS AN INDIVIDUAL LICENSED TO ENGAGE IN THE PRACTICE OF MEDICINE, REGISTERED TO ENGAGE IN THE PRACTICE OF ADVANCED PRACTICE REGISTERED NURSING, LICENSED TO PRACTICE AS A CERTIFIED MIDWIFE, OR LICENSED TO ENGAGE IN THE PRACTICE OF DENTISTRY." *S.B. 25-083, 75th Gen. Assemb., Reg. Sess. (Colo. 2025) (adding C.R.S. § 8-2-113(2)(c)(I.3)).* <https://leg.colorado.gov/bills/sb25-083>
+
+[^sb25083-patient-communication]: **S.B. 25-083 (Limitations on Restrictive Employment Agreements)** — "(a) THE HEALTH-CARE PROVIDER'S CONTINUING PRACTICE OF MEDICINE; (b) THE HEALTH-CARE PROVIDER'S NEW PROFESSIONAL CONTACT INFORMATION; OR (c) THE PATIENT'S RIGHT TO CHOOSE A HEALTH-CARE PROVIDER." *S.B. 25-083, 75th Gen. Assemb., Reg. Sess. (Colo. 2025) (adding C.R.S. § 8-2-113(5.5)).* <https://leg.colorado.gov/bills/sb25-083>
+
+[^crs-sale-of-business]: **C.R.S. § 8-2-113** — "A covenant for the purchase and sale of a business or the assets of a business" *C.R.S. § 8-2-113(3)(c).* <https://content.leg.colorado.gov/sites/default/files/images/olls/crs2024-title-08.pdf>
+
+[^sb25083-minority-owner-formula]: **S.B. 25-083 (Limitations on Restrictive Employment Agreements)** — "THE DURATION IN YEARS OF A COVENANT NOT TO COMPETE DESCRIBED IN THIS SUBSECTION (3)(c) MUST NOT EXCEED A NUMBER CALCULATED BY THE TOTAL CONSIDERATION RECEIVED BY THE INDIVIDUAL FROM THE SALE DIVIDED BY THE AVERAGE ANNUALIZED CASH COMPENSATION RECEIVED BY THE INDIVIDUAL FROM THE BUSINESS, INCLUDING INCOME RECEIVED ON ACCOUNT OF THEIR OWNERSHIP INTEREST DURING THE PRECEDING TWO YEARS OR DURING THE PERIOD OF TIME THAT THE INDIVIDUAL WAS AFFILIATED WITH THE BUSINESS, WHICHEVER PERIOD OF TIME IS SHORTER." *S.B. 25-083, 75th Gen. Assemb., Reg. Sess. (Colo. 2025) (amending C.R.S. § 8-2-113(3)(c)).* <https://leg.colorado.gov/bills/sb25-083>
+
+[^crs-traps]: **C.R.S. § 8-2-113** — "A provision providing for an employer's recovery of the expense of educating and training a worker where the training is distinct from normal, on-the-job training and satisfies any other requirements established by the attorney general, by rule, regarding the transferability of the training or credentialing that is available to the employee as a result of the training. The employer's recovery is limited to the reasonable costs of the training and decreases over the course of the two years subsequent to the training" *C.R.S. § 8-2-113(3)(a).* <https://content.leg.colorado.gov/sites/default/files/images/olls/crs2024-title-08.pdf>
+
+[^crs-traps-treble]: **C.R.S. § 8-2-113** — "The attorney general may recover three times the amount of any recovery or attempted recovery by an employer in violation of subsection (3)(a) of this section." *C.R.S. § 8-2-113(8)(b).* <https://content.leg.colorado.gov/sites/default/files/images/olls/crs2024-title-08.pdf>
+
+[^crs-confidentiality]: **C.R.S. § 8-2-113** — "A reasonable confidentiality provision relevant to the employer's business that does not prohibit disclosure of information that arises from the worker's general training, knowledge, skill, or experience, whether gained on the job or otherwise, information that is readily ascertainable to the public, or information that a worker otherwise has a right to disclose as legally protected conduct" *C.R.S. § 8-2-113(3)(b).* <https://content.leg.colorado.gov/sites/default/files/images/olls/crs2024-title-08.pdf>
+
+[^crs-prohibited-conduct]: **C.R.S. § 8-2-113** — "An employer shall not enter into, present to a worker or prospective worker as a term of employment, or attempt to enforce any covenant that is void under this section." *C.R.S. § 8-2-113(8)(a).* <https://content.leg.colorado.gov/sites/default/files/images/olls/crs2024-title-08.pdf>
+
+[^crs-penalty]: **C.R.S. § 8-2-113** — "An employer that violates subsection (8)(a) of this section is liable for actual damages and a penalty of five thousand dollars per worker or prospective worker harmed by the conduct." *C.R.S. § 8-2-113(8)(b).* <https://content.leg.colorado.gov/sites/default/files/images/olls/crs2024-title-08.pdf>
+
+[^crs-misdemeanor]: **C.R.S. § 8-2-113** — "It is unlawful to use force, threats, or other means of intimidation to prevent any person from engaging in any lawful occupation at any place the person sees fit." *C.R.S. § 8-2-113(1.5)(a).* <https://content.leg.colorado.gov/sites/default/files/images/olls/crs2024-title-08.pdf>
+
+[^crs-choice-of-law]: **C.R.S. § 8-2-113** — "Notwithstanding any contractual provision to the contrary, Colorado law governs the enforceability of a covenant not to compete for a worker who, at the time of termination of employment, primarily resided and worked in Colorado." *C.R.S. § 8-2-113(6).* <https://content.leg.colorado.gov/sites/default/files/images/olls/crs2024-title-08.pdf>
+
+[^crs-venue]: **C.R.S. § 8-2-113** — "A covenant not to compete that applies to a worker who, at the time of termination of employment, primarily resided or worked in Colorado may not require the worker to adjudicate the enforceability of the covenant outside of Colorado." *C.R.S. § 8-2-113(6).* <https://content.leg.colorado.gov/sites/default/files/images/olls/crs2024-title-08.pdf>
+
+[^luchts-continued-employment]: **Lucht's Concrete Pumping, Inc. v. Horner** — "We hold that an employer that forbears from terminating an existing at-will employee forbears from exercising a legal right, and that therefore such forbearance constitutes adequate consideration for a noncompetition agreement" *Lucht's Concrete Pumping, Inc. v. Horner, 255 P.3d 1058 (Colo. 2011).* <https://www.courtlistener.com/opinion/2454091/luchts-concrete-pumping-inc-v-horner/#:~:text=We%20hold%20that%20an%20employer,consideration%20for%20a%20noncompetition%20agreement>
+
+[^crs-consideration-notice]: **C.R.S. § 8-2-113** — "A current worker at least fourteen days before the earlier of: (A) The effective date of the covenant; or (B) The effective date of any additional compensation or change in the terms or conditions of employment that provides consideration for the covenant." *C.R.S. § 8-2-113(4)(a)(II).* <https://content.leg.colorado.gov/sites/default/files/images/olls/crs2024-title-08.pdf>
+
+[^twentythree-ltd-discretion]: **23 LTD v. Herman** — "they have made clear that trial courts have the discretion to blue pencil unenforceable noncompete provisions, at least to some extent." *23 LTD v. Herman, 2019 COA 113.* <https://www.courtlistener.com/opinion/4644233/23-ltd-v-herman/#:~:text=they%20have%20made%20clear%20that,at%20least%20to%20some%20extent.>
+
+[^twentythree-ltd-no-contractual-compulsion]: **23 LTD v. Herman** — "Thus, parties to an employment or noncompete agreement cannot contractually obligate a court to blue pencil noncompete provisions that it determines are unreasonable." *23 LTD v. Herman, 2019 COA 113.* <https://www.courtlistener.com/opinion/4644233/23-ltd-v-herman/#:~:text=Thus%2C%20parties%20to%20an%20employment,that%20it%20determines%20are%20unreasonable.>
+
+[^twentythree-ltd-no-rewrite]: **23 LTD v. Herman** — "It is not the function of a court to write or rewrite contracts for parties to enable enforcement of a contract that, as written, violates the public policy of the state." *23 LTD v. Herman, 2019 COA 113.* <https://www.courtlistener.com/opinion/4644233/23-ltd-v-herman/#:~:text=It%20is%20not%20the%20function,public%20policy%20of%20the%20state.>
+
+[^crs-present-void-narrowing]: **C.R.S. § 8-2-113** — "An employer shall not enter into, present to a worker or prospective worker as a term of employment, or attempt to enforce any covenant that is void under this section." *C.R.S. § 8-2-113(8)(a).* <https://content.leg.colorado.gov/sites/default/files/images/olls/crs2024-title-08.pdf>
+
+[^phoenix-employee-nonsolicit]: **Phoenix Capital, Inc. v. Dowell** — "Where a nonsolicitation provision is limited to prohibiting only initiating contacts or ‘active’ solicitation of the employer's employees, it is enforceable, despite the invalidity of an accompanying noncompetition provision." *Phoenix Capital, Inc. v. Dowell, 176 P.3d 835 (Colo. App. 2007).* <https://www.courtlistener.com/opinion/2633761/phoenix-capital-inc-v-dowell/#:~:text=Where%20a%20nonsolicitation%20provision%20is,of%20an%20accompanying%20noncompetition%20provision.>
+
+[^phoenix-livelihood-distinction]: **Phoenix Capital, Inc. v. Dowell** — "In contrast, an agreement not to solicit employees would not impair the former employee's ability to make a living." *Phoenix Capital, Inc. v. Dowell, 176 P.3d 835 (Colo. App. 2007).* <https://www.courtlistener.com/opinion/2633761/phoenix-capital-inc-v-dowell/#:~:text=In%20contrast%2C%20an%20agreement%20not,ability%20to%20make%20a%20living.>
+
+[^phoenix-conclusion-distinction]: **Phoenix Capital, Inc. v. Dowell** — "We conclude that, although the invalidity of the noncompetition provision did not render invalid Dowell's agreement not to solicit Phoenix's employees, it rendered invalid Dowell's agreement not to solicit Phoenix's customers." *Phoenix Capital, Inc. v. Dowell, 176 P.3d 835 (Colo. App. 2007).* <https://www.courtlistener.com/opinion/2633761/phoenix-capital-inc-v-dowell/#:~:text=We%20conclude%20that%2C%20although%20the,not%20to%20solicit%20Phoenix's%20customers.>
+
+[^crs-customer-nonsolicit-silence]: **C.R.S. § 8-2-113** — "This subsection (2) does not apply to a covenant not to solicit customers governing a person who, at the time the covenant is entered into and at the time it is enforced, earns an amount of annualized cash compensation equivalent to or greater than sixty percent of the threshold amount for highly compensated workers if the nonsolicitation covenant is no broader than reasonably necessary to protect the employer's legitimate interest in protecting trade secrets." *C.R.S. § 8-2-113(2)(d).* <https://content.leg.colorado.gov/sites/default/files/images/olls/crs2024-title-08.pdf>
+
+[^phoenix-no-extension]: **Phoenix Capital, Inc. v. Dowell** — "Consequently, we discern no error in the trial court's refusing to extend the terms of the preliminary injunction beyond the one-year term specified in the parties' agreement." *Phoenix Capital, Inc. v. Dowell, 176 P.3d 835 (Colo. App. 2007).* <https://www.courtlistener.com/opinion/2633761/phoenix-capital-inc-v-dowell/#:~:text=Consequently%2C%20we%20discern%20no%20error,specified%20in%20the%20parties'%20agreement.>
+
+[^crs-enforced-time]: **C.R.S. § 8-2-113** — "This subsection (2) does not apply to a covenant not to compete governing a person who, at the time the covenant not to compete is entered into and at the time it is enforced, earns an amount of annualized cash compensation equivalent to or greater than the threshold amount for highly compensated workers" *C.R.S. § 8-2-113(2)(b).* <https://content.leg.colorado.gov/sites/default/files/images/olls/crs2024-title-08.pdf>
+
+[^dev-misdemeanor]: **C.R.S. § 8-2-113** — "A person who violates this subsection (1.5) commits a class 2 misdemeanor, as defined in section 18-1.3-501." *C.R.S. § 8-2-113(1.5)(b).* <https://content.leg.colorado.gov/sites/default/files/images/olls/crs2024-title-08.pdf>
+
+[^dev-hb22-1317]: **C.R.S. § 8-2-113** — "An employer that violates subsection (8)(a) of this section is liable for actual damages and a penalty of five thousand dollars per worker or prospective worker harmed by the conduct." *C.R.S. § 8-2-113(8)(b).* <https://content.leg.colorado.gov/sites/default/files/images/olls/crs2024-title-08.pdf>
+
+[^dev-hb24-1324]: **C.R.S. § 8-2-113** — "The attorney general may recover three times the amount of any recovery or attempted recovery by an employer in violation of subsection (3)(a) of this section." *C.R.S. § 8-2-113(8)(b).* <https://content.leg.colorado.gov/sites/default/files/images/olls/crs2024-title-08.pdf>
+
+[^dev-sb25-083]: **S.B. 25-083 (Limitations on Restrictive Employment Agreements)** — "EXCEPT FOR A COVENANT NOT TO COMPETE THAT RESTRICTS THE PRACTICE OF MEDICINE, THE PRACTICE OF ADVANCED PRACTICE REGISTERED NURSING, OR THE PRACTICE OF DENTISTRY IN THIS STATE, this subsection (2) does not apply to a covenant not to compete" *S.B. 25-083, 75th Gen. Assemb., Reg. Sess. (Colo. 2025) (amending C.R.S. § 8-2-113(2)(b)).* <https://leg.colorado.gov/bills/sb25-083>
+
+[^ebg-recent-thresholds]: **Raising the Cost of Noncompetes: 2026 State Noncompete Salary Threshold Changes** — "Effective January 1, 2026, the threshold amount for highly compensated workers is $130,014." *Epstein Becker Green, Raising the Cost of Noncompetes: 2026 State Noncompete Salary Threshold Changes (Dec. 10, 2025).* <https://www.tradesecretsandemployeemobility.com/raising-the-cost-of-noncompetes-2026-state-noncompete-salary-threshold-changes>

--- a/skills/non-compete-contract-explainer/content/connecticut.md
+++ b/skills/non-compete-contract-explainer/content/connecticut.md
@@ -1,0 +1,220 @@
+---
+jurisdiction: "Connecticut"
+slug: connecticut
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-02"
+canonicalUrl: https://openagreements.org/legal/non-compete/connecticut
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/connecticut · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in Connecticut[^about]
+
+Connecticut generally enforces non-competes only when the restraint is reasonable under common law and not displaced by an occupation-specific statutory limit.
+
+
+## At a glance
+
+| Question | Connecticut |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed if reasonable |
+| **Bottom line** | Connecticut enforces employee non-competes only if reasonable under common law, but several occupation-specific statutes cap or void covenants for covered workers. |
+| **Main law or case** | common law (Scott v. Gen. Iron & Welding Co., 171 Conn. 132 (1976)); occupation statutes |
+| **Main exceptions** | Physician/PA/APRN 1-yr & 15-mile caps; security guards; broadcast employees; homemaker-companion/home-health bans |
+| **Can a court narrow it?** | Unsettled |
+| **Applies to contractors?** | Unclear |
+| **Restriction extended during a breach?** | Silent — open question |
+| **Maximum length set by law** | No general statutory cap; physicians/PAs/APRNs capped at 1 year |
+
+## Are employee non-compete agreements enforceable in Connecticut? {#employee-noncompetes}
+
+**Short answer.** Yes, sometimes. Connecticut is a reasonableness state, not a general ban state, and an employee non-compete is enforceable only if it is partial, reasonable, protective of a fair employer interest, not unduly harsh on the employee, and not injurious to the public interest [^scott-employee-noncompete-reasonableness][^scott-employee-livelihood].
+
+The common-law analysis comes from *Scott v. General Iron & Welding Co.* and related Connecticut cases. In practice, the five recurring questions are duration, geography, fair protection of the employer, restraint on the employee, and public interest [^scott-employee-noncompete-reasonableness][^scott-employee-livelihood].
+
+Connecticut also has targeted statutory overrides. Physicians, physician assistants, APRNs, security guards, broadcast employees, and homemaker-companion or home-health workers have separate statutory rules that can cap, narrow, or void a covenant before ordinary common-law balancing matters.
+
+"The interests of the employee himself must also be protected, and a restrictive covenant is unenforceable if by its terms the employee is precluded from pursuing his occupation and thus prevented from supporting himself and his family."[^scott-employee-livelihood]
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not classify Connecticut as a total-ban jurisdiction. Start with the worker category, then apply the statutory rule if one exists, and only then apply common-law reasonableness to any remaining covenant [^scott-employee-noncompete-reasonableness][^physician-statutory-cap-overview][^home-health-worker-ban-overview].
+
+## What legitimate business interests can support a Connecticut non-compete? {#protectable-interests}
+
+**Short answer.** Trade secrets, confidential information, customer lists, and customer goodwill are the core interests that can justify a tailored Connecticut restraint [^scott-customer-confidential-information][^roessler-customer-goodwill-protection][^cutsa-trade-secret-definition].
+
+*Scott* upheld protection for a customer list and other confidential information when the employee had access to them in a managerial role [^scott-customer-confidential-information]. *Roessler* treated customer relationships as protectable when the restriction was limited to customers the employee had serviced and solicited for the employer [^roessler-customer-goodwill-protection].
+
+CUTSA supplies the trade-secret overlay. A trade secret includes information such as a formula, process, cost data, or customer list only when it has independent economic value from not being generally known and is subject to reasonable secrecy efforts [^cutsa-trade-secret-definition]. CUTSA also authorizes injunctions for actual or threatened misappropriation and damages for actual loss and unjust enrichment [^cutsa-injunctive-relief][^cutsa-damages].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not use a non-compete to block ordinary competition disconnected from a protectable interest. Tie the restraint to specific confidential information, trade secrets, customer lists, or goodwill, and keep trade-secret remedies in a separate confidentiality and CUTSA strategy [^scott-customer-confidential-information][^cutsa-trade-secret-definition][^cutsa-injunctive-relief].
+
+## What duration and geographic scope are reasonable for a Connecticut non-compete? {#duration-geography}
+
+**Short answer.** There is no single statewide cap for ordinary employees. Connecticut courts balance time, geography, employer protection, employee burden, and public interest as a whole [^scott-geographic-area-reasonable][^scott-five-year-duration][^van-dyck-time-geography-intertwined].
+
+*Scott* upheld a statewide management restriction because the employer had customers throughout Connecticut and did business in many towns [^scott-geographic-area-reasonable]. The same case upheld a five-year period based on the facts, including the years required to build the customer base and the employee's ability to keep working in his trade [^scott-five-year-duration].
+
+Customer-focused limits can be easier to defend than broad territory limits. In *Roessler*, a one-year restriction with broad locality language was upheld because it was limited to soliciting the employer's customers that the employee had serviced [^roessler-one-year-customer-limit]. *Van Dyck* likewise treated time and geography as intertwined rather than mechanical boxes [^van-dyck-time-geography-intertwined].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Avoid copying a duration or radius from another Connecticut form without matching the worker's role and customer exposure. A larger area may need a shorter period, a longer period may need a narrower area, and a customer-specific restriction may be safer than a broad market ban [^van-dyck-time-geography-intertwined][^roessler-one-year-customer-limit].
+
+## Is continued at-will employment enough consideration for a Connecticut non-compete? {#continued-employment-consideration}
+
+**Short answer.** Yes, if the continued employment is connected to the covenant. The current Connecticut rule is that continued at-will employment can supply sufficient consideration for a restrictive covenant signed after employment has begun [^dur-a-flex-consideration-reversal][^schimenti-continued-employment-rule].
+
+*Dur-A-Flex* is the current Connecticut Supreme Court anchor. It reversed a lack-of-consideration ruling and required further proceedings on whether the non-compete was supported by adequate consideration [^dur-a-flex-consideration-reversal]. *Schimenti* had already read *Roessler* as binding precedent that continued at-will employment can be sufficient consideration when the employee receives the benefit of continued employment after signing [^schimenti-continued-employment-rule].
+
+The important limitation is connection. *Schimenti* held that continued employment can be sufficient if connected to the covenant, but a defendant may still try to prove no connection between signing and continued employment [^schimenti-connected-consideration]. *Thoma* is now best read as fact-specific: the later agreement removed severance rights, and continued employment was not predicated on the new agreement [^thoma-fact-specific-consideration].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not rely on a recital alone. Connecticut now permits continued at-will employment as consideration, but the enforcement record is stronger when the offer letter, promotion letter, or covenant states that signing is a condition of continued employment and the employee actually receives that continued employment [^schimenti-continued-employment-rule][^schimenti-connected-consideration].
+
+## Will a Connecticut court blue-pencil or narrow an overbroad non-compete? {#court-narrowing}
+
+**Short answer.** Do not count on judicial rewriting. Connecticut authority gives employers no reliable rule that a court will rewrite an overbroad covenant into an enforceable one — internally inconsistent restraint language can be construed against the drafter, and the one statutory severance rule in this area preserves only the *non-covenant* provisions of a contract when the covenant itself is void [^thoma-ambiguous-duration-against-drafter][^physician-void-covenant-remainder-survives].
+
+The practical lesson is to draft severable and tiered restrictions. If the contract states one indivisible radius or one indivisible activity ban, a court may have no narrower text to preserve. Separable tiers, customer-specific alternatives, and a severability clause give a court cleaner text to enforce or strike.
+
+*Thoma* illustrates the risk of internally inconsistent noncompetition language: the court could not reasonably reconcile the conflicting terms and construed the ambiguity against the drafter [^thoma-ambiguous-duration-against-drafter]. The physician statute separately shows a narrow statutory severance model — when a physician covenant is void in whole or in part, the contract's remaining provisions survive [^physician-void-covenant-remainder-survives].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Use tiered and severable drafting rather than an aggressive savings clause. A clause that asks a court to supply a new Connecticut radius, duration, or job-function limit is riskier than contract text that lets a court strike an unenforceable tier and leave a narrower tier intact [^thoma-ambiguous-duration-against-drafter][^physician-void-covenant-remainder-survives].
+
+## Which Connecticut industries and professions have special non-compete limits? {#industry-specific-limits}
+
+**Short answer.** Connecticut has targeted statutory limits for physicians, physician assistants, APRNs, security guards, broadcast employees, and homemaker-companion or home-health service workers [^physician-one-year-fifteen-mile-limit][^physician-assistant-one-year-fifteen-mile-limit][^aprn-one-year-fifteen-mile-limit][^security-guard-trade-secret-exception][^broadcast-employee-restriction-ban][^home-health-worker-covenant-void].
+
+For physicians, a covenant must be necessary to protect a legitimate business interest, reasonably limited, and consistent with law and public policy; for covenants entered, amended, extended, or renewed on or after July 1, 2016, the restraint cannot exceed one year or a fifteen-mile radius from the primary practice site [^physician-one-year-fifteen-mile-limit][^physician-termination-nonrenewal-limit]. Physician assistants and APRNs have parallel one-year and fifteen-mile limits for covenants entered, amended, extended, or renewed on or after October 1, 2023 [^physician-assistant-one-year-fifteen-mile-limit][^aprn-one-year-fifteen-mile-limit].
+
+Security-guard covenants are barred for covered guards working the same or similar job at the same location unless the employer proves the guard obtained employer trade secrets [^security-guard-trade-secret-exception]. Broadcast-industry employers cannot require covered broadcast employees to refrain from other broadcast employment in a specified area for a specified time after termination [^broadcast-employee-restriction-ban].
+
+For homemaker-companion and home-health services, Connecticut voids covenants not to compete, and a companion statute voids client no-hire clauses that impose penalties, fees, breach claims, damages, or injunction exposure for directly hiring the agency employee [^home-health-worker-covenant-void][^home-health-client-no-hire-ban].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not use the ordinary *Scott* reasonableness test to rescue a covenant that a Connecticut occupation-specific statute voids. For covered workers, the statute controls first, and common-law reasonableness matters only if the statutory rule leaves room for enforcement [^physician-one-year-fifteen-mile-limit][^security-guard-trade-secret-exception][^home-health-worker-covenant-void].
+
+## Does a Connecticut non-compete toll or extend during breach or litigation? {#tolling-extension}
+
+**Short answer.** This is an open Connecticut question. No staged Connecticut statute or appellate decision squarely endorses automatic judicial tolling or enforcement of an extension-on-breach clause after the stated restricted period expires [^van-dyck-injunction-moot-after-period][^scott-reasonableness-backdrop-for-tolling].
+
+The best staged Connecticut authority points toward caution. In *Van Dyck*, the plaintiff sought injunctive relief on a covenant whose claimed period had already run, and the Superior Court treated the request for injunctive relief as moot rather than automatically extending the restraint [^van-dyck-injunction-moot-after-period]. That does not decide every contractual tolling clause, but it is not an endorsement of automatic extension.
+
+Contractual extension-on-breach language still has to fit the *Scott* reasonableness lens. If the extension turns a fixed covenant into an open-ended restraint, or if litigation delay creates a much longer practical restraint than the employer could justify at signing, enforceability is unsettled and fact-dependent [^scott-reasonableness-backdrop-for-tolling].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Open question: Connecticut law is unsettled on whether an extension-on-breach clause is enforceable after the original restricted period expires. Draft any tolling clause as a separate, reasonable restraint tied to breach duration and a legitimate interest, and do not assume a court will extend an expired covenant automatically [^van-dyck-injunction-moot-after-period][^scott-reasonableness-backdrop-for-tolling].
+
+## Did the FTC's federal non-compete rule change Connecticut non-compete law? {#federal-ftc-overlay}
+
+**Short answer.** No. The FTC's 2024 nationwide Non-Compete Rule was set aside by a federal district court, so Connecticut non-competes remain governed by Connecticut statutes, Connecticut common law, and any other applicable state or federal claim-specific rules [^ryan-ftc-rule-set-aside].
+
+*Ryan LLC v. FTC* held that the FTC lacked statutory authority to promulgate the rule and that the rule was arbitrary and capricious [^ryan-ftc-unlawful-agency-action]. The court then set aside the rule and stated that it would not be enforced or take effect on September 4, 2024, or later [^ryan-ftc-rule-set-aside].
+
+That federal outcome does not make every Connecticut covenant enforceable. It simply removes the FTC rule as the nationwide overlay. Connecticut's common-law reasonableness test and occupation-specific statutes still control the Connecticut analysis.
+
+"The Non-Compete Rule, 16 C.F.R. § 910.1–.6, is hereby SET ASIDE and shall not be enforced or otherwise take effect on September 4, 2024, or thereafter."[^ryan-ftc-rule-set-aside]
+
+## What recent Connecticut non-compete reform efforts should employers watch? {#pending-reform}
+
+**Short answer.** None is currently law. Connecticut's most recent reform effort, House Bill 5492 (2026), would have voided non-competes for lower-wage workers [^hb-5492-wage-threshold-bill]. It did not pass: the bill reached the House Calendar but got no floor vote before the General Assembly adjourned, the latest in a line of failed attempts.
+
+The enacted baseline remains common-law reasonableness plus the occupation-specific statutes described above. HB 5492 matters because it signals the likely direction of future legislation, not because it is current law.
+
+HB 5492 would have made a covenant void and unenforceable against employees earning less than two times, and independent contractors earning less than five times, the minimum fair wage [^hb-5492-wage-threshold-bill]. The Labor and Public Employees Committee reported it favorably and it reached the House Calendar as File No. 393 on April 2, 2026, but it received no floor vote before the General Assembly adjourned for the 2026 session, so it died — following House Bill 7196 in 2025 and House Bill 5269 in 2024.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Treat a failed bill like HB 5492 as a monitoring item, not as present Connecticut law. Recheck the official Connecticut General Assembly bill status each session before changing forms or telling workers that Connecticut has enacted a general wage-threshold non-compete statute [^hb-5492-wage-threshold-bill].
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-02. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not Connecticut. This article synthesizes Connecticut primary law and is not legal advice from a Connecticut-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^scott-employee-noncompete-reasonableness]: **Scott v. General Iron & Welding Co.** — "In order to be valid and binding, a covenant which restricts the activities of an employee following the termination of his employment must be partial and restricted in its operation ‘in respect either to time or place, . . . and must be reasonable — that is, it should afford only a fair protection to the interest of the party in whose favor it is made and must not be so large in its operation as to interfere with the interests of the public." *Scott v. Gen. Iron & Welding Co., 171 Conn. 132 (1976).* <https://www.courtlistener.com/opinion/2268855/scott-v-general-iron-welding-co/#:~:text=In%20order%20to%20be%20valid,the%20interests%20of%20the%20public.>
+
+[^scott-employee-livelihood]: **Scott v. General Iron & Welding Co.** — "The interests of the employee himself must also be protected, and a restrictive covenant is unenforceable if by its terms the employee is precluded from pursuing his occupation and thus prevented from supporting himself and his family." *Scott v. Gen. Iron & Welding Co., 171 Conn. 132 (1976).* <https://www.courtlistener.com/opinion/2268855/scott-v-general-iron-welding-co/#:~:text=The%20interests%20of%20the%20employee,supporting%20himself%20and%20his%20family.>
+
+[^physician-statutory-cap-overview]: **Conn. Gen. Stat. § 20-14p** — "A covenant not to compete is valid and enforceable only if it is: (A) Necessary to protect a legitimate business interest; (B) reasonably limited in time, geographic scope and practice restrictions as necessary to protect such business interest; and (C) otherwise consistent with the law and public policy." *Conn. Gen. Stat. § 20-14p(b)(1).* <https://www.cga.ct.gov/current/pub/chap_370.htm#sec_20-14p>
+
+[^home-health-worker-ban-overview]: **Conn. Gen. Stat. § 20-681** — "Any covenant not to compete is against public policy and shall be void and unenforceable." *Conn. Gen. Stat. § 20-681.* <https://www.cga.ct.gov/current/pub/chap_400o.htm#sec_20-681>
+
+[^scott-customer-confidential-information]: **Scott v. General Iron & Welding Co.** — "The plaintiff’s knowledge of the defendant’s customer list was a potential threat to the defendant’s business, and the defendant was entitled to protect that and other confidential information for a reasonable period of time." *Scott v. Gen. Iron & Welding Co., 171 Conn. 132 (1976).* <https://www.courtlistener.com/opinion/2268855/scott-v-general-iron-welding-co/#:~:text=The%20plaintiff%E2%80%99s%20knowledge%20of%20the,a%20reasonable%20period%20of%20time.>
+
+[^roessler-customer-goodwill-protection]: **Roessler v. Burwell** — "The limitation of the solicitation to such customers was one well calculated to afford to the plaintiff a reasonable protection in his business against deprivation of customers with whom the defendant had very likely established friendly relations, and whom he could approach upon the definite basis of affording them as good or better service than the plaintiff had done in the past." *Roessler v. Burwell, 119 Conn. 289 (1934).* <https://www.courtlistener.com/opinion/3323907/roessler-v-burwell/#:~:text=The%20limitation%20of%20the%20solicitation,had%20done%20in%20the%20past.>
+
+[^cutsa-trade-secret-definition]: **Conn. Gen. Stat. § 35-51** — "Notwithstanding the provisions of sections 1-210 , 31-40j to 31-40p , inclusive, and subsection (c) of section 12-62 , ‘trade secret’ means information, including a formula, pattern, compilation, program, device, method, technique, process, drawing, cost data or customer list that: (1) Derives independent economic value, actual or potential, from not being generally known to, and not being readily ascertainable by proper means by, other persons who can obtain economic value from its disclosure or use, and (2) is the subject of efforts that are reasonable under the circumstances to maintain its secrecy." *Conn. Gen. Stat. § 35-51(d).* <https://www.cga.ct.gov/current/pub/chap_625.htm#sec_35-51>
+
+[^cutsa-injunctive-relief]: **Conn. Gen. Stat. § 35-52** — "Actual or threatened misappropriation may be enjoined upon application to any court of competent jurisdiction." *Conn. Gen. Stat. § 35-52(a).* <https://www.cga.ct.gov/current/pub/chap_625.htm#sec_35-52>
+
+[^cutsa-damages]: **Conn. Gen. Stat. § 35-53** — "In addition to or in lieu of injunctive relief, a complainant may recover damages for the actual loss caused by misappropriation. A complainant also may recover for the unjust enrichment caused by misappropriation that is not taken into account in computing damages for actual loss." *Conn. Gen. Stat. § 35-53(a).* <https://www.cga.ct.gov/current/pub/chap_625.htm#sec_35-53>
+
+[^scott-geographic-area-reasonable]: **Scott v. General Iron & Welding Co.** — "A restrictive covenant which protects the employer in areas in which he does not do business or is unlikely to do business is unreasonable with respect to area." *Scott v. Gen. Iron & Welding Co., 171 Conn. 132 (1976).* <https://www.courtlistener.com/opinion/2268855/scott-v-general-iron-welding-co/#:~:text=A%20restrictive%20covenant%20which%20protects,unreasonable%20with%20respect%20to%20area.>
+
+[^scott-five-year-duration]: **Scott v. General Iron & Welding Co.** — "In this case, the court could reasonably and logically conclude that a five-year restriction is reasonable, as the finding reveals that it had taken years of effort for the defendant to acquire its customers." *Scott v. Gen. Iron & Welding Co., 171 Conn. 132 (1976).* <https://www.courtlistener.com/opinion/2268855/scott-v-general-iron-welding-co/#:~:text=In%20this%20case%2C%20the%20court,defendant%20to%20acquire%20its%20customers.>
+
+[^van-dyck-time-geography-intertwined]: **Van Dyck Printing Co. v. DiNicola** — "A restriction covering a large area might be reasonable if in effect for a brief time, while a restriction covering a small area might be reasonable for a longer time." *Van Dyck Printing Co. v. DiNicola, 43 Conn. Supp. 191 (1993).* <https://www.courtlistener.com/opinion/3334840/van-dyck-printing-co-v-dinicola/#:~:text=A%20restriction%20covering%20a%20large,reasonable%20for%20a%20longer%20time.>
+
+[^roessler-one-year-customer-limit]: **Roessler v. Burwell** — "The time was only for one year, and while the statement of the locality itself was broad, the covenant was definitely restricted to the solicitation of customers of the plaintiff." *Roessler v. Burwell, 119 Conn. 289 (1934).* <https://www.courtlistener.com/opinion/3323907/roessler-v-burwell/#:~:text=The%20time%20was%20only%20for,of%20customers%20of%20the%20plaintiff.>
+
+[^dur-a-flex-consideration-reversal]: **Dur-A-Flex, Inc. v. Dy** — "We conclude, therefore, that the trial court incorrectly determined that continued employment can never be consideration for a noncompete agreement." *Dur-A-Flex, Inc. v. Dy, 349 Conn. 513 (2024).* <https://www.courtlistener.com/opinion/10131708/dur-a-flex-inc-v-dy/#:~:text=We%20conclude%2C%20therefore%2C%20that%20the%20trial%20court%20incorrectly,consideration%20for%20a%20noncompete%20agreement.>
+
+[^schimenti-continued-employment-rule]: **Schimenti Construction Co., LLC v. Schimenti** — "Its holding that consideration in the form of continued employment for at-will employees can be sufficient to make enforceable a restrictive covenant agreed to by the parties at some point after the commencement of employment remains binding precedent." *Schimenti Constr. Co., LLC v. Schimenti, 217 Conn. App. 224 (2023).* <https://www.courtlistener.com/opinion/9367427/schimenti-construction-co-llc-v-schimenti/#:~:text=Its%20holding%20that%20consideration%20in,of%20employment%20remains%20binding%20precedent.>
+
+[^schimenti-connected-consideration]: **Schimenti Construction Co., LLC v. Schimenti** — "At trial, as the plaintiff did in Thoma, the defendant may present evidence that there was no con- nection between the nondisclosure agreement and his continued employment; but, if connected, continued employment can be sufficient consideration for a restrictive covenant." *Schimenti Constr. Co., LLC v. Schimenti, 217 Conn. App. 224 (2023).* <https://www.courtlistener.com/opinion/9367427/schimenti-construction-co-llc-v-schimenti/#:~:text=At%20trial%2C%20as%20the%20plaintiff,consideration%20for%20a%20restrictive%20covenant.>
+
+[^thoma-fact-specific-consideration]: **Thoma v. Oxford Performance Materials, Inc.** — "Consequently, the record supports the court’s conclusion that the defendant’s financing and the plaintiff’s continued employment were not predicated on the second agreement’s execution." *Thoma v. Oxford Performance Materials, Inc., 153 Conn. App. 50 (2014).* <https://www.courtlistener.com/opinion/2733143/thoma-v-oxford-performance-materials-inc/#:~:text=Consequently%2C%20the%20record%20supports%20the,on%20the%20second%20agreement%E2%80%99s%20execution.>
+
+[^thoma-ambiguous-duration-against-drafter]: **Thoma v. Oxford Performance Materials, Inc.** — "Such a reasonable construction is not possible in this case." *Thoma v. Oxford Performance Materials, Inc., 153 Conn. App. 50 (2014).* <https://www.courtlistener.com/opinion/2733143/thoma-v-oxford-performance-materials-inc/#:~:text=Such%20a%20reasonable%20construction%20is,not%20possible%20in%20this%20case.>
+
+[^physician-void-covenant-remainder-survives]: **Conn. Gen. Stat. § 20-14p** — "The remaining provisions of any contract or agreement that includes a covenant not to compete that is rendered void and unenforceable, in whole or in part, under the provisions of this section shall remain in full force and effect, including provisions that require the payment of damages resulting from any injury suffered by reason of termination of such contract or agreement." *Conn. Gen. Stat. § 20-14p(c).* <https://www.cga.ct.gov/current/pub/chap_370.htm#sec_20-14p>
+
+[^physician-one-year-fifteen-mile-limit]: **Conn. Gen. Stat. § 20-14p** — "A covenant not to compete that is entered into, amended, extended or renewed on or after July 1, 2016, shall not: (A) Restrict the physician's competitive activities (i) for a period of more than one year, and (ii) in a geographic region of more than fifteen miles from the primary site where such physician practices; or (B) be enforceable against a physician if (i) such employment contract or agreement was not made in anticipation of, or as part of, a partnership or ownership agreement and such contract or agreement expires and is not renewed, unless, prior to such expiration, the employer makes a bona fide offer to renew the contract on the same or similar terms and conditions, or (ii) the employment or contractual relationship is terminated by the employer, unless such employment or contractual relationship is terminated for cause." *Conn. Gen. Stat. § 20-14p(b)(2).* <https://www.cga.ct.gov/current/pub/chap_370.htm#sec_20-14p>
+
+[^physician-assistant-one-year-fifteen-mile-limit]: **Conn. Gen. Stat. § 20-12k** — "A covenant not to compete that is entered into, amended, extended or renewed on or after October 1, 2023, shall not: (A) Restrict the physician assistant's competitive activities (i) for a period of more than one year, and (ii) in a geographic region of more than fifteen miles from the primary site where such physician assistant practices; or (B) be enforceable against a physician assistant if (i) such employment contract or agreement was not made in anticipation of, or as part of, a partnership or ownership agreement and such contract or agreement expires and is not renewed, unless, prior to such expiration, the employer makes a bona fide offer to renew the contract on the same or similar terms and conditions, or (ii) the employment or contractual relationship is terminated by the employer, unless such employment or contractual relationship is terminated for cause." *Conn. Gen. Stat. § 20-12k(b)(2).* <https://www.cga.ct.gov/current/pub/chap_370.htm#sec_20-12k>
+
+[^aprn-one-year-fifteen-mile-limit]: **Conn. Gen. Stat. § 20-101d** — "A covenant not to compete that is entered into, amended, extended or renewed on or after October 1, 2023, shall not: (A) Restrict the advanced practice registered nurse's competitive activities (i) for a period of more than one year, and (ii) in a geographic region of more than fifteen miles from the primary site where such advanced practice registered nurse practices; or (B) be enforceable against an advanced practice registered nurse if (i) such employment contract or agreement was not made in anticipation of, or as part of, a partnership or ownership agreement and such contract or agreement expires and is not renewed, unless, prior to such expiration, the employer makes a bona fide offer to renew the contract on the same or similar terms and conditions, or (ii) the employment or contractual relationship is terminated by the employer, unless such employment or contractual relationship is terminated for cause." *Conn. Gen. Stat. § 20-101d(b)(2).* <https://www.cga.ct.gov/current/pub/chap_378.htm#sec_20-101d>
+
+[^security-guard-trade-secret-exception]: **Conn. Gen. Stat. § 31-50a** — "No employer may require any person employed in the classification 339032 of the standard occupational classification system of the Bureau of Labor Statistics of the United States Department of Labor to enter into an agreement prohibiting such person from engaging in the same or a similar job, at the same location at which the employer employs such person, for another employer or as a self-employed person, unless the employer proves that such person has obtained trade secrets, as defined in subsection (d) of section 35-51 , of the employer." *Conn. Gen. Stat. § 31-50a(a).* <https://www.cga.ct.gov/current/pub/chap_557.htm#sec_31-50a>
+
+[^broadcast-employee-restriction-ban]: **Conn. Gen. Stat. § 31-50b** — "No broadcast industry employer employment contract for the services of a broadcast employee may contain a provision requiring that such broadcast employee: (1) Refrain from obtaining employment in a specified geographical area for a specified period of time after termination of employment with that broadcast industry employer; (2) Disclose the terms or conditions of an offer of employment, or the existence of any such offer, from any other broadcast industry employer following the expiration of the term of the employment contract; or (3) Agree to enter into a subsequent employment contract with the broadcast industry employer, or extend or renew the existing employment contract, upon the same terms and conditions offered by a prospective employer." *Conn. Gen. Stat. § 31-50b(b).* <https://www.cga.ct.gov/current/pub/chap_557.htm#sec_31-50b>
+
+[^home-health-worker-covenant-void]: **Conn. Gen. Stat. § 20-681** — "Any covenant not to compete is against public policy and shall be void and unenforceable." *Conn. Gen. Stat. § 20-681.* <https://www.cga.ct.gov/current/pub/chap_400o.htm#sec_20-681>
+
+[^physician-termination-nonrenewal-limit]: **Conn. Gen. Stat. § 20-14p** — "A covenant not to compete that is entered into, amended, extended or renewed on or after October 1, 2023, shall not be enforceable if (A) the physician who is a party to the employment or other contract or agreement does not agree to a proposed material change to the compensation terms of such contract or agreement prior to or at the time of the extension or renewal of such contract or agreement, and (B) the contract or agreement expires and is not renewed by the employer or the employment or contractual relationship is terminated by the employer, unless such employment or contractual relationship is terminated by the employer for cause." *Conn. Gen. Stat. § 20-14p(b)(3).* <https://www.cga.ct.gov/current/pub/chap_370.htm#sec_20-14p>
+
+[^home-health-client-no-hire-ban]: **Conn. Gen. Stat. § 20-683** — "Any no-hire clause in a contract between a homemaker-companion agency and a client of such agency is against public policy and shall be void." *Conn. Gen. Stat. § 20-683(b).* <https://www.cga.ct.gov/current/pub/chap_400o.htm#sec_20-683>
+
+[^van-dyck-injunction-moot-after-period]: **Van Dyck Printing Co. v. DiNicola** — "Because the plaintiffs claim concerning the covenant at issue applied to a two year period commencing in April, 1987, the plaintiff’s request for injunctive relief has become moot." *Van Dyck Printing Co. v. DiNicola, 43 Conn. Supp. 191 (1993).* <https://www.courtlistener.com/opinion/3334840/van-dyck-printing-co-v-dinicola/#:~:text=Because%20the%20plaintiffs%20claim%20concerning,injunctive%20relief%20has%20become%20moot.>
+
+[^scott-reasonableness-backdrop-for-tolling]: **Scott v. General Iron & Welding Co.** — "In determining whether a restrictive covenant of employment is in restraint of trade, ‘[t]he test of its validity is the reasonableness of the restraint it imposes.’" *Scott v. Gen. Iron & Welding Co., 171 Conn. 132 (1976).* <https://www.courtlistener.com/opinion/2268855/scott-v-general-iron-welding-co/#:~:text=In%20determining%20whether%20a%20restrictive,of%20the%20restraint%20it%20imposes.%E2%80%9D>
+
+[^ryan-ftc-rule-set-aside]: **Ryan LLC v. Federal Trade Commission** — "The Non-Compete Rule, 16 C.F.R. § 910.1–.6, is hereby SET ASIDE and shall not be enforced or otherwise take effect on September 4, 2024, or thereafter." *Ryan LLC v. Fed. Trade Comm'n, 746 F. Supp. 3d 369 (N.D. Tex. 2024).* <https://www.courtlistener.com/opinion/10205745/ryan-llc-v-federal-trade-commission/#:~:text=The%20Non%2DCompete%20Rule%2C%2016%20C.F.R.,September%204%2C%202024%2C%20or%20thereafter.>
+
+[^ryan-ftc-unlawful-agency-action]: **Ryan LLC v. Federal Trade Commission** — "In sum, the Court concludes that the FTC lacks statutory authority to promulgate the Non- Compete Rule, and that the Rule is arbitrary and capricious." *Ryan LLC v. Fed. Trade Comm'n, 746 F. Supp. 3d 369 (N.D. Tex. 2024).* <https://www.courtlistener.com/opinion/10205745/ryan-llc-v-federal-trade-commission/#:~:text=In%20sum%2C%20the%20Court%20concludes%20that,Rule%20is%20arbitrary%20and%20capricious.>
+
+[^hb-5492-wage-threshold-bill]: **An Act Concerning Limitations on the Use on Noncompete Agreements (H.B. 5492)** — "A covenant not to compete shall be void and unenforceable against a worker if (1) such worker is (A) an employee whose hourly wage is less than two times the minimum fair wage, or (B) an independent contractor whose hourly wage is less than five times the minimum fair wage" *H.B. 5492, 2026 Gen. Assemb., Feb. Sess. (Conn. 2026) (File No. 393).* <https://www.cga.ct.gov/2026/fc/pdf/2026HB-05492-R000393-FC.pdf>

--- a/skills/non-compete-contract-explainer/content/delaware.md
+++ b/skills/non-compete-contract-explainer/content/delaware.md
@@ -1,0 +1,222 @@
+---
+jurisdiction: "Delaware"
+slug: delaware
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-02"
+canonicalUrl: https://openagreements.org/legal/non-compete/delaware
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/delaware · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in Delaware[^about]
+
+Delaware enforces reasonable non-competes under Court of Chancery and Supreme Court case law, but modern decisions refuse to blue-pencil overbroad covenants and must be read with the physician ban and choice-of-law statute.
+
+
+## At a glance
+
+| Question | Delaware |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed if reasonable |
+| **Bottom line** | Delaware enforces reasonable non-competes under Chancery/Supreme Court case law but increasingly refuses to blue-pencil overbroad ones, and physician practice-restricting covenants are void by statute. |
+| **Main law or case** | common law (FP UC Holdings, LLC v. Hamilton, 2020 (Del. Ch.)); physician ban 6 Del. C. § 2707 |
+| **Main exceptions** | Physician practice covenants void (§ 2707); home-inspector trainees; sale-of-business reviewed less searchingly |
+| **Can a court narrow it?** | No |
+| **Applies to contractors?** | Unclear |
+| **Restriction extended during a breach?** | Not addressed |
+| **Maximum length set by law** | No statutory limit |
+
+## Are employee non-compete agreements enforceable in Delaware? {#employee-noncompetes}
+
+**Short answer.** Yes, if the covenant is reasonable, protects a legitimate economic interest, and survives the equities. Delaware courts do not mechanically enforce non-competes [^fp-uc-reasonableness-test].
+
+Delaware has no general wage-threshold, notice, or garden-leave statute for ordinary employee non-competes. The baseline rule is common law. The covenant must meet contract-law requirements, fit the protected business interest, and avoid imposing unusual hardship or an unreasonable restraint on trade [^fp-uc-reasonableness-test][^sunder-chancery-holistic-review].
+
+The practical posture is pro-enforcement only for disciplined drafting. A Delaware choice of law clause, executive status, or equity grant does not replace the reasonableness inquiry for a true restraint on post-employment competition.
+
+## What makes a Delaware non-compete reasonable? {#reasonableness-test}
+
+**Short answer.** Delaware looks at the covenant's time, geography, activity scope, protected interest, consideration, and equitable effect together. A covenant should be no broader than the business interest it protects [^payscale-legitimate-interests].
+
+Recognized interests include employer goodwill and confidential information. In *Payscale*, the Delaware Supreme Court held at the pleading stage that an eighteen-month nationwide restriction could proceed where Payscale pleaded a nationwide business, high-value customer relationships, and confidential compensation-data strategy [^payscale-legitimate-interests][^payscale-specific-interests-pleaded].
+
+That is not a safe harbor for nationwide clauses. It is a procedural and factual point: broad scope may be supportable when the pleaded business reality is equally broad, but Delaware still requires tailoring. Surviving a motion to dismiss is not a ruling that the covenant is reasonable; it means only that the complaint pleaded enough to proceed past the pleading stage.
+
+## Will a Delaware court narrow or blue-pencil an overbroad non-compete? {#court-narrowing}
+
+**Short answer.** Usually not as a litigation strategy. Delaware courts retain equitable discretion, but recent Chancery and Supreme Court decisions warn that overbroad covenants may fall rather than be rewritten [^sunder-supreme-blue-pencil-discretion].
+
+The modern no-blue-pencil spine comes from *Kodiak*, *Intertek*, and *Sunder*. The reason is incentive-based: if courts routinely trim overbroad restrictions, employers can draft broadly, chill workers, and still get a lawful restraint if challenged [^kodiak-blue-pencil-inequity][^intertek-no-rescue][^sunder-supreme-perverse-incentives].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not draft a Delaware covenant on the assumption that a court will narrow it later. Put the actual enforceable scope in the contract: protected business, restricted activities, customer set, geography, and duration [^sunder-supreme-blue-pencil-discretion][^intertek-no-rescue].
+
+## How does Delaware treat sale-of-business non-competes? {#sale-of-business}
+
+**Short answer.** Delaware gives sale-of-business covenants a less searching review than ordinary employment covenants, but the restraint still must match the goodwill and competitive space bought in the deal [^derge-sale-less-searching].
+
+*Kodiak* is the cautionary example. The buyer acquired Northwest, but the covenant also protected unrelated Kodiak business segments and affiliates. The Court of Chancery refused preliminary enforcement because the restraint exceeded the interest purchased in the transaction [^kodiak-goodwill-limit].
+
+*Derge* shows the other side. The Court of Chancery enforced a five-year sale-linked covenant against a C-suite executive who received nearly one million dollars in merger consideration and had operational knowledge across the acquired business [^derge-substantial-consideration][^derge-reasonable-sale-scope].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> In a Delaware M&A covenant, define the restricted business by the acquired business and the goodwill actually purchased. Do not use buyer-family affiliate language to protect unrelated legacy businesses unless the record supports that scope [^kodiak-goodwill-limit].
+
+## Are equity-forfeiture or forfeiture-for-competition provisions enforceable in Delaware? {#forfeiture-for-competition}
+
+**Short answer.** Yes — and not only in the limited-partnership setting. Delaware treats a forfeiture-for-competition provision as a condition on a deferred benefit rather than an injunction-backed restraint, and reviews it under the employee-choice doctrine instead of the ordinary reasonableness test [^ainslie-condition-precedent].
+
+The distinction matters. A true non-compete restrains work and is reviewed for reasonableness. A forfeiture-for-competition provision can let the former partner compete while losing a contingent benefit. In that setting, the Delaware Supreme Court held that public policy favored enforcing the limited partnership agreement against sophisticated parties [^ainslie-employee-choice-distinction][^ainslie-summary-rule].
+
+*Ainslie* itself arose from a limited-partnership agreement, but the doctrine is not confined to that setting. In *LKQ Corp. v. Rutledge*, the Delaware Supreme Court advised the Seventh Circuit that *Ainslie* is not restricted to the limited-partnership context, extending the employee-choice doctrine to a corporate restricted-stock-unit forfeiture-for-competition provision [^lkq-not-limited-to-lp].
+
+Do not overread the doctrine. It governs forfeiture conditions on deferred benefits such as partnership distributions or equity awards; it does not let an employer relabel a covenant that directly bars work and thereby escape the reasonableness review that still governs true restraints on post-employment competition.
+
+## What consideration is required for a Delaware non-compete? {#consideration}
+
+**Short answer.** Delaware can treat continued at-will employment as sufficient consideration when signing is a condition of continued employment, and the Delaware Supreme Court measures consideration at contract formation rather than enforcement [^powell-continued-employment][^doorly-formation-timing].
+
+*Powell* upheld a restrictive covenant where the employee was told he would lose the position if he did not sign. *Doorly* later addressed equity-linked covenants and reversed dismissal where the Court of Chancery had evaluated consideration after the employee forfeited incentive units [^powell-condition-employment][^doorly-not-reevaluated].
+
+Consideration is not the whole analysis. A covenant supported by employment, promotion, cash, or equity still must satisfy the Delaware reasonableness test if it restrains post-employment competition. *Doorly* fixes whether consideration *exists* at formation, but the *adequacy* of that consideration is not irrelevant — the balancing of the equities still lets a court weigh how much the employee actually received against the breadth of the restraint [^payscale-adequacy-equities].
+
+## Are physician non-competes allowed in Delaware? {#physician-noncompetes}
+
+**Short answer.** No, not if the covenant restricts a physician's right to practice medicine by place or time after termination. Delaware Code § 2707 makes that type of physician non-compete void [^delaware-physician-void].
+
+The statute is targeted. It applies to physician covenants in employment, partnership, or corporate agreements, and it leaves other agreement provisions enforceable. It also permits damages provisions if the amount is reasonably related to injury from termination, including damages related to competition [^delaware-physician-damages].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> For Delaware physician agreements, separate any damages clause from a prohibited practice restriction and tie the damages amount to actual injury. Section 2707 voids the locale-or-time restraint but preserves reasonably related damages provisions [^delaware-physician-void][^delaware-physician-damages].
+
+## Can a contract choose Delaware law to govern a non-compete? {#delaware-choice-of-law}
+
+**Short answer.** Often yes for qualifying contracts, but not absolutely. Section 2708 supports Delaware choice-of-law clauses, while Delaware conflict-of-law decisions can still defer to another state's fundamental non-compete policy [^delaware-choice-law-statute][^ascension-public-policy-limit].
+
+Section 2708 creates a strong Delaware-law anchor when the written contract selects Delaware law and the parties are subject to Delaware jurisdiction and service. The statute excludes contracts involving less than $100,000 [^delaware-choice-law-threshold].
+
+But *Ascension* refused to let Delaware's contractarian policy automatically override California's statutory policy for a California employee and California-centered performance. *FP UC Holdings* applied the same Restatement-style framework when Alabama had the stronger interest in an Alabama non-compete issue [^ascension-public-policy-limit][^fp-uc-choice-law-limit].
+
+> [!NOTE]
+> **Practice note.**
+>
+> A Delaware choice-of-law clause is not a universal workaround for another state's non-compete restrictions. Before enforcing against an out-of-state worker, analyze the default state, its fundamental policy, and whether it has a materially greater interest in the specific covenant [^ascension-public-policy-limit][^fp-uc-choice-law-limit].
+
+## How do trade-secret and confidentiality protections fit in? {#trade-secrets-confidentiality}
+
+**Short answer.** DUTSA gives Delaware employers targeted trade-secret remedies that can substitute for, or sit beside, a narrower covenant package. It protects information that has independent economic value from secrecy and is subject to reasonable secrecy efforts [^dutsa-trade-secret-definition].
+
+DUTSA authorizes injunctions for actual or threatened misappropriation, damages for actual loss and unjust enrichment, exemplary damages for wilful and malicious misappropriation, and fee shifting in specified bad-faith or wilful-and-malicious cases [^dutsa-injunctive-relief][^dutsa-damages][^dutsa-fees].
+
+It also preserves contract remedies, whether or not based on trade-secret misappropriation. That matters for confidentiality clauses, but a confidentiality clause should still be drafted around actual confidential information rather than as an indefinite non-compete by another name [^dutsa-contract-remedies].
+
+## Are there other Delaware statutory non-compete limits? {#home-inspector-trainees}
+
+**Short answer.** Yes. Delaware separately protects home inspector trainees: a trainee cannot be required to sign a non-compete with a supervising licensed home inspector as a condition of satisfying trainee requirements [^home-inspector-trainee-ban].
+
+This is a narrow licensing rule, not a general employee non-compete statute. It should be included in profession-specific reviews, especially for inspection businesses and trainee-supervision arrangements.
+
+## What are the key recent developments in Delaware non-compete law? {#recent-developments}
+
+**Short answer.** From 2024 through 2026, the Delaware Supreme Court issued a run of restrictive-covenant decisions spanning the employee-choice doctrine, blue-pencil discretion, consideration timing, and pleading-stage treatment of broad employee covenants [^ainslie-recent-track][^lkq-recent-track][^sunder-recent-track][^doorly-recent-track][^payscale-recent-track].
+
+- 
+- 
+- 
+- 
+- 
+
+The through-line is not that Delaware became anti-enforcement. It is that Delaware separates contract forms carefully and demands fact-specific tailoring before enforcing true restraints on work.
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-02. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not Delaware. This article synthesizes Delaware primary law and is not legal advice from a Delaware-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^fp-uc-reasonableness-test]: **FP UC Holdings, LLC v. Hamilton** — "Instead, our courts carefully review the covenants to assure they ‘(1) [are] reasonable in geographic scope and temporal duration, (2) advance a legitimate economic interest of the party seeking its enforcement, and (3) survive a balancing of the equities.’" *FP UC Holdings, LLC v. Hamilton, 2020 WL 1492783, at *6 (Del. Ch. Mar. 27, 2020).* <https://www.courtlistener.com/opinion/4739986/fp-uc-holdings-llc-fpmcm-llc-and-fast-pace-medical-clinic-pllc-v/#:~:text=Instead%2C%20our%20courts%20carefully%20review,a%20balancing%20of%20the%20equities.%E2%80%9D>
+
+[^sunder-chancery-holistic-review]: **Sunder Energy, LLC v. Jackson** — "When evaluating the reasonableness of a restrictive covenant, a court examines the restriction holistically and in context. That means evaluating all of the dimensions of the restrictive covenant and considering how it operates with other restrictions in the contract." *Sunder Energy, LLC v. Jackson, 305 A.3d 723, 754 (Del. Ch. 2023), aff'd in relevant part, 332 A.3d 472 (Del. 2024).* <https://www.courtlistener.com/opinion/9444424/sunder-energy-llc-v-jackson/#:~:text=When%20evaluating%20the%20reasonableness%20of,other%20restrictions%20in%20the%20contract.>
+
+[^payscale-legitimate-interests]: **Payscale Inc. v. Norman** — "For a restrictive covenant, ‘‘[l]egitimate interests’ recognized by Delaware law include protection of employer goodwill[] and protection of employer confidential information from misuse.’" *Payscale Inc. v. Norman, No. 297, 2025, slip op. at 15-16 (Del. Mar. 19, 2026).* <https://www.courtlistener.com/opinion/10811247/payscale-inc-v-erin-norman-and-bettercomp-inc/#:~:text=For%20a%20restrictive%20covenant%2C%20%E2%80%9C%E2%80%98%5Bl%5Degitimate,employer%20confidential%20information%20from%20misuse.%E2%80%9D>
+
+[^payscale-specific-interests-pleaded]: **Payscale Inc. v. Norman** — "Payscale alleges that the non-compete’s terms are directly tied to protecting specific contracts with its most valued customers; at the pleadings stage, it is reasonable to infer that protecting relationships with these key ... customers is in Payscale’s ‘particularly strong economic interest.’" *Payscale Inc. v. Norman, No. 297, 2025, slip op. at 18 (Del. Mar. 19, 2026).* <https://www.courtlistener.com/opinion/10811247/payscale-inc-v-erin-norman-and-bettercomp-inc/#:~:text=Payscale%20alleges%20that%20the%20non%2Dcompete%E2%80%99s,Payscale%E2%80%99s%20%E2%80%9Cparticularly%20strong%20economic%20interest.%E2%80%9D>
+
+[^sunder-supreme-blue-pencil-discretion]: **Sunder Energy, LLC v. Jackson** — "This is not to say that Delaware courts should never blue pencil an agreement that is overbroad in some respects. But the relief Appellant sought was a wholesale reformation of the parties’ agreement." *Sunder Energy, LLC v. Jackson, 332 A.3d 472, 495 (Del. 2024).* <https://www.courtlistener.com/opinion/10291288/sunder-energy-llc-v-tyler-jackson/#:~:text=This%20is%20not%20to%20say,reformation%20of%20the%20parties%E2%80%99%20agreement.>
+
+[^kodiak-blue-pencil-inequity]: **Kodiak Building Partners, LLC v. Adams** — "The inequities inherent in blue-penciling a noncompete also counsel against enforcing only those portions of the RCA that are supported by Kodiak’s legitimate business interests, even as Adams appears to have violated those portions." *Kodiak Bldg. Partners, LLC v. Adams, 2022 WL 5240507, at *13 n.108 (Del. Ch. Oct. 6, 2022).* <https://www.courtlistener.com/opinion/8247185/kodiak-building-partners-llc-v-philip-d-adams/#:~:text=The%20inequities%20inherent%20in%20blue%2Dpenciling,to%20have%20violated%20those%20portions.>
+
+[^intertek-no-rescue]: **Intertek Testing Services NA, Inc. v. Eastman** — "In my view, revising the non-compete to save Intertek—a sophisticated party—from its overreach would be inequitable." *Intertek Testing Servs. NA, Inc. v. Eastman, 2023 WL 2544236, at *5 (Del. Ch. Mar. 16, 2023).* <https://www.courtlistener.com/opinion/9384707/intertek-testing-services-na-inc-v-jeff-eastman/#:~:text=In%20my%20view%2C%20revising%20the,its%20overreach%20would%20be%20inequitable.>
+
+[^sunder-supreme-perverse-incentives]: **Sunder Energy, LLC v. Jackson** — "This argument, however, turns the analysis on its head and creates perverse incentives for employers drafting restrictive covenants. If employers know that even the most unreasonable covenants will be enforced if an employee’s conduct is sufficiently flagrant, employers will be less incentivized to craft reasonable restrictions from the outset." *Sunder Energy, LLC v. Jackson, 332 A.3d 472, 495 (Del. 2024).* <https://www.courtlistener.com/opinion/10291288/sunder-energy-llc-v-tyler-jackson/#:~:text=This%20argument%2C%20however%2C%20turns%20the,reasonable%20restrictions%20from%20the%20outset.>
+
+[^derge-sale-less-searching]: **Derge v. D&H United Fueling Solutions, Inc.** — "By comparison, ‘covenants not to compete in the context of a business sale are subject to a ‘less searching’ inquiry than if the covenant ‘had been contained in an employment contract.’’" *Derge v. D&H United Fueling Sols., Inc., C.A. No. 2025-0087-BWD, slip op. at 12 (Del. Ch. Dec. 8, 2025).* <https://www.courtlistener.com/opinion/10749078/william-brian-derge-v-dh-united-fueling-solutions-inc/#:~:text=By%20comparison%2C%20%E2%80%9Ccovenants%20not%20to,contained%20in%20an%20employment%20contract.%E2%80%99%E2%80%9D>
+
+[^kodiak-goodwill-limit]: **Kodiak Building Partners, LLC v. Adams** — "In sum, Kodiak has a legitimate business interest in protecting the goodwill it purchased when it bought Northwest, and the confidential information about Kodiak operations that Adams knows or could access." *Kodiak Bldg. Partners, LLC v. Adams, 2022 WL 5240507, at *8 (Del. Ch. Oct. 6, 2022).* <https://www.courtlistener.com/opinion/8247185/kodiak-building-partners-llc-v-philip-d-adams/#:~:text=In%20sum%2C%20Kodiak%20has%20a,Adams%20knows%20or%20could%20access.>
+
+[^derge-substantial-consideration]: **Derge v. D&H United Fueling Solutions, Inc.** — "Plaintiff received substantial consideration ... $1 million—in a merger that was conditioned on his agreement to the Non-Compete." *Derge v. D&H United Fueling Sols., Inc., C.A. No. 2025-0087-BWD, slip op. at 16-17 (Del. Ch. Dec. 8, 2025).* <https://www.courtlistener.com/opinion/10749078/william-brian-derge-v-dh-united-fueling-solutions-inc/#:~:text=Plaintiff%20received%20substantial%20consideration,conditioned%20on%20his%20agreement%20to%20the%20Non%2DCompete.>
+
+[^derge-reasonable-sale-scope]: **Derge v. D&H United Fueling Solutions, Inc.** — "The record here shows that Tanknology conducted business across the United States and internationally, and that, as COO, Plaintiff had responsibility over operations across all markets. Thus, Defendants have a legitimate business interest in the Protected Area." *Derge v. D&H United Fueling Sols., Inc., C.A. No. 2025-0087-BWD, slip op. at 19 (Del. Ch. Dec. 8, 2025).* <https://www.courtlistener.com/opinion/10749078/william-brian-derge-v-dh-united-fueling-solutions-inc/#:~:text=The%20record%20here%20shows%20that,interest%20in%20the%20Protected%20Area.>
+
+[^ainslie-condition-precedent]: **Cantor Fitzgerald, L.P. v. Ainslie** — "It found, instead, that the Competitive Activity Condition was a condition precedent to Cantor Fitzgerald’s duty to pay the Conditioned Amounts. We agree with that conclusion, and the Plaintiffs do not contest it on appeal." *Cantor Fitzgerald, L.P. v. Ainslie, 312 A.3d 674, 690 (Del. 2024).* <https://www.courtlistener.com/opinion/9469727/cantor-fitzgerald-lp-v-ainslie/#:~:text=It%20found%2C%20instead%2C%20that%20the,not%20contest%20it%20on%20appeal.>
+
+[^ainslie-employee-choice-distinction]: **Cantor Fitzgerald, L.P. v. Ainslie** — "Thus, the Competitive Activity Condition does not restrict competition or a former partner’s ability to work; nor does competition support injunctive relief." *Cantor Fitzgerald, L.P. v. Ainslie, 312 A.3d 674, 694 (Del. 2024).* <https://www.courtlistener.com/opinion/9469727/cantor-fitzgerald-lp-v-ainslie/#:~:text=Thus%2C%20the%20Competitive%20Activity%20Condition,does%20competition%20support%20injunctive%20relief.>
+
+[^ainslie-summary-rule]: **Cantor Fitzgerald, L.P. v. Ainslie** — "To sum up, we disagree with the Court of Chancery’s conclusion that forfeiture-for-competition provisions like the one at issue here are restraints of trade subject to review for reasonableness." *Cantor Fitzgerald, L.P. v. Ainslie, 312 A.3d 674, 700 (Del. 2024).* <https://www.courtlistener.com/opinion/9469727/cantor-fitzgerald-lp-v-ainslie/#:~:text=To%20sum%20up%2C%20we%20disagree,subject%20to%20review%20for%20reasonableness.>
+
+[^lkq-not-limited-to-lp]: **LKQ Corp. v. Rutledge** — "Cantor Fitzgerald is not restricted to the limited partnership context." *LKQ Corp. v. Rutledge, No. 110, 2024 (Del. Dec. 18, 2024).* <https://www.courtlistener.com/opinion/10296559/lkq-corporation-v-robert-rutledge/#:~:text=Cantor%20Fitzgerald%20is%20not%20restricted,to%20the%20limited%20partnership%20context.>
+
+[^powell-continued-employment]: **Research & Trading Corp. v. Powell** — "The Court finds there was sufficient consideration at the time of the signing of the covenant to support an enforceable restrictive covenant." *Research & Trading Corp. v. Powell, 468 A.2d 1301, 1305 (Del. Ch. 1983).* <https://www.courtlistener.com/opinion/2275060/research-trading-corp-v-powell/#:~:text=The%20Court%20finds%20there%20was,support%20an%20enforceable%20restrictive%20covenant.>
+
+[^doorly-formation-timing]: **North American Fire Ultimate Holdings, LP v. Doorly** — "Because consideration is measured at the time of contracting and not at the time of enforcement, we reverse and remand for further proceedings." *N. Am. Fire Ultimate Holdings, LP v. Doorly, No. 142, 2025, order at 2 (Del. Feb. 3, 2026).* <https://www.courtlistener.com/opinion/10783312/north-american-fire-ultimate-holdings-lp-v-alan-doorly/#:~:text=Because%20consideration%20is%20measured%20at,and%20remand%20for%20further%20proceedings.>
+
+[^powell-condition-employment]: **Research & Trading Corp. v. Powell** — "Powell was told he would lose the position if he did not sign." *Research & Trading Corp. v. Powell, 468 A.2d 1301, 1305 (Del. Ch. 1983).* <https://www.courtlistener.com/opinion/2275060/research-trading-corp-v-powell/#:~:text=Powell%20was%20told%20he%20would,if%20he%20did%20not%20sign.>
+
+[^doorly-not-reevaluated]: **North American Fire Ultimate Holdings, LP v. Doorly** — "Consideration is measured at the time of formation and is not reevaluated at the time of enforcement." *N. Am. Fire Ultimate Holdings, LP v. Doorly, No. 142, 2025, order at 6 (Del. Feb. 3, 2026).* <https://www.courtlistener.com/opinion/10783312/north-american-fire-ultimate-holdings-lp-v-alan-doorly/#:~:text=Consideration%20is%20measured%20at%20the%20time%20of%20formation,at%20the%20time%20of%20enforcement.>
+
+[^payscale-adequacy-equities]: **Payscale Inc. v. Norman** — "That is not to suggest that the adequacy of consideration is irrelevant in the context of restrictive covenants; the balancing-of-the-equities inquiry affords the court discretion to weigh the breadth of a restrictive covenant against the consideration that supports it." *Payscale Inc. v. Norman, No. 297, 2025, slip op. at 17 (Del. Mar. 19, 2026).* <https://www.courtlistener.com/opinion/10811247/payscale-inc-v-erin-norman-and-bettercomp-inc/#:~:text=That%20is%20not%20to%20suggest,the%20consideration%20that%20supports%20it.>
+
+[^delaware-physician-void]: **6 Del. C. § 2707** — "Any covenant not to compete provision of an employment, partnership or corporate agreement between and/or among physicians which restricts the right of a physician to practice medicine in a particular locale and/or for a defined period of time, upon the termination of the principal agreement of which the said provision is a part, shall be void; except that all other provisions of such an agreement shall be enforceable at law, including provisions which require the payment of damages in an amount that is reasonably related to the injury suffered by reason of termination of the principal agreement." *6 Del. C. § 2707.* <https://delcode.delaware.gov/title6/c027/sc01/index.html>
+
+[^delaware-physician-damages]: **6 Del. C. § 2707** — "Provisions which require the payment of damages upon termination of the principal agreement may include, but not be limited to, damages related to competition." *6 Del. C. § 2707.* <https://delcode.delaware.gov/title6/c027/sc01/index.html>
+
+[^delaware-choice-law-statute]: **6 Del. C. § 2708** — "The foregoing shall conclusively be presumed to be a significant, material and reasonable relationship with this State and shall be enforced whether or not there are other relationships with this State." *6 Del. C. § 2708(a).* <https://delcode.delaware.gov/title6/c027/sc01/index.html>
+
+[^ascension-public-policy-limit]: **Ascension Insurance Holdings, LLC v. Underwood** — "I cannot agree with the Plaintiff, however, that the teaching of DGWL is that Delaware’s broad interest in freedom of contract will always, or even routinely, trump the default state’s public policy." *Ascension Ins. Holdings, LLC v. Underwood, 2015 WL 356002, at *5 (Del. Ch. Jan. 28, 2015).* <https://www.courtlistener.com/opinion/2774269/ascension-insurance-holdings-llc-v-roberts-f-under/#:~:text=I%20cannot%20agree%20with%20the,the%20default%20state%E2%80%99s%20public%20policy.>
+
+[^delaware-choice-law-threshold]: **6 Del. C. § 2708** — "This section shall not apply to any contract, agreement or other undertaking: (1) To the extent provided to the contrary in § 1-301(c) of this title; or (2) Involving less than $100,000." *6 Del. C. § 2708(c).* <https://delcode.delaware.gov/title6/c027/sc01/index.html>
+
+[^fp-uc-choice-law-limit]: **FP UC Holdings, LLC v. Hamilton** — "If these narrow ‘questions are answered in the affirmative, [Alabama] law will apply notwithstanding the choice-of-law provision.’" *FP UC Holdings, LLC v. Hamilton, 2020 WL 1492783, at *10 (Del. Ch. Mar. 27, 2020).* <https://www.courtlistener.com/opinion/4739986/fp-uc-holdings-llc-fpmcm-llc-and-fast-pace-medical-clinic-pllc-v/#:~:text=If%20these%20narrow%20%E2%80%9Cquestions%20are,apply%20notwithstanding%20the%20choice%2Dof%2Dlaw%20provision.%E2%80%9D>
+
+[^dutsa-trade-secret-definition]: **6 Del. C. § 2001** — "‘Trade secret’ shall mean information, including a formula, pattern, compilation, program, device, method, technique or process, that: a. Derives independent economic value, actual or potential, from not being generally known to, and not being readily ascertainable by proper means by, other persons who can obtain economic value from its disclosure or use; and b. Is the subject of efforts that are reasonable under the circumstances to maintain its secrecy." *6 Del. C. § 2001(4).* <https://delcode.delaware.gov/title6/c020/index.html>
+
+[^dutsa-injunctive-relief]: **6 Del. C. § 2002** — "(a) Actual or threatened misappropriation may be enjoined." *6 Del. C. § 2002(a).* <https://delcode.delaware.gov/title6/c020/index.html>
+
+[^dutsa-damages]: **6 Del. C. § 2003** — "Damages can include both the actual loss caused by misappropriation and the unjust enrichment caused by misappropriation that is not taken into account in computing actual loss." *6 Del. C. § 2003(a).* <https://delcode.delaware.gov/title6/c020/index.html>
+
+[^dutsa-fees]: **6 Del. C. § 2004** — "If a claim of misappropriation is made in bad faith, a motion to terminate an injunction is made or resisted in bad faith, or wilful and malicious misappropriation exists, the court may award reasonable attorney’s fees to the prevailing party." *6 Del. C. § 2004.* <https://delcode.delaware.gov/title6/c020/index.html>
+
+[^dutsa-contract-remedies]: **6 Del. C. § 2007** — "(1) Contractual remedies, whether or not based upon misappropriation of a trade secret;" *6 Del. C. § 2007(b)(1).* <https://delcode.delaware.gov/title6/c020/index.html>
+
+[^home-inspector-trainee-ban]: **24 Del. C. § 4109(d)** — "(d) No person, while registered as a home inspector trainee, shall be required to pay any fee, charge or other thing of value to a supervising licensed home inspector, or be required to execute a covenant not to compete with a supervising licensed home inspector, as a condition of satisfying the home inspector trainee requirements of this subchapter." *24 Del. C. § 4109(d).* <https://delcode.delaware.gov/title24/c041/sc02/index.html>
+
+[^ainslie-recent-track]: **Cantor Fitzgerald, L.P. v. Ainslie** — "Thus, the Competitive Activity Condition does not restrict competition or a former partner’s ability to work; nor does competition support injunctive relief." *Cantor Fitzgerald, L.P. v. Ainslie, 312 A.3d 674, 695 (Del. 2024).* <https://www.courtlistener.com/opinion/9469727/cantor-fitzgerald-lp-v-ainslie/#:~:text=Thus%2C%20the%20Competitive%20Activity%20Condition,does%20competition%20support%20injunctive%20relief.>
+
+[^lkq-recent-track]: **LKQ Corp. v. Rutledge** — "Cantor Fitzgerald is not restricted to the limited partnership context." *LKQ Corp. v. Rutledge, No. 110, 2024 (Del. Dec. 18, 2024).* <https://www.courtlistener.com/opinion/10296559/lkq-corporation-v-robert-rutledge/#:~:text=Cantor%20Fitzgerald%20is%20not%20restricted,to%20the%20limited%20partnership%20context.>
+
+[^sunder-recent-track]: **Sunder Energy, LLC v. Jackson** — "The Court of Chancery was well within its discretion to apply that precedent and refuse to blue pencil the covenants." *Sunder Energy, LLC v. Jackson, 332 A.3d 472, 492 (Del. 2024).* <https://www.courtlistener.com/opinion/10291288/sunder-energy-llc-v-tyler-jackson/#:~:text=The%20Court%20of%20Chancery%20was,to%20blue%20pencil%20the%20covenants.>
+
+[^doorly-recent-track]: **North American Fire Ultimate Holdings, LP v. Doorly** — "Because consideration is measured at the time of contracting and not at the time of enforcement, we reverse and remand for further proceedings." *N. Am. Fire Ultimate Holdings, LP v. Doorly, No. 142, 2025, order at 2 (Del. Feb. 3, 2026).* <https://www.courtlistener.com/opinion/10783312/north-american-fire-ultimate-holdings-lp-v-alan-doorly/#:~:text=Because%20consideration%20is%20measured%20at,and%20remand%20for%20further%20proceedings.>
+
+[^payscale-recent-track]: **Payscale Inc. v. Norman** — "Accordingly, the trial court erred in dismissing Payscale’s claim that Norman breached the non-compete provision." *Payscale Inc. v. Norman, No. 297, 2025, slip op. at 18 (Del. Mar. 19, 2026).* <https://www.courtlistener.com/opinion/10811247/payscale-inc-v-erin-norman-and-bettercomp-inc/#:~:text=Accordingly%2C%20the%20trial%20court%20erred,Norman%20breached%20the%20non%2Dcompete%20provision.>

--- a/skills/non-compete-contract-explainer/content/district-of-columbia.md
+++ b/skills/non-compete-contract-explainer/content/district-of-columbia.md
@@ -1,0 +1,263 @@
+---
+jurisdiction: "District of Columbia"
+slug: district-of-columbia
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-03"
+canonicalUrl: https://openagreements.org/legal/non-compete/district-of-columbia
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/district-of-columbia · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in the District of Columbia[^about]
+
+The District of Columbia bans non-compete provisions for most employees and allows them only for highly compensated employees who earn above an annually adjusted threshold and sign a covenant that meets strict scope, duration, and notice requirements.
+
+
+## At a glance
+
+| Question | District of Columbia |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed above a pay level |
+| **Bottom line** | The District bans non-competes for most employees and permits them only for highly compensated employees (above an annually adjusted pay floor) whose covenant meets strict scope, duration, and 14-day notice requirements. |
+| **Main law or case** | D.C. Code § 32-581.02 (Ban on Non-Compete Agreements Amendment Act of 2020) |
+| **Main exceptions** | Highly compensated employees above the pay threshold ($162,164 in 2026); medical specialists ($270,274 in 2026, 730-day cap); sale-of-business; confidentiality/long-term-incentive carve-outs; broadcast employees cannot be bound; pre-Oct 1, 2022 agreements under common law |
+| **When the ban took effect** | October 1, 2022 |
+| **Can a court narrow it?** | Yes — rewrites to reasonable |
+| **Applies to contractors?** | Unclear |
+| **Restriction extended during a breach?** | Open question — caps run as fixed days from separation |
+| **Maximum length set by law** | 365 days (non-medical highly compensated employee); 730 days (medical specialist) |
+
+## Are employee non-compete agreements enforceable in the District of Columbia? {#enforceability}
+
+**Short answer.** Usually no. Since October 1, 2022, a District employer may not require or request that a *covered employee* — broadly, most employees who do not meet a high compensation threshold — sign or comply with a non-compete provision, and a non-compete provision in a covered employee's agreement entered into on or after that date is void as a matter of law [^ban-covered][^void-rule].
+
+The governing law is the District's Ban on Non-Compete Agreements Amendment Act of 2020, codified at D.C. Code §§ 32-581.01 through 32-581.05 and operative since October 1, 2022. The prohibition is a flat rule for covered employees, not a reasonableness test [^ban-covered]. A non-compete provision that violates the ban in a covered employee's agreement is void and unenforceable by force of statute [^void-rule].
+
+The District law does leave a path for one group: a *highly compensated employee* may be bound by a non-compete that satisfies the strict scope, duration, and notice requirements described below [^hce-overview].
+
+"A non-compete provision that violates paragraph (1) of this subsection contained in an agreement between a covered employee and an employer that was entered into on or after October 1, 2022, shall be void as a matter of law and unenforceable."[^void-rule]
+
+## Who counts as a covered employee protected by the District's non-compete ban? {#covered-employee}
+
+**Short answer.** Most District-based employees who earn below the high compensation threshold. A covered employee is one who is not a highly compensated employee and who either spends more than 50% of work time for the employer in the District, or is District-based and regularly spends a substantial amount of work time in the District and not more than half elsewhere [^covered-definition].
+
+Coverage turns on two things: the District-work test above and compensation. For a non-broadcast employee who meets that work test, compensation is the dividing line — the ban protects everyone below the *minimum qualifying annual compensation*, which the statute set at a base of $150,000 (or $250,000 for a medical specialist) and which is adjusted upward each year for inflation [^min-qualifying-comp][^threshold-2026]. As of January 1, 2026, the District's Department of Employment Services puts the figures at $162,164 for most employees and $270,274 for medical specialists [^threshold-2026].
+
+Coverage also turns on where the work happens, not where the employer is headquartered, so a District-based role can be covered even if the employer is elsewhere [^covered-definition]. The chapter does not, however, override a valid collective bargaining agreement [^cba-carveout].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not assume an out-of-District employer escapes the ban. Coverage follows the employee's District work — more than 50% of work time in the District, or a District-based role with substantial District work — so a company anywhere can be subject to the prohibition for a worker based in the District [^covered-definition].
+
+## When can a District of Columbia employer use a non-compete agreement? {#highly-compensated-exception}
+
+**Short answer.** Only with a highly compensated employee, and only if the covenant meets every statutory requirement. A non-compete with a highly compensated employee is valid only if the agreement specifies the functional scope of the restriction and its geographic limits, caps the post-employment term, and is delivered in writing at least 14 days in advance [^hce-requirements][^hce-duration][^hce-notice-timing].
+
+A highly compensated employee is one — other than a broadcast employee — who is reasonably expected to earn, or who earned in the preceding consecutive 12-month period, at or above the minimum qualifying annual compensation [^hce-definition]. Broadcast employees are carved out of that definition, so an on-air or off-air creator for a broadcaster cannot be bound by a non-compete under this exception even at a high salary [^hce-definition][^broadcast-exclusion].
+
+For a qualifying employee, the agreement must do three things to be enforceable: specify the functional scope of the competitive restriction, specify the geographic limits, and cap the post-employment term — 365 calendar days for a non-medical employee [^hce-requirements][^hce-duration]. The employer must also deliver the non-compete provision in writing at least 14 days before the employee starts work, or at least 14 days before a current employee must sign [^hce-notice-timing].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> A high salary alone does not make a District non-compete enforceable. The agreement must spell out the functional scope and geographic limits, stay within the duration cap, and be delivered at least 14 days in advance — miss any element and the covenant is not valid and enforceable under § 32-581.03(a) [^hce-requirements][^hce-notice-timing].
+
+## How does the District treat non-competes for physicians and medical specialists? {#medical-specialists}
+
+**Short answer.** Medical specialists can be bound, but only above a higher pay floor and for a longer maximum term. A *medical specialist* — a licensed physician who has completed a residency and earns at least $250,000 (as annually adjusted) — may be subject to a non-compete capped at 730 calendar days, double the 365-day cap for other employees [^medical-specialist-def][^medical-duration].
+
+The medical specialist category is narrow: the statute requires a license to practice medicine, status as a physician, a completed medical residency, and total compensation of at least $250,000 before annual inflation adjustments [^medical-specialist-def]. For 2026, the Department of Employment Services sets the medical specialist threshold at $270,274 [^medical-threshold-2026].
+
+A medical specialist's non-compete must still meet all of the other § 32-581.03 requirements — functional scope, geographic limits, and 14-day advance written notice — and only the duration cap differs, at 730 calendar days from separation [^medical-duration][^medical-requirements].
+
+## What notices and disclosures must a District employer provide? {#notice-disclosures}
+
+**Short answer.** A specific statutory notice for proposed non-competes, plus written disclosure of any workplace-policy carve-outs. Whenever an employer proposes a non-compete to a highly compensated employee, it must provide a prescribed statutory notice, and an employer that relies on the policy exceptions to the non-compete definition must give employees a written copy of those provisions on a set timeline [^statutory-notice][^policy-disclosure].
+
+The statutory notice has fixed content: it must tell the employee that the District's Ban on Non-Compete Agreements Amendment Act of 2020 limits non-competes, that the employer has determined the employee to be highly compensated, and that the employee can contact the District of Columbia Department of Employment Services for more information [^statutory-notice]. This notice requirement is separate from, and in addition to, the 14-day advance delivery rule for the non-compete provision itself.
+
+An employer whose workplace policy uses one of the exceptions to the non-compete definition — for example, an anti-moonlighting or conflict-of-interest restriction — must give affected employees a written copy of those provisions within 30 days of acceptance of employment, within 30 days after October 1, 2022, and whenever the policy changes [^policy-disclosure].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Build the disclosures into onboarding. A District employer that proposes a non-compete to a highly compensated employee must hand over the exact statutory notice, and any employer relying on a policy carve-out must distribute the written provisions within 30 days of hire and on every change — a missed disclosure is itself a violation carrying $250-per-employee monetary relief [^statutory-notice][^policy-disclosure][^disclosure-relief].
+
+## Does the District's ban reach workplace policies, not just signed contracts? {#workplace-policies}
+
+**Short answer.** Yes. The ban applies to a non-compete provision in either a written agreement or a *workplace policy*, and a workplace policy includes unwritten rules applied as a matter of practice [^noncompete-definition][^workplace-policy-def].
+
+A *non-compete provision* is defined as a provision in a written agreement or a workplace policy that prohibits an employee from performing work for another for pay or from operating the employee's own business [^noncompete-definition]. Because a *workplace policy* reaches rules and restrictions whether written or applied in practice, an employer cannot avoid the ban by moving a competition restriction out of the signed agreement and into a handbook or an informal rule [^workplace-policy-def].
+
+The definition does, however, leave room for a narrow set of during-employment restrictions. An anti-moonlighting or conflict-of-interest limit on outside work for pay is not a banned non-compete provision when the employer reasonably believes the outside work will disclose confidential information, conflict with established conflict-of-interest rules, create a conflict of commitment at a higher education institution, or impair the employer's ability to comply with law or a contract [^outside-work-carveout].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> A restriction on a current employee's outside work survives only if it fits the statutory carve-out. Tie it to the enumerated risks — confidential information, established conflict-of-interest rules, conflict of commitment at a higher education institution, or a legal or contractual compliance concern — and to a reasonable belief that the risk applies; a broad ban on any outside work risks being treated as a prohibited non-compete provision [^outside-work-carveout].
+
+## Are confidentiality and trade-secret protections still allowed in the District? {#confidentiality-trade-secrets}
+
+**Short answer.** Yes. A provision protecting the employer's confidential or proprietary information is expressly excluded from the non-compete definition, and the District's Uniform Trade Secrets Act gives an independent remedy [^confidentiality-carveout][^utsa-injunction].
+
+The statute carves a confidentiality restriction out of the non-compete definition, so a properly drafted nondisclosure obligation covering the employer's confidential or proprietary information is not a banned non-compete provision [^confidentiality-carveout]. The statute likewise excludes a provision that provides a long-term incentive, so a genuine long-term incentive arrangement — equity, options, or performance awards earned over more than one year — is not treated as a banned non-compete [^lti-carveout]. Separately, the District's Uniform Trade Secrets Act allows a court to enjoin actual or threatened misappropriation of a trade secret, giving employers a protection that does not depend on the non-compete rules at all [^utsa-injunction].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Keep a confidentiality clause to genuine confidential and proprietary information. The carve-out protects restrictions on disclosing or using employer information; a nondisclosure clause drafted so broadly that it effectively prevents the employee from working for a competitor risks being recharacterized as a prohibited non-compete provision [^confidentiality-carveout].
+
+## Are sale-of-business non-competes enforceable in the District of Columbia? {#sale-of-business}
+
+**Short answer.** They are not banned by the statute, but their enforceability still turns on common-law reasonableness. A covenant in which the seller of a business agrees not to compete with the buyer is excluded from the non-compete definition, so it is not void under the ban; it remains subject to the District's common-law rule of reason [^sale-carveout][^ellis-reasonableness].
+
+The statute excludes a non-compete contained within or executed contemporaneously with an agreement between the seller and buyer of a business, where the seller agrees not to compete with the buyer's business [^sale-carveout]. Because such a covenant sits outside the statute, the District's pre-existing common law controls its enforceability, and District courts evaluate a restraint of trade against the Restatement's reasonableness principles [^ellis-reasonableness].
+
+"A promise is unenforceable on grounds of public policy if it is unreasonably in restraint of trade."[^ellis-reasonableness]
+
+## What law applies to non-competes signed before October 1, 2022? {#older-agreements-common-law}
+
+**Short answer.** Common-law reasonableness, not the statutory ban. The voiding rule in § 32-581.02 reaches agreements entered into on or after October 1, 2022, so an earlier covenant — and any covenant outside the statute's scope — is governed by the District's common-law rule of reason [^void-rule-retroactivity][^ellis-partial][^cumulative-rule].
+
+Under that common law, a District court asks whether the restraint is reasonable, and it need not treat an overbroad covenant as all-or-nothing: the District has joined the jurisdictions that allow partial enforcement of a covenant only to the extent its terms are reasonable [^ellis-partial]. Courts apply the multi-factor reasonableness inquiry, and a trial court that declares a covenant unreasonable without properly applying those factors can be reversed [^deutsch-factors]. The statute also preserves these common-law rights expressly, providing that its remedies are in addition to and cumulative of the common law [^cumulative-rule].
+
+## Will a District of Columbia court rewrite or narrow an overbroad covenant? {#court-narrowing}
+
+**Short answer.** It can reform a covenant, but only by narrowing — never by broadening. The District of Columbia Court of Appeals has formally adopted the doctrine of equitable reformation to modify an overbroad restrictive covenant, but a court exceeds that doctrine if it expands the restriction beyond the contract's own terms [^steiner-reformation].
+
+In *Steiner v. American Friends of Lubavitch (Chabad)*, the court adopted equitable reformation but vacated an injunction because the trial court had used broader language than the employment contract, effectively enlarging the restraint [^steiner-reformation]. The lesson for drafters is that reformation is a backstop for narrowing, not a license to write an aggressive covenant and rely on a court to fix it.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not draft an overbroad District covenant expecting a court to rescue it. A court may narrow an unreasonable restraint under *Steiner*, but it may not broaden one beyond the contract's terms, and for a covered or highly compensated employee the statutory rules — not judicial reformation — control whether the covenant is valid at all [^steiner-reformation][^hce-requirements-narrowing].
+
+## What are the penalties for using a banned non-compete in the District? {#penalties-enforcement}
+
+**Short answer.** Administrative penalties plus per-employee monetary relief, and active enforcement by the Attorney General. An employer that violates the ban faces administrative penalties and owes statutory relief to each affected employee — and the District's Office of the Attorney General has pursued and settled non-compete cases [^relief-amounts][^oag-enforcement].
+
+The statute sets graduated monetary relief: an employer that subjects an employee to a banned non-compete owes that employee not less than $500 and not more than $1,000 [^relief-subjecting], an employer that attempts to enforce a void non-compete owes at least $1,500 [^relief-amounts], and subsequent violations carry at least $3,000 per employee [^relief-subsequent]. The Mayor may also assess administrative penalties for each violation [^admin-penalty]. Both the Mayor and the Attorney General enforce the chapter [^enforcement-authority], and a harmed person may also bring a civil action [^private-enforcement].
+
+The chapter also forbids retaliation: an employer may not retaliate or threaten to retaliate against a covered employee for refusing, failing to comply with, or complaining about a banned non-compete, and an employer that retaliates owes each affected employee between $1,000 and $2,500 [^retaliation-ban][^retaliation-relief].
+
+Enforcement is real. In November 2023, the Attorney General announced settlements with three employers and described the ban as making it illegal to impose non-compete agreements on most District workers earning less than $150,000 a year [^oag-enforcement]. The Attorney General has also treated a franchise *no-poach* clause as violating both the ban and the District's Antitrust Act, which declares contracts in restraint of trade illegal [^oag-nopoach][^antitrust].
+
+> [!NOTE]
+> **Practice note.**
+>
+> The exposure attaches per employee and to attempted enforcement, not just to a lawsuit you lose. Before presenting any District non-compete, confirm the worker is a highly compensated employee, the covenant meets every § 32-581.03 requirement, and the disclosures are made — because subjecting a covered employee to a banned covenant, or trying to enforce a void one, triggers fixed per-employee relief and Attorney General enforcement [^relief-amounts][^oag-enforcement].
+
+## Does a District of Columbia non-compete toll or extend during a breach or litigation? {#tolling-extension}
+
+**Short answer.** This is an open question, and the statute's structure cuts against automatic extension. The District's non-compete statute sets no tolling rule, and its caps run as a fixed number of calendar days measured from separation — language that sits uneasily with extending a highly compensated employee's restricted period during a breach or while litigation is pending [^tolling-duration-cap][^tolling-cumulative].
+
+The duration limits are written as hard caps: a non-medical highly compensated employee's term of non-competition may not exceed 365 calendar days, and a medical specialist's may not exceed 730 calendar days, each measured from the date of separation — not from the end of any breach [^tolling-duration-cap]. A tolling-on-breach clause that pushes enforcement past those caps would be in tension with the statutory ceiling. Because the District has no decision resolving whether a contractual extension survives, the safest reading is that an employer cannot rely on one.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Open question: District law does not say whether a clause extending the restricted period during a breach is enforceable, and the statute caps the term in calendar days measured from separation. Do not assume a District court will toll or extend an expired non-compete, and do not draft a highly compensated employee's covenant in a way that depends on running past the 365-day or 730-day cap [^tolling-duration-cap][^tolling-cumulative].
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-03. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not District of Columbia. This article synthesizes District of Columbia primary law and is not legal advice from a District of Columbia-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^ban-covered]: **D.C. Code § 32-581.02** — "Beginning October 1, 2022, no employer may require or request that a covered employee sign an agreement or comply with a workplace policy that includes a non-compete provision." *D.C. Code § 32-581.02(a)(1).* <https://code.dccouncil.gov/us/dc/council/code/sections/32-581.02>
+
+[^void-rule]: **D.C. Code § 32-581.02** — "A non-compete provision that violates paragraph (1) of this subsection contained in an agreement between a covered employee and an employer that was entered into on or after October 1, 2022, shall be void as a matter of law and unenforceable." *D.C. Code § 32-581.02(a)(2).* <https://code.dccouncil.gov/us/dc/council/code/sections/32-581.02>
+
+[^hce-overview]: **D.C. Code § 32-581.03** — "For a non-compete agreement between an employer and a highly compensated employee executed on or after October 1, 2022, to be valid and enforceable:" *D.C. Code § 32-581.03(a).* <https://code.dccouncil.gov/us/dc/council/code/sections/32-581.03>
+
+[^covered-definition]: **D.C. Code § 32-581.01** — "an employee who is not a highly compensated employee and: (A) If the employee has commenced work for the employer: (i) Spends more than 50% of his or her work time for the employer working in the District; or (ii) Whose employment for the employer is based in the District and the employee regularly spends a substantial amount of his or her work time for the employer in the District and not more than 50% of his or her work time for that employer in another jurisdiction" *D.C. Code § 32-581.01(6)(A).* <https://code.dccouncil.gov/us/dc/council/code/sections/32-581.01>
+
+[^min-qualifying-comp]: **D.C. Code § 32-581.01** — "Beginning with the calendar year in which this chapter becomes applicable: (i) $150,000; or (ii) $250,000, if the employee is a medical specialist. (B) For the calendar year beginning January 1, 2024, and each calendar year thereafter, an amount equal to the previous calendar year's minimum qualifying annual compensation, increased in proportion to the annual average increase, if any, in the Consumer Price Index for All Urban Consumers in the Washington Metropolitan Statistical Area published by the Bureau of Labor Statistics of the United States Department of Labor for the previous calendar year adjusted to the nearest whole dollar." *D.C. Code § 32-581.01(13).* <https://code.dccouncil.gov/us/dc/council/code/sections/32-581.01>
+
+[^threshold-2026]: **DOES Public Notice: District of Columbia Prohibition on Non-Compete Clauses (2026)** — "As of January 1, 2026, the restriction on non-compete clauses applies to employees earning less than $162,164 and to medical specialists earning less than $270,274." *D.C. Dep't of Emp't Servs., Office of Wage-Hour, Public Notice: District of Columbia Prohibition on Non-Compete Clauses (Jan. 1, 2026).* <https://does.dc.gov/sites/default/files/dc/sites/does/publication/attachments/2026%20Ban%20on%20Non-Compete%20Clauses_0.pdf>
+
+[^cba-carveout]: **D.C. Code § 32-581.04a** — "Nothing in this chapter shall be interpreted as superseding the terms of a valid collective bargaining agreement." *D.C. Code § 32-581.04a.* <https://code.dccouncil.gov/us/dc/council/code/sections/32-581.04a>
+
+[^hce-requirements]: **D.C. Code § 32-581.03** — "The agreement must specify: (A) The functional scope of the competitive restriction, including what services, roles, industry, or competing entities the employee is restricted from performing work in or on behalf of; (B) The geographical limitations of the work restriction" *D.C. Code § 32-581.03(a)(1).* <https://code.dccouncil.gov/us/dc/council/code/sections/32-581.03>
+
+[^hce-duration]: **D.C. Code § 32-581.03** — "If the employee is not a medical specialist, a term of non-competition that does not exceed 365 calendar days from the date the employee separates from employment with the employer" *D.C. Code § 32-581.03(a)(1)(C)(i).* <https://code.dccouncil.gov/us/dc/council/code/sections/32-581.03>
+
+[^hce-notice-timing]: **D.C. Code § 32-581.03** — "The employer shall provide the non-compete provision to the employee in writing: (A) At least 14 days before the individual commences employment for the employer; or (B) If the employer already employs the highly compensated employee, at least 14 days before the employee must execute the agreement." *D.C. Code § 32-581.03(a)(2).* <https://code.dccouncil.gov/us/dc/council/code/sections/32-581.03>
+
+[^hce-definition]: **D.C. Code § 32-581.01** — "other than a broadcast employee, an employee: (A) Who is reasonably expected to earn from the employer in a consecutive 12-month period compensation greater than or equal to the minimum qualifying annual compensation; or (B) Whose compensation earned from the employer in the consecutive 12-month period preceding the date on which the proposed term of non-competition is to begin is greater than or equal to the minimum qualifying annual compensation." *D.C. Code § 32-581.01(10).* <https://code.dccouncil.gov/us/dc/council/code/sections/32-581.01>
+
+[^broadcast-exclusion]: **D.C. Code § 32-581.01** — "‘Broadcast employee’ means an on- or off-air creator (such as an anchor, disc jockey, editor, producer, program host, reporter, or writer) of a legal entity that owns or operates one or more of the following: (A) A television station or network" *D.C. Code § 32-581.01(2).* <https://code.dccouncil.gov/us/dc/council/code/sections/32-581.01>
+
+[^medical-specialist-def]: **D.C. Code § 32-581.01** — "‘Medical specialist’ means a highly compensated employee who is engaged primarily in the delivery of medical services and who: (A) Holds a license to practice medicine; (B) Is a physician ; (C) Has completed a medical residency; and (D) Receives total compensation in the amount equal to or greater than $ 250,000." *D.C. Code § 32-581.01(12).* <https://code.dccouncil.gov/us/dc/council/code/sections/32-581.01>
+
+[^medical-duration]: **D.C. Code § 32-581.03** — "If the employee is a medical specialist, a term of non-competition that does not exceed 730 calendar days from the date the employee separates from employment with the employer" *D.C. Code § 32-581.03(a)(1)(C)(ii).* <https://code.dccouncil.gov/us/dc/council/code/sections/32-581.03>
+
+[^medical-threshold-2026]: **DOES Public Notice: District of Columbia Prohibition on Non-Compete Clauses (2026)** — "As of January 1, 2026, the restriction on non-compete clauses applies to employees earning less than $162,164 and to medical specialists earning less than $270,274." *D.C. Dep't of Emp't Servs., Public Notice: District of Columbia Prohibition on Non-Compete Clauses (Jan. 1, 2026).* <https://does.dc.gov/sites/default/files/dc/sites/does/publication/attachments/2026%20Ban%20on%20Non-Compete%20Clauses_0.pdf>
+
+[^medical-requirements]: **D.C. Code § 32-581.03** — "The agreement must specify: (A) The functional scope of the competitive restriction, including what services, roles, industry, or competing entities the employee is restricted from performing work in or on behalf of; (B) The geographical limitations of the work restriction" *D.C. Code § 32-581.03(a)(1).* <https://code.dccouncil.gov/us/dc/council/code/sections/32-581.03>
+
+[^statutory-notice]: **D.C. Code § 32-581.03a** — "A highly compensated employee's employer shall provide the following notice to the employee whenever a non-compete provision is proposed to the employee:" *D.C. Code § 32-581.03a(b).* <https://code.dccouncil.gov/us/dc/council/code/sections/32-581.03a>
+
+[^policy-disclosure]: **D.C. Code § 32-581.03a** — "An employer with a workplace policy that includes one or more of the exceptions to the definition of non-compete provision, as detailed in § 32-581.01(15) , shall provide a written copy of the provisions to an employee: (1) Within 30 days after the employee's acceptance of employment with the employer; (2) Within 30 days after October 1, 2022; and (3) Any time such policy changes." *D.C. Code § 32-581.03a(a).* <https://code.dccouncil.gov/us/dc/council/code/sections/32-581.03a>
+
+[^disclosure-relief]: **D.C. Code § 32-581.04** — "An employer that violates § 32-581.03a shall be liable for each violation to each employee subjected to the violation for monetary relief in an amount of $250." *D.C. Code § 32-581.04(d)(4).* <https://code.dccouncil.gov/us/dc/council/code/sections/32-581.04>
+
+[^noncompete-definition]: **D.C. Code § 32-581.01** — "‘Non-compete provision’ means a provision in a written agreement or a workplace policy that prohibits an employee from performing work for another for pay or from operating the employee's own business." *D.C. Code § 32-581.01(15).* <https://code.dccouncil.gov/us/dc/council/code/sections/32-581.01>
+
+[^workplace-policy-def]: **D.C. Code § 32-581.01** — "‘Workplace policy’ means the rules and restrictions, whether written or as a matter of practice, implemented by an employer to govern the conduct of the employer's employees." *D.C. Code § 32-581.01(19).* <https://code.dccouncil.gov/us/dc/council/code/sections/32-581.01>
+
+[^outside-work-carveout]: **D.C. Code § 32-581.01** — "Accepting money or a thing of value for performing work for a person other than the employer, during the employee's employment with the employer, because the employer reasonably believes the employee's acceptance of money or a thing of value under such circumstances will: (I) Result in the employee's disclosure or use of confidential employer information or proprietary employer information; (II) Conflict with the employer's, industry's, or profession's established rules regarding conflicts of interest; (III) Constitute a conflict of commitment if the employee is employed by a higher education institution; or (IV) Impair the employer's ability to comply with District or federal laws or regulations; a contract; or a grant agreement" *D.C. Code § 32-581.01(15)(B)(ii).* <https://code.dccouncil.gov/us/dc/council/code/sections/32-581.01>
+
+[^confidentiality-carveout]: **D.C. Code § 32-581.01** — "Disclosing, using, selling, or accessing the employer's confidential employer information or proprietary employer information" *D.C. Code § 32-581.01(15)(B)(i).* <https://code.dccouncil.gov/us/dc/council/code/sections/32-581.01>
+
+[^utsa-injunction]: **D.C. Code § 36-402** — "Actual or threatened misappropriation may be enjoined." *D.C. Code § 36-402(a).* <https://code.dccouncil.gov/us/dc/council/code/sections/36-402>
+
+[^lti-carveout]: **D.C. Code § 32-581.01** — "That provides a long-term incentive." *D.C. Code § 32-581.01(15)(C).* <https://code.dccouncil.gov/us/dc/council/code/sections/32-581.01>
+
+[^sale-carveout]: **D.C. Code § 32-581.01** — "Contained within or executed contemporaneously with an agreement between the seller of a business and one or more buyers of that business wherein the seller agrees not to compete with the buyer's business" *D.C. Code § 32-581.01(15)(A).* <https://code.dccouncil.gov/us/dc/council/code/sections/32-581.01>
+
+[^ellis-reasonableness]: **Ellis v. James V. Hurson Associates, Inc.** — "A promise is unenforceable on grounds of public policy if it is unreasonably in restraint of trade." *Ellis v. James V. Hurson Assocs., Inc., 565 A.2d 615 (D.C. 1989).* <https://www.courtlistener.com/opinion/1561257/ellis-v-james-v-hurson-associates-inc/#:~:text=A%20promise%20is%20unenforceable%20on,unreasonably%20in%20restraint%20of%20trade.>
+
+[^void-rule-retroactivity]: **D.C. Code § 32-581.02** — "A non-compete provision that violates paragraph (1) of this subsection contained in an agreement between a covered employee and an employer that was entered into on or after October 1, 2022, shall be void as a matter of law and unenforceable." *D.C. Code § 32-581.02(a)(2).* <https://code.dccouncil.gov/us/dc/council/code/sections/32-581.02>
+
+[^ellis-partial]: **Ellis v. James V. Hurson Associates, Inc.** — "we join those jurisdictions which have rejected the view that covenants not to compete must be enforceable in whole or not at all." *Ellis v. James V. Hurson Assocs., Inc., 565 A.2d 615 (D.C. 1989).* <https://www.courtlistener.com/opinion/1561257/ellis-v-james-v-hurson-associates-inc/#:~:text=we%20join%20those%20jurisdictions%20which,whole%20or%20not%20at%20all.>
+
+[^cumulative-rule]: **D.C. Code § 32-581.04b** — "The rights, remedies, and prohibitions accorded by the provisions of this chapter are in addition to and cumulative of any right, remedy, or prohibition accorded by the common law, federal law, or any District statute, and nothing contained in this chapter shall be construed to deny, abrogate, or impair any such common law or statutory right, remedy, or prohibition." *D.C. Code § 32-581.04b.* <https://code.dccouncil.gov/us/dc/council/code/sections/32-581.04b>
+
+[^deutsch-factors]: **Deutsch v. Barsky** — "we reverse that part of the trial court’s summary judgment decision relating to the validity and enforceability of the covenant" *Deutsch v. Barsky, 795 A.2d 669 (D.C. 2002).* <https://www.courtlistener.com/opinion/1439721/deutsch-v-barsky/#:~:text=we%20reverse%20that%20part%20of,and%20enforceability%20of%20the%20covenant>
+
+[^steiner-reformation]: **Steiner v. American Friends of Lubavitch (Chabad)** — "We also formally adopt the doctrine of equitable reformation to modify contract provisions, but hold that the trial court's equitable revision of the noncompete clause in this case exceeded the bounds of that doctrine by describing the activities the Steiners were precluded from engaging in using broader language than the terms of the employment contract itself and thus effectively expanding the scope of the restrictions contained in the noncompete clause." *Steiner v. Am. Friends of Lubavitch (Chabad), 177 A.3d 1246 (D.C. 2018).* <https://www.courtlistener.com/opinion/4464037/yehuda-steiner-v-american-friends-of-lubavitch-chaabad/#:~:text=We%20also%20formally%20adopt%20the,contained%20in%20the%20noncompete%20clause.>
+
+[^hce-requirements-narrowing]: **D.C. Code § 32-581.03** — "For a non-compete agreement between an employer and a highly compensated employee executed on or after October 1, 2022, to be valid and enforceable:" *D.C. Code § 32-581.03(a).* <https://code.dccouncil.gov/us/dc/council/code/sections/32-581.03>
+
+[^relief-amounts]: **D.C. Code § 32-581.04** — "An employer that attempts to enforce a non-compete provision that is unenforceable or void as provided in §§ 32-581.02(a)(2) and 32-581.03(a) shall be liable to each employee against whom the employer attempted to enforce the invalid non-compete provision for relief in an amount not less than $1,500." *D.C. Code § 32-581.04(d)(2)(A).* <https://code.dccouncil.gov/us/dc/council/code/sections/32-581.04>
+
+[^oag-enforcement]: **OAG Press Release on Non-Compete Settlements (Nov. 17, 2023)** — "On October 1, 2022, a new DC law went into effect that makes it illegal for employers to impose non-compete agreements on most DC workers who earn less than $150,000 per year." *Office of the Attorney General for the District of Columbia, Press Release (Nov. 17, 2023).* <https://oag.dc.gov/release/attorney-general-schwalb-announces-three-district>
+
+[^relief-subjecting]: **D.C. Code § 32-581.04** — "An employer that violates § 32-581.02(a)(1) shall be liable for each violation to each employee subjected to the violation for monetary relief in an amount not less than $500 and not greater than $1,000." *D.C. Code § 32-581.04(d)(1)(A).* <https://code.dccouncil.gov/us/dc/council/code/sections/32-581.04>
+
+[^relief-subsequent]: **D.C. Code § 32-581.04** — "For any subsequent violation of § 32-581.02(a)(1) , an employer that has been found liable pursuant to subparagraph (A) of this paragraph shall be liable for relief in an amount not less than $3,000 to each affected employee." *D.C. Code § 32-581.04(d)(1)(B).* <https://code.dccouncil.gov/us/dc/council/code/sections/32-581.04>
+
+[^admin-penalty]: **D.C. Code § 32-581.04** — "The Mayor may assess an administrative penalty of no less than $350 and no more than $1,000 for each violation of this chapter" *D.C. Code § 32-581.04(b)(1).* <https://code.dccouncil.gov/us/dc/council/code/sections/32-581.04>
+
+[^enforcement-authority]: **D.C. Code § 32-581.04** — "The Mayor and Attorney General shall administer and enforce this chapter consistent with their respective powers and rights under § 32-1306(a) , (a-1) , (b) , and (c) ." *D.C. Code § 32-581.04(a)(1).* <https://code.dccouncil.gov/us/dc/council/code/sections/32-581.04>
+
+[^private-enforcement]: **D.C. Code § 32-581.04** — "A person aggrieved by a violation of this chapter may pursue relief by filing:" *D.C. Code § 32-581.04(c)(1).* <https://code.dccouncil.gov/us/dc/council/code/sections/32-581.04>
+
+[^retaliation-ban]: **D.C. Code § 32-581.02** — "No employer may retaliate or threaten to retaliate against a covered employee for:" *D.C. Code § 32-581.02(b).* <https://code.dccouncil.gov/us/dc/council/code/sections/32-581.02>
+
+[^retaliation-relief]: **D.C. Code § 32-581.04** — "An employer that retaliates against an employee in violation of § 32-581.02(b) or § 32-581.03(b) shall be liable for each instance of retaliation to each employee subject to the retaliation in an amount not less than $1,000 and not more than $2,500." *D.C. Code § 32-581.04(d)(3)(A).* <https://code.dccouncil.gov/us/dc/council/code/sections/32-581.04>
+
+[^oag-nopoach]: **OAG Press Release on Non-Compete Settlements (Nov. 17, 2023)** — "Through its investigation, OAG uncovered evidence that Hissho violated the District’s Antitrust Act and the District’s ban on non-compete agreements by including a ‘no-poach’ clause in its contracts with franchisees, which prevented employees from leaving one fast food franchise to work for another franchise in the same chain." *Office of the Attorney General for the District of Columbia, Press Release (Nov. 17, 2023).* <https://oag.dc.gov/release/attorney-general-schwalb-announces-three-district>
+
+[^antitrust]: **D.C. Code § 28-4502** — "Every contract, combination in the form of a trust or otherwise, or conspiracy in restraint of trade or commerce all or any part of which is within the District of Columbia is declared to be illegal." *D.C. Code § 28-4502.* <https://code.dccouncil.gov/us/dc/council/code/sections/28-4502>
+
+[^tolling-duration-cap]: **D.C. Code § 32-581.03** — "If the employee is not a medical specialist, a term of non-competition that does not exceed 365 calendar days from the date the employee separates from employment with the employer" *D.C. Code § 32-581.03(a)(1)(C)(i).* <https://code.dccouncil.gov/us/dc/council/code/sections/32-581.03>
+
+[^tolling-cumulative]: **D.C. Code § 32-581.04b** — "The rights, remedies, and prohibitions accorded by the provisions of this chapter are in addition to and cumulative of any right, remedy, or prohibition accorded by the common law, federal law, or any District statute" *D.C. Code § 32-581.04b.* <https://code.dccouncil.gov/us/dc/council/code/sections/32-581.04b>

--- a/skills/non-compete-contract-explainer/content/florida.md
+++ b/skills/non-compete-contract-explainer/content/florida.md
@@ -1,0 +1,267 @@
+---
+jurisdiction: "Florida"
+slug: florida
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-03"
+canonicalUrl: https://openagreements.org/legal/non-compete/florida
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/florida · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in Florida[^about]
+
+Florida enforces non-competes by statute and is among the most employer-friendly states, requiring a legitimate business interest and reasonable terms, with a separate 2025 CHOICE Act track for high earners.
+
+
+## At a glance
+
+| Question | Florida |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed if reasonable |
+| **Bottom line** | Among the most employer-friendly states — enforceable with a legitimate business interest and reasonable terms, with a 2025 CHOICE Act high-earner track. |
+| **Main law or case** | Fla. Stat. § 542.335 |
+| **Main exceptions** | Specialist-physician ban in monopolized counties (§ 542.336) |
+| **Can a court narrow it?** | Yes — rewrites to reasonable |
+| **Applies to contractors?** | Yes |
+| **Restriction extended during a breach?** | Not addressed by statute |
+| **Maximum length set by law** | No hard cap; over 2 years presumed unreasonable for employees |
+| **Must the employer pay to enforce?** | Only on the optional paid track |
+
+## Are employee non-compete agreements enforceable in Florida? {#employee-noncompetes}
+
+**Short answer.** Yes. Florida is one of the most employer-friendly non-compete states in the country. Every restraint of trade is unlawful as a baseline, but section 542.335 of the Florida Statutes creates a broad statutory exception: a restrictive covenant is enforceable when it is in a signed writing, justified by a legitimate business interest, and reasonably necessary to protect that interest in time, area, and line of business [^q1-542018-baseline][^q1-542335-intro][^q1-542335-writing][^q1-542335-necessary].
+
+Florida courts treat section 542.335 as a comprehensive statutory framework for restrictive covenants. As the Fifth District put it, the statute is built on an unfair-competition approach, rather than the older common-law hostility to restraints [^q1-henao-framework].
+
+Since July 2025, Florida has run two parallel tracks. Most agreements are governed by the traditional section 542.335 standard described throughout this note. A second, even more employer-favorable track — the CHOICE Act, sections 542.41 through 542.45 — applies only to defined high-earning *covered employees*; covenants that do not fit the CHOICE Act definitions fall back to section 542.335 [^q1-choice-fallback].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not assume an agreement is *unenforceable* just because it looks broad. Florida starts from the opposite presumption of most states: tie the restraint to a pleaded legitimate business interest and reasonable terms, and a court is directed to enforce it [^q1-542335-intro][^q1-henao-framework].
+
+## What legitimate business interests can support a Florida non-compete? {#legitimate-business-interest}
+
+**Short answer.** The enforcing party must plead and prove a legitimate business interest, and a covenant supported by none is void. The statute lists trade secrets, other valuable confidential information, substantial relationships with specific customers or patients, customer goodwill, and extraordinary or specialized training — but the list is illustrative, not exhaustive [^q2-542335-lbi-list][^q2-white-referral].
+
+The Florida Supreme Court confirmed in *White v. Mederi Caretenders* that the statutory list is open-ended. It held that home health service referral sources can qualify as a protected interest depending on the context and proof, because the statute says *includes, but is not limited to* [^q2-white-referral].
+
+"In light of the foregoing, we conclude that home health service referral sources may be a protected legitimate business interest within the meaning of section 542.335, depending upon the context and proof adduced."[^q2-white-referral]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> A naked interest in avoiding ordinary competition is not protectable. Plead and prove a specific interest from the statutory categories — or an analogous one supported by evidence — because a restraint not tied to a legitimate business interest is void and unenforceable [^q2-542335-void].
+
+## How long can a Florida non-compete last? {#duration-reasonableness}
+
+**Short answer.** Under section 542.335, duration is governed by rebuttable presumptions that vary by context. Against a former employee, a restraint of six months or less is presumed reasonable and one longer than two years is presumed unreasonable. The window widens for the sale of a business and for covenants predicated on trade secrets, where five years or less is presumed reasonable [^q3-542335-employee-presumption][^q3-542335-tradesecret-presumption].
+
+These are presumptions, not caps — either side can rebut them with evidence. For sale-of-business covenants the statute presumes three years or less reasonable and more than seven years unreasonable, reflecting the stronger interest a buyer has in the goodwill it paid for [^q3-542335-sale-presumption]. Geography and line-of-business scope are judged by the same reasonableness standard, and an overbroad term is narrowed rather than voided (see below) [^q3-542335-employee-presumption].
+
+The presumptions vary by the relationship between the parties; for distributors, dealers, franchisees, or licensees of a mark, a restraint of one year or less is presumed reasonable [^q3-542335-distributor-presumption].
+
+## Will a Florida court rewrite an overbroad non-compete instead of voiding it? {#blue-pencil-reformation}
+
+**Short answer.** Yes — reformation is mandatory. If a restraint is overbroad, overlong, or otherwise broader than necessary, section 542.335 directs the court to *modify the restraint and grant only the relief reasonably necessary* to protect the legitimate business interest, rather than strike the covenant entirely [^q4-542335-modify].
+
+This is one of Florida's most consequential rules for employees. In many states, proving a covenant is too broad defeats it; in Florida, the usual result is a narrowed, court-rewritten restriction that is then enforced. The burden also shifts: once the employer shows the restraint is prima facie reasonably necessary, the employee must prove it is overbroad [^q4-542335-modify].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Because Florida blue-pencils rather than voids, an overbroad covenant is not a *free pass* for the worker — but neither should employers draft for the moon expecting a court to fix it. Tailor duration, geography, and scope to the proven interest so the enforced version matches the drafted version [^q4-542335-modify].
+
+## Can a Florida court refuse to enforce a non-compete because of hardship to the employee? {#economic-hardship}
+
+**Short answer.** No. Section 542.335 expressly forbids a court from weighing the individualized economic or other hardship enforcement might cause the restrained person. The same subsection directs courts to construe covenants in favor of protecting the employer's interests, not narrowly against the drafter [^q5-542335-hardship][^q5-542335-construe].
+
+This makes Florida unusually predictable for employers. The familiar argument that a non-compete will cost the worker a livelihood — often decisive elsewhere — is statutorily off the table in Florida, though courts still consider other equitable defenses and the effect of enforcement on public health, safety, and welfare [^q5-542335-hardship].
+
+"A court shall construe a restrictive covenant in favor of providing reasonable protection to all legitimate business interests established by the person seeking enforcement."[^q5-542335-construe]
+
+## What did the 2025 CHOICE Act change for high earners? {#choice-act-high-earners}
+
+**Short answer.** The CHOICE Act, effective July 1, 2025, created a second, even more employer-favorable track for high-earning *covered employees* — those earning more than twice the annual mean wage of the relevant Florida county. It authorizes covered non-competes of up to four years and *garden leave* agreements of up to four years, and it makes a preliminary injunction mandatory on an employer's application [^q6-choice-effective][^q6-543-covered-employee][^q6-545-injunction].
+
+To qualify, the employer must advise the worker of the right to counsel, give at least seven days' written notice, and obtain a written acknowledgment of access to confidential information or customer relationships; a compliant covered non-compete is then *fully enforceable according to its terms* [^q6-545-fully-enforceable][^q6-545-counsel][^q6-545-notice]. A covered non-compete may run up to four years and reach work *similar* to the prior role or work likely to use the employer's confidential information [^q6-543-covered-noncompete].
+
+Garden leave is new to Florida statutory law: the employee stays on payroll during a notice period of up to four years, but after the first 90 days need not perform services and may engage in nonwork activities — and may work for another employer only with the covered employer's permission [^q6-544-garden-leave][^q6-544-outside-work]. The two tools do not simply stack: a covered non-compete must reduce its noncompete period day-for-day by any nonworking portion of a garden-leave notice period [^q6-545-offset]. Once an employer applies to enforce a covered non-compete, the court must enjoin the employee and may dissolve the injunction only if the employee shows, by *clear and convincing evidence*, one of the narrow statutory grounds [^q6-545-injunction].
+
+"This act shall take effect July 1, 2025."[^q6-effective-law]
+
+> [!NOTE]
+> **Practice note.**
+>
+> The CHOICE Act is new and largely untested in court. Treat the four-year duration and mandatory-injunction mechanics as the statute's design, not yet as settled judicial practice, and confirm the current threshold before relying on coverage — it is measured by the statutory *salary* definition and the annual mean wage of the employer's principal-place-of-business county (or the employee's residence county if the employer is out of state) [^q6-543-covered-employee][^q6-effective-law].
+
+## Are physician and health care non-competes treated differently in Florida? {#physician-healthcare}
+
+**Short answer.** Yes, in two ways. Section 542.336 voids a specialist physician's non-compete in any county where a single entity employs or contracts with *all* physicians in that specialty, and keeps it void for three years after a second entity enters the market. Separately, the CHOICE Act's high-earner track excludes health care practitioners entirely, so their covenants stay under the ordinary section 542.335 standard [^q7-542336-trigger][^q7-542336-physician][^q7-543-healthcare-exclusion].
+
+The physician carve-out is narrow and fact-specific: it targets local specialty monopolies that the Legislature found restrict patient access and raise costs. It is not a general ban on physician non-competes [^q7-542336-physician]. The CHOICE Act exclusion is categorical — a health care practitioner, as defined in section 456.001, is excluded from the *covered employee* definition no matter how much they earn [^q7-543-healthcare-exclusion].
+
+"Such restrictive covenants shall remain void and unenforceable for 3 years after the date on which a second entity that employs or contracts with, either directly or through related or affiliated entities, one or more physicians who practice such specialty begins offering such specialty services in that county."[^q7-542336-physician]
+
+## How are non-solicitation and no-hire clauses treated in Florida? {#non-solicitation-no-hire}
+
+**Short answer.** Section 542.335 governs *all* restrictive covenants, so customer non-solicitation, non-dealing, and employee no-hire clauses are analyzed under the same legitimate-business-interest and reasonableness framework as non-competes. Florida courts apply that framework both to enforce these covenants and, where the facts require, to narrow or decline to enforce them [^q8-balasco-nohire][^q8-carter-nonsolicit].
+
+In *Balasco v. Gulf Auto Holding*, the Second District enforced an anti-piracy clause barring a former manager from soliciting the dealership's other employees, but blue-penciled its three-year term down to two years under the duration presumption [^q8-balasco-nohire]. *Environmental Services v. Carter* shows the limits: a customer non-solicitation covenant can be valid yet still go unenforced where the clients sought out the employee without any solicitation [^q8-carter-nonsolicit].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> The CHOICE Act defines *covered noncompete* and *covered garden leave* agreements but does not mention non-solicitation clauses. A four-year CHOICE Act non-compete may sit beside a non-solicit that still defaults to section 542.335's two-year presumption, so draft and analyze the two clauses separately rather than assuming the four-year term carries over [^q8-choice-other-agreements][^q8-542335-presumption].
+
+## Is continued at-will employment enough consideration for a Florida non-compete? {#consideration}
+
+**Short answer.** Yes. Florida courts treat continued at-will employment as sufficient consideration, so an employee can be bound by a non-compete signed months or years after the hire date. No separate signing bonus, raise, or promotion is required [^q9-omi-consideration].
+
+In *Open Magnetic Imaging v. Nieves-Garcia*, the Third District found no Florida decision refusing to enforce a non-compete merely because the employee signed it after employment began [^q9-omi-consideration]. That rule governs the traditional section 542.335 track; under the CHOICE Act, by contrast, an employer's failure to pay the consideration the agreement promised — after a reasonable chance to cure — is itself a statutory ground to dissolve the mandatory injunction [^q9-545-consideration].
+
+"In fact, we have located no Florida decision to date which has declined to enforce a non-compete agreement by virtue of the fact that an employee has been required to execute it after employment has commenced."[^q9-omi-consideration]
+
+## Does a Florida non-compete period pause or extend if the employee breaches or litigates? {#tolling-extension}
+
+**Short answer.** Section 542.335 does not expressly address tolling — it neither requires nor forbids extending the restricted period for the time a former employee was in breach. What the statute does provide is a strong enforcement remedy: a violation creates a presumption of irreparable injury, and courts enforce covenants by injunction [^q10-542335-injunction].
+
+Because the statute is silent, whether a court will extend a covenant by the period of breach — or honor a contractual *tolling* clause that does so — is not settled by section 542.335 itself. Employers who want the clock to pause during a violation should say so expressly in the agreement and be prepared to argue for it as equitable relief, rather than assume Florida law supplies it automatically [^q10-542335-injunction].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not assume the non-compete period automatically tolls while an employee competes in breach. Section 542.335 does not provide for it, so build any extension-on-breach mechanism into the contract and treat its enforceability as an open question under Florida law [^q10-542335-injunction].
+
+## How do Florida courts enforce non-competes, and who pays attorney's fees? {#injunctions-fees}
+
+**Short answer.** Courts enforce restrictive covenants by injunction, and a violation of an enforceable covenant *creates a presumption of irreparable injury* — a major advantage for employers seeking emergency relief. The prevailing party can recover attorney's fees and costs even without a fee clause, and any contractual provision limiting that authority is unenforceable [^q11-542335-injunction][^q11-542335-fees].
+
+The irreparable-injury presumption does real work. In *DePuy Orthopaedics v. Waxman*, the First District reversed a trial court that had denied an injunction for lack of irreparable injury, applying the statutory presumption [^q11-depuy-injunction]. The statute also requires a proper injunction bond and bars any contractual waiver of the bond requirement [^q11-542335-bond].
+
+## Will a Florida non-compete be enforced across state lines? {#choice-of-law-multistate}
+
+**Short answer.** Florida law strongly favors its own enforcement standard — the CHOICE Act even applies to a covered employee whose primary place of work is Florida *regardless of any applicable choice of law provisions*. But another state can refuse to apply Florida law where it conflicts with that state's public policy [^q12-545-applicability][^q12-brown-publicpolicy].
+
+In *Brown & Brown v. Johnson*, New York's highest court declined to apply Florida law to a customer non-solicit, holding that doing so would violate New York public policy [^q12-brown-publicpolicy]. The practical lesson: a Florida choice-of-law clause is powerful inside Florida but not a guarantee of enforcement against a worker centered in a more employee-protective state.
+
+"On this appeal, we hold that applying Florida law on restrictive covenants related to the non-solicitation of customers by a former employee would violate the public policy of this state."[^q12-brown-publicpolicy]
+
+## How do trade secrets and the Florida Uniform Trade Secrets Act interact with non-competes? {#trade-secrets}
+
+**Short answer.** Trade secrets are both a listed legitimate business interest under section 542.335 and independently protectable under the Florida Uniform Trade Secrets Act (FUTSA). FUTSA defines a trade secret, authorizes injunctions for actual or threatened misappropriation, and — importantly — preserves contractual remedies even though it displaces conflicting tort law [^q13-688002-def][^q13-688003-injunction][^q13-688008-contract].
+
+Because FUTSA expressly does not affect contractual remedies, employers commonly pursue parallel claims — breach of a non-compete or non-disclosure agreement and statutory misappropriation — for the same conduct [^q13-688008-contract]. FUTSA allows an injunction against *threatened* misappropriation [^q13-688003-injunction], but whether that reaches the *inevitable disclosure* doctrine — enjoining a worker from a new job on the theory they will inevitably use trade secrets, with no written non-compete — is unsettled in Florida, so do not rely on it in place of a properly drafted covenant.
+
+## Does the FTC non-compete ban affect Florida? {#federal-ftc-overlay}
+
+**Short answer.** No. The Federal Trade Commission's 2024 Non-Compete Rule never took effect: federal courts set it aside, the FTC acceded to vacatur, and in February 2026 the Commission formally removed the rule from the Code of Federal Regulations. Florida's statutes are the operative law [^q14-fr-removal].
+
+The Federal Register notice records that a federal court held the rule unlawful and set it aside, and that the Commission then removed 16 CFR part 910 to conform to the court decisions [^q14-fr-removal]. The FTC may still pursue case-by-case antitrust enforcement (for example, against naked no-poach agreements between rival employers), but there is no nationwide ban displacing Florida law.
+
+"In the third case, the court held that the Non-Compete Rule was unlawful and set it aside."[^q14-fr-removal]
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-03. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not Florida. This article synthesizes Florida primary law and is not legal advice from a Florida-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^q1-542018-baseline]: **Fla. Stat. § 542.18** — "Every contract, combination, or conspiracy in restraint of trade or commerce in this state is unlawful." *Fla. Stat. § 542.18 (2025).* <https://www.flsenate.gov/Laws/Statutes/2025/542.18>
+
+[^q1-542335-intro]: **Fla. Stat. § 542.335** — "enforcement of contracts that restrict or prohibit competition during or after the term of restrictive covenants, so long as such contracts are reasonable in time, area, and line of business, is not prohibited." *Fla. Stat. § 542.335(1) (2025).* <https://www.flsenate.gov/Laws/Statutes/2025/542.335>
+
+[^q1-542335-writing]: **Fla. Stat. § 542.335** — "A court shall not enforce a restrictive covenant unless it is set forth in a writing signed by the person against whom enforcement is sought." *Fla. Stat. § 542.335(1)(a) (2025).* <https://www.flsenate.gov/Laws/Statutes/2025/542.335>
+
+[^q1-542335-necessary]: **Fla. Stat. § 542.335** — "A person seeking enforcement of a restrictive covenant also shall plead and prove that the contractually specified restraint is reasonably necessary to protect the legitimate business interest or interests justifying the restriction." *Fla. Stat. § 542.335(1)(c) (2025).* <https://www.flsenate.gov/Laws/Statutes/2025/542.335>
+
+[^q1-henao-framework]: **Henao v. Professional Shoe Repair, Inc.** — "Section 542.335 contains a comprehensive framework for analyzing, evaluating and enforcing restrictive covenants in Florida based on an ‘unfair competition’ analysis." *Henao v. Prof'l Shoe Repair, Inc., 929 So. 2d 723 (Fla. 5th DCA 2006).* <https://www.courtlistener.com/opinion/1825627/henao-v-professional-shoe-repair-inc/#:~:text=Section%20542.335%20contains%20a%20comprehensive,on%20an%20%22unfair%20competition%22%20analysis.>
+
+[^q1-choice-fallback]: **Fla. Stat. § 542.45** — "Any action regarding a restrictive covenant that does not meet the definition of a covered garden leave agreement or a covered noncompete agreement as provided in this part is governed by s. 542.335." *Fla. Stat. § 542.45(5)(e) (2025).* <https://www.flsenate.gov/Laws/Statutes/2025/542.45>
+
+[^q2-542335-lbi-list]: **Fla. Stat. § 542.335** — "The person seeking enforcement of a restrictive covenant shall plead and prove the existence of one or more legitimate business interests justifying the restrictive covenant." *Fla. Stat. § 542.335(1)(b) (2025).* <https://www.flsenate.gov/Laws/Statutes/2025/542.335>
+
+[^q2-white-referral]: **White v. Mederi Caretenders Visiting Servs. of Se. Fla., LLC** — "In light of the foregoing, we conclude that home health service referral sources may be a protected legitimate business interest within the meaning of section 542.335, depending upon the context and proof adduced." *White v. Mederi Caretenders Visiting Servs. of Se. Fla., LLC, 226 So. 3d 774 (Fla. 2017).* <https://www.courtlistener.com/opinion/4426106/sc16-400-elizabeth-white-v-mederi-caretenders-visiting-services-of/#:~:text=In%20light%20of%20the%20foregoing%2C,the%20context%20and%20proof%20adduced.>
+
+[^q2-542335-void]: **Fla. Stat. § 542.335** — "Any restrictive covenant not supported by a legitimate business interest is unlawful and is void and unenforceable." *Fla. Stat. § 542.335(1)(b)5 (2025).* <https://www.flsenate.gov/Laws/Statutes/2025/542.335>
+
+[^q3-542335-employee-presumption]: **Fla. Stat. § 542.335** — "a court shall presume reasonable in time any restraint 6 months or less in duration and shall presume unreasonable in time any restraint more than 2 years in duration." *Fla. Stat. § 542.335(1)(d)1 (2025).* <https://www.flsenate.gov/Laws/Statutes/2025/542.335>
+
+[^q3-542335-tradesecret-presumption]: **Fla. Stat. § 542.335** — "a court shall presume reasonable in time any restraint of 5 years or less and shall presume unreasonable in time any restraint of more than 10 years." *Fla. Stat. § 542.335(1)(e) (2025).* <https://www.flsenate.gov/Laws/Statutes/2025/542.335>
+
+[^q3-542335-sale-presumption]: **Fla. Stat. § 542.335** — "a court shall presume reasonable in time any restraint 3 years or less in duration and shall presume unreasonable in time any restraint more than 7 years in duration." *Fla. Stat. § 542.335(1)(d)3 (2025).* <https://www.flsenate.gov/Laws/Statutes/2025/542.335>
+
+[^q3-542335-distributor-presumption]: **Fla. Stat. § 542.335** — "a court shall presume reasonable in time any restraint 1 year or less in duration and shall presume unreasonable in time any restraint more than 3 years in duration." *Fla. Stat. § 542.335(1)(d)2 (2025).* <https://www.flsenate.gov/Laws/Statutes/2025/542.335>
+
+[^q4-542335-modify]: **Fla. Stat. § 542.335** — "If a contractually specified restraint is overbroad, overlong, or otherwise not reasonably necessary to protect the legitimate business interest or interests, a court shall modify the restraint and grant only the relief reasonably necessary to protect such interest or interests." *Fla. Stat. § 542.335(1)(c) (2025).* <https://www.flsenate.gov/Laws/Statutes/2025/542.335>
+
+[^q5-542335-hardship]: **Fla. Stat. § 542.335** — "Shall not consider any individualized economic or other hardship that might be caused to the person against whom enforcement is sought." *Fla. Stat. § 542.335(1)(g)1 (2025).* <https://www.flsenate.gov/Laws/Statutes/2025/542.335>
+
+[^q5-542335-construe]: **Fla. Stat. § 542.335** — "A court shall construe a restrictive covenant in favor of providing reasonable protection to all legitimate business interests established by the person seeking enforcement." *Fla. Stat. § 542.335(1)(h) (2025).* <https://www.flsenate.gov/Laws/Statutes/2025/542.335>
+
+[^q6-choice-effective]: **Fla. Stat. § 542.41** — "This part may be cited as the ‘Florida Contracts Honoring Opportunity, Investment, Confidentiality, and Economic Growth (CHOICE) Act.’" *Fla. Stat. § 542.41 (2025).* <https://www.flsenate.gov/Laws/Statutes/2025/542.41>
+
+[^q6-543-covered-employee]: **Fla. Stat. § 542.43** — "earns or is reasonably expected to earn a salary greater than twice the annual mean wage of the county in this state in which the covered employer has its principal place of business" *Fla. Stat. § 542.43(3) (2025).* <https://www.flsenate.gov/Laws/Statutes/2025/542.43>
+
+[^q6-545-injunction]: **Fla. Stat. § 542.45** — "a court must preliminarily enjoin a covered employee from providing services to any business, entity, or individual other than the covered employer during the noncompete period." *Fla. Stat. § 542.45(5)(a) (2025).* <https://www.flsenate.gov/Laws/Statutes/2025/542.45>
+
+[^q6-545-fully-enforceable]: **Fla. Stat. § 542.45** — "is fully enforceable according to its terms" *Fla. Stat. § 542.45(2) (2025).* <https://www.flsenate.gov/Laws/Statutes/2025/542.45>
+
+[^q6-545-counsel]: **Fla. Stat. § 542.45** — "A covered employee was advised, in writing, of the right to seek counsel before execution of the covered noncompete agreement and was provided notice as described in subsection (3)" *Fla. Stat. § 542.45(2)(a) (2025).* <https://www.flsenate.gov/Laws/Statutes/2025/542.45>
+
+[^q6-545-notice]: **Fla. Stat. § 542.45** — "A prospective covered employee at least 7 days before an offer of employment expires" *Fla. Stat. § 542.45(3)(a) (2025).* <https://www.flsenate.gov/Laws/Statutes/2025/542.45>
+
+[^q6-543-covered-noncompete]: **Fla. Stat. § 542.43** — "for a period not to exceed 4 years and within the geographic area defined in the agreement, the covered employee agrees not to assume a role" *Fla. Stat. § 542.43(6) (2025).* <https://www.flsenate.gov/Laws/Statutes/2025/542.43>
+
+[^q6-544-garden-leave]: **Fla. Stat. § 542.44** — "After the first 90 days of the notice period, the covered employee does not have to provide services to the covered employer" *Fla. Stat. § 542.44(2)(c)1 (2025).* <https://www.flsenate.gov/Laws/Statutes/2025/542.44>
+
+[^q6-544-outside-work]: **Fla. Stat. § 542.44** — "The covered employee may, with the permission of the covered employer, work for another employer while still employed by the covered employer during the remainder of the notice period" *Fla. Stat. § 542.44(2)(c)3 (2025).* <https://www.flsenate.gov/Laws/Statutes/2025/542.44>
+
+[^q6-545-offset]: **Fla. Stat. § 542.45** — "A covered noncompete agreement provides that the noncompete period is reduced day-for-day by any nonworking portion of the notice period" *Fla. Stat. § 542.45(2)(c) (2025).* <https://www.flsenate.gov/Laws/Statutes/2025/542.45>
+
+[^q6-effective-law]: **Ch. 2025-213, Laws of Fla. (Florida CHOICE Act)** — "This act shall take effect July 1, 2025." *Ch. 2025-213, Laws of Fla., § 22.* <https://laws.flrules.org/2025/213>
+
+[^q7-542336-trigger]: **Fla. Stat. § 542.336** — "A restrictive covenant entered into with a physician who is licensed under chapter 458 or chapter 459 and who practices a medical specialty in a county wherein one entity employs or contracts with, either directly or through related or affiliated entities, all physicians who practice such specialty in that county is not supported by a legitimate business interest." *Fla. Stat. § 542.336 (2025).* <https://www.flsenate.gov/Laws/Statutes/2025/542.336>
+
+[^q7-542336-physician]: **Fla. Stat. § 542.336** — "Such restrictive covenants shall remain void and unenforceable for 3 years after the date on which a second entity that employs or contracts with, either directly or through related or affiliated entities, one or more physicians who practice such specialty begins offering such specialty services in that county." *Fla. Stat. § 542.336 (2025).* <https://www.flsenate.gov/Laws/Statutes/2025/542.336>
+
+[^q7-543-healthcare-exclusion]: **Fla. Stat. § 542.43** — "The term does not include a person classified as a health care practitioner as defined in s. 456.001." *Fla. Stat. § 542.43(3) (2025).* <https://www.flsenate.gov/Laws/Statutes/2025/542.43>
+
+[^q8-balasco-nohire]: **Balasco v. Gulf Auto Holding, Inc.** — "We agree that the agreement is enforceable but remand to shorten the period of restraint to no more than two years." *Balasco v. Gulf Auto Holding, Inc., 707 So. 2d 858 (Fla. 2d DCA 1998).* <https://www.courtlistener.com/opinion/1671732/balasco-v-gulf-auto-holding-inc/#:~:text=We%20agree%20that%20the%20agreement,no%20more%20than%20two%20years.>
+
+[^q8-carter-nonsolicit]: **Environmental Services, Inc. v. Carter** — "While the court ruled that the non-solicitation covenant was valid, it refused to enforce that covenant, finding that ESI’s clients sought out Carter and Hannon without any solicitation from them." *Env't Servs., Inc. v. Carter, 9 So. 3d 1258 (Fla. 5th DCA 2009).* <https://www.courtlistener.com/opinion/1645720/environmental-services-inc-v-carter/#:~:text=While%20the%20court%20ruled%20that,without%20any%20solicitation%20from%20them.>
+
+[^q8-choice-other-agreements]: **Fla. Stat. § 542.45** — "Any action regarding a restrictive covenant that does not meet the definition of a covered garden leave agreement or a covered noncompete agreement as provided in this part is governed by s. 542.335." *Fla. Stat. § 542.45(5)(e) (2025).* <https://www.flsenate.gov/Laws/Statutes/2025/542.45>
+
+[^q8-542335-presumption]: **Fla. Stat. § 542.335** — "a court shall presume reasonable in time any restraint 6 months or less in duration and shall presume unreasonable in time any restraint more than 2 years in duration." *Fla. Stat. § 542.335(1)(d)1 (2025).* <https://www.flsenate.gov/Laws/Statutes/2025/542.335>
+
+[^q9-omi-consideration]: **Open Magnetic Imaging, Inc. v. Nieves-Garcia** — "In fact, we have located no Florida decision to date which has declined to enforce a non-compete agreement by virtue of the fact that an employee has been required to execute it after employment has commenced." *Open Magnetic Imaging, Inc. v. Nieves-Garcia, 826 So. 2d 415 (Fla. 3d DCA 2002).* <https://www.courtlistener.com/opinion/1630166/omi-inc-v-nieves-garcia/#:~:text=In%20fact%2C%20we%20have%20located,it%20after%20employment%20has%20commenced.>
+
+[^q9-545-consideration]: **Fla. Stat. § 542.45** — "The covered employer has failed to pay or provide the consideration provided for in the covered noncompete agreement and has had a reasonable opportunity to cure the failure" *Fla. Stat. § 542.45(5)(a)2 (2025).* <https://www.flsenate.gov/Laws/Statutes/2025/542.45>
+
+[^q10-542335-injunction]: **Fla. Stat. § 542.335** — "The violation of an enforceable restrictive covenant creates a presumption of irreparable injury to the person seeking enforcement of a restrictive covenant." *Fla. Stat. § 542.335(1)(j) (2025).* <https://www.flsenate.gov/Laws/Statutes/2025/542.335>
+
+[^q11-542335-injunction]: **Fla. Stat. § 542.335** — "The violation of an enforceable restrictive covenant creates a presumption of irreparable injury to the person seeking enforcement of a restrictive covenant." *Fla. Stat. § 542.335(1)(j) (2025).* <https://www.flsenate.gov/Laws/Statutes/2025/542.335>
+
+[^q11-542335-fees]: **Fla. Stat. § 542.335** — "a court may award attorney’s fees and costs to the prevailing party in any action seeking enforcement of, or challenging the enforceability of, a restrictive covenant." *Fla. Stat. § 542.335(1)(k) (2025).* <https://www.flsenate.gov/Laws/Statutes/2025/542.335>
+
+[^q11-depuy-injunction]: **DePuy Orthopaedics, Inc. v. Waxman** — "we reverse the trial court’s order denying DePuy’s motion for temporary injunction and remand with instructions to enter a temporary injunction against Appellees" *DePuy Orthopaedics, Inc. v. Waxman, 95 So. 3d 928 (Fla. 1st DCA 2012).* <https://www.courtlistener.com/opinion/5061403/depuy-orthopaedics-inc-v-waxman/#:~:text=we%20reverse%20the%20trial%20court%E2%80%99s,a%20temporary%20injunction%20against%20Appellees>
+
+[^q11-542335-bond]: **Fla. Stat. § 542.335** — "No temporary injunction shall be entered unless the person seeking enforcement of a restrictive covenant gives a proper bond" *Fla. Stat. § 542.335(1)(j) (2025).* <https://www.flsenate.gov/Laws/Statutes/2025/542.335>
+
+[^q12-545-applicability]: **Fla. Stat. § 542.45** — "A covered noncompete agreement with a covered employee who maintains a primary place of work in this state, regardless of any applicable choice of law provisions" *Fla. Stat. § 542.45(1)(a) (2025).* <https://www.flsenate.gov/Laws/Statutes/2025/542.45>
+
+[^q12-brown-publicpolicy]: **Brown & Brown, Inc. v. Johnson** — "On this appeal, we hold that applying Florida law on restrictive covenants related to the non-solicitation of customers by a former employee would violate the public policy of this state." *Brown & Brown, Inc. v. Johnson, 25 N.Y.3d 364 (2015).* <https://www.courtlistener.com/opinion/2807346/brown-brown-v-theresa-a-johnson/#:~:text=On%20this%20appeal%2C%20we%20hold,public%20policy%20of%20this%20state.>
+
+[^q13-688002-def]: **Fla. Stat. § 688.002** — "‘Trade secret’ means information, including a formula, pattern, compilation, program, device, method, technique, or process" *Fla. Stat. § 688.002(4) (2025).* <https://www.flsenate.gov/Laws/Statutes/2025/688.002>
+
+[^q13-688003-injunction]: **Fla. Stat. § 688.003** — "Actual or threatened misappropriation may be enjoined." *Fla. Stat. § 688.003(1) (2025).* <https://www.flsenate.gov/Laws/Statutes/2025/688.003>
+
+[^q13-688008-contract]: **Fla. Stat. § 688.008** — "Contractual remedies, whether or not based upon misappropriation of a trade secret" *Fla. Stat. § 688.008(2)(a) (2025).* <https://www.flsenate.gov/Laws/Statutes/2025/688.008>
+
+[^q14-fr-removal]: **Removal of the Non-Compete Rule (16 CFR Part 910)** — "In the third case, the court held that the Non-Compete Rule was unlawful and set it aside." *Removal of the Non-Compete Rule, 91 Fed. Reg. 6507 (Feb. 12, 2026).* <https://www.federalregister.gov/documents/2026/02/12/2026-02866/revision-of-the-negative-option-rule-withdrawal-of-the-cars-rule-removal-of-the-non-compete-rule-to>

--- a/skills/non-compete-contract-explainer/content/georgia.md
+++ b/skills/non-compete-contract-explainer/content/georgia.md
@@ -1,0 +1,323 @@
+---
+jurisdiction: "Georgia"
+slug: georgia
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-03"
+canonicalUrl: https://openagreements.org/legal/non-compete/georgia
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/georgia · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in Georgia[^about]
+
+A question-by-question summary of Georgia non-compete law under the Georgia Restrictive Covenants Act (O.C.G.A. §§ 13-8-50 to 13-8-59), covering the reasonableness standard, the employee-category limits, the two-, three-, and five-year durational presumptions, implied geographic scope after Wimmer, customer and employee non-solicitation covenants, material contact, judicial modification (blue-pencil), choice-of-law limits under Motorsports of Conyers, tolling and the no-equitable-extension rule of Daneshgari, confidentiality and trade-secret alternatives, physician covenants, and the May 11, 2011 effective date.
+
+
+## At a glance
+
+| Question | Georgia |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed if reasonable |
+| **Bottom line** | Georgia enforces non-competes that are reasonable in time, area, and scope under the Restrictive Covenants Act, but only against employees who perform covered higher-level job functions. |
+| **Main law or case** | Georgia Restrictive Covenants Act, O.C.G.A. §§ 13-8-50 to 13-8-59 |
+| **Main exceptions** | Employee-category gate (§ 13-8-53(a)); longer presumptions for distributors/franchisees (3 yr) and sellers (5 yr+) |
+| **Can a court narrow it?** | Yes — rewrites to reasonable |
+| **Applies to contractors?** | — |
+| **Restriction extended during a breach?** | No — courts will not extend beyond expiration |
+| **Maximum length set by law** | 2 years for employees (rebuttable presumption) |
+
+## Are employee non-compete agreements enforceable in Georgia? {#employee-noncompetes}
+
+**Short answer.** Yes, when they are reasonable and the worker performs a covered job function. Under the Georgia Restrictive Covenants Act, a post-employment non-compete is permitted so long as it is reasonable in time, geographic area, and scope of prohibited activities [^q1-grca-13-8-53a-reasonable]. As the next question explains, the Act separately limits which employees can be bound by a post-employment non-compete.
+
+Georgia was historically a strict, covenant-hostile state, but a 2010 constitutional amendment and the Georgia Restrictive Covenants Act (the GRCA), O.C.G.A. §§ 13-8-50 to 13-8-59, replaced that regime with a reasonableness standard backed by statutory presumptions and judicial modification. The legislature said as much in the Act's findings.
+
+"The General Assembly finds that reasonable restrictive covenants contained in employment and commercial contracts serve the legitimate purpose of protecting legitimate business interests and creating an environment that is favorable to attracting commercial enterprises to Georgia and keeping existing businesses within the state."[^q1-grca-13-8-50-findings]
+
+The core enforcement rule appears in O.C.G.A. § 13-8-53(a). It permits a covenant that restricts competition if the restraint is reasonable in time, geographic area, and scope, and the rest of the Act supplies the presumptions and limits that give that reasonableness test concrete content.
+
+"Notwithstanding any other provision of this chapter, enforcement of contracts that restrict competition during the term of a restrictive covenant, so long as such restrictions are reasonable in time, geographic area, and scope of prohibited activities, shall be permitted."[^q1-grca-13-8-53a-reasonable]
+
+The party seeking to enforce a covenant carries the initial burden. O.C.G.A. § 13-8-55 requires the enforcing party to plead and prove a legitimate business interest, and only then does the burden shift to the worker.
+
+"The person seeking enforcement of a restrictive covenant shall plead and prove the existence of one or more legitimate business interests justifying the restrictive covenant. If a person seeking enforcement of the restrictive covenant establishes by prima-facie evidence that the restraint is in compliance with the provisions of Code Section 13-8-53, then any person opposing enforcement has the burden of establishing that the contractually specified restraint does not comply with such requirements or that such covenant is unreasonable."[^q1-grca-13-8-55-burden]
+
+## Which Georgia employees can be bound by a non-compete? {#covered-employees}
+
+**Short answer.** Only employees who perform certain higher-level functions. O.C.G.A. § 13-8-53(a) provides that a post-employment non-compete may not be enforced against an employee who does not customarily solicit customers, make sales, perform defined managerial duties, or qualify as a key employee or professional — and in *Blair v. Pantera Enterprises, Inc.* the Court of Appeals held that an hourly equipment operator did not meet the key-employee definition [^q2-grca-13-8-53a-categories][^q2-blair-key-employee].
+
+This employee-category gate is the most important structural limit in the GRCA, and national surveys often miss it. Even a covenant that is perfectly reasonable in time, area, and scope is unenforceable as a post-employment non-compete if the worker does not fall into one of the listed categories. Customer non-solicitation and confidentiality provisions, discussed below, are treated separately and are not subject to this gate.
+
+"However, enforcement of contracts that restrict competition after the term of employment, as distinguished from a customer nonsolicitation provision, as described in subsection (b) of this Code section, or a nondisclosure of confidential information provision, as described in subsection (e) of this Code section, shall not be permitted against any employee who does not, in the course of his or her employment: (1) Customarily and regularly solicit for the employer customers or prospective customers; (2) Customarily and regularly engage in making sales or obtaining orders or contracts for products or services to be performed by others; (3) Perform the following duties: (A) Have a primary duty of managing the enterprise in which the employee is employed or of a customarily recognized department or subdivision thereof; (B) Customarily and regularly direct the work of two or more other employees; and (C) Have the authority to hire or fire other employees or have particular weight given to suggestions and recommendations as to the hiring, firing, advancement, promotion, or any other change of status of other employees; or (4) Perform the duties of a key employee or of a professional."[^q2-grca-13-8-53a-categories]
+
+The *key employee* and *professional* categories are defined narrowly, and courts police them. In *Blair* — a decision issued as physical precedent only, so it is persuasive rather than binding — the employer tried to bind an hourly backhoe operator as a key employee, and the Court of Appeals rejected that characterization.
+
+"Thus, Blair is not a ‘key employee’ as that term is defined in OCGA § 13-8-51 (8). Consequently, the trial court erred in issuing injunctive relief to Pantera."[^q2-blair-key-employee]
+
+> [!NOTE]
+> **Practice note.**
+>
+> Confirm that the employee actually performs a covered function before relying on a non-compete. A reasonable covenant is still void as a post-employment non-compete against a worker who does not solicit, sell, manage, or qualify as a key employee or professional, as *Blair v. Pantera Enterprises* shows [^q2-grca-13-8-53a-categories][^q2-blair-key-employee].
+
+## How long can a Georgia non-compete last? {#duration}
+
+**Short answer.** It depends on the relationship, with rebuttable presumptions of two, three, or five years. O.C.G.A. § 13-8-57 presumes a restraint of two years or less reasonable against a former employee, three years or less against a distributor, dealer, franchisee, lessee, or licensee, and the longer of five years or the payout period reasonable against the seller or owner of a business [^q3-grca-13-8-57b-employee][^q3-grca-13-8-57c-other][^q3-grca-13-8-57d-sale].
+
+The durational presumptions are the clearest drafting safe harbors in the GRCA. For an ordinary former employee, the dividing line is two years, measured from the date the relationship ends.
+
+"a court shall presume to be reasonable in time any restraint two years or less in duration and shall presume to be unreasonable in time any restraint more than two years in duration, measured from the date of the termination of the business relationship."[^q3-grca-13-8-57b-employee]
+
+The Act gives more latitude outside the ordinary employment relationship. A covenant against a distributor, dealer, franchisee, lessee of real or personal property, or licensee gets a three-year presumption.
+
+"a court shall presume to be reasonable in time any restraint three years or less in duration and shall presume to be unreasonable in time any restraint more than three years in duration, measured from the date of termination of the business relationship."[^q3-grca-13-8-57c-other]
+
+A covenant tied to the sale or ownership of a business gets the most latitude of all — the longer of five years or the period over which the buyer is paying the seller.
+
+"a court shall presume to be reasonable in time any restraint the longer of five years or less in duration or equal to the period of time during which payments are being made to the owner or seller as a result of any sale referred to in this subsection and shall presume to be unreasonable in time any restraint more than the longer of five years in duration or the period of time during which payments are being made to the owner or seller as a result of any sale referred to in this subsection, measured from the date of termination or disposition of such interest."[^q3-grca-13-8-57d-sale]
+
+Because these presumptions are rebuttable, a covenant within the safe harbor can still be attacked as unreasonable in geography or scope, and a covenant beyond it can still be defended — but the burden flips with the time period.
+
+## Does a Georgia non-compete need an express geographic territory? {#geography}
+
+**Short answer.** No. In *North American Senior Benefits, LLC v. Wimmer*, decided September 4, 2024, the Supreme Court of Georgia held that O.C.G.A. § 13-8-53(a) does not require an express geographic term and reversed the Court of Appeals' contrary rule; geographic reasonableness is instead assessed in context [^q4-wimmer-no-express-term][^q4-grca-13-8-56-geography].
+
+For several years the Court of Appeals had read § 13-8-53(a) to require non-compete and employee-non-solicitation covenants to spell out an explicit geographic area. The Supreme Court rejected that reading in *Wimmer*.
+
+"The petitioner — a Georgia corporation seeking to enforce a restrictive covenant against two former employees — asks us to review the conclusion reached by the Court of Appeals that, to be deemed geographically reasonable under OCGA § 13-8-53 (a), a restrictive covenant must contain an express geographic term. In light of the statutory text and context of the GRCA, we conclude that the Court of Appeals erred, so we reverse and remand this case for further proceedings."[^q4-wimmer-no-express-term]
+
+The statute supports an implied-geography approach. O.C.G.A. § 13-8-56 supplies a presumption that the areas where the employer does business can be a reasonable territory, provided the total distance is reasonable, so the geographic inquiry turns on overall reasonableness rather than the presence of a magic-words territory clause.
+
+"In determining the reasonableness of a restrictive covenant that limits or restricts competition during or after the term of an employment or business or commercial relationship, the court shall make the following presumptions:...(2) A geographic territory which includes the areas in which the employer does business at any time during the parties' relationship, even if not known at the time of entry into the restrictive covenant, is reasonable provided that: (A) The total distance encompassed by the provisions of the covenant also is reasonable; (B) The agreement contains a list of particular competitors as prohibited employers for a limited period of time after the term of employment or a business or commercial relationship; or (C) Both subparagraphs (A) and (B) of this paragraph"[^q4-grca-13-8-56-geography]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not assume a Georgia covenant fails for lack of an express territory, and do not assume one with a territory is automatically safe. After *Wimmer*, geographic scope is judged for overall reasonableness under O.C.G.A. § 13-8-56, so an unreasonably broad express territory is still vulnerable [^q4-wimmer-no-express-term][^q4-grca-13-8-56-geography].
+
+## Are customer non-solicitation covenants treated differently in Georgia? {#customer-nonsolicit}
+
+**Short answer.** Yes. O.C.G.A. § 13-8-53(b) lets an employer restrict solicitation of customers with whom the employee had material contact, and it expressly says no geographic term is required. The Act defines material contact narrowly, focusing on customers the employee actually dealt with or learned about [^q5-grca-13-8-53b-customer][^q5-grca-13-8-51-material-contact].
+
+Customer non-solicitation provisions sit outside the employee-category gate and outside the express-geography question entirely. The statute allows them without a territory, so long as they are tied to material-contact customers and competitive products or services.
+
+"an employee may agree in writing for the benefit of an employer to refrain, for a stated period of time following termination, from soliciting, or attempting to solicit, directly or by assisting others, any business from any of such employer's customers, including actively seeking prospective customers, with whom the employee had material contact during his or her employment for purposes of providing products or services that are competitive with those provided by the employer's business. No express reference to geographic area or the types of products or services considered to be competitive shall be required in order for the restraint to be enforceable."[^q5-grca-13-8-53b-customer]
+
+The leverage in a customer non-solicit is the definition of *material contact*. O.C.G.A. § 13-8-51 limits it to customers the employee dealt with, supervised, learned confidential information about, or earned compensation from in the two years before termination.
+
+"'Material contact' means the contact between an employee and each customer or potential customer: (A) With whom or which the employee dealt on behalf of the employer; (B) Whose dealings with the employer were coordinated or supervised by the employee; (C) About whom the employee obtained confidential information in the ordinary course of business as a result of such employee's association with the employer; or (D) Who receives products or services authorized by the employer, the sale or provision of which results or resulted in compensation, commissions, or earnings for the employee within two years prior to the date of the employee's termination."[^q5-grca-13-8-51-material-contact]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Anchor a customer non-solicitation clause to material-contact customers rather than the employer's entire customer base. O.C.G.A. § 13-8-53(b) narrowly construes these covenants to customers the employee actually dealt with and to competitive products or services [^q5-grca-13-8-53b-customer][^q5-grca-13-8-51-material-contact].
+
+## Are employee non-recruitment and no-hire covenants governed by the GRCA? {#employee-nonsolicit}
+
+**Short answer.** Yes. In *Belt Power, LLC v. Reed*, the Court of Appeals held that the covenants at issue fell within the GRCA, and in *Wimmer* the Supreme Court applied § 13-8-53(a) to a two-year employee non-recruitment provision — so these covenants are analyzed under the Act and, after *Wimmer*, do not require an express geographic term [^q6-beltpower-grca][^q6-wimmer-nonrecruit].
+
+The statute carves out customer non-solicitation and confidentiality, but it does not separately address employee non-recruitment or no-hire covenants, so the courts have placed them inside the GRCA framework. *Belt Power* confirmed that a covenant restricting the recruitment of employees is analyzed under the Act rather than common law.
+
+"Upon a close reading of the entire statute, we conclude that the restrictive covenants at issue do fall within the ambit of the Act."[^q6-beltpower-grca]
+
+*Wimmer* itself involved a non-recruitment provision barring former employees from hiring or interfering with the employer's workforce for two years. The Supreme Court reviewed that provision under § 13-8-53(a) and held that it need not contain an express geographic term to be enforceable.
+
+"In light of the statutory text and context of the GRCA, we conclude that the Court of Appeals erred, so we reverse and remand this case for further proceedings."[^q6-wimmer-nonrecruit]
+
+> [!NOTE]
+> **Practice note.**
+>
+> Treat an employee non-recruitment or no-hire clause as a GRCA covenant, not a common-law one. *Belt Power v. Reed* placed these covenants within the Act, which means the reasonableness standard and modification limits apply [^q6-beltpower-grca][^q6-wimmer-nonrecruit].
+
+## Can a Georgia court blue-pencil an overbroad covenant? {#blue-pencil}
+
+**Short answer.** Yes, within a limit. O.C.G.A. § 13-8-53(d) makes a non-compliant covenant void but allows a court to modify it, so long as the modification does not make the covenant more restrictive for the employee than as originally drafted; O.C.G.A. § 13-8-54(b) directs courts to grant only the relief reasonably necessary [^q7-grca-13-8-53d-modify][^q7-grca-13-8-54b-relief].
+
+The GRCA replaced Georgia's old all-or-nothing rule with a modification power, but that power runs in only one direction — a court can narrow an overbroad covenant, never broaden it.
+
+"Any restrictive covenant not in compliance with the provisions of this article is unlawful and is void and unenforceable; provided, however, that a court may modify a covenant that is otherwise void and unenforceable so long as the modification does not render the covenant more restrictive with regard to the employee than as originally drafted by the parties."[^q7-grca-13-8-53d-modify]
+
+O.C.G.A. § 13-8-54 frames the interpretive posture. Courts construe covenants in favor of reasonable protection of legitimate interests, and when a restraint does not comply they may modify it to grant only the relief reasonably necessary.
+
+"A court shall construe a restrictive covenant to comport with the reasonable intent and expectations of the parties to the covenant and in favor of providing reasonable protection to all legitimate business interests established by the person seeking enforcement."[^q7-grca-13-8-54-construe]
+
+The modification power is discretionary, not automatic. In *Belt Power, LLC v. Reed*, the Court of Appeals held the trial court did not abuse its discretion in declining to blue-pencil the covenants at all, leaving them unenforceable as written [^q7-beltpower-modify].
+
+"We nevertheless conclude that the trial court did not abuse its discretion in declining to apply the ‘blue pencil’ provision in the Act to modify the terms of the covenants."[^q7-beltpower-modify]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not draft an overbroad covenant on the assumption a Georgia court will rewrite it into shape. Modification under O.C.G.A. § 13-8-53(d) is discretionary and can only narrow, not expand — and in *Belt Power v. Reed* the court declined to modify at all [^q7-grca-13-8-53d-modify][^q7-beltpower-modify].
+
+## Is continued employment sufficient consideration for a Georgia non-compete? {#consideration}
+
+**Short answer.** The GRCA does not codify a consideration rule. The Act sets the conditions for enforcing a covenant without addressing what consideration must support it, and Georgia practitioners generally treat continued at-will employment as sufficient — but no modern GRCA-era appellate decision squarely settles the point, so treat it as an area to monitor [^q8-grca-13-8-53a-consideration].
+
+A common in-house question is whether an existing at-will employee can be asked to sign a new covenant without a raise, bonus, or other new benefit. The GRCA itself is silent on consideration; § 13-8-53(a) speaks to reasonableness and the employee categories, not to what the employer must give in exchange.
+
+"Notwithstanding any other provision of this chapter, enforcement of contracts that restrict competition during the term of a restrictive covenant, so long as such restrictions are reasonable in time, geographic area, and scope of prohibited activities, shall be permitted."[^q8-grca-13-8-53a-consideration]
+
+Because the statute does not address consideration, the question is governed by Georgia contract principles, and practitioner commentary generally describes continued at-will employment as adequate consideration for a covenant signed during employment. That said, a definitive modern appellate decision applying that rule under the GRCA is harder to find, so the conservative course is to pair a mid-employment covenant with some additional consideration where practical.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not assume continued employment alone will always suffice as consideration for a mid-employment Georgia covenant. The GRCA does not codify a consideration rule, and there is no clear modern GRCA-era appellate capstone, so where practical provide additional consideration and monitor for new case law [^q8-grca-13-8-53a-consideration].
+
+## Can an out-of-state choice-of-law clause avoid the GRCA? {#choice-of-law}
+
+**Short answer.** Generally no. In *Motorsports of Conyers, LLC v. Burbach*, the Supreme Court of Georgia held that Georgia law remains the touchstone, so a Georgia court must first determine whether a covenant complies with the GRCA; if the covenant is unreasonable under the Act, the court may not apply another state's law to enforce it [^q9-motorsports-touchstone][^q9-motorsports-mechanism].
+
+Employers with multi-state forms often insert a choice-of-law clause selecting a more permissive state. *Motorsports* makes clear that such a clause will not rescue a covenant that fails Georgia's public policy.
+
+"Having taken a fresh look, we conclude that Georgia law remains the touchstone for determining whether a given restrictive covenant is enforceable in our courts, even where the contract says another state's law applies."[^q9-motorsports-touchstone]
+
+The court set out a sequence: test the covenant against the GRCA first, and only honor the foreign law if the covenant is reasonable under Georgia law.
+
+"If the restrictive covenant is unreasonable under the GRCA, a Georgia court may not apply foreign law to enforce it."[^q9-motorsports-mechanism]
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not rely on a Delaware, Florida, or other out-of-state choice-of-law clause to enforce a covenant that would fail in Georgia. *Motorsports of Conyers v. Burbach* requires a Georgia court to test GRCA compliance first and bars foreign law when the covenant is unreasonable under the Act [^q9-motorsports-touchstone][^q9-motorsports-mechanism].
+
+## Does a Georgia non-compete toll or extend during breach or litigation? {#tolling-during-breach}
+
+**Short answer.** A court will not extend it, and a private tolling clause is on uncertain ground. In *Daneshgari v. Patriot Towing Services, LLC*, the Court of Appeals held that a trial court cannot extend a non-compete beyond its contractual expiration, even against a party violating an injunction, because Georgia courts have rejected the idea that equity lets a court extend the period of a non-compete. Whether a contractual clause that pauses and extends the restraint would fare better has not been squarely decided [^q10-daneshgari-no-extend][^q10-daneshgari-equity].
+
+Many covenants include a tolling clause stating that the restricted period pauses while the employee is in breach or while litigation is pending, so the employer gets a full period of compliance. Georgia law is hostile to judicial extension of the restraint past its stated end date.
+
+"On appeal, the defendants contend that the trial court erred in extending its injunction beyond the contractual expiration of the noncompete agreement. For the reasons set forth infra, we agree and reverse."[^q10-daneshgari-no-extend]
+
+The Court of Appeals agreed with the defendants and relied on Georgia precedent rejecting equitable extension of a covenant's duration.
+
+"But the Supreme Court of Georgia has rejected—at least implicitly—the idea that ‘equity permits a court to extend the period of a non-compete agreement.’"[^q10-daneshgari-equity]
+
+That said, the GRCA's broad remedies provision lets courts enforce a covenant by injunction during the agreement's term, and an employer can still pursue contempt for violating an injunction — it simply cannot stretch the covenant's duration past its contractual end. A contractual tolling clause that purports to extend the restraint beyond its stated term is therefore on uncertain ground, and counsel should not count on a court enforcing it [^q10-grca-13-8-58-remedies].
+
+"A court shall enforce a restrictive covenant by any appropriate and effective remedy available at law or equity, including, but not limited to, temporary and permanent injunctions."[^q10-grca-13-8-58-remedies]
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not rely on a tolling clause to extend a Georgia non-compete past its stated end date. *Daneshgari v. Patriot Towing Services* holds that a court cannot extend a covenant beyond its contractual expiration even against a party violating an injunction [^q10-daneshgari-no-extend][^q10-daneshgari-equity].
+
+## How do confidentiality and trade-secret protections compare to a Georgia non-compete? {#confidentiality-trade-secrets}
+
+**Short answer.** They are available and not subject to the non-compete limits. O.C.G.A. § 13-8-53(e) provides that confidentiality and trade-secret obligations are not limited in time or geography for as long as the information stays confidential or qualifies as a trade secret, and § 13-8-53(a) treats a nondisclosure-of-confidential-information provision as distinct from a post-employment competition restraint, so it sits outside the employee-category gate [^q11-grca-13-8-53e-confidentiality][^q11-grca-13-8-53a-carveout].
+
+For information-protection interests, a confidentiality covenant is often the better tool than a non-compete because it is not capped by the durational presumptions and does not depend on the employee's job category. The GRCA preserves indefinite confidentiality protection.
+
+"Nothing in this article shall be construed to limit the period of time for which a party may agree to maintain information as confidential or as a trade secret, or to limit the geographic area within which such information must be kept confidential or as a trade secret, for so long as the information or material remains confidential or a trade secret, as applicable."[^q11-grca-13-8-53e-confidentiality]
+
+The Act also recognizes trade secrets and valuable confidential information as legitimate business interests in their own right, which means a well-drafted confidentiality program can protect the same competitive concerns a non-compete addresses, while remaining enforceable against rank-and-file employees who could not be bound by a non-compete.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Use confidentiality and trade-secret covenants for information-protection interests, especially against employees outside the non-compete categories. O.C.G.A. § 13-8-53(e) allows these obligations to run for as long as the information stays confidential, without the durational or category limits that apply to non-competes [^q11-grca-13-8-53e-confidentiality].
+
+## Are physician and other healthcare non-competes enforceable in Georgia? {#healthcare-physicians}
+
+**Short answer.** Yes, under the same GRCA rules. Georgia has no special statutory ban on physician non-competes; a physician is typically a *professional* under O.C.G.A. § 13-8-51, so a reasonable covenant is enforceable on the ordinary reasonableness terms. Because the legislature could change this, the area is worth monitoring [^q12-grca-13-8-51-professional][^q12-grca-13-8-53a-physician].
+
+Unlike a growing number of states, Georgia has not enacted a carve-out for physicians or other medical licensees. A physician generally qualifies as a *professional* under the Act, which is one of the employee categories that can be bound by a post-employment non-compete.
+
+"'Professional' means an employee who has as a primary duty the performance of work requiring knowledge of an advanced type in a field of science or learning customarily acquired by a prolonged course of specialized intellectual instruction or requiring invention, imagination, originality, or talent in a recognized field of artistic or creative endeavor."[^q12-grca-13-8-51-professional]
+
+A physician covenant is therefore enforceable on the same terms as any other professional's — reasonable in time, geographic area, and scope under § 13-8-53(a). Other healthcare workers are not automatically covered, however: a nurse, technician, or staff member can be bound by a post-employment non-compete only if he or she independently falls within one of the § 13-8-53(a) employee categories.
+
+"Notwithstanding any other provision of this chapter, enforcement of contracts that restrict competition during the term of a restrictive covenant, so long as such restrictions are reasonable in time, geographic area, and scope of prohibited activities, shall be permitted."[^q12-grca-13-8-53a-physician]
+
+> [!NOTE]
+> **Practice note.**
+>
+> Treat Georgia physician non-competes as enforceable under the ordinary GRCA reasonableness rules, but watch the legislature. Healthcare non-competes are a recurring subject of proposed legislation in Georgia, none of which has yet become law, so confirm the statute has not changed before relying on a physician covenant [^q12-grca-13-8-51-professional][^q12-grca-13-8-53a-physician].
+
+## Which agreements does the Georgia Restrictive Covenants Act cover? {#effective-date}
+
+**Short answer.** Only agreements entered on or after May 11, 2011. The GRCA applies to contracts entered into on and after its effective date and does not apply when a court determines the enforceability of a covenant entered before that date — those older covenants are still judged under Georgia's stricter pre-2011 common law [^q13-grca-effective-date].
+
+Georgia restrictive-covenant law is effectively two-track, divided by the date the covenant was signed. The Act expressly limits itself to agreements entered on or after its effective date.
+
+"This Act shall become effective upon its approval by the Governor or upon its becoming law without such approval and shall apply to contracts entered into on and after such date and shall not apply in actions determining the enforceability of restrictive covenants entered into before such date."[^q13-grca-effective-date]
+
+The Act was signed and took effect on May 11, 2011. A covenant signed before that date is governed by the older, far less forgiving common-law regime, under which Georgia courts strictly scrutinized employee covenants and would not blue-pencil an overbroad employment non-compete. The Act applies only between the listed contracting relationships — employers and employees, franchisors and franchisees, sellers and buyers of a business, and the others § 13-8-52 lists.
+
+"The provisions of this article shall be applicable only to contracts and agreements between or among: (1) Employers and employees; (2) Distributors and manufacturers; (3) Lessors and lessees; (4) Partnerships and partners; (5) Franchisors and franchisees; (6) Sellers and purchasers of a business or commercial enterprise; and (7) Two or more employers."[^q13-grca-13-8-52-application]
+
+> [!NOTE]
+> **Practice note.**
+>
+> Check the signing date before applying the GRCA. A covenant entered before May 11, 2011 is judged under Georgia's stricter pre-Act common law, where modification was unavailable for employment non-competes, so the modern reasonableness and blue-pencil rules do not apply to it [^q13-grca-effective-date][^q13-grca-13-8-52-application].
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-03. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not Georgia. This article synthesizes Georgia primary law and is not legal advice from a Georgia-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^q1-grca-13-8-53a-reasonable]: **O.C.G.A. § 13-8-53** — "Notwithstanding any other provision of this chapter, enforcement of contracts that restrict competition during the term of a restrictive covenant, so long as such restrictions are reasonable in time, geographic area, and scope of prohibited activities, shall be permitted." *O.C.G.A. § 13-8-53(a).* <https://www.legis.ga.gov/api/legislation/document/20112012/114248>
+
+[^q1-grca-13-8-50-findings]: **O.C.G.A. § 13-8-50** — "The General Assembly finds that reasonable restrictive covenants contained in employment and commercial contracts serve the legitimate purpose of protecting legitimate business interests and creating an environment that is favorable to attracting commercial enterprises to Georgia and keeping existing businesses within the state." *O.C.G.A. § 13-8-50.* <https://www.legis.ga.gov/api/legislation/document/20112012/114248>
+
+[^q1-grca-13-8-55-burden]: **O.C.G.A. § 13-8-55** — "The person seeking enforcement of a restrictive covenant shall plead and prove the existence of one or more legitimate business interests justifying the restrictive covenant. If a person seeking enforcement of the restrictive covenant establishes by prima-facie evidence that the restraint is in compliance with the provisions of Code Section 13-8-53, then any person opposing enforcement has the burden of establishing that the contractually specified restraint does not comply with such requirements or that such covenant is unreasonable." *O.C.G.A. § 13-8-55.* <https://www.legis.ga.gov/api/legislation/document/20112012/114248>
+
+[^q2-grca-13-8-53a-categories]: **O.C.G.A. § 13-8-53** — "However, enforcement of contracts that restrict competition after the term of employment, as distinguished from a customer nonsolicitation provision, as described in subsection (b) of this Code section, or a nondisclosure of confidential information provision, as described in subsection (e) of this Code section, shall not be permitted against any employee who does not, in the course of his or her employment: (1) Customarily and regularly solicit for the employer customers or prospective customers; (2) Customarily and regularly engage in making sales or obtaining orders or contracts for products or services to be performed by others; (3) Perform the following duties: (A) Have a primary duty of managing the enterprise in which the employee is employed or of a customarily recognized department or subdivision thereof; (B) Customarily and regularly direct the work of two or more other employees; and (C) Have the authority to hire or fire other employees or have particular weight given to suggestions and recommendations as to the hiring, firing, advancement, promotion, or any other change of status of other employees; or (4) Perform the duties of a key employee or of a professional." *O.C.G.A. § 13-8-53(a).* <https://www.legis.ga.gov/api/legislation/document/20112012/114248>
+
+[^q2-blair-key-employee]: **Blair v. Pantera Enterprises, Inc.** — "Thus, Blair is not a ‘key employee’ as that term is defined in OCGA § 13-8-51 (8). Consequently, the trial court erred in issuing injunctive relief to Pantera." *Blair v. Pantera Enterprises, Inc., 349 Ga. App. 846 (2019) (physical precedent only).* <https://www.courtlistener.com/opinion/4601931/blair-v-pantera-enterprises-inc/#:~:text=Thus%2C%20Blair%20is%20not%20a,issuing%20injunctive%20relief%20to%20Pantera.>
+
+[^q3-grca-13-8-57b-employee]: **O.C.G.A. § 13-8-57** — "a court shall presume to be reasonable in time any restraint two years or less in duration and shall presume to be unreasonable in time any restraint more than two years in duration, measured from the date of the termination of the business relationship." *O.C.G.A. § 13-8-57(b).* <https://www.legis.ga.gov/api/legislation/document/20112012/114248>
+
+[^q3-grca-13-8-57c-other]: **O.C.G.A. § 13-8-57** — "a court shall presume to be reasonable in time any restraint three years or less in duration and shall presume to be unreasonable in time any restraint more than three years in duration, measured from the date of termination of the business relationship." *O.C.G.A. § 13-8-57(c).* <https://www.legis.ga.gov/api/legislation/document/20112012/114248>
+
+[^q3-grca-13-8-57d-sale]: **O.C.G.A. § 13-8-57** — "a court shall presume to be reasonable in time any restraint the longer of five years or less in duration or equal to the period of time during which payments are being made to the owner or seller as a result of any sale referred to in this subsection and shall presume to be unreasonable in time any restraint more than the longer of five years in duration or the period of time during which payments are being made to the owner or seller as a result of any sale referred to in this subsection, measured from the date of termination or disposition of such interest." *O.C.G.A. § 13-8-57(d).* <https://www.legis.ga.gov/api/legislation/document/20112012/114248>
+
+[^q4-wimmer-no-express-term]: **North American Senior Benefits, LLC v. Wimmer** — "The petitioner — a Georgia corporation seeking to enforce a restrictive covenant against two former employees — asks us to review the conclusion reached by the Court of Appeals that, to be deemed geographically reasonable under OCGA § 13-8-53 (a), a restrictive covenant must contain an express geographic term. In light of the statutory text and context of the GRCA, we conclude that the Court of Appeals erred, so we reverse and remand this case for further proceedings." *North American Senior Benefits, LLC v. Wimmer, 319 Ga. 641 (2024).* <https://www.courtlistener.com/opinion/10680273/north-american-senior-benefits-llc-v-wimmer/#:~:text=The%20petitioner%20%E2%80%94%20a%20Georgia,this%20case%20for%20further%20proceedings.>
+
+[^q4-grca-13-8-56-geography]: **O.C.G.A. § 13-8-56** — "In determining the reasonableness of a restrictive covenant that limits or restricts competition during or after the term of an employment or business or commercial relationship, the court shall make the following presumptions:...(2) A geographic territory which includes the areas in which the employer does business at any time during the parties' relationship, even if not known at the time of entry into the restrictive covenant, is reasonable provided that: (A) The total distance encompassed by the provisions of the covenant also is reasonable; (B) The agreement contains a list of particular competitors as prohibited employers for a limited period of time after the term of employment or a business or commercial relationship; or (C) Both subparagraphs (A) and (B) of this paragraph" *O.C.G.A. § 13-8-56(2).* <https://www.legis.ga.gov/api/legislation/document/20112012/114248>
+
+[^q5-grca-13-8-53b-customer]: **O.C.G.A. § 13-8-53** — "an employee may agree in writing for the benefit of an employer to refrain, for a stated period of time following termination, from soliciting, or attempting to solicit, directly or by assisting others, any business from any of such employer's customers, including actively seeking prospective customers, with whom the employee had material contact during his or her employment for purposes of providing products or services that are competitive with those provided by the employer's business. No express reference to geographic area or the types of products or services considered to be competitive shall be required in order for the restraint to be enforceable." *O.C.G.A. § 13-8-53(b).* <https://www.legis.ga.gov/api/legislation/document/20112012/114248>
+
+[^q5-grca-13-8-51-material-contact]: **O.C.G.A. § 13-8-51** — "'Material contact' means the contact between an employee and each customer or potential customer: (A) With whom or which the employee dealt on behalf of the employer; (B) Whose dealings with the employer were coordinated or supervised by the employee; (C) About whom the employee obtained confidential information in the ordinary course of business as a result of such employee's association with the employer; or (D) Who receives products or services authorized by the employer, the sale or provision of which results or resulted in compensation, commissions, or earnings for the employee within two years prior to the date of the employee's termination." *O.C.G.A. § 13-8-51(10).* <https://www.legis.ga.gov/api/legislation/document/20112012/114248>
+
+[^q6-beltpower-grca]: **Belt Power, LLC v. Reed** — "Upon a close reading of the entire statute, we conclude that the restrictive covenants at issue do fall within the ambit of the Act." *Belt Power, LLC v. Reed, 354 Ga. App. 289 (2020).* <https://www.courtlistener.com/opinion/4735721/belt-power-llc-v-steve-reed/#:~:text=Upon%20a%20close%20reading%20of,the%20ambit%20of%20the%20Act.>
+
+[^q6-wimmer-nonrecruit]: **North American Senior Benefits, LLC v. Wimmer** — "In light of the statutory text and context of the GRCA, we conclude that the Court of Appeals erred, so we reverse and remand this case for further proceedings." *North American Senior Benefits, LLC v. Wimmer, 319 Ga. 641 (2024).* <https://www.courtlistener.com/opinion/10680273/north-american-senior-benefits-llc-v-wimmer/#:~:text=In%20light%20of%20the%20statutory,this%20case%20for%20further%20proceedings.>
+
+[^q7-grca-13-8-53d-modify]: **O.C.G.A. § 13-8-53** — "Any restrictive covenant not in compliance with the provisions of this article is unlawful and is void and unenforceable; provided, however, that a court may modify a covenant that is otherwise void and unenforceable so long as the modification does not render the covenant more restrictive with regard to the employee than as originally drafted by the parties." *O.C.G.A. § 13-8-53(d).* <https://www.legis.ga.gov/api/legislation/document/20112012/114248>
+
+[^q7-grca-13-8-54b-relief]: **O.C.G.A. § 13-8-54** — "In any action concerning enforcement of a restrictive covenant, a court shall not enforce a restrictive covenant unless it is in compliance with the provisions of Code Section 13-8-53; provided, however, that if a court finds that a contractually specified restraint does not comply with the provisions of Code Section 13-8-53, then the court may modify the restraint provision and grant only the relief reasonably necessary to protect such interest or interests and to achieve the original intent of the contracting parties to the extent possible." *O.C.G.A. § 13-8-54(b).* <https://www.legis.ga.gov/api/legislation/document/20112012/114248>
+
+[^q7-grca-13-8-54-construe]: **O.C.G.A. § 13-8-54** — "A court shall construe a restrictive covenant to comport with the reasonable intent and expectations of the parties to the covenant and in favor of providing reasonable protection to all legitimate business interests established by the person seeking enforcement." *O.C.G.A. § 13-8-54(a).* <https://www.legis.ga.gov/api/legislation/document/20112012/114248>
+
+[^q7-beltpower-modify]: **Belt Power, LLC v. Reed** — "We nevertheless conclude that the trial court did not abuse its discretion in declining to apply the ‘blue pencil’ provision in the Act to modify the terms of the covenants." *Belt Power, LLC v. Reed, 354 Ga. App. 289 (2020).* <https://www.courtlistener.com/opinion/4735721/belt-power-llc-v-steve-reed/#:~:text=We%20nevertheless%20conclude%20that%20the,the%20terms%20of%20the%20covenants.>
+
+[^q8-grca-13-8-53a-consideration]: **O.C.G.A. § 13-8-53** — "Notwithstanding any other provision of this chapter, enforcement of contracts that restrict competition during the term of a restrictive covenant, so long as such restrictions are reasonable in time, geographic area, and scope of prohibited activities, shall be permitted." *O.C.G.A. § 13-8-53(a).* <https://www.legis.ga.gov/api/legislation/document/20112012/114248>
+
+[^q9-motorsports-touchstone]: **Motorsports of Conyers, LLC v. Burbach** — "Having taken a fresh look, we conclude that Georgia law remains the touchstone for determining whether a given restrictive covenant is enforceable in our courts, even where the contract says another state's law applies." *Motorsports of Conyers, LLC v. Burbach, 317 Ga. 206 (2023).* <https://www.courtlistener.com/opinion/10680038/motorsports-of-conyers-llc-v-burbach/#:~:text=Having%20taken%20a%20fresh%20look%2C,says%20another%20state's%20law%20applies.>
+
+[^q9-motorsports-mechanism]: **Motorsports of Conyers, LLC v. Burbach** — "If the restrictive covenant is unreasonable under the GRCA, a Georgia court may not apply foreign law to enforce it." *Motorsports of Conyers, LLC v. Burbach, 317 Ga. 206 (2023).* <https://www.courtlistener.com/opinion/10680038/motorsports-of-conyers-llc-v-burbach/#:~:text=If%20the%20restrictive%20covenant%20is,foreign%20law%20to%20enforce%20it.>
+
+[^q10-daneshgari-no-extend]: **Daneshgari v. Patriot Towing Services, LLC** — "On appeal, the defendants contend that the trial court erred in extending its injunction beyond the contractual expiration of the noncompete agreement. For the reasons set forth infra, we agree and reverse." *Daneshgari v. Patriot Towing Services, LLC, 361 Ga. App. 555 (2021).* <https://www.courtlistener.com/opinion/5295364/khosrow-daneshgari-v-patriot-towing-services-llc/#:~:text=On%20appeal%2C%20the%20defendants%20contend,infra%2C%20we%20agree%20and%20reverse.>
+
+[^q10-daneshgari-equity]: **Daneshgari v. Patriot Towing Services, LLC** — "But the Supreme Court of Georgia has rejected—at least implicitly—the idea that ‘equity permits a court to extend the period of a non-compete agreement.’" *Daneshgari v. Patriot Towing Services, LLC, 361 Ga. App. 555 (2021).* <https://www.courtlistener.com/opinion/5295364/khosrow-daneshgari-v-patriot-towing-services-llc/#:~:text=But%20the%20Supreme%20Court%20of,period%20of%20a%20non%2Dcompete%20agreement.%E2%80%9D>
+
+[^q10-grca-13-8-58-remedies]: **O.C.G.A. § 13-8-58** — "A court shall enforce a restrictive covenant by any appropriate and effective remedy available at law or equity, including, but not limited to, temporary and permanent injunctions." *O.C.G.A. § 13-8-58(c).* <https://www.legis.ga.gov/api/legislation/document/20112012/114248>
+
+[^q11-grca-13-8-53e-confidentiality]: **O.C.G.A. § 13-8-53** — "Nothing in this article shall be construed to limit the period of time for which a party may agree to maintain information as confidential or as a trade secret, or to limit the geographic area within which such information must be kept confidential or as a trade secret, for so long as the information or material remains confidential or a trade secret, as applicable." *O.C.G.A. § 13-8-53(e).* <https://www.legis.ga.gov/api/legislation/document/20112012/114248>
+
+[^q11-grca-13-8-53a-carveout]: **O.C.G.A. § 13-8-53** — "However, enforcement of contracts that restrict competition after the term of employment, as distinguished from a customer nonsolicitation provision, as described in subsection (b) of this Code section, or a nondisclosure of confidential information provision, as described in subsection (e) of this Code section, shall not be permitted against any employee who does not, in the course of his or her employment:" *O.C.G.A. § 13-8-53(a).* <https://www.legis.ga.gov/api/legislation/document/20112012/114248>
+
+[^q12-grca-13-8-51-professional]: **O.C.G.A. § 13-8-51** — "'Professional' means an employee who has as a primary duty the performance of work requiring knowledge of an advanced type in a field of science or learning customarily acquired by a prolonged course of specialized intellectual instruction or requiring invention, imagination, originality, or talent in a recognized field of artistic or creative endeavor." *O.C.G.A. § 13-8-51(14).* <https://www.legis.ga.gov/api/legislation/document/20112012/114248>
+
+[^q12-grca-13-8-53a-physician]: **O.C.G.A. § 13-8-53** — "Notwithstanding any other provision of this chapter, enforcement of contracts that restrict competition during the term of a restrictive covenant, so long as such restrictions are reasonable in time, geographic area, and scope of prohibited activities, shall be permitted." *O.C.G.A. § 13-8-53(a).* <https://www.legis.ga.gov/api/legislation/document/20112012/114248>
+
+[^q13-grca-effective-date]: **2011 Ga. HB 30, § 5 (O.C.G.A. § 13-8-50 et seq.)** — "This Act shall become effective upon its approval by the Governor or upon its becoming law without such approval and shall apply to contracts entered into on and after such date and shall not apply in actions determining the enforceability of restrictive covenants entered into before such date." *2011 Ga. HB 30, § 5 (eff. May 11, 2011).* <https://www.legis.ga.gov/api/legislation/document/20112012/114248>
+
+[^q13-grca-13-8-52-application]: **O.C.G.A. § 13-8-52** — "The provisions of this article shall be applicable only to contracts and agreements between or among: (1) Employers and employees; (2) Distributors and manufacturers; (3) Lessors and lessees; (4) Partnerships and partners; (5) Franchisors and franchisees; (6) Sellers and purchasers of a business or commercial enterprise; and (7) Two or more employers." *O.C.G.A. § 13-8-52(a).* <https://www.legis.ga.gov/api/legislation/document/20112012/114248>

--- a/skills/non-compete-contract-explainer/content/guam.md
+++ b/skills/non-compete-contract-explainer/content/guam.md
@@ -1,0 +1,180 @@
+---
+jurisdiction: "Guam"
+slug: guam
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-03"
+canonicalUrl: https://openagreements.org/legal/non-compete/guam
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/guam · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in Guam[^about]
+
+Guam voids employee non-compete agreements by statute — 18 GCA § 88105 derives from former California Civil Code § 1673 and is virtually identical to California's Business and Professions Code § 16600 — and the Supreme Court of Guam reads it as a per-se ban, leaving only narrow sale-of-business and partnership-dissolution exceptions.
+
+
+## At a glance
+
+| Question | Guam |
+| --- | --- |
+| **Are non-competes enforceable?** | Banned |
+| **Bottom line** | Guam voids employee non-competes by statute — 18 GCA § 88105, a transplant of California's restraint-of-trade rule that the Supreme Court of Guam reads as a per-se ban — leaving only narrow sale-of-business and partnership-dissolution exceptions. |
+| **Main law or case** | 18 GCA § 88105; Island Eye Ctr., Inc. v. Lombard, 2020 Guam 32 |
+| **Main exceptions** | Sale of business good will (§ 88106); partnership dissolution (§ 88107) |
+| **Can a court narrow it?** | No |
+| **Applies to contractors?** | Unclear |
+| **Restriction extended during a breach?** | Not addressed |
+| **Maximum length set by law** | Not applicable (employee covenant void regardless of duration) |
+
+## Are employee non-compete agreements enforceable in Guam? {#employee-noncompetes}
+
+**Short answer.** No. Guam voids employee non-compete agreements by statute. Title 18 of the Guam Code Annotated, section 88105, makes every contract that restrains someone from exercising a lawful profession, trade, or business void to that extent, except for two narrow statutory exceptions — and in *Island Eye Center, Inc. v. Lombard* the Supreme Court of Guam read that language as a per-se ban [^stat-88105][^ie-void-holding].
+
+Guam's restraint-of-trade statute is not the product of local drafting — it is California law transplanted. Section 88105 descends from the former California Civil Code section 1673, since recodified as the heavily litigated Business and Professions Code section 16600, and the *Island Eye* court said so in the first case to construe the provision [^ie-first-time][^ie-derived].
+
+"Our statute is derived from California Civil Code section 1673, since replaced by California Business and Professions Code section 16600."[^ie-derived]
+
+Because the statutes are nearly identical, the court treats California's interpretation as persuasive and adopted its strict employee-mobility reading for the non-compete before it. That means Guam, like California, does not weigh a covenant's duration or geography the way a reasonableness state does. A clause that restrains a former employee from competing is simply outside the statute and void — the court reads section 88105 as an expression of public policy favoring employee mobility [^ie-policy].
+
+"Therefore, we hold that section 88105 evidences public policy for employee mobility and every citizen's right to pursue lawful employment or enterprise of his or her choice."[^ie-policy]
+
+Applying that rule, the court struck the non-compete in *Island Eye*, which barred an ophthalmologist from practicing for 30 months across Guam and the Mariana Islands, as void rather than narrowing it to something enforceable [^ie-void-holding].
+
+"These post-employment terms are undoubtedly a restraint of trade in violation of 18 GCA § 88105 and are to that extent void."[^ie-void-holding]
+
+This is not a new development. Decades earlier, the Ninth Circuit applied the same statute in *Shelton v. Guam Service Games* and voided a Guam-wide covenant, holding that a positive legislative declaration overrode any common-law reasonableness argument [^shelton-void].
+
+"Since this agreement attempted to make the prohibition and restraint complete within the Territory of Guam, it is to that extent void."[^shelton-void]
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not paper a Guam employee with an out-of-state non-compete form and assume a court will blue-pencil it down to something enforceable. The Supreme Court of Guam voided the non-compete in *Island Eye* outright, and it expressly left open whether blue-penciling an overbroad covenant is even permissible — so reformation is no safe harbor. The only reliable paths to a valid covenant are the narrow sale-of-business and partnership exceptions discussed below [^stat-88105][^ie-void-holding].
+
+## Are customer and employee non-solicitation clauses enforceable in Guam? {#non-solicitation}
+
+**Short answer.** Neither sits on firm ground, and a customer non-solicitation clause likely shares the non-compete's fate. No Guam decision squarely rules on a customer non-solicitation clause, but because *Island Eye* adopted California's section 16600 framework — under which a covenant that forecloses a former employee's ability to compete for business is an impermissible restraint — a customer non-solicit likely carries the same void risk. For clauses barring the solicitation of a former employer's *staff*, the Supreme Court of Guam expressly left the question of facial validity open in *Island Eye* [^q2-ie-postemp][^q2-ie-facial].
+
+Guam took its restraint-of-trade rule from California, where post-employment covenants that foreclose a worker's ability to compete are impermissible restraints regardless of how they are labeled — including the former-client service restriction the court invalidated in *Edwards*, the decision *Island Eye* adopted. *Island Eye* itself distinguished employee anti-raiding clauses from client non-solicits and did not separately rule on a customer non-solicitation clause, so the customer-restriction conclusion is a prediction from the adopted framework rather than a Guam holding [^q2-ie-postemp].
+
+"California courts interpret post-employment covenants not to compete as impermissible restraints of trade which violate section 16600."[^q2-ie-postemp]
+
+Employee *anti-raiding* clauses — barring a departing worker from soliciting the employer's remaining staff — are the open question. In *Island Eye*, the employer conceded that such clauses are typically invalidated under California law, and the court resolved the dispute without deciding whether they facially violate section 88105 [^q2-ie-concede][^q2-ie-facial].
+
+"Because of Island Eye's concession, the parties' arguments on appeal are limited to whether non-solicitation clauses facially violate 18 GCA § 88105."[^q2-ie-facial]
+
+> [!NOTE]
+> **Practice note.**
+>
+> Treat a customer non-solicitation clause in a Guam employment agreement as carrying the same void risk as a non-compete, and recognize that an employee anti-raiding clause rests on unsettled ground after *Island Eye* — the court declined to rule on its facial validity, and the employer there conceded California voids such clauses. Protect customer relationships and workforce stability through a properly scoped trade-secret and confidentiality program instead [^q2-ie-postemp][^q2-ie-concede].
+
+## Are non-competes tied to the sale of a business enforceable in Guam? {#sale-of-business}
+
+**Short answer.** Yes, within a narrow statutory exception. Section 88106 lets a person who sells the good will of a business agree not to carry on a similar business within a *specified district, city, or a part thereof*, so long as the buyer continues a like business there — but courts read the geographic limit strictly [^stat-88106][^shelton-goodwill].
+
+The sale-of-business exception exists so a buyer can protect the good will it pays for; without it, a seller could reopen next door and take back the customer base just sold. But the covenant must be tied to a genuine sale of good will and confined to a specified district, city, or part of one [^stat-88106].
+
+"One who sells the good will of a business may agree with the buyer to refrain from carrying on a similar business within a specified district, city, or a part thereof, so long as the buyer, or any person deriving title to the good will from him, carries on a like business therein."[^stat-88106]
+
+That geographic limit has teeth. In *Shelton v. Guam Service Games*, the Ninth Circuit refused to fit a Territory-wide covenant within the good-will exception, reasoning that a restraint covering the entire Territory of Guam is too broad to be the *specified district, city, or part* the statute allows [^shelton-goodwill].
+
+"By no theory could it include the entire Territory of Guam or any major portion thereof."[^shelton-goodwill]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Tie a Guam sale-of-business covenant to the good will actually sold and confine it to a specified district, city, or part of one — not the whole island. A covenant scoped to the entire Territory of Guam falls outside section 88106 and, under *Shelton*, leaves section 88105 to void it [^stat-88106][^shelton-goodwill].
+
+## Can partners agree not to compete on dissolution of a Guam partnership? {#partnership-dissolution}
+
+**Short answer.** Yes, within the second statutory exception. Section 88107 lets partners, on or in anticipation of dissolving a partnership, agree not to carry on a similar business within the same city or town where the partnership did business, or a specified part of it [^stat-88107].
+
+This is the partnership analogue to the sale-of-business exception, and it is drafted just as narrowly: the permissible restraint is bounded to the same city or town — or a specified part of it — where the partnership transacted business [^stat-88107].
+
+"Partners may, upon or in anticipation of a dissolution of a partnership, agree that none of them will carry on a similar business within the same city or town where the partnership business has been transacted, or within a specified part thereof."[^stat-88107]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Scope a partnership non-compete to the same city or town — or a specified part of it — where the partnership actually did business, and tie it to dissolution. A clause reaching beyond that geography, or imposed outside the dissolution context, falls outside section 88107 and is exposed to the section 88105 ban [^stat-88107][^q4-stat-88105].
+
+## Can a liquidated-damages or penalty clause back up a Guam covenant? {#liquidated-damages}
+
+**Short answer.** Generally no. Guam's contract statute voids a clause that fixes damages for breach in advance, except where actual damages would be impracticable or extremely difficult to fix — so a penalty bolted onto a covenant cannot do work the covenant itself cannot [^stat-88103][^stat-88104].
+
+Section 88103 sets the default rule: a contract that fixes the amount of damages in anticipation of a breach is void to that extent [^stat-88103].
+
+"Every contract by which the amount of damage to be paid, or other compensation to be made, for a breach of an obligation, is determined in anticipation thereof, is to that extent void, except as expressly provided in the next section."[^stat-88103]
+
+The lone exception, section 88104, permits a genuine liquidated-damages estimate only where actual damages would be impracticable or extremely difficult to fix [^stat-88104].
+
+"The parties to a contract may agree therein on an amount which shall be presumed to be the amount of damage sustained by a breach thereof; when, from the nature of the case, it would be impracticable or extremely difficult to fix the actual damage."[^stat-88104]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not try to rescue a Guam non-compete with a liquidated-damages or penalty clause. The covenant itself is void under section 88105, and section 88103 independently voids a damages-fixing clause unless it meets the narrow section 88104 standard for situations where actual damages are impracticable to calculate [^stat-88103][^stat-88104].
+
+## What can a Guam employer protect instead of a non-compete? {#trade-secrets}
+
+**Short answer.** Trade secrets and narrowly drawn confidentiality. Guam has not adopted the Uniform Trade Secrets Act, so in *Island Eye* the Supreme Court of Guam borrowed the trade-secret definition from the territory's criminal code — 9 GCA § 43.10(f) — to govern civil misappropriation claims; that protection guards genuine secrets without restraining the employee's right to compete [^q6-ie-tradesecret].
+
+Because the *Island Eye* employer had no statutory trade-secret regime to point to, the court had to decide what definition applies to a civil claim. It adopted the criminal-code definition as a matter of first impression [^q6-ie-tradesecret].
+
+"Therefore, we hold that the definition of trade secrets in 9 GCA § 43.10(f) is the definition of trade secrets for civil trade-secret-misappropriation claims."[^q6-ie-tradesecret]
+
+A confidentiality or trade-secret program protects the *information* rather than the employment relationship, which is why it is the durable tool a Guam employer has after section 88105 takes a non-compete off the table. The discipline it requires is precision: a confidentiality clause cannot be written so broadly that it functions as a back-door non-compete barring the employee from the field, because that would be the very restraint section 88105 voids.
+
+The court drew that line itself. *Island Eye* rejected the *inevitable disclosure* doctrine — the theory that a departing employee will inevitably use trade secrets in a new job — precisely because it would convert trade-secret protection into a de facto covenant not to compete, and stressed that such protection is a shield rather than a sword [^q6-ie-shield].
+
+"Trade-secret protection should be a shield, not a sword used by employers to retain its employees by threat of rendering them substantially unemployable in their field of experience or prevent workers from pursuing their livelihoods when they leave their current positions."[^q6-ie-shield]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not define *confidential information* so broadly that it sweeps in the employee's general skills, knowledge, and industry experience — a confidentiality clause that effectively prevents the worker from practicing their profession is a non-compete in substance and void under section 88105. Tie confidentiality to genuine secrets that meet the 9 GCA § 43.10(f) definition the Supreme Court of Guam adopted, and remember that hiring a former competitor's at-will staff is not itself misappropriation absent an identifiable trade secret [^q6-ie-tradesecret][^q6-ie-shield].
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-03. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not Guam. This article synthesizes Guam primary law and is not legal advice from a Guam-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^stat-88105]: **18 GCA § 88105 — Contracts in Restraint of Trade** — "Every contract, by which anyone is restrained from exercising a lawful profession, trade, or business of any kind, otherwise than is provided in the next two sections, is to that extent void." *18 GCA § 88105.* <https://col.guamcourts.gov/sites/default/files/18gc088.pdf>
+
+[^ie-void-holding]: **Island Eye Center, Inc. v. Lombard** — "These post-employment terms are undoubtedly a restraint of trade in violation of 18 GCA § 88105 and are to that extent void." *Island Eye Ctr., Inc. v. Lombard, 2020 Guam 32.* <https://case-law.vlex.com/vid/island-eye-ctr-v-1039283384>
+
+[^ie-first-time]: **Island Eye Center, Inc. v. Lombard** — "This is the first time we have been asked to interpret our restraint-of-trade provision." *Island Eye Ctr., Inc. v. Lombard, 2020 Guam 32.* <https://case-law.vlex.com/vid/island-eye-ctr-v-1039283384>
+
+[^ie-derived]: **Island Eye Center, Inc. v. Lombard** — "Our statute is derived from California Civil Code section 1673, since replaced by California Business and Professions Code section 16600." *Island Eye Ctr., Inc. v. Lombard, 2020 Guam 32.* <https://case-law.vlex.com/vid/island-eye-ctr-v-1039283384>
+
+[^ie-policy]: **Island Eye Center, Inc. v. Lombard** — "Therefore, we hold that section 88105 evidences public policy for employee mobility and every citizen's right to pursue lawful employment or enterprise of his or her choice." *Island Eye Ctr., Inc. v. Lombard, 2020 Guam 32.* <https://case-law.vlex.com/vid/island-eye-ctr-v-1039283384>
+
+[^shelton-void]: **Shelton v. Guam Service Games** — "Since this agreement attempted to make the prohibition and restraint complete within the Territory of Guam, it is to that extent void." *Shelton v. Guam Service Games, 239 F.2d 902 (9th Cir. 1956).* <https://www.courtlistener.com/opinion/241093/austin-j-shelton-v-guam-service-games-a-copartnership/#:~:text=Since%20this%20agreement%20attempted%20to,is%20to%20that%20extent%20void.>
+
+[^q2-ie-postemp]: **Island Eye Center, Inc. v. Lombard** — "California courts interpret post-employment covenants not to compete as impermissible restraints of trade which violate section 16600." *Island Eye Ctr., Inc. v. Lombard, 2020 Guam 32.* <https://case-law.vlex.com/vid/island-eye-ctr-v-1039283384>
+
+[^q2-ie-facial]: **Island Eye Center, Inc. v. Lombard** — "Because of Island Eye's concession, the parties' arguments on appeal are limited to whether non-solicitation clauses facially violate 18 GCA § 88105." *Island Eye Ctr., Inc. v. Lombard, 2020 Guam 32.* <https://case-law.vlex.com/vid/island-eye-ctr-v-1039283384>
+
+[^q2-ie-concede]: **Island Eye Center, Inc. v. Lombard** — "Island Eye concedes that employee non-solicitation clauses are typically invalidated under California law as unlawful restraints of trade." *Island Eye Ctr., Inc. v. Lombard, 2020 Guam 32.* <https://case-law.vlex.com/vid/island-eye-ctr-v-1039283384>
+
+[^stat-88106]: **18 GCA § 88106 — Exception: Sale of Good Will** — "One who sells the good will of a business may agree with the buyer to refrain from carrying on a similar business within a specified district, city, or a part thereof, so long as the buyer, or any person deriving title to the good will from him, carries on a like business therein." *18 GCA § 88106.* <https://col.guamcourts.gov/sites/default/files/18gc088.pdf>
+
+[^shelton-goodwill]: **Shelton v. Guam Service Games** — "By no theory could it include the entire Territory of Guam or any major portion thereof." *Shelton v. Guam Service Games, 239 F.2d 902 (9th Cir. 1956).* <https://www.courtlistener.com/opinion/241093/austin-j-shelton-v-guam-service-games-a-copartnership/#:~:text=By%20no%20theory%20could%20it,or%20any%20major%20portion%20thereof.>
+
+[^stat-88107]: **18 GCA § 88107 — Exception: Partnership Agreement** — "Partners may, upon or in anticipation of a dissolution of a partnership, agree that none of them will carry on a similar business within the same city or town where the partnership business has been transacted, or within a specified part thereof." *18 GCA § 88107.* <https://col.guamcourts.gov/sites/default/files/18gc088.pdf>
+
+[^q4-stat-88105]: **18 GCA § 88105 — Contracts in Restraint of Trade** — "Every contract, by which anyone is restrained from exercising a lawful profession, trade, or business of any kind, otherwise than is provided in the next two sections, is to that extent void." *18 GCA § 88105.* <https://col.guamcourts.gov/sites/default/files/18gc088.pdf>
+
+[^stat-88103]: **18 GCA § 88103 — Contract Fixing Damages** — "Every contract by which the amount of damage to be paid, or other compensation to be made, for a breach of an obligation, is determined in anticipation thereof, is to that extent void, except as expressly provided in the next section." *18 GCA § 88103.* <https://col.guamcourts.gov/sites/default/files/18gc088.pdf>
+
+[^stat-88104]: **18 GCA § 88104 — Exceptions** — "The parties to a contract may agree therein on an amount which shall be presumed to be the amount of damage sustained by a breach thereof; when, from the nature of the case, it would be impracticable or extremely difficult to fix the actual damage." *18 GCA § 88104.* <https://col.guamcourts.gov/sites/default/files/18gc088.pdf>
+
+[^q6-ie-tradesecret]: **Island Eye Center, Inc. v. Lombard** — "Therefore, we hold that the definition of trade secrets in 9 GCA § 43.10(f) is the definition of trade secrets for civil trade-secret-misappropriation claims." *Island Eye Ctr., Inc. v. Lombard, 2020 Guam 32.* <https://case-law.vlex.com/vid/island-eye-ctr-v-1039283384>
+
+[^q6-ie-shield]: **Island Eye Center, Inc. v. Lombard** — "Trade-secret protection should be a shield, not a sword used by employers to retain its employees by threat of rendering them substantially unemployable in their field of experience or prevent workers from pursuing their livelihoods when they leave their current positions." *Island Eye Ctr., Inc. v. Lombard, 2020 Guam 32.* <https://case-law.vlex.com/vid/island-eye-ctr-v-1039283384>

--- a/skills/non-compete-contract-explainer/content/hawaii.md
+++ b/skills/non-compete-contract-explainer/content/hawaii.md
@@ -1,0 +1,236 @@
+---
+jurisdiction: "Hawaii"
+slug: hawaii
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-02"
+canonicalUrl: https://openagreements.org/legal/non-compete/hawaii
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/hawaii · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in Hawaii[^about]
+
+Hawaii treats non-competes through HRS chapter 480's antitrust framework, including ancillary-covenant exceptions, the technology-worker ban, sale-of-business covenants, non-solicitation limits, remedies, and trade-secret alternatives.
+
+
+## At a glance
+
+| Question | Hawaii |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed if reasonable |
+| **Bottom line** | Hawaii treats non-competes as restraints of trade under its antitrust statute, enforcing only covenants ancillary to a legitimate purpose, and flatly banning non-compete/non-solicit clauses for technology-business employees. |
+| **Main law or case** | Haw. Rev. Stat. § 480-4 |
+| **Main exceptions** | Technology-business employee ban (§ 480-4(d)); statutory categories: sale-of-business, partner-withdrawal, lease-use, trade-secret covenants |
+| **Can a court narrow it?** | Unsettled |
+| **Applies to contractors?** | Unclear |
+| **Restriction extended during a breach?** | Open question |
+| **Maximum length set by law** | No statutory limit (reasonable period required) |
+
+## Are employee non-compete agreements enforceable in Hawaii? {#employee-noncompetes}
+
+**Short answer.** Sometimes, but Hawaii starts from an antitrust rule. HRS 480-4(a) makes every in-state restraint of trade illegal, and HRS 480-4(c) allows only restrictive covenants that are ancillary to a legitimate purpose and do not substantially lessen competition or tend to create a monopoly [^employee-hrs-480-4-baseline][^employee-hrs-480-4-ancillary].
+
+The practical test is not ordinary contract reasonableness alone. *Gagnon* says a covenant can satisfy the *Traeger* reasonableness factors and still fail if it is not ancillary to a legitimate purpose under HRS chapter 480 [^employee-gagnon-legitimate-purpose-required].
+
+That matters most for ordinary employee covenants. A restraint whose real purpose is to block new competition is not enough. The employer needs a protectable interest such as trade secrets, genuinely confidential information, special customer relationships, workforce stability for an employee-solicitation covenant, or specialized training combined with other protectable factors [^employee-gagnon-competition-not-purpose][^employee-del-rosario-special-training].
+
+> [!NOTE]
+> **Practice note.**
+>
+> A Hawaii covenant that fits a familiar category is not automatically enforceable. Keep the record focused on the specific protected interest and on why the restraint is no broader than that interest requires [^employee-gagnon-legitimate-purpose-required][^employee-traeger-reasonableness-factors].
+
+## What legitimate interests can support a Hawaii non-compete? {#protectable-interests}
+
+**Short answer.** Trade secrets are expressly covered, and Hawaii cases also recognize a narrow set of non-statutory interests. HRS 480-4(c)(4) covers employee or agent covenants not to use employer trade secrets, while *Gagnon* and *Del Rosario* require a legitimate ancillary purpose beyond suppressing competition [^interests-hrs-480-4-trade-secrets][^interests-gagnon-competition-not-purpose][^interests-del-rosario-special-training].
+
+The statute lists several categories, each still subject to the same chapter 480 limits: business-sale covenants, partner-withdrawal covenants, lease-use covenants, and employee or agent covenants tied to trade-secret use [^interests-hrs-480-4-sale][^interests-hrs-480-4-partner][^interests-hrs-480-4-lease][^interests-hrs-480-4-trade-secrets].
+
+Outside the text, *Traeger* says the statutory categories are not exclusive, but *Gagnon* adds the modern limiting rule: the covenant still must be ancillary to a legitimate purpose under chapter 480 [^interests-traeger-not-exclusive][^interests-gagnon-legitimate-purpose-required].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not label ordinary market knowledge as confidential and expect that label to carry the covenant. In *Gagnon*, the claimed confidential-interest theory failed where similarly situated workers were not restricted, information was shared more broadly, and no trade-secret violation was shown [^interests-gagnon-no-confidential-record].
+
+## Are sale-of-business non-competes enforceable in Hawaii? {#sale-of-business}
+
+**Short answer.** Yes, if they are tied to the sale of a business and limited to a reasonable area and reasonable period. HRS 480-4(c)(1) expressly permits a transferor covenant in connection with a business sale, subject to the broader antitrust limit in HRS 480-4(c) [^sale-hrs-480-4-business-sale][^sale-hrs-480-4-ancillary].
+
+The sale context is stronger than an ordinary employment restraint because the buyer is usually protecting purchased goodwill. Still, the covenant must be reasonable. *Traeger* frames reasonableness around protection needed, hardship on the restricted party, public injury, geography, time, and breadth [^sale-traeger-reasonableness-factors][^sale-traeger-scope-factors].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Tie a Hawaii sale covenant to the goodwill and competitive risk actually transferred. HRS 480-4(c)(1) requires reasonable area and time, and *Traeger* requires the restraint not to be greater than the protection needed [^sale-hrs-480-4-business-sale][^sale-traeger-reasonableness-factors].
+
+## What special non-compete rule applies to Hawaii technology-business employees? {#technology-workers}
+
+**Short answer.** Hawaii has a specific technology-business ban. Except for trade-secret covenants under HRS 480-4(c)(4), HRS 480-4(d) prohibits noncompete and nonsolicit clauses in employment contracts for employees of a technology business and makes the clause void and of no force and effect [^tech-hrs-480-4-technology-ban].
+
+The definition focuses on the business, not just the employee title. A technology business is a trade or business deriving a majority of gross income from products or services resulting from software development, information technology development, or both [^tech-hrs-480-4-technology-definition].
+
+The same definition excludes the broadcast industry and certain telecommunications carriers. The statute separately defines noncompete and nonsolicit clauses for this subsection [^tech-hrs-480-4-technology-definition][^tech-hrs-480-4-noncompete-definition][^tech-hrs-480-4-nonsolicit-definition].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not use a broad employment noncompete or employee nonsolicit for a Hawaii technology-business employee. Draft around actual trade-secret use instead, because HRS 480-4(d) preserves only the HRS 480-4(c)(4) trade-secret path [^tech-hrs-480-4-technology-ban][^tech-hrs-480-4-trade-secret-exception].
+
+## Are customer or employee non-solicitation agreements enforceable in Hawaii? {#non-solicitation}
+
+**Short answer.** Sometimes, but they are analyzed as restraints of trade and need a legitimate ancillary purpose. *Gagnon* held that solicitation clauses require a legitimate ancillary purpose under HRS 480-4(a), and that a solicitation violation requires active initiation of contact [^nonsolicit-gagnon-legitimate-purpose][^nonsolicit-gagnon-active-contact].
+
+The active-solicitation rule is important. Telling coworkers that the employee is leaving, or passively accepting a decision to follow, does not automatically prove solicitation. The employer needs evidence that the restricted person actively initiated the contact that allegedly breached the clause [^nonsolicit-gagnon-no-automatic-violation][^nonsolicit-gagnon-active-contact].
+
+For technology-business employees, the statutory rule is stricter. HRS 480-4(d) voids nonsolicit clauses in covered employment contracts except for the trade-secret carve-out in HRS 480-4(c)(4) [^nonsolicit-hrs-480-4-technology-ban][^nonsolicit-hrs-480-4-trade-secret-exception].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Avoid no-contact, no-service, and no-acceptance language if the intended restraint is a Hawaii solicitation covenant. *Gagnon* frames solicitation around active initiation of contact, and HRS 480-4 still requires a legitimate ancillary purpose [^nonsolicit-gagnon-active-contact][^nonsolicit-gagnon-legitimate-purpose].
+
+## What remedies or consequences can follow an unlawful Hawaii non-compete? {#remedies}
+
+**Short answer.** Hawaii chapter 480 has private remedies. A person injured in business or property by conduct forbidden by the chapter may sue for damages, may seek an injunction, and, if the judgment or decree is for the plaintiff, receives reasonable attorney fees and costs [^remedies-hrs-480-13-private-remedies].
+
+For damages claims under HRS 480-13(a), the award is at least $1,000 or threefold damages, whichever is greater, plus reasonable attorney fees and costs for a prevailing plaintiff. For injunction proceedings, a plaintiff who obtains the decree is also awarded reasonable attorney fees and costs [^remedies-hrs-480-13-injunction-fees].
+
+The fee rule is therefore plaintiff-focused, not a general loser-pays rule. In a non-compete dispute, the party suing under chapter 480 must still show injury to business or property by something forbidden or declared unlawful by the chapter [^remedies-hrs-480-13-private-remedies].
+
+HRS 480-2 can also matter because it separately declares unfair methods of competition unlawful and allows any person to bring an action based on that theory [^remedies-hrs-480-2-unfair-competition][^remedies-hrs-480-2-person-actions].
+
+## Are trade-secret, confidentiality, and NDA alternatives available in Hawaii? {#trade-secrets-ndas}
+
+**Short answer.** Yes. HRS 480-4(c)(4) expressly allows an employee or agent covenant not to use trade secrets in competition for the time reasonably necessary to protect the employer or principal, without undue hardship on the employee or agent [^alternatives-hrs-480-4-trade-secrets].
+
+Hawaii's trade-secret statute also preserves contractual remedies. HRS 482B-8 displaces conflicting tort, restitutionary, and other civil remedies for trade-secret misappropriation, but it does not affect contractual remedies, other non-misappropriation civil remedies, or criminal remedies [^alternatives-hrs-482b-8-displacement][^alternatives-hrs-482b-8-contracts-preserved].
+
+The drafting point is to protect information rather than work. A confidentiality or NDA covenant is safer when it targets actual trade secrets or confidential information and avoids operating as a practical ban on ordinary employment competition [^alternatives-hrs-480-4-trade-secrets][^alternatives-gagnon-no-confidential-record].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not make an NDA do non-compete work. Hawaii preserves trade-secret and contract remedies, but *Gagnon* rejected a confidentiality theory where the record did not show real protected information or a trade-secret violation [^alternatives-hrs-482b-8-contracts-preserved][^alternatives-gagnon-no-confidential-record].
+
+## Does a Hawaii non-compete period toll during breach or litigation? {#tolling}
+
+**Short answer.** Open question. The staged Hawaii authorities do not squarely resolve whether a covenant period pauses while the former employee is allegedly breaching or while enforcement litigation is pending, so a tolling clause should be analyzed as part of the effective duration of the restraint under HRS 480-4(c) and *Traeger* [^tolling-hrs-480-4-ancillary][^tolling-traeger-scope-factors].
+
+The reason is practical. A contractual extension-on-breach clause lengthens the actual restraint. Hawaii's framework asks whether the covenant is ancillary to a legitimate purpose, whether its effect may substantially lessen competition, and whether its geography, time, and breadth are reasonable [^tolling-hrs-480-4-ancillary][^tolling-traeger-scope-factors].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not assume a Hawaii court will automatically enforce a tolling or extension-on-breach clause. The clause is untested in the staged Hawaii sources, and because it extends the effective restricted period, it should be drafted and justified under the same HRS 480-4 antitrust and reasonableness limits that govern the covenant itself [^tolling-hrs-480-4-ancillary][^tolling-traeger-reasonableness-factors].
+
+## Will Hawaii courts narrow or reform an overbroad non-compete? {#court-narrowing}
+
+**Short answer.** Do not rely on it as a drafting strategy. The staged Hawaii sources support judicial reasonableness review and case-specific limits on injunctions, but they do not supply a broad rule that courts will rewrite any overbroad employee non-compete into an enforceable one [^narrowing-traeger-reasonableness-factors][^narrowing-del-rosario-honolulu-limit].
+
+*Del Rosario* is the best example in the staged sources of a court correcting the enforced scope. The trial court had enjoined work as a briefer statewide, but the covenant itself was limited to the County of Honolulu, and the appellate court remanded to amend the judgment to that county limit [^narrowing-del-rosario-honolulu-limit].
+
+That is not the same as permission to draft broadly. *Gagnon* refused enforcement of a non-compete that lacked a legitimate ancillary purpose, even though the employer argued confidentiality and competition concerns [^narrowing-gagnon-legitimate-purpose-required][^narrowing-gagnon-competition-not-purpose].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Draft Hawaii restrictions at the minimum scope supported by the protected interest. A court may limit an injunction to the contract and record before it, but *Gagnon* shows that a covenant lacking a legitimate ancillary purpose can fail rather than be saved by narrower wording [^narrowing-del-rosario-honolulu-limit][^narrowing-gagnon-legitimate-purpose-required].
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-02. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not Hawaii. This article synthesizes Hawaii primary law and is not legal advice from a Hawaii-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^employee-hrs-480-4-baseline]: **HRS 480-4** — "Every contract, combination in the form of trust or otherwise, or conspiracy, in restraint of trade or commerce in the State, or in any section of this State is illegal." *Haw. Rev. Stat. 480-4(a).* <https://www.capitol.hawaii.gov/hrscurrent/Vol11_Ch0476-0490/HRS0480/HRS_0480-0004.htm>
+
+[^employee-hrs-480-4-ancillary]: **HRS 480-4** — "Notwithstanding subsection (b) and without limiting the application of subsection (a), it shall be lawful for a person to enter into any of the following restrictive covenants or agreements ancillary to a legitimate purpose not violative of this chapter, unless the effect thereof may be substantially to lessen competition or to tend to create a monopoly in any line of commerce in any section of the State: (1) A covenant or agreement by the transferor of a business not to compete within a reasonable area and within a reasonable period of time in connection with the sale of the business; (2) A covenant or agreement between partners not to compete with the partnership within a reasonable area and for a reasonable period of time upon the withdrawal of a partner from the partnership; (3) A covenant or agreement of the lessee to be restricted in the use of the leased premises to certain business or agricultural uses, or covenant or agreement of the lessee to be restricted in the use of the leased premises to certain business uses and of the lessor to be restricted in the use of premises reasonably proximate to any such leased premises to certain business uses; (4) A covenant or agreement by an employee or agent not to use the trade secrets of the employer or principal in competition with the employee's or agent's employer or principal, during the term of the agency or thereafter, or after the termination of employment, within such time as may be reasonably necessary for the protection of the employer or principal, without imposing undue hardship on the employee or agent." *Haw. Rev. Stat. 480-4(c).* <https://www.capitol.hawaii.gov/hrscurrent/Vol11_Ch0476-0490/HRS0480/HRS_0480-0004.htm>
+
+[^employee-gagnon-legitimate-purpose-required]: **Prudential Locations, LLC v. Gagnon** — "Even if a restrictive covenant otherwise satisfies the Traeger three-factor reasonableness test, it is unenforceable unless it is ancillary to a legitimate purpose not violative of Chapter 480." *Prudential Locations, LLC v. Gagnon, 151 Haw. 136, 509 P.3d 1099 (2022).* <https://www.courtlistener.com/opinion/6358303/prudential-locations-llc-v-gagnon/#:~:text=Even%20if%20a%20restrictive%20covenant,not%20violative%20of%20Chapter%20480.>
+
+[^employee-gagnon-competition-not-purpose]: **Prudential Locations, LLC v. Gagnon** — "Preventing competition, however, is not a legitimate ancillary purpose under HRS § 480-4(a)." *Prudential Locations, LLC v. Gagnon, 151 Haw. 136, 509 P.3d 1099 (2022).* <https://www.courtlistener.com/opinion/6358303/prudential-locations-llc-v-gagnon/#:~:text=Preventing%20competition%2C%20however%2C%20is%20not,purpose%20under%20HRS%20%C2%A7%20480%2D4(a).>
+
+[^employee-del-rosario-special-training]: **7's Enterprises, Inc. v. Del Rosario** — "Hence, as a matter of law, we hold that training that provides skills beyond those of a general nature is a legitimate interest which may be considered in weighing the reasonableness of a non-competition covenant, when combined with other factors weighing in favor of a protectable business interest such as trade secrets, confidential information, or special customer relationships." *7's Enterprises, Inc. v. Del Rosario, 111 Haw. 484, 143 P.3d 23 (2006).* <https://www.courtlistener.com/opinion/2626419/7s-enterprises-inc-v-del-rosario/#:~:text=Hence%2C%20as%20a%20matter%20of,information%2C%20or%20special%20customer%20relationships.>
+
+[^employee-traeger-reasonableness-factors]: **7's Enterprises, Inc. v. Del Rosario** — "As observed in Traeger, courts will find a non-competition provision unreasonable if ‘ ‘(i) it is greater than required for the protection of the person for whose benefit it is imposed; (ii) it imposes undue hardship on the person restricted; or (iii) its benefit to the covenantee is outweighed by injury to the public.’ ’" *7's Enterprises, Inc. v. Del Rosario, 111 Haw. 484, 143 P.3d 23 (2006).* <https://www.courtlistener.com/opinion/2626419/7s-enterprises-inc-v-del-rosario/#:~:text=As%20observed%20in%20Traeger%2C%20courts,injury%20to%20the%20public.%E2%80%99%20%E2%80%9D>
+
+[^interests-hrs-480-4-trade-secrets]: **HRS 480-4** — "A covenant or agreement by an employee or agent not to use the trade secrets of the employer or principal in competition with the employee's or agent's employer or principal, during the term of the agency or thereafter, or after the termination of employment, within such time as may be reasonably necessary for the protection of the employer or principal, without imposing undue hardship on the employee or agent." *Haw. Rev. Stat. 480-4(c)(4).* <https://www.capitol.hawaii.gov/hrscurrent/Vol11_Ch0476-0490/HRS0480/HRS_0480-0004.htm>
+
+[^interests-gagnon-competition-not-purpose]: **Prudential Locations, LLC v. Gagnon** — "Preventing competition, however, is not a legitimate ancillary purpose under HRS § 480-4(a)." *Prudential Locations, LLC v. Gagnon, 151 Haw. 136, 509 P.3d 1099 (2022).* <https://www.courtlistener.com/opinion/6358303/prudential-locations-llc-v-gagnon/#:~:text=Preventing%20competition%2C%20however%2C%20is%20not,purpose%20under%20HRS%20%C2%A7%20480%2D4(a).>
+
+[^interests-del-rosario-special-training]: **7's Enterprises, Inc. v. Del Rosario** — "Hence, as a matter of law, we hold that training that provides skills beyond those of a general nature is a legitimate interest which may be considered in weighing the reasonableness of a non-competition covenant, when combined with other factors weighing in favor of a protectable business interest such as trade secrets, confidential information, or special customer relationships." *7's Enterprises, Inc. v. Del Rosario, 111 Haw. 484, 143 P.3d 23 (2006).* <https://www.courtlistener.com/opinion/2626419/7s-enterprises-inc-v-del-rosario/#:~:text=Hence%2C%20as%20a%20matter%20of,information%2C%20or%20special%20customer%20relationships.>
+
+[^interests-hrs-480-4-sale]: **HRS 480-4** — "Notwithstanding subsection (b) and without limiting the application of subsection (a), it shall be lawful for a person to enter into any of the following restrictive covenants or agreements ancillary to a legitimate purpose not violative of this chapter, unless the effect thereof may be substantially to lessen competition or to tend to create a monopoly in any line of commerce in any section of the State: (1) A covenant or agreement by the transferor of a business not to compete within a reasonable area and within a reasonable period of time in connection with the sale of the business; (2) A covenant or agreement between partners not to compete with the partnership within a reasonable area and for a reasonable period of time upon the withdrawal of a partner from the partnership; (3) A covenant or agreement of the lessee to be restricted in the use of the leased premises to certain business or agricultural uses, or covenant or agreement of the lessee to be restricted in the use of the leased premises to certain business uses and of the lessor to be restricted in the use of premises reasonably proximate to any such leased premises to certain business uses; (4) A covenant or agreement by an employee or agent not to use the trade secrets of the employer or principal in competition with the employee's or agent's employer or principal, during the term of the agency or thereafter, or after the termination of employment, within such time as may be reasonably necessary for the protection of the employer or principal, without imposing undue hardship on the employee or agent." *Haw. Rev. Stat. 480-4(c)(1).* <https://www.capitol.hawaii.gov/hrscurrent/Vol11_Ch0476-0490/HRS0480/HRS_0480-0004.htm>
+
+[^interests-hrs-480-4-partner]: **HRS 480-4** — "Notwithstanding subsection (b) and without limiting the application of subsection (a), it shall be lawful for a person to enter into any of the following restrictive covenants or agreements ancillary to a legitimate purpose not violative of this chapter, unless the effect thereof may be substantially to lessen competition or to tend to create a monopoly in any line of commerce in any section of the State: (1) A covenant or agreement by the transferor of a business not to compete within a reasonable area and within a reasonable period of time in connection with the sale of the business; (2) A covenant or agreement between partners not to compete with the partnership within a reasonable area and for a reasonable period of time upon the withdrawal of a partner from the partnership; (3) A covenant or agreement of the lessee to be restricted in the use of the leased premises to certain business or agricultural uses, or covenant or agreement of the lessee to be restricted in the use of the leased premises to certain business uses and of the lessor to be restricted in the use of premises reasonably proximate to any such leased premises to certain business uses; (4) A covenant or agreement by an employee or agent not to use the trade secrets of the employer or principal in competition with the employee's or agent's employer or principal, during the term of the agency or thereafter, or after the termination of employment, within such time as may be reasonably necessary for the protection of the employer or principal, without imposing undue hardship on the employee or agent." *Haw. Rev. Stat. 480-4(c)(2).* <https://www.capitol.hawaii.gov/hrscurrent/Vol11_Ch0476-0490/HRS0480/HRS_0480-0004.htm>
+
+[^interests-hrs-480-4-lease]: **HRS 480-4** — "Notwithstanding subsection (b) and without limiting the application of subsection (a), it shall be lawful for a person to enter into any of the following restrictive covenants or agreements ancillary to a legitimate purpose not violative of this chapter, unless the effect thereof may be substantially to lessen competition or to tend to create a monopoly in any line of commerce in any section of the State: (1) A covenant or agreement by the transferor of a business not to compete within a reasonable area and within a reasonable period of time in connection with the sale of the business; (2) A covenant or agreement between partners not to compete with the partnership within a reasonable area and for a reasonable period of time upon the withdrawal of a partner from the partnership; (3) A covenant or agreement of the lessee to be restricted in the use of the leased premises to certain business or agricultural uses, or covenant or agreement of the lessee to be restricted in the use of the leased premises to certain business uses and of the lessor to be restricted in the use of premises reasonably proximate to any such leased premises to certain business uses; (4) A covenant or agreement by an employee or agent not to use the trade secrets of the employer or principal in competition with the employee's or agent's employer or principal, during the term of the agency or thereafter, or after the termination of employment, within such time as may be reasonably necessary for the protection of the employer or principal, without imposing undue hardship on the employee or agent." *Haw. Rev. Stat. 480-4(c)(3).* <https://www.capitol.hawaii.gov/hrscurrent/Vol11_Ch0476-0490/HRS0480/HRS_0480-0004.htm>
+
+[^interests-traeger-not-exclusive]: **Technicolor, Inc. v. Traeger** — "Our understanding of the above committee report is that the restrictive covenants and agreements enumerated under § 480-4(c) were not meant to be exclusive in their respective fields." *Technicolor, Inc. v. Traeger, 57 Haw. 113, 551 P.2d 163 (1976).* <https://www.courtlistener.com/opinion/1175722/technicolor-inc-v-traeger/#:~:text=Our%20understanding%20of%20the%20above,exclusive%20in%20their%20respective%20fields.>
+
+[^interests-gagnon-legitimate-purpose-required]: **Prudential Locations, LLC v. Gagnon** — "Even if a restrictive covenant otherwise satisfies the Traeger three-factor reasonableness test, it is unenforceable unless it is ancillary to a legitimate purpose not violative of Chapter 480." *Prudential Locations, LLC v. Gagnon, 151 Haw. 136, 509 P.3d 1099 (2022).* <https://www.courtlistener.com/opinion/6358303/prudential-locations-llc-v-gagnon/#:~:text=Even%20if%20a%20restrictive%20covenant,not%20violative%20of%20Chapter%20480.>
+
+[^interests-gagnon-no-confidential-record]: **Prudential Locations, LLC v. Gagnon** — "In addition, Locations did not produce any evidence of and did not dispute that there was no trade secret violation." *Prudential Locations, LLC v. Gagnon, 151 Haw. 136, 509 P.3d 1099 (2022).* <https://www.courtlistener.com/opinion/6358303/prudential-locations-llc-v-gagnon/#:~:text=In%20addition%2C%20Locations%20did%20not,was%20no%20trade%20secret%20violation.>
+
+[^sale-hrs-480-4-business-sale]: **HRS 480-4** — "Notwithstanding subsection (b) and without limiting the application of subsection (a), it shall be lawful for a person to enter into any of the following restrictive covenants or agreements ancillary to a legitimate purpose not violative of this chapter, unless the effect thereof may be substantially to lessen competition or to tend to create a monopoly in any line of commerce in any section of the State: (1) A covenant or agreement by the transferor of a business not to compete within a reasonable area and within a reasonable period of time in connection with the sale of the business; (2) A covenant or agreement between partners not to compete with the partnership within a reasonable area and for a reasonable period of time upon the withdrawal of a partner from the partnership; (3) A covenant or agreement of the lessee to be restricted in the use of the leased premises to certain business or agricultural uses, or covenant or agreement of the lessee to be restricted in the use of the leased premises to certain business uses and of the lessor to be restricted in the use of premises reasonably proximate to any such leased premises to certain business uses; (4) A covenant or agreement by an employee or agent not to use the trade secrets of the employer or principal in competition with the employee's or agent's employer or principal, during the term of the agency or thereafter, or after the termination of employment, within such time as may be reasonably necessary for the protection of the employer or principal, without imposing undue hardship on the employee or agent." *Haw. Rev. Stat. 480-4(c)(1).* <https://www.capitol.hawaii.gov/hrscurrent/Vol11_Ch0476-0490/HRS0480/HRS_0480-0004.htm>
+
+[^sale-hrs-480-4-ancillary]: **HRS 480-4** — "Notwithstanding subsection (b) and without limiting the application of subsection (a), it shall be lawful for a person to enter into any of the following restrictive covenants or agreements ancillary to a legitimate purpose not violative of this chapter, unless the effect thereof may be substantially to lessen competition or to tend to create a monopoly in any line of commerce in any section of the State: (1) A covenant or agreement by the transferor of a business not to compete within a reasonable area and within a reasonable period of time in connection with the sale of the business; (2) A covenant or agreement between partners not to compete with the partnership within a reasonable area and for a reasonable period of time upon the withdrawal of a partner from the partnership; (3) A covenant or agreement of the lessee to be restricted in the use of the leased premises to certain business or agricultural uses, or covenant or agreement of the lessee to be restricted in the use of the leased premises to certain business uses and of the lessor to be restricted in the use of premises reasonably proximate to any such leased premises to certain business uses; (4) A covenant or agreement by an employee or agent not to use the trade secrets of the employer or principal in competition with the employee's or agent's employer or principal, during the term of the agency or thereafter, or after the termination of employment, within such time as may be reasonably necessary for the protection of the employer or principal, without imposing undue hardship on the employee or agent." *Haw. Rev. Stat. 480-4(c).* <https://www.capitol.hawaii.gov/hrscurrent/Vol11_Ch0476-0490/HRS0480/HRS_0480-0004.htm>
+
+[^sale-traeger-reasonableness-factors]: **7's Enterprises, Inc. v. Del Rosario** — "As observed in Traeger, courts will find a non-competition provision unreasonable if ‘ ‘(i) it is greater than required for the protection of the person for whose benefit it is imposed; (ii) it imposes undue hardship on the person restricted; or (iii) its benefit to the covenantee is outweighed by injury to the public.’ ’" *7's Enterprises, Inc. v. Del Rosario, 111 Haw. 484, 143 P.3d 23 (2006).* <https://www.courtlistener.com/opinion/2626419/7s-enterprises-inc-v-del-rosario/#:~:text=As%20observed%20in%20Traeger%2C%20courts,injury%20to%20the%20public.%E2%80%99%20%E2%80%9D>
+
+[^sale-traeger-scope-factors]: **7's Enterprises, Inc. v. Del Rosario** — "A court ‘must examine such factors as geographical scope, length of time, and breadth of the restriction placed on a given activity.’" *7's Enterprises, Inc. v. Del Rosario, 111 Haw. 484, 143 P.3d 23 (2006).* <https://www.courtlistener.com/opinion/2626419/7s-enterprises-inc-v-del-rosario/#:~:text=A%20court%20%E2%80%9Cmust%20examine%20such,placed%20on%20a%20given%20activity.%E2%80%9D>
+
+[^tech-hrs-480-4-technology-ban]: **HRS 480-4** — "Except as provided in subsection (c)(4), it shall be prohibited to include a noncompete clause or a nonsolicit clause in any employment contract relating to an employee of a technology business. The clause shall be void and of no force and effect." *Haw. Rev. Stat. 480-4(d).* <https://www.capitol.hawaii.gov/hrscurrent/Vol11_Ch0476-0490/HRS0480/HRS_0480-0004.htm>
+
+[^tech-hrs-480-4-technology-definition]: **HRS 480-4** — "‘Technology business’ means a trade or business that derives the majority of its gross income from the sale or license of products or services resulting from its software development or information technology development, or both. A ‘technology business’ excludes any trade or business that is considered by standard practice as part of the broadcast industry or any telecommunications carrier, as defined in section 269-1, that holds a franchise or charter enacted or granted by the legislative or executive authority of the State or its predecessor governments." *Haw. Rev. Stat. 480-4(d).* <https://www.capitol.hawaii.gov/hrscurrent/Vol11_Ch0476-0490/HRS0480/HRS_0480-0004.htm>
+
+[^tech-hrs-480-4-noncompete-definition]: **HRS 480-4** — "‘Noncompete clause’ means a clause in an employment contract that prohibits an employee from working in a specific geographic area for a specific period of time after leaving employment with the employer." *Haw. Rev. Stat. 480-4(d).* <https://www.capitol.hawaii.gov/hrscurrent/Vol11_Ch0476-0490/HRS0480/HRS_0480-0004.htm>
+
+[^tech-hrs-480-4-nonsolicit-definition]: **HRS 480-4** — "‘Nonsolicit clause’ means a clause in an employment contract that prohibits an employee from soliciting employees of the employer after leaving employment with the employer." *Haw. Rev. Stat. 480-4(d).* <https://www.capitol.hawaii.gov/hrscurrent/Vol11_Ch0476-0490/HRS0480/HRS_0480-0004.htm>
+
+[^tech-hrs-480-4-trade-secret-exception]: **HRS 480-4** — "A covenant or agreement by an employee or agent not to use the trade secrets of the employer or principal in competition with the employee's or agent's employer or principal, during the term of the agency or thereafter, or after the termination of employment, within such time as may be reasonably necessary for the protection of the employer or principal, without imposing undue hardship on the employee or agent." *Haw. Rev. Stat. 480-4(c)(4).* <https://www.capitol.hawaii.gov/hrscurrent/Vol11_Ch0476-0490/HRS0480/HRS_0480-0004.htm>
+
+[^nonsolicit-gagnon-legitimate-purpose]: **Prudential Locations, LLC v. Gagnon** — "Solicitation clauses are also contracts in restraint of trade or commerce that require a legitimate ancillary purpose under HRS § 480-4(a)." *Prudential Locations, LLC v. Gagnon, 151 Haw. 136, 509 P.3d 1099 (2022).* <https://www.courtlistener.com/opinion/6358303/prudential-locations-llc-v-gagnon/#:~:text=Solicitation%20clauses%20are%20also%20contracts,purpose%20under%20HRS%20%C2%A7%20480%2D4(a).>
+
+[^nonsolicit-gagnon-active-contact]: **Prudential Locations, LLC v. Gagnon** — "Our law does not clearly define ‘solicitation.’ We agree with reasoned opinions from other jurisdictions and now hold that ‘solicitation’ requires an active initiation of contact." *Prudential Locations, LLC v. Gagnon, 151 Haw. 136, 509 P.3d 1099 (2022).* <https://www.courtlistener.com/opinion/6358303/prudential-locations-llc-v-gagnon/#:~:text=Our%20law%20does%20not%20clearly,an%20active%20initiation%20of%20contact.>
+
+[^nonsolicit-gagnon-no-automatic-violation]: **Prudential Locations, LLC v. Gagnon** — "These agents’ termination of their employment with Locations and subsequent employment with Prestige do not automatically demonstrate a violation of the non-solicitation clause." *Prudential Locations, LLC v. Gagnon, 151 Haw. 136, 509 P.3d 1099 (2022).* <https://www.courtlistener.com/opinion/6358303/prudential-locations-llc-v-gagnon/#:~:text=These%20agents%E2%80%99%20termination%20of%20their,violation%20of%20the%20non%2Dsolicitation%20clause.>
+
+[^nonsolicit-hrs-480-4-technology-ban]: **HRS 480-4** — "Except as provided in subsection (c)(4), it shall be prohibited to include a noncompete clause or a nonsolicit clause in any employment contract relating to an employee of a technology business. The clause shall be void and of no force and effect." *Haw. Rev. Stat. 480-4(d).* <https://www.capitol.hawaii.gov/hrscurrent/Vol11_Ch0476-0490/HRS0480/HRS_0480-0004.htm>
+
+[^nonsolicit-hrs-480-4-trade-secret-exception]: **HRS 480-4** — "A covenant or agreement by an employee or agent not to use the trade secrets of the employer or principal in competition with the employee's or agent's employer or principal, during the term of the agency or thereafter, or after the termination of employment, within such time as may be reasonably necessary for the protection of the employer or principal, without imposing undue hardship on the employee or agent." *Haw. Rev. Stat. 480-4(c)(4).* <https://www.capitol.hawaii.gov/hrscurrent/Vol11_Ch0476-0490/HRS0480/HRS_0480-0004.htm>
+
+[^remedies-hrs-480-13-private-remedies]: **HRS 480-13** — "Except as provided in subsections (b) and (c), any person who is injured in the person's business or property by reason of anything forbidden or declared unlawful by this chapter: (1) May sue for damages sustained by the person, and, if the judgment is for the plaintiff, the plaintiff shall be awarded a sum not less than $1,000 or threefold damages by the plaintiff sustained, whichever sum is the greater, and reasonable attorney's fees together with the costs of suit; provided that indirect purchasers injured by an illegal overcharge shall recover only compensatory damages, and reasonable attorney's fees together with the costs of suit in actions not brought under section 480-14(c); and (2) May bring proceedings to enjoin the unlawful practices, and if the decree is for the plaintiff, the plaintiff shall be awarded reasonable attorney's fees together with the costs of suit." *Haw. Rev. Stat. 480-13(a).* <https://www.capitol.hawaii.gov/hrscurrent/Vol11_Ch0476-0490/HRS0480/HRS_0480-0013.htm>
+
+[^remedies-hrs-480-13-injunction-fees]: **HRS 480-13** — "Except as provided in subsections (b) and (c), any person who is injured in the person's business or property by reason of anything forbidden or declared unlawful by this chapter: (1) May sue for damages sustained by the person, and, if the judgment is for the plaintiff, the plaintiff shall be awarded a sum not less than $1,000 or threefold damages by the plaintiff sustained, whichever sum is the greater, and reasonable attorney's fees together with the costs of suit; provided that indirect purchasers injured by an illegal overcharge shall recover only compensatory damages, and reasonable attorney's fees together with the costs of suit in actions not brought under section 480-14(c); and (2) May bring proceedings to enjoin the unlawful practices, and if the decree is for the plaintiff, the plaintiff shall be awarded reasonable attorney's fees together with the costs of suit." *Haw. Rev. Stat. 480-13(a)(2).* <https://www.capitol.hawaii.gov/hrscurrent/Vol11_Ch0476-0490/HRS0480/HRS_0480-0013.htm>
+
+[^remedies-hrs-480-2-unfair-competition]: **HRS 480-2** — "Unfair methods of competition and unfair or deceptive acts or practices in the conduct of any trade or commerce are unlawful." *Haw. Rev. Stat. 480-2(a).* <https://www.capitol.hawaii.gov/hrscurrent/Vol11_Ch0476-0490/HRS0480/HRS_0480-0002.htm>
+
+[^remedies-hrs-480-2-person-actions]: **HRS 480-2** — "Any person may bring an action based on unfair methods of competition declared unlawful by this section." *Haw. Rev. Stat. 480-2(e).* <https://www.capitol.hawaii.gov/hrscurrent/Vol11_Ch0476-0490/HRS0480/HRS_0480-0002.htm>
+
+[^alternatives-hrs-480-4-trade-secrets]: **HRS 480-4** — "A covenant or agreement by an employee or agent not to use the trade secrets of the employer or principal in competition with the employee's or agent's employer or principal, during the term of the agency or thereafter, or after the termination of employment, within such time as may be reasonably necessary for the protection of the employer or principal, without imposing undue hardship on the employee or agent." *Haw. Rev. Stat. 480-4(c)(4).* <https://www.capitol.hawaii.gov/hrscurrent/Vol11_Ch0476-0490/HRS0480/HRS_0480-0004.htm>
+
+[^alternatives-hrs-482b-8-displacement]: **HRS 482B-8** — "Except as provided in subsection (b) this chapter displaces conflicting tort, restitutionary, and other law of this State providing civil remedies for misappropriation of a trade secret." *Haw. Rev. Stat. 482B-8(a).* <https://www.capitol.hawaii.gov/hrscurrent/Vol11_Ch0476-0490/HRS0482B/HRS_0482B-0008.htm>
+
+[^alternatives-hrs-482b-8-contracts-preserved]: **HRS 482B-8** — "This chapter does not affect: (1) Contractual remedies, whether or not based upon misappropriation of a trade secret; (2) Other civil remedies that are not based upon misappropriation of a trade secret; or (3) Criminal remedies, whether or not based upon misappropriation of a trade secret." *Haw. Rev. Stat. 482B-8(b).* <https://www.capitol.hawaii.gov/hrscurrent/Vol11_Ch0476-0490/HRS0482B/HRS_0482B-0008.htm>
+
+[^alternatives-gagnon-no-confidential-record]: **Prudential Locations, LLC v. Gagnon** — "In addition, Locations did not produce any evidence of and did not dispute that there was no trade secret violation." *Prudential Locations, LLC v. Gagnon, 151 Haw. 136, 509 P.3d 1099 (2022).* <https://www.courtlistener.com/opinion/6358303/prudential-locations-llc-v-gagnon/#:~:text=In%20addition%2C%20Locations%20did%20not,was%20no%20trade%20secret%20violation.>
+
+[^tolling-hrs-480-4-ancillary]: **HRS 480-4** — "Notwithstanding subsection (b) and without limiting the application of subsection (a), it shall be lawful for a person to enter into any of the following restrictive covenants or agreements ancillary to a legitimate purpose not violative of this chapter, unless the effect thereof may be substantially to lessen competition or to tend to create a monopoly in any line of commerce in any section of the State: (1) A covenant or agreement by the transferor of a business not to compete within a reasonable area and within a reasonable period of time in connection with the sale of the business; (2) A covenant or agreement between partners not to compete with the partnership within a reasonable area and for a reasonable period of time upon the withdrawal of a partner from the partnership; (3) A covenant or agreement of the lessee to be restricted in the use of the leased premises to certain business or agricultural uses, or covenant or agreement of the lessee to be restricted in the use of the leased premises to certain business uses and of the lessor to be restricted in the use of premises reasonably proximate to any such leased premises to certain business uses; (4) A covenant or agreement by an employee or agent not to use the trade secrets of the employer or principal in competition with the employee's or agent's employer or principal, during the term of the agency or thereafter, or after the termination of employment, within such time as may be reasonably necessary for the protection of the employer or principal, without imposing undue hardship on the employee or agent." *Haw. Rev. Stat. 480-4(c).* <https://www.capitol.hawaii.gov/hrscurrent/Vol11_Ch0476-0490/HRS0480/HRS_0480-0004.htm>
+
+[^tolling-traeger-scope-factors]: **7's Enterprises, Inc. v. Del Rosario** — "A court ‘must examine such factors as geographical scope, length of time, and breadth of the restriction placed on a given activity.’" *7's Enterprises, Inc. v. Del Rosario, 111 Haw. 484, 143 P.3d 23 (2006).* <https://www.courtlistener.com/opinion/2626419/7s-enterprises-inc-v-del-rosario/#:~:text=A%20court%20%E2%80%9Cmust%20examine%20such,placed%20on%20a%20given%20activity.%E2%80%9D>
+
+[^tolling-traeger-reasonableness-factors]: **7's Enterprises, Inc. v. Del Rosario** — "As observed in Traeger, courts will find a non-competition provision unreasonable if ‘ ‘(i) it is greater than required for the protection of the person for whose benefit it is imposed; (ii) it imposes undue hardship on the person restricted; or (iii) its benefit to the covenantee is outweighed by injury to the public.’ ’" *7's Enterprises, Inc. v. Del Rosario, 111 Haw. 484, 143 P.3d 23 (2006).* <https://www.courtlistener.com/opinion/2626419/7s-enterprises-inc-v-del-rosario/#:~:text=As%20observed%20in%20Traeger%2C%20courts,injury%20to%20the%20public.%E2%80%99%20%E2%80%9D>
+
+[^narrowing-traeger-reasonableness-factors]: **Technicolor, Inc. v. Traeger** — "This ‘reasonableness analysis’ is done by the court, as a matter of law, and not as appellant contends, by a jury, as a matter of fact." *Technicolor, Inc. v. Traeger, 57 Haw. 113, 551 P.2d 163 (1976).* <https://www.courtlistener.com/opinion/1175722/technicolor-inc-v-traeger/#:~:text=This%20%E2%80%9Creasonableness%20analysis%E2%80%9D%20is%20done,as%20a%20matter%20of%20fact.>
+
+[^narrowing-del-rosario-honolulu-limit]: **7's Enterprises, Inc. v. Del Rosario** — "The case is remanded to the court to amend its judgment to reflect that the injunction involved herein is limited to the County of Honolulu." *7's Enterprises, Inc. v. Del Rosario, 111 Haw. 484, 143 P.3d 23 (2006).* <https://www.courtlistener.com/opinion/2626419/7s-enterprises-inc-v-del-rosario/#:~:text=The%20case%20is%20remanded%20to,to%20the%20County%20of%20Honolulu.>
+
+[^narrowing-gagnon-legitimate-purpose-required]: **Prudential Locations, LLC v. Gagnon** — "Even if a restrictive covenant otherwise satisfies the Traeger three-factor reasonableness test, it is unenforceable unless it is ancillary to a legitimate purpose not violative of Chapter 480." *Prudential Locations, LLC v. Gagnon, 151 Haw. 136, 509 P.3d 1099 (2022).* <https://www.courtlistener.com/opinion/6358303/prudential-locations-llc-v-gagnon/#:~:text=Even%20if%20a%20restrictive%20covenant,not%20violative%20of%20Chapter%20480.>
+
+[^narrowing-gagnon-competition-not-purpose]: **Prudential Locations, LLC v. Gagnon** — "Preventing competition, however, is not a legitimate ancillary purpose under HRS § 480-4(a)." *Prudential Locations, LLC v. Gagnon, 151 Haw. 136, 509 P.3d 1099 (2022).* <https://www.courtlistener.com/opinion/6358303/prudential-locations-llc-v-gagnon/#:~:text=Preventing%20competition%2C%20however%2C%20is%20not,purpose%20under%20HRS%20%C2%A7%20480%2D4(a).>

--- a/skills/non-compete-contract-explainer/content/idaho.md
+++ b/skills/non-compete-contract-explainer/content/idaho.md
@@ -1,0 +1,258 @@
+---
+jurisdiction: "Idaho"
+slug: idaho
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-02"
+canonicalUrl: https://openagreements.org/legal/non-compete/idaho
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/idaho · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in Idaho[^about]
+
+A question-by-question summary of Idaho non-compete law under Idaho Code title 44 chapter 27, including the key-employee requirement, 18-month presumption, blue-pencil rule, non-solicitation versus non-dealing clauses, healthcare providers, sale-of-business covenants, choice-of-law limits, and trade-secret alternatives.
+
+
+## At a glance
+
+| Question | Idaho |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed if reasonable |
+| **Bottom line** | Idaho enforces non-competes only against key employees or key independent contractors and only if reasonable, with an 18-month duration safe harbor and mandatory judicial modification of overbroad terms. |
+| **Main law or case** | Idaho Code §§ 44-2701 to 44-2704 |
+| **Main exceptions** | Only key employees/independent contractors; healthcare weighed against patient access; sale-of-business reviewed less strictly |
+| **Can a court narrow it?** | Yes — rewrites to reasonable |
+| **Applies to contractors?** | Yes |
+| **Restriction extended during a breach?** | Unsettled — no authority |
+| **Maximum length set by law** | 18 months (rebuttable presumption) |
+
+## Are employee non-compete agreements enforceable in Idaho? {#employee-noncompetes}
+
+**Short answer.** Yes, but only for key employees or key independent contractors and only if the covenant is reasonable. Idaho Code § 44-2701 makes a qualifying covenant enforceable if reasonable[^idaho-44-2701-key-employee-enforceable] as to duration, geography, work scope, and business need.
+
+Idaho is a statute-first jurisdiction for employment non-competes. The chapter 44-27 framework is employer-friendly, but it is not open-ended: the worker must be key, the restraint must protect legitimate business interests, and it cannot impose more restraint than reasonably necessary [^idaho-44-2701-key-employee-enforceable].
+
+Idaho courts still treat employment covenants as disfavored and strictly construed against the employer. *Blaskiewicz* reversed summary judgment because the district court skipped the Idaho statutes, while also preserving the older reasonableness and public-policy limits [^blaskiewicz-statute-first].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not draft Idaho as a common-law-only state. A court should start with Idaho Code §§ 44-2701 through 44-2704, then evaluate the facts that bear on reasonableness, business interest, worker hardship, and public injury [^idaho-44-2701-key-employee-enforceable][^blaskiewicz-statute-first].
+
+## Who is a key employee or key independent contractor under Idaho non-compete law? {#key-employees}
+
+**Short answer.** A covered worker is key if the employer can show high-level inside knowledge, influence, credibility, notoriety, or similar ability to threaten the employer's business interests. Idaho Code § 44-2702 defines the category, and Idaho Code § 44-2704 creates a highest-paid-five-percent presumption [^idaho-44-2702-key-worker-definition][^idaho-44-2704-top-five-presumption].
+
+The statutory definition is functional. It focuses on what the employer exposed the worker to, how the worker represented the employer, and whether the worker can harm legitimate business interests after leaving [^idaho-44-2702-key-worker-definition].
+
+The pay presumption helps employers but does not end the case. If the worker is among the highest-paid five percent, Idaho presumes key status; the worker may rebut that by showing no ability to adversely affect the employer's legitimate business interests [^idaho-44-2704-top-five-presumption].
+
+Independent contractors can be covered if they are key independent contractors. *Sky Down Skydiving* notes that non-competition clauses are permitted for independent contractors under section 44-2701, though the case itself used that point in a worker-classification analysis [^sky-down-independent-contractors].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not rely on salary rank alone when the worker is outside the top five percent or when rebuttal evidence is likely. The agreement and enforcement record should identify the inside knowledge, public exposure, customer influence, or similar facts that make the worker key [^idaho-44-2702-key-worker-definition][^idaho-44-2704-top-five-presumption].
+
+## What counts as a legitimate business interest for an Idaho non-compete? {#legitimate-business-interests}
+
+**Short answer.** Idaho defines legitimate business interests broadly. The statutory list includes goodwill, technologies, intellectual property, business plans, business processes, customers, customer lists and contacts, referral sources, vendors, financial and marketing information, and trade secrets [^idaho-44-2702-legitimate-interests].
+
+The list is not exclusive. The phrase includes, but is not limited to, gives employers room to prove other protectable interests that fit the same business-protection logic [^idaho-44-2702-legitimate-interests].
+
+That broad definition does not eliminate tailoring. Idaho Code § 44-2701 still requires the restraint not to exceed what is reasonably necessary to protect those interests [^idaho-44-2701-tailoring].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Name the protected interest and connect it to the worker. A generic competition ban is weaker than a covenant tied to the actual customer contacts, referral sources, confidential processes, technologies, or similar interests the worker can use against the employer [^idaho-44-2702-legitimate-interests][^idaho-44-2701-tailoring].
+
+## How long can an Idaho non-compete last, and what consideration is required? {#duration-consideration}
+
+**Short answer.** Eighteen months or less is the statutory safe-harbor term. Idaho Code § 44-2704 presumes an eighteen-month-or-shorter postemployment term reasonable, and a restriction longer than eighteen months requires consideration beyond employment or continued employment [^idaho-44-2704-duration-presumption][^idaho-44-2704-duration-consideration].
+
+The statute is unusually specific about consideration. It says a direct-competition restriction cannot exceed eighteen months unless the employer gives additional consideration beyond employment or continued employment [^idaho-44-2704-duration-consideration].
+
+That means continued at-will employment can support an eighteen-month-or-shorter covenant, but it is not enough by itself for a longer restriction. The older *Insurance Associates* litigation involved an at-will insurance salesperson who had to sign or be fired, and the Court of Appeals held that agreement supported by consideration; the Supreme Court later repeated that procedural holding while resolving damages and related claims [^hansen-consideration].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> If the business needs more than eighteen months, document independent consideration and expect to lose the duration presumption. Without that additional consideration, section 44-2704 makes the over-eighteen-month term vulnerable at the threshold [^idaho-44-2704-duration-consideration].
+
+## What geographic and line-of-business limits apply to Idaho non-competes? {#geography-work-scope}
+
+**Short answer.** Idaho presumes geography reasonable when it is limited to areas where the worker provided services or had significant presence or influence. It also presumes work scope reasonable when limited to the type of employment or line of business the worker actually conducted for the employer [^idaho-44-2704-geographic-presumption][^idaho-44-2704-line-of-business-presumption].
+
+The geographic rule is tied to the worker's footprint, not simply to everywhere the employer does business [^idaho-44-2704-geographic-presumption]. The line-of-business rule is tied to the worker's actual work, not every possible role in the employer's industry [^idaho-44-2704-line-of-business-presumption].
+
+Those presumptions matter in practice because a court may still ask whether the covenant imposes more restraint than reasonably necessary. *Blaskiewicz* noted that a physician restriction could potentially be modified to cover only the medicine performed for the former employer, rather than all medicine the physician could perform [^blaskiewicz-modify-work-scope].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Avoid statewide or all-industry language unless the facts justify it. Idaho's presumptions are strongest when the territory tracks the worker's actual service area or influence and the restricted business tracks the worker's actual work for the employer [^idaho-44-2704-geographic-presumption][^idaho-44-2704-line-of-business-presumption].
+
+## Will an Idaho court modify an overbroad non-compete? {#court-modification}
+
+**Short answer.** Usually yes, because Idaho's statute uses mandatory modification language. Idaho Code § 44-2703 says a court shall limit or modify[^idaho-44-2703-mandatory-modification] an unreasonable covenant and enforce it as limited or modified.
+
+That blue-pencil rule is strong, but it is not a license to omit essential terms. Idaho courts have long treated employment restraints as strictly construed against the employer, and *Intermountain Eye* cautioned that a court may blue-pencil only if it can be done simply and accurately [^intermountain-simple-blue-pencil].
+
+*Blaskiewicz* applied the statute's modification power after chapter 44-27 was enacted. It faulted the district court for declaring the covenant void without considering statutory modification [^blaskiewicz-blue-pencil-statute].
+
+In practice, *Brand Makers Promotional Products, LLC v. Archibald* refused to rewrite a covenant that lacked geographic and line-of-business limits, while *Timberline Drilling v. American Drilling* reduced a five-year period to eighteen months. Those cases are useful drafting context, but the source corpus here does not include quote-verified text for them.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Give the court something workable to modify. Section 44-2703 supports narrowing unreasonable terms, but strict construction and the simple-and-accurate limit make absent geography, absent work scope, or a missing protectable-interest theory materially riskier [^idaho-44-2703-mandatory-modification][^intermountain-simple-blue-pencil].
+
+## Are customer non-solicitation clauses enforceable in Idaho, and what counts as solicitation? {#customer-nonsolicits}
+
+**Short answer.** Yes, customer non-solicitation clauses can be enforced, but solicitation requires affirmative conduct. In 2025, *Insure Idaho v. Horn* held that solicitation requires an overt act seeking business, and that mere acceptance of business is not solicitation [^horn-overt-act].
+
+This is Idaho's headline recent development for customer restrictions. *Horn* distinguishes active solicitation from accepting a customer who independently reaches out. The court said the restricted party must take affirmative action that entreats, implores, pleads, or petitions for the business at issue [^horn-affirmative-action].
+
+That makes no-service or non-dealing clauses a drafting risk. A clause that bars accepting unsolicited business may be broader than a true non-solicit, and Idaho has not yet fully resolved whether that broader alternative is enforceable as a non-compete, a modified non-solicit, or something else.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Draft customer restrictions around affirmative solicitation, not passive acceptance of unsolicited work. If the business wants a no-service or non-dealing restriction, treat it as an unsettled Idaho question and analyze whether it functions as a direct-competition restraint under chapter 44-27 [^horn-overt-act][^horn-no-mere-acceptance].
+
+## Are non-competes for Idaho healthcare providers enforceable? {#healthcare-providers}
+
+**Short answer.** Yes, Idaho does not categorically ban physician or healthcare-provider non-competes. But courts weigh the employer's interests against patient access, continuity of care, and the public interest in the physician-patient relationship [^intermountain-patient-choice].
+
+*Intermountain Eye* rejected an outright ban but treated physician covenants as different from ordinary commercial restraints. The court held that the employer's interest in patients is limited by patient continuity and choice [^intermountain-patient-choice].
+
+*Dick v. Geist* reached a similar public-interest result in a Twin Falls physician dispute. Even assuming the covenant was otherwise valid, the court refused an injunction because enforcing it would seriously impair public welfare in the affected community [^dick-public-welfare].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Healthcare enforcement needs evidence about actual services, patient access, referral sources, continuity of care, and community need. A reasonable time and radius may still fail as an injunction if the public-interest showing favors patient access to the provider [^intermountain-patient-choice][^dick-public-welfare].
+
+## Does an Idaho non-compete period toll or extend during a breach or litigation? {#tolling-during-breach}
+
+**Short answer.** Idaho law is unsettled. No Idaho statute or Idaho appellate decision in the staged source corpus squarely addresses whether a non-compete term tolls during breach or litigation, so the safer answer is that the issue remains open.
+
+The statutory tension is real. Section 44-2704 presumes terms of eighteen months or less reasonable and requires additional consideration for a direct-competition restriction that exceeds eighteen months [^idaho-44-2704-tolling-tension]. Section 44-2703 tells courts to modify unreasonable covenants and enforce them as modified [^idaho-44-2703-tolling-modification].
+
+That leaves an unresolved question: if a tolling or extension-on-breach clause pushes the effective restraint beyond eighteen months, an Idaho court may treat the extension as outside the duration presumption and may require independent consideration. No Idaho court has resolved that issue.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Treat tolling and extension-on-breach language as an open Idaho drafting question, not a settled remedy. A clause that extends the effective restraint past eighteen months risks losing the statutory duration presumption and triggering the additional-consideration requirement, even though section 44-2703 may let a court modify unreasonable terms [^idaho-44-2704-tolling-tension][^idaho-44-2703-tolling-modification].
+
+## Will Idaho enforce an out-of-state choice-of-law or forum-selection clause? {#choice-of-law-forum}
+
+**Short answer.** Often no for clauses that keep an Idaho party from enforcing contract rights in Idaho tribunals or require out-of-state arbitration. Idaho Code § 29-110 voids those restrictions as Idaho public policy, and *Off-Spec Solutions* applied that policy to require Idaho arbitration [^idaho-29-110-public-policy].
+
+Section 29-110 is not a non-compete statute, but it matters in Idaho restrictive-covenant disputes because employers sometimes pair a non-compete with another state's law or forum. The statute protects access to Idaho tribunals and says out-of-state arbitration is not protected by the arbitration carveout [^idaho-29-110-public-policy].
+
+*Off-Spec Solutions* held that Idaho Code § 29-110 is a strong public policy sufficient to invalidate forum-selection clauses in the agreements before the court [^off-spec-strong-policy].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not assume a foreign law or out-of-state forum clause will move an Idaho resident's restrictive-covenant dispute out of Idaho. At minimum, separate forum, arbitration location, and choice-of-law analysis and account for Idaho Code § 29-110 [^idaho-29-110-public-policy][^off-spec-strong-policy].
+
+## Are sale-of-business non-competes treated differently in Idaho? {#sale-of-business}
+
+**Short answer.** Yes. Idaho gives more deference to non-competes ancillary to the sale of a business than to ordinary employment non-competes, because the buyer is usually purchasing goodwill and is entitled to reasonable protection from seller competition [^bybee-sale-goodwill].
+
+*Bybee v. Isaac* involved a crop-dusting business sale. The Idaho Supreme Court emphasized that employment non-competes are disfavored, but sale-of-business covenants are not construed as strictly because they protect purchased goodwill [^bybee-sale-goodwill].
+
+Sale covenants still must be reasonable in time, scope, and territory. In *Bybee*, the five-year, fifty-mile covenant was not facially overbroad as a matter of law in the sale context [^bybee-not-overbroad].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Tie the restraint to the sold business and its goodwill. Sale-of-business status helps, but it does not eliminate the reasonableness requirement for duration, geography, and scope [^bybee-sale-goodwill][^bybee-not-overbroad].
+
+## What trade-secret protection remains if an Idaho non-compete fails? {#trade-secrets}
+
+**Short answer.** Trade-secret protection remains available independently. Idaho Code § 44-2704 says chapter 44-27 does not limit protection for trade secrets or proprietary and confidential information, and the Idaho Trade Secrets Act authorizes injunctions for actual or threatened misappropriation [^idaho-44-2704-trade-secret-preserved][^idaho-48-802-injunction].
+
+The Idaho Trade Secrets Act defines trade secrets by economic value from secrecy and reasonable efforts to maintain secrecy. That can protect confidential formulas, compilations, programs, methods, techniques, processes, and similar information even when a non-compete is unavailable or narrowed [^idaho-48-801-trade-secret-definition].
+
+The remedy is also different. A trade-secret injunction targets actual or threatened misappropriation, not ordinary competition by a former worker [^idaho-48-802-injunction].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Separate confidentiality, trade-secret, and non-compete obligations. If the real risk is misuse of secret information, an Idaho Trade Secrets Act claim may be better tailored than a broad work ban, but the employer still needs secrecy efforts and misappropriation evidence [^idaho-48-801-trade-secret-definition][^idaho-48-802-injunction].
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-02. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not Idaho. This article synthesizes Idaho primary law and is not legal advice from a Idaho-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^idaho-44-2701-key-employee-enforceable]: **Idaho Code § 44-2701** — "A key employee or key independent contractor may enter into a written agreement or covenant that protects the employer’s legitimate business interests and prohibits the key employee or key independent contractor from engaging in employment or a line of business that is in direct competition with the employer’s business after termination of employment, and the same shall be enforceable, if the agreement or covenant is reasonable as to its duration, geographical area, type of employment or line of business, and does not impose a greater restraint than is reasonably necessary to protect the employer’s legitimate business interests." *Idaho Code § 44-2701.* <https://legislature.idaho.gov/statutesrules/idstat/Title44/T44CH27/SECT44-2701/>
+
+[^blaskiewicz-statute-first]: **Blaskiewicz v. Spine Institute of Idaho, P.A.** — "While Intermountain Eye and Freiburger remain instructive, the district court’s failure to address the relevant statutes constitutes clear error." *Blaskiewicz v. Spine Inst. of Idaho, P.A., 171 Idaho 70, 518 P.3d 386 (2022).* <https://www.courtlistener.com/opinion/8436739/blaskiewicz-v-spine-institute-of-idaho/#:~:text=While%20Intermountain%20Eye%20and%20Freiburger,relevant%20statutes%20constitutes%20clear%20error.>
+
+[^idaho-44-2702-key-worker-definition]: **Idaho Code § 44-2702** — "(1) ‘Key employees’ and ‘key independent contractors’ shall include those employees or independent contractors who, by reason of the employer’s investment of time, money, trust, exposure to the public, or exposure to technologies, intellectual property, business plans, business processes and methods of operation, customers, vendors or other business relationships during the course of employment, have gained a high level of inside knowledge, influence, credibility, notoriety, fame, reputation or public persona as a representative or spokesperson of the employer and, as a result, have the ability to harm or threaten an employer’s legitimate business interests." *Idaho Code § 44-2702.* <https://legislature.idaho.gov/statutesrules/idstat/Title44/T44CH27/SECT44-2702/>
+
+[^idaho-44-2704-top-five-presumption]: **Idaho Code § 44-2704** — "(5) It shall be a rebuttable presumption that an employee or independent contractor who is among the highest paid five percent (5%) of the employer’s employees or independent contractors is a ‘key employee’ or a ‘key independent contractor.’" *Idaho Code § 44-2704.* <https://legislature.idaho.gov/statutesrules/idstat/Title44/T44CH27/SECT44-2704/>
+
+[^sky-down-independent-contractors]: **State ex rel. Industrial Commission v. Sky Down Skydiving, LLC** — "Although non-competition clauses are permitted for independent contractors under Idaho Code section 44-2701, such a provision is more indicative of the type of control an employer typically exercises over an employee." *Indus. Comm'n v. Sky Down Skydiving, LLC, 166 Idaho 564, 462 P.3d 92 (2020).* <https://www.courtlistener.com/opinion/10732876/industrial-commission-v-sky-down-skydiving/#:~:text=Although%20non%2Dcompetition%20clauses%20are%20permitted,typically%20exercises%20over%20an%20employee.>
+
+[^idaho-44-2702-legitimate-interests]: **Idaho Code § 44-2702** — "(2) ‘Legitimate business interests’ shall include, but not be limited to, an employer’s goodwill, technologies, intellectual property, business plans, business processes and methods of operation, customers, customer lists, customer contacts and referral sources, vendors and vendor contacts, financial and marketing information, and trade secrets as that term is defined by chapter 8, title 48, Idaho Code." *Idaho Code § 44-2702.* <https://legislature.idaho.gov/statutesrules/idstat/Title44/T44CH27/SECT44-2702/>
+
+[^idaho-44-2701-tailoring]: **Idaho Code § 44-2701** — "A key employee or key independent contractor may enter into a written agreement or covenant that protects the employer’s legitimate business interests and prohibits the key employee or key independent contractor from engaging in employment or a line of business that is in direct competition with the employer’s business after termination of employment, and the same shall be enforceable, if the agreement or covenant is reasonable as to its duration, geographical area, type of employment or line of business, and does not impose a greater restraint than is reasonably necessary to protect the employer’s legitimate business interests." *Idaho Code § 44-2701.* <https://legislature.idaho.gov/statutesrules/idstat/Title44/T44CH27/SECT44-2701/>
+
+[^idaho-44-2704-duration-presumption]: **Idaho Code § 44-2704** — "(2) It shall be a rebuttable presumption that an agreement or covenant with a postemployment term of eighteen (18) months or less is reasonable as to duration." *Idaho Code § 44-2704(2).* <https://legislature.idaho.gov/statutesrules/idstat/Title44/T44CH27/SECT44-2704/>
+
+[^idaho-44-2704-duration-consideration]: **Idaho Code § 44-2704** — "(1) Under no circumstances shall a provision of such agreement or covenant, as set forth herein, establish a postemployment restriction of direct competition that exceeds a period of eighteen (18) months from the time of the key employee’s or key independent contractor’s termination unless consideration, in addition to employment or continued employment, is given to a key employee or key independent contractor." *Idaho Code § 44-2704(1).* <https://legislature.idaho.gov/statutesrules/idstat/Title44/T44CH27/SECT44-2704/>
+
+[^hansen-consideration]: **Insurance Associates Corp. v. Hansen** — "The Court of Appeals further (1) ‘conclude[d] that the findings of fact made by the district court are supported by the evidence, are not clearly erroneous and should not be set aside,’ id. at 206-207 , 723 P.2d at 194-195 ; (2) ‘[held] the agreement was supported by consideration,’ id. at 207-208 , 723 P.2d at 195-196 ; and (3) declined to award attorney fees on appeal to either party." *Ins. Assocs. Corp. v. Hansen, 116 Idaho 948, 782 P.2d 1230 (1989).* <https://www.courtlistener.com/opinion/1147183/insurance-associates-corp-v-hansen/#:~:text=The%20Court%20of%20Appeals%20further,on%20appeal%20to%20either%20party.>
+
+[^idaho-44-2704-geographic-presumption]: **Idaho Code § 44-2704** — "(3) It shall be a rebuttable presumption that an agreement or covenant is reasonable as to geographic area if it is restricted to the geographic areas in which the key employee or key independent contractor provided services or had a significant presence or influence." *Idaho Code § 44-2704(3).* <https://legislature.idaho.gov/statutesrules/idstat/Title44/T44CH27/SECT44-2704/>
+
+[^idaho-44-2704-line-of-business-presumption]: **Idaho Code § 44-2704** — "(4) It shall be a rebuttable presumption that an agreement or covenant is reasonable as to type of employment or line of business if it is limited to the type of employment or line of business conducted by the key employee or key independent contractor, as defined in section 44-2702, Idaho Code, while working for the employer." *Idaho Code § 44-2704(4).* <https://legislature.idaho.gov/statutesrules/idstat/Title44/T44CH27/SECT44-2704/>
+
+[^blaskiewicz-modify-work-scope]: **Blaskiewicz v. Spine Institute of Idaho, P.A.** — "For example, it is possible that, under the proper factual findings, the district court could have modified the agreement to preclude Blaskiewicz from practicing only the type of medicine he did for the Spine Institute, i.e., complex spinal deformity surgery, yet allow him to perform other surgeries he is otherwise qualified to perform." *Blaskiewicz v. Spine Inst. of Idaho, P.A., 171 Idaho 70, 518 P.3d 386 (2022).* <https://www.courtlistener.com/opinion/8436739/blaskiewicz-v-spine-institute-of-idaho/#:~:text=For%20example%2C%20it%20is%20possible,is%20otherwise%20qualified%20to%20perform.>
+
+[^idaho-44-2703-mandatory-modification]: **Idaho Code § 44-2703** — "To the extent any such agreement or covenant is found to be unreasonable in any respect, a court shall limit or modify the agreement or covenant as it shall determine necessary to reflect the intent of the parties and render it reasonable in light of the circumstances in which it was made and specifically enforce the agreement or covenant as limited or modified." *Idaho Code § 44-2703.* <https://legislature.idaho.gov/statutesrules/idstat/Title44/T44CH27/SECT44-2703/>
+
+[^intermountain-simple-blue-pencil]: **Intermountain Eye & Laser Centers, P.L.L.C. v. Miller** — "While the court may blue-pencil, if it can be done simply and accurately, the court will not do a substantial rewrite of the contract." *Intermountain Eye & Laser Ctrs., P.L.L.C. v. Miller, 142 Idaho 218, 127 P.3d 121 (2005).* <https://www.courtlistener.com/opinion/2510251/intermountain-eye-laser-centers-pllc-v-miller/#:~:text=While%20the%20court%20may%20blue%2Dpencil%2C,substantial%20rewrite%20of%20the%20contract.>
+
+[^blaskiewicz-blue-pencil-statute]: **Blaskiewicz v. Spine Institute of Idaho, P.A.** — "However, even if the provision is too broad, the district court had within its power the ability to limit or modify the non-compete provision through blue-penciling." *Blaskiewicz v. Spine Inst. of Idaho, P.A., 171 Idaho 70, 518 P.3d 386 (2022).* <https://www.courtlistener.com/opinion/8436739/blaskiewicz-v-spine-institute-of-idaho/#:~:text=However%2C%20even%20if%20the%20provision,the%20non%2Dcompete%20provision%20through%20blue%2Dpenciling.>
+
+[^horn-overt-act]: **Insure Idaho, LLC v. Horn** — "We hold that the plain meaning of solicitation requires some overt act initiated by one party, seeking something in return from a second party." *Insure Idaho, LLC v. Horn, No. 49936 (Idaho July 11, 2025).* <https://www.courtlistener.com/opinion/10634458/insure-idaho-v-horn/#:~:text=We%20hold%20that%20the%20plain,return%20from%20a%20second%20party.>
+
+[^horn-affirmative-action]: **Insure Idaho, LLC v. Horn** — "Although ‘the difference between accepting and receiving business, on the one hand, and indirectly soliciting on the other, may be more metaphysical than real,’ Alexander & Alexander, Inc. v. Danahy, 488 N.E.2d 22, 30 (Mass. App. Ct. 1986), one thing is certain: the restricted party needs to take affirmative action that entreats, implores, pleads, or petitions for the business at issue." *Insure Idaho, LLC v. Horn, No. 49936 (Idaho July 11, 2025).* <https://www.courtlistener.com/opinion/10634458/insure-idaho-v-horn/#:~:text=Although%20%E2%80%9Cthe%20difference%20between%20accepting,for%20the%20business%20at%20issue.>
+
+[^horn-no-mere-acceptance]: **Insure Idaho, LLC v. Horn** — "To be clear, the mere acceptance of business, without more, does not fall within the plain meaning of solicitation; nor can a court infer solicitation from the simple communication between parties alone." *Insure Idaho, LLC v. Horn, No. 49936 (Idaho July 11, 2025).* <https://www.courtlistener.com/opinion/10634458/insure-idaho-v-horn/#:~:text=To%20be%20clear%2C%20the%20mere,simple%20communication%20between%20parties%20alone.>
+
+[^intermountain-patient-choice]: **Intermountain Eye & Laser Centers, P.L.L.C. v. Miller** — "The extent of Intermountain Eye’s interest in those patients Dr. Miller inherited when he joined the firm and those patients it provided him thereafter is limited by those patients’ interests in continuity of care and access to the health care provider of their choice." *Intermountain Eye & Laser Ctrs., P.L.L.C. v. Miller, 142 Idaho 218, 127 P.3d 121 (2005).* <https://www.courtlistener.com/opinion/2510251/intermountain-eye-laser-centers-pllc-v-miller/#:~:text=The%20extent%20of%20Intermountain%20Eye%E2%80%99s%20interest%20in%20those,care%20provider%20of%20their%20choice.>
+
+[^dick-public-welfare]: **Dick v. Geist** — "It has been shown, in this case, by sufficient competent, though disputed, evidence that the welfare of the public in the Twin Falls area would have been seriously impaired by enjoining Geist and Miles from practicing their specialty." *Dick v. Geist, 107 Idaho 931, 693 P.2d 1133 (Ct. App. 1985).* <https://www.courtlistener.com/opinion/1173077/dick-v-geist/#:~:text=It%20has%20been%20shown%2C%20in,Miles%20from%20practicing%20their%20specialty.>
+
+[^idaho-44-2704-tolling-tension]: **Idaho Code § 44-2704** — "(2) It shall be a rebuttable presumption that an agreement or covenant with a postemployment term of eighteen (18) months or less is reasonable as to duration." *Idaho Code § 44-2704.* <https://legislature.idaho.gov/statutesrules/idstat/Title44/T44CH27/SECT44-2704/>
+
+[^idaho-44-2703-tolling-modification]: **Idaho Code § 44-2703** — "To the extent any such agreement or covenant is found to be unreasonable in any respect, a court shall limit or modify the agreement or covenant as it shall determine necessary to reflect the intent of the parties and render it reasonable in light of the circumstances in which it was made and specifically enforce the agreement or covenant as limited or modified." *Idaho Code § 44-2703.* <https://legislature.idaho.gov/statutesrules/idstat/Title44/T44CH27/SECT44-2703/>
+
+[^idaho-29-110-public-policy]: **Idaho Code § 29-110** — "(1) Every stipulation or condition in a contract, by which any party thereto is restricted from enforcing his rights under the contract in Idaho tribunals, or which limits the time within which he may thus enforce his rights, is void as it is against the public policy of Idaho." *Idaho Code § 29-110.* <https://legislature.idaho.gov/statutesrules/idstat/Title29/T29CH1/SECT29-110/>
+
+[^off-spec-strong-policy]: **Off-Spec Solutions, LLC v. Transportation Investors, LLC** — "Therefore, we hold that Idaho Code section 29-110(1) constitutes a strong public policy that is sufficient to invalidate the forum selection clauses in the purchase agreement and the LLC agreement." *Off-Spec Sols., LLC v. Transp. Invs., LLC, No. 47940 (Idaho May 19, 2021).* <https://www.courtlistener.com/opinion/10732800/off-spec-solutions-llc-v-transportation-investors-llc/#:~:text=Therefore%2C%20we%20hold%20that%20Idaho,agreement%20and%20the%20LLC%20agreement.>
+
+[^bybee-sale-goodwill]: **Bybee v. Isaac** — "When the covenant not to compete is ancillary to the sale of a business, any decision on the reasonableness of the covenants must recognize ‘that the vendee is usually purchasing the good will of the business and thus is entitled to reasonable protection from competition by the seller.’" *Bybee v. Isaac, 145 Idaho 251, 178 P.3d 616 (2008).* <https://www.courtlistener.com/opinion/2507705/bybee-v-isaac/#:~:text=When%20the%20covenant%20not%20to,from%20competition%20by%20the%20seller.%E2%80%9D>
+
+[^bybee-not-overbroad]: **Bybee v. Isaac** — "However, when viewing the non-compete covenant in this case in the context of the sale of a business, it is not so over-broad and vague as to be unenforceable as a matter of law." *Bybee v. Isaac, 145 Idaho 251, 178 P.3d 616 (2008).* <https://www.courtlistener.com/opinion/2507705/bybee-v-isaac/#:~:text=However%2C%20when%20viewing%20the%20non%2Dcompete,as%20a%20matter%20of%20law.>
+
+[^idaho-44-2704-trade-secret-preserved]: **Idaho Code § 44-2704** — "Nothing in this chapter shall be construed to limit a party’s ability to otherwise protect trade secrets or other information deemed proprietary or confidential." *Idaho Code § 44-2704.* <https://legislature.idaho.gov/statutesrules/idstat/Title44/T44CH27/SECT44-2704/>
+
+[^idaho-48-802-injunction]: **Idaho Code § 48-802** — "(1) Actual or threatened misappropriation may be enjoined." *Idaho Code § 48-802.* <https://legislature.idaho.gov/statutesrules/idstat/Title48/T48CH8/SECT48-802/>
+
+[^idaho-48-801-trade-secret-definition]: **Idaho Code § 48-801** — "(5) ‘Trade secret’ means information, including a formula, pattern, compilation, program, computer program, device, method, technique, or process, that: (a) Derives independent economic value, actual or potential, from not being generally known to, and not being readily ascertainable by proper means by, other persons who can obtain economic value from its disclosure or use; and (b) Is the subject of efforts that are reasonable under the circumstances to maintain its secrecy." *Idaho Code § 48-801.* <https://legislature.idaho.gov/statutesrules/idstat/Title48/T48CH8/SECT48-801/>

--- a/skills/non-compete-contract-explainer/content/illinois.md
+++ b/skills/non-compete-contract-explainer/content/illinois.md
@@ -1,0 +1,266 @@
+---
+jurisdiction: "Illinois"
+slug: illinois
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-03"
+canonicalUrl: https://openagreements.org/legal/non-compete/illinois
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/illinois · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in Illinois[^about]
+
+A question-by-question summary of Illinois non-compete law under the Illinois Freedom to Work Act (820 ILCS 90), including the $75,000/$45,000 earnings thresholds, the codified two-year consideration rule and the Midwest Lending express-delineation trap, the 14-day notice requirement, the Reliable Fire reasonableness test, the construction, broadcaster, nurse-agency, and mental-health carve-outs, judicial reformation limits, tolling-during-breach clauses, trade-secret alternatives, employee fee-shifting and Attorney General enforcement, and the 2026 Workplace Transparency Act limits on out-of-state choice-of-law and venue clauses.
+
+
+## At a glance
+
+| Question | Illinois |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed above a pay level |
+| **Bottom line** | Illinois enforces employee non-competes only above a $75,000 earnings floor and only if they clear the Freedom to Work Act's consideration and 14-day-notice gates and the Reliable Fire reasonableness test. |
+| **Main law or case** | Illinois Freedom to Work Act, 820 ILCS 90 (Reliable Fire Equipment Co. v. Arredondo) |
+| **Main exceptions** | Construction workers; broadcasters; temp-agency nurses; public-sector CBA; COVID-19 layoffs; certain mental-health professionals; sale of business excluded |
+| **When the ban took effect** | Jan 1, 2022 (Public Act 102-358) |
+| **Can a court narrow it?** | Yes — rewrites to reasonable |
+| **Applies to contractors?** | Unclear |
+| **Restriction extended during a breach?** | Not addressed by statute — open question |
+| **Maximum length set by law** | No statutory maximum (duration judged for reasonableness) |
+
+## Are employee non-compete agreements enforceable in Illinois? {#employee-noncompetes}
+
+**Short answer.** Yes, but only if the covenant clears the statutory gates of the Illinois Freedom to Work Act and then survives the common-law reasonableness test. A covenant not to compete or not to solicit is illegal and void unless the employee received adequate consideration, the restraint is ancillary to a valid employment relationship, it is no greater than necessary to protect a legitimate business interest, it imposes no undue hardship, and it is not injurious to the public [^ifwa-15-enforceability][^reliable-fire-3prong].
+
+Illinois is not a ban state, but it regulates employee non-competes and non-solicits through several statutory gates. Since amendments effective January 1, 2022 (Public Act 102-358), these covenants are governed first by the Illinois Freedom to Work Act, 820 ILCS 90, which layers statutory earnings thresholds, a codified consideration rule, a notice requirement, fee-shifting, and Attorney General enforcement on top of Illinois's long-standing common-law reasonableness analysis. The Act applies to covenants entered on or after its effective date.
+
+"A covenant not to compete or a covenant not to solicit is illegal and void unless (1) the employee receives adequate consideration, (2) the covenant is ancillary to a valid employment relationship, (3) the covenant is no greater than is required for the protection of a legitimate business interest of the employer, (4) the covenant does not impose undue hardship on the employee, and (5) the covenant is not injurious to the public."[^ifwa-15-enforceability]
+
+Clearing the statute is necessary but not sufficient: the covenant must also be reasonable under the three-prong rule of reason the Illinois Supreme Court restated in *Reliable Fire Equipment Co. v. Arredondo* [^reliable-fire-3prong]. So the practical question in Illinois is layered — does the worker earn enough to be bound, was the covenant supported and properly noticed, and is the restraint reasonable on the facts.
+
+This note reflects current enacted law as of the review date. Two bills introduced in the 104th General Assembly would change it — HB 3213 would prohibit covenants not to compete and not to solicit outright, and HB 1642 would raise the non-compete earnings threshold to $300,000 — but as of the review date both remained in committee and neither had been enacted, so they do not yet affect enforceability.
+
+## Who can be bound by a non-compete in Illinois? {#earnings-thresholds}
+
+**Short answer.** Only workers above the statutory earnings floors. A non-compete is void unless the employee's actual or expected annualized earnings exceed $75,000, and a non-solicit is void unless they exceed $45,000; both floors step up over time [^ifwa-10-noncompete-threshold][^ifwa-10-nonsolicit-threshold].
+
+The earnings thresholds are the first and most mechanical filter. They are hard floors: a covenant used below the threshold is void regardless of how reasonable its scope is.
+
+"No employer shall enter into a covenant not to compete with any employee unless the employee's actual or expected annualized rate of earnings exceeds $75,000 per year."[^ifwa-10-noncompete-threshold]
+
+The non-solicit threshold is lower but works the same way [^ifwa-10-nonsolicit-threshold]. Both thresholds escalate on a fixed schedule — the non-compete floor rises to $80,000 on January 1, 2027, then $85,000 in 2032 and $90,000 in 2037, with the non-solicit floor climbing to $47,500, $50,000, and $52,500 on the same dates. The Act also defines *earnings* broadly to include salary, bonuses, commissions, and elective W-2 deferrals such as 401(k) and HSA contributions, so the calculation is not limited to base salary.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not assume a covenant is enforceable just because the worker is salaried. Under 820 ILCS 90/10 a non-compete is void below $75,000 and a non-solicit below $45,000 in annualized earnings, and those floors rise in 2027, so confirm the worker clears the current threshold — counting bonuses, commissions, and elective deferrals — before relying on the covenant [^ifwa-10-noncompete-threshold][^ifwa-10-nonsolicit-threshold].
+
+## What counts as adequate consideration for an Illinois non-compete? {#adequate-consideration}
+
+**Short answer.** Either two years of continued employment after signing, or other professional or financial benefits adequate to support the restraint. Illinois codified the *Fifield* two-year rule, but a financial benefit relied on as consideration must be expressly tied to the covenant — a *Midwest Lending* trap [^ifwa-5-consideration][^fifield-2yr][^midwest-delineation].
+
+The IFWA defines adequate consideration in 820 ILCS 90/5, codifying a rule Illinois courts developed under the common law [^ifwa-5-consideration]. The two-year benchmark traces to *Fifield v. Premier Dealer Services, Inc.*, where the employee resigned about three months after starting and the court held the covenant unsupported.
+
+"Generally, Illinois courts have held that continued employment for two years or more constitutes adequate consideration."[^fifield-2yr]
+
+The statute offers an alternative to the two-year clock — a shorter period of employment plus additional professional or financial benefits, or such benefits standing alone — but the case law makes the drafting mechanics unforgiving. In *Midwest Lending Corp. v. Horton*, the employer pointed to a $25,000 signing bonus mentioned in an offer letter, but the restrictive-covenant document did not state that the bonus was given in exchange for the covenant, and the court refused to treat it as consideration.
+
+"Accordingly, we reject Midwest's argument that the ‘signing bonus’ in the offer letter provided adequate consideration for Horton's later agreement to the nonsolicitation provision."[^midwest-delineation]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> If you rely on a bonus, equity grant, or other benefit as consideration for an Illinois covenant, draft the exchange clearly and tie the benefit to the covenant. In *Midwest Lending Corp. v. Horton*, a signing bonus mentioned only in an offer letter did not support a later, integrated nonsolicitation agreement that never identified the bonus as consideration for the covenant — so do not assume a benefit described elsewhere will carry an integrated covenant [^midwest-delineation].
+
+## Must an Illinois employer give advance notice before a non-compete is signed? {#notice-requirement}
+
+**Short answer.** Yes. The covenant is void unless the employer advises the employee in writing to consult an attorney and either provides a copy of the covenant at least 14 calendar days before employment begins or otherwise gives the employee at least 14 calendar days to review it [^ifwa-20-notice].
+
+This is a procedural gate with teeth: failing either step makes the covenant void, no matter how reasonable its terms.
+
+"A covenant not to compete or a covenant not to solicit is illegal and void unless (1) the employer advises the employee in writing to consult with an attorney before entering into the covenant and (2) the employer provides the employee with a copy of the covenant at least 14 calendar days before the commencement of the employee's employment or the employer provides the employee with at least 14 calendar days to review the covenant."[^ifwa-20-notice]
+
+The statute gives two ways to satisfy the timing prong — a copy at least 14 days before the start date, or at least 14 days to review the covenant — but the written attorney-consultation advisement is mandatory either way. The employee may choose to sign early, but the employer must still extend the full 14-day window.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Build a 14-day review window and a written instruction to consult counsel into your Illinois onboarding workflow. Under 820 ILCS 90/20 a covenant is void if either step is missing, so give the employee the covenant with the written advisement and at least 14 calendar days to review it, and document both — an employee's early signature does not excuse offering the full period [^ifwa-20-notice].
+
+## How do Illinois courts judge whether a non-compete is reasonable? {#reasonableness}
+
+**Short answer.** By the totality of the circumstances, not a rigid formula. A legitimate business interest exists based on all the facts of the case, and the same restraint can be reasonable in one situation and unreasonable in another [^ifwa-7-lbi][^reliable-fire-totality].
+
+Even a covenant that clears the earnings, consideration, and notice gates must still be reasonable. The IFWA codifies the legitimate-business-interest inquiry as a totality test in 820 ILCS 90/7.
+
+"In determining the legitimate business interest of the employer, the totality of the facts and circumstances of the individual case shall be considered."[^ifwa-7-lbi]
+
+That codification tracks *Reliable Fire*, where the Illinois Supreme Court rejected rigid appellate tests for a protectable interest in favor of a fact-driven inquiry.
+
+"Rather, we adopt the position of Justice Hudson's special concurrence, which is: whether a legitimate business interest exists is based on the totality of the facts and circumstances of the individual case."[^reliable-fire-totality]
+
+The statutory factors include the employee's exposure to customer relationships, the near-permanence of those relationships, access to confidential information, and the time, place, and scope of the restriction — but no factor is decisive, and reasonableness is gauged by all of the circumstances together.
+
+## Which Illinois workers are categorically off-limits for non-competes? {#industry-bans}
+
+**Short answer.** Several, though they differ in kind. Construction workers, broadcasters, and temporary agency nurses face flat bans; covenants against public-sector collective-bargaining-covered employees, COVID-19-related layoffs, and mental-health professionals treating veterans and first responders are voided or unenforceable on narrower, conditional terms [^ifwa-10-construction][^broadcast-ban][^nurse-ban].
+
+Beyond the earnings thresholds, the IFWA and related statutes carve out categories of workers regardless of reasonableness. Construction is a flat ban, subject to a role-based carve-out.
+
+"A covenant not to compete or a covenant not to solicit is void and illegal with respect to individuals employed in construction, regardless of whether an individual is covered by a collective bargaining agreement."[^ifwa-10-construction]
+
+That construction ban does not reach employees who primarily perform management, engineering, architectural, design, or sales functions, or who are owners [^ifwa-10-construction]. The IFWA adds three narrower, conditional limits. It voids *non-competes* (not non-solicits) against public-sector employees covered by a collective bargaining agreement under the Illinois Public Labor Relations Act or the Illinois Educational Labor Relations Act [^ifwa-10-cba]. It bars enforcement against employees laid off due to COVID-19 or similar circumstances unless the employer pays base salary, minus subsequent earnings, through the restricted period [^ifwa-10-covid]. And a 2025 amendment makes a covenant unenforceable as to a mental-health professional treating veterans and first responders where enforcement would likely increase the cost or difficulty of obtaining those services [^ifwa-10-mentalhealth].
+
+Two industry-specific statutes outside the IFWA add their own bans. The Broadcast Industry Free Market Act bars *post-employment* non-competes for broadcasters, though it still allows enforcement during the contract term or against an employee who breaches [^broadcast-ban], and the Nurse Agency Licensing Act voids non-competes against agency nurses and certified nurse aides placed on a temporary basis [^nurse-ban].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Check the worker's industry and role before relying on an Illinois covenant. Construction workers (outside the management/sales/owner carve-out), broadcasters, and temporary agency nurses face flat statutory voids that no reasonable drafting will cure, and covenants against public-sector union employees, COVID-era layoffs, and mental-health professionals serving veterans and first responders face their own conditional bars [^ifwa-10-construction][^ifwa-10-cba][^ifwa-10-covid][^ifwa-10-mentalhealth][^broadcast-ban][^nurse-ban].
+
+## Will an Illinois court rewrite an overbroad non-compete instead of voiding it? {#reformation}
+
+**Short answer.** Sometimes, but it is discretionary and far from guaranteed. The IFWA permits reformation yet warns that extensive judicial rewriting may be against public policy, and Illinois courts have refused to rescue patently overbroad covenants [^ifwa-35-reformation][^assured-overbroad].
+
+Illinois gives courts a discretionary, policy-limited blue-pencil power rather than a guarantee of reformation.
+
+"Extensive judicial reformation of a covenant not to compete or a covenant not to solicit may be against the public policy of this State and a court may refrain from wholly rewriting contracts."[^ifwa-35-reformation]
+
+Courts weigh factors such as the fairness of the restraints as originally written, whether the original draft was a good-faith effort to protect a legitimate interest, the extent of reformation required, and whether the agreement authorized modification. When a covenant is drafted far broader than necessary, Illinois courts have declined to fix it.
+
+"We decline to rescue a draftor from the risks of crafting a restrictive covenant that is patently overbroad."[^assured-overbroad]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not treat Illinois reformation as a safety net for an aggressive covenant. Section 35 lets a court reform or sever in its discretion but warns that extensive rewriting may violate public policy, and *AssuredPartners, Inc. v. Schmitt* refused to rescue a patently overbroad restraint — so draft to the narrowest defensible scope rather than relying on a judge to cut it down [^ifwa-35-reformation][^assured-overbroad].
+
+## Does a tolling or extension-during-breach clause extend an Illinois non-compete? {#tolling-during-breach}
+
+**Short answer.** Illinois law does not squarely answer this. No IFWA provision addresses a clause that pauses or extends the restricted period during breach or litigation, and an extension that pushes the effective restraint past a reasonable duration is exposed under the statute's reasonableness requirement and its limits on reformation [^q8-ifwa-15][^q8-ifwa-35].
+
+Many non-compete forms add a tolling or extension clause so the employer gets the full restricted period even if the former employee competes during it. The IFWA neither authorizes nor prohibits such clauses, and no Illinois decision under the Act has squarely ruled on one, so this is an open question that calls for caution rather than confidence.
+
+The statutory framework still constrains it. Duration is part of the reasonableness analysis, and a covenant is void unless it is no greater than required to protect a legitimate business interest [^q8-ifwa-15]. A tolling clause that adds the period of breach plus the time spent in litigation can stretch the effective restraint well beyond what the parties wrote, raising a duration-reasonableness problem. And because Illinois warns against extensive judicial reformation, an employer cannot assume a court will trim an open-ended extension back to a reasonable term rather than decline to enforce it [^q8-ifwa-35].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Treat an open-ended tolling-during-breach clause in an Illinois covenant as unsettled and risky. No IFWA provision or decision under the Act endorses one, duration bears on reasonableness under Section 15, and Section 35 cautions against extensive judicial rewriting — so a defined, reasonable fixed term is the safer choice than relying on a clause that extends the period during breach or litigation [^q8-ifwa-15][^q8-ifwa-35].
+
+## What protections can Illinois employers use when a non-compete is risky? {#trade-secret-alternative}
+
+**Short answer.** Confidentiality and trade-secret protections, which sit outside the IFWA. The Act excludes confidentiality, trade-secret, and invention agreements from its definitions, and the Illinois Trade Secrets Act says a duty of secrecy is not void merely for lacking time or geographic limits [^ifwa-5-exclusions][^itsa-8-secrecy].
+
+The IFWA's definitions deliberately leave several common protections untouched. A *covenant not to compete* does not include confidentiality agreements, trade-secret or invention-protection covenants, or sale-of-business covenants, so those tools are not subject to the Act's thresholds and notice rules [^ifwa-5-exclusions].
+
+The Illinois Trade Secrets Act backs up confidentiality drafting by confirming that a secrecy duty does not need the durational and geographic limits a non-compete requires.
+
+"This Act does not affect: (1) contractual remedies, whether or not based upon misappropriation of a trade secret, provided however, that a contractual or other duty to maintain secrecy or limit use of a trade secret shall not be deemed to be void or unenforceable solely for lack of durational or geographical limitation on the duty"[^itsa-8-secrecy]
+
+That makes well-drafted confidentiality and trade-secret protections a durable alternative where an Illinois non-compete is unavailable or risky — though they protect information, not the employer against ordinary competition.
+
+## What does an Illinois employer risk by overreaching on a non-compete? {#remedies-enforcement}
+
+**Short answer.** Paying the employee's legal fees and facing Attorney General penalties. In an employer-filed action or arbitration to enforce a covenant, a prevailing employee recovers costs and reasonable attorney's fees, and the Attorney General can pursue pattern-and-practice violations with civil penalties — and has done so [^ifwa-25-fees][^ifwa-30-ag][^valvoline].
+
+The IFWA shifts litigation economics toward employees. If an employer sues or arbitrates to enforce a covenant and the employee prevails, the employer pays the employee's side of that fight.
+
+"in a civil action or arbitration filed by an employer (including, but not limited to, a complaint or counterclaim), if an employee prevails on a claim to enforce a covenant not to compete or a covenant not to solicit, the employee shall recover from the employer all costs and all reasonable attorney's fees regarding such claim to enforce a covenant not to compete or a covenant not to solicit, and the court or arbitrator may award appropriate relief."[^ifwa-25-fees]
+
+The Act also adds a public-enforcement overlay. The Attorney General may investigate and sue for a pattern and practice of violations, with civil penalties.
+
+"the Attorney General may request and the court may impose a civil penalty not to exceed $5,000 for each violation or $10,000 for each repeat violation within a 5-year period."[^ifwa-30-ag]
+
+This is not a dormant power. In 2024, the Attorney General reached a multistate settlement with Valvoline over non-competes imposed on hourly oil-change workers.
+
+"Raoul and the attorneys general allege Valvoline required its hourly employees to sign non-competition agreements that prohibited them from working in the oil change business at any store within 100 miles of a Valvoline location for one year after leaving Valvoline."[^valvoline]
+
+## Can an out-of-state choice-of-law or venue clause bypass Illinois non-compete law? {#choice-of-law}
+
+**Short answer.** Only in a limited, but important, way. The Workplace Transparency Act, effective 2026, voids a unilateral employment clause that applies non-Illinois law or requires an out-of-state venue to the extent it diminishes an Illinois employee's rights related to an unlawful employment practice — but it is not a general rule that every non-compete choice-of-law clause is void [^wta-choice-of-law].
+
+Multi-state employers often designate Delaware or New York law and venue to escape Illinois's strict limits. Amendments to the Workplace Transparency Act effective January 1, 2026 (Public Act 104-320) constrain that move — but read the provision precisely. The void is tethered to claims, rights, or benefits *related to an unlawful employment practice*, not to non-compete enforcement at large.
+
+"(b) Any agreement, clause, covenant, or waiver that is a unilateral condition of employment or continued employment and requires the employee or prospective employee to waive, arbitrate, or otherwise diminish any existing or future claim, right, or benefit related to an unlawful employment practice to which the employee or prospective employee would otherwise be entitled under any provision of State or federal law, including that which purports to shorten the applicable statute of limitation, apply non-Illinois law to an Illinois employee's claim, or require a venue outside of Illinois to adjudicate an Illinois employee's claim, is against public policy, void to the extent it denies an employee or prospective employee a substantive or procedural right or remedy related to alleged unlawful employment practices, and severable from an otherwise valid and enforceable contract under this Act."[^wta-choice-of-law]
+
+The bar also applies only to *unilateral* conditions of employment; a mutual provision can survive if it is in writing, demonstrates actual, knowing, and bargained-for consideration, and preserves the listed employee rights. The practical takeaway is narrower than the headlines suggest: the WTA limits boilerplate forum-shifting where an Illinois employee's statutory employment claims are at stake, but a covenant-holder cannot assume it broadly defeats every out-of-state choice-of-law clause in a non-compete dispute. Where it does not apply, Illinois's ordinary conflict-of-laws and public-policy analysis governs.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not over-read the Workplace Transparency Act as a blanket bar on out-of-state choice-of-law and venue clauses. As of January 1, 2026, it voids a unilateral clause applying non-Illinois law or requiring an out-of-state venue to the extent it diminishes an Illinois employee's rights related to an unlawful employment practice, and a mutual, separately bargained clause can survive — so treat it as a meaningful but bounded check on forum-shifting, not a general non-compete choice-of-law rule [^wta-choice-of-law].
+
+## Are no-poach agreements between employers treated like employee non-competes? {#no-poach}
+
+**Short answer.** No. An agreement between competing employers not to hire each other's workers is analyzed under the Illinois Antitrust Act, not the IFWA, and the Illinois Supreme Court has held such agreements are not exempt from antitrust scrutiny [^elite-nopoach].
+
+It is easy to conflate two different things: a covenant an *employee* signs, and an agreement between *employers* not to poach one another's workers. The IFWA governs the former; the latter is a labor-market restraint reached by state antitrust law. In *State ex rel. Raoul v. Elite Staffing, Inc.*, the Illinois Supreme Court addressed staffing agencies that allegedly agreed to fix wages and not hire each other's employees.
+
+"We hold that the Illinois Antitrust Act does not exempt from antitrust scrutiny all agreements between competitors to hold down wages and to limit employment opportunities for their employees."[^elite-nopoach]
+
+So an inter-employer no-poach or wage-fixing arrangement can draw antitrust exposure independent of the IFWA's rules for employee covenants.
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-03. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not Illinois. This article synthesizes Illinois primary law and is not legal advice from a Illinois-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^ifwa-15-enforceability]: **820 ILCS 90/15** — "A covenant not to compete or a covenant not to solicit is illegal and void unless (1) the employee receives adequate consideration, (2) the covenant is ancillary to a valid employment relationship, (3) the covenant is no greater than is required for the protection of a legitimate business interest of the employer, (4) the covenant does not impose undue hardship on the employee, and (5) the covenant is not injurious to the public." *820 ILCS 90/15.* <https://www.ilga.gov/documents/legislation/ilcs/documents/082000900K15.htm>
+
+[^reliable-fire-3prong]: **Reliable Fire Equipment Co. v. Arredondo** — "A restrictive covenant, assuming it is ancillary to a valid employment relationship, is reasonable only if the covenant: (1) is no greater than is required for the protection of a legitimate business interest of the employer-promisee; (2) does not impose undue hardship on the employee-promisor, and (3) is not injurious to the public." *Reliable Fire Equipment Co. v. Arredondo, 2011 IL 111871.* <https://www.courtlistener.com/opinion/3135645/reliable-fire-equipment-co-v-arredondo/#:~:text=A%20restrictive%20covenant%2C%20assuming%20it,not%20injurious%20to%20the%20public.>
+
+[^ifwa-10-noncompete-threshold]: **820 ILCS 90/10** — "No employer shall enter into a covenant not to compete with any employee unless the employee's actual or expected annualized rate of earnings exceeds $75,000 per year." *820 ILCS 90/10(a).* <https://www.ilga.gov/documents/legislation/ilcs/documents/082000900K10.htm>
+
+[^ifwa-10-nonsolicit-threshold]: **820 ILCS 90/10** — "No employer shall enter into a covenant not to solicit with any employee unless the employee's actual or expected annualized rate of earnings exceeds $45,000 per year." *820 ILCS 90/10(b).* <https://www.ilga.gov/documents/legislation/ilcs/documents/082000900K10.htm>
+
+[^ifwa-5-consideration]: **820 ILCS 90/5** — "‘Adequate consideration’ means (1) the employee worked for the employer for at least 2 years after the employee signed an agreement containing a covenant not to compete or a covenant not to solicit or (2) the employer otherwise provided consideration adequate to support an agreement to not compete or to not solicit, which consideration can consist of a period of employment plus additional professional or financial benefits or merely professional or financial benefits adequate by themselves." *820 ILCS 90/5.* <https://www.ilga.gov/documents/legislation/ilcs/documents/082000900K5.htm>
+
+[^fifield-2yr]: **Fifield v. Premier Dealer Services, Inc.** — "Generally, Illinois courts have held that continued employment for two years or more constitutes adequate consideration." *Fifield v. Premier Dealer Services, Inc., 2013 IL App (1st) 120327.* <https://www.courtlistener.com/opinion/3148347/fifield-v-premier-dealer-services-inc/#:~:text=Generally%2C%20Illinois%20courts%20have%20held,or%20more%20constitutes%20adequate%20consideration.>
+
+[^midwest-delineation]: **Midwest Lending Corp. v. Horton** — "Accordingly, we reject Midwest's argument that the ‘signing bonus’ in the offer letter provided adequate consideration for Horton's later agreement to the nonsolicitation provision." *Midwest Lending Corp. v. Horton, 2023 IL App (3d) 220132.* <https://www.courtlistener.com/opinion/9401053/midwest-lending-corp-v-horton/#:~:text=Accordingly%2C%20we%20reject%20Midwest's%20argument,agreement%20to%20the%20nonsolicitation%20provision.>
+
+[^ifwa-20-notice]: **820 ILCS 90/20** — "A covenant not to compete or a covenant not to solicit is illegal and void unless (1) the employer advises the employee in writing to consult with an attorney before entering into the covenant and (2) the employer provides the employee with a copy of the covenant at least 14 calendar days before the commencement of the employee's employment or the employer provides the employee with at least 14 calendar days to review the covenant." *820 ILCS 90/20.* <https://www.ilga.gov/documents/legislation/ilcs/documents/082000900K20.htm>
+
+[^ifwa-7-lbi]: **820 ILCS 90/7** — "In determining the legitimate business interest of the employer, the totality of the facts and circumstances of the individual case shall be considered." *820 ILCS 90/7.* <https://www.ilga.gov/documents/legislation/ilcs/documents/082000900K7.htm>
+
+[^reliable-fire-totality]: **Reliable Fire Equipment Co. v. Arredondo** — "Rather, we adopt the position of Justice Hudson's special concurrence, which is: whether a legitimate business interest exists is based on the totality of the facts and circumstances of the individual case." *Reliable Fire Equipment Co. v. Arredondo, 2011 IL 111871.* <https://www.courtlistener.com/opinion/3135645/reliable-fire-equipment-co-v-arredondo/#:~:text=Rather%2C%20we%20adopt%20the%20position,circumstances%20of%20the%20individual%20case.>
+
+[^ifwa-10-construction]: **820 ILCS 90/10** — "A covenant not to compete or a covenant not to solicit is void and illegal with respect to individuals employed in construction, regardless of whether an individual is covered by a collective bargaining agreement. This subsection (e) does not apply to construction employees who primarily perform management, engineering or architectural, design, or sales functions for the employer or who are shareholders, partners, or owners in any capacity of the employer." *820 ILCS 90/10(e).* <https://www.ilga.gov/documents/legislation/ilcs/documents/082000900K10.htm>
+
+[^broadcast-ban]: **820 ILCS 17/10** — "No broadcasting industry employer may require in an employment contract that an employee or prospective employee refrain from obtaining employment in a specific geographic area for a specific period of time after termination of employment with that broadcasting industry employer. (b) This Section does not prevent the enforcement of a covenant not to compete during the term of an employment contract or against an employee who breaches an employment contract." *820 ILCS 17/10.* <https://www.ilga.gov/documents/legislation/ilcs/documents/082000170K10.htm>
+
+[^nurse-ban]: **225 ILCS 510/14** — "Nurse agencies are prohibited from entering into covenants not to compete with nurses and certified nurse aides if the nurse is employed, assigned, or referred by a nurse agency to a health care facility on a temporary basis or the certified nurse aide is employed, assigned, or referred by a nurse agency to a health care facility on a temporary basis." *225 ILCS 510/14(g).* <https://www.ilga.gov/documents/legislation/ilcs/documents/022505100K14.htm>
+
+[^ifwa-10-cba]: **820 ILCS 90/10** — "A covenant not to compete is void and illegal with respect to individuals covered by a collective bargaining agreement under the Illinois Public Labor Relations Act or the Illinois Educational Labor Relations Act." *820 ILCS 90/10(d).* <https://www.ilga.gov/documents/legislation/ilcs/documents/082000900K10.htm>
+
+[^ifwa-10-covid]: **820 ILCS 90/10** — "No employer shall enter into a covenant not to compete or a covenant not to solicit with any employee who an employer terminates or furloughs or lays off as the result of business circumstances or governmental orders related to the COVID-19 pandemic or under circumstances that are similar to the COVID-19 pandemic, unless enforcement of the covenant not to compete includes compensation equivalent to the employee's base salary at the time of termination for the period of enforcement minus compensation earned through subsequent employment during the period of enforcement." *820 ILCS 90/10(c).* <https://www.ilga.gov/documents/legislation/ilcs/documents/082000900K10.htm>
+
+[^ifwa-10-mentalhealth]: **820 ILCS 90/10** — "Any covenant not to compete or covenant not to solicit entered into after January 1, 2025 (the effective date of Public Act 103-915) shall not be enforceable with respect to the provision of mental health services to veterans and first responders by any licensed mental health professional in this State if the enforcement of the covenant not to compete or covenant not to solicit is likely to result in an increase in cost or difficulty for any veteran or first responder seeking mental health services." *820 ILCS 90/10(f).* <https://www.ilga.gov/documents/legislation/ilcs/documents/082000900K10.htm>
+
+[^ifwa-35-reformation]: **820 ILCS 90/35** — "Extensive judicial reformation of a covenant not to compete or a covenant not to solicit may be against the public policy of this State and a court may refrain from wholly rewriting contracts. (b) In some circumstances, a court may, in its discretion, choose to reform or sever provisions of a covenant not to compete or a covenant not to solicit rather than hold such covenant unenforceable. Factors which may be considered when deciding whether such reformation is appropriate include the fairness of the restraints as originally written, whether the original restriction reflects a good-faith effort to protect a legitimate business interest of the employer, the extent of such reformation, and whether the parties included a clause authorizing such modifications in their agreement." *820 ILCS 90/35.* <https://www.ilga.gov/documents/legislation/ilcs/documents/082000900K35.htm>
+
+[^assured-overbroad]: **AssuredPartners, Inc. v. Schmitt** — "We decline to rescue a draftor from the risks of crafting a restrictive covenant that is patently overbroad." *AssuredPartners, Inc. v. Schmitt, 2015 IL App (1st) 141863.* <https://www.courtlistener.com/opinion/3173530/assuredpartners-inc-v-schmitt/#:~:text=We%20decline%20to%20rescue%20a,covenant%20that%20is%20patently%20overbroad.>
+
+[^q8-ifwa-15]: **820 ILCS 90/15** — "A covenant not to compete or a covenant not to solicit is illegal and void unless (1) the employee receives adequate consideration, (2) the covenant is ancillary to a valid employment relationship, (3) the covenant is no greater than is required for the protection of a legitimate business interest of the employer, (4) the covenant does not impose undue hardship on the employee, and (5) the covenant is not injurious to the public." *820 ILCS 90/15.* <https://www.ilga.gov/documents/legislation/ilcs/documents/082000900K15.htm>
+
+[^q8-ifwa-35]: **820 ILCS 90/35** — "Extensive judicial reformation of a covenant not to compete or a covenant not to solicit may be against the public policy of this State and a court may refrain from wholly rewriting contracts." *820 ILCS 90/35(a).* <https://www.ilga.gov/documents/legislation/ilcs/documents/082000900K35.htm>
+
+[^ifwa-5-exclusions]: **820 ILCS 90/5** — "‘Covenant not to compete’ does not include (1) a covenant not to solicit, (2) a confidentiality agreement or covenant, (3) a covenant or agreement prohibiting use or disclosure of trade secrets or inventions, (4) invention assignment agreements or covenants, (5) a covenant or agreement entered into by a person purchasing or selling the goodwill of a business or otherwise acquiring or disposing of an ownership interest" *820 ILCS 90/5.* <https://www.ilga.gov/documents/legislation/ilcs/documents/082000900K5.htm>
+
+[^itsa-8-secrecy]: **765 ILCS 1065/8** — "This Act does not affect: (1) contractual remedies, whether or not based upon misappropriation of a trade secret, provided however, that a contractual or other duty to maintain secrecy or limit use of a trade secret shall not be deemed to be void or unenforceable solely for lack of durational or geographical limitation on the duty" *765 ILCS 1065/8(b)(1).* <https://www.ilga.gov/documents/legislation/ilcs/documents/076510650K8.htm>
+
+[^ifwa-25-fees]: **820 ILCS 90/25** — "in a civil action or arbitration filed by an employer (including, but not limited to, a complaint or counterclaim), if an employee prevails on a claim to enforce a covenant not to compete or a covenant not to solicit, the employee shall recover from the employer all costs and all reasonable attorney's fees regarding such claim to enforce a covenant not to compete or a covenant not to solicit, and the court or arbitrator may award appropriate relief." *820 ILCS 90/25.* <https://www.ilga.gov/documents/legislation/ilcs/documents/082000900K25.htm>
+
+[^ifwa-30-ag]: **820 ILCS 90/30** — "the Attorney General may request and the court may impose a civil penalty not to exceed $5,000 for each violation or $10,000 for each repeat violation within a 5-year period." *820 ILCS 90/30(d).* <https://www.ilga.gov/documents/legislation/ilcs/documents/082000900K30.htm>
+
+[^valvoline]: **Attorney General Raoul Reaches Settlement With Valvoline Over Use of Non-Compete Agreements** — "Raoul and the attorneys general allege Valvoline required its hourly employees to sign non-competition agreements that prohibited them from working in the oil change business at any store within 100 miles of a Valvoline location for one year after leaving Valvoline." *Ill. Att'y Gen., Settlement with Valvoline (Aug. 1, 2024).* <https://illinoisattorneygeneral.gov/news/story/attorney-general-raoul-reaches-settlement-with-valvoline-over-use-of-non-compete-agreements>
+
+[^wta-choice-of-law]: **820 ILCS 96/1-25** — "(b) Any agreement, clause, covenant, or waiver that is a unilateral condition of employment or continued employment and requires the employee or prospective employee to waive, arbitrate, or otherwise diminish any existing or future claim, right, or benefit related to an unlawful employment practice to which the employee or prospective employee would otherwise be entitled under any provision of State or federal law, including that which purports to shorten the applicable statute of limitation, apply non-Illinois law to an Illinois employee's claim, or require a venue outside of Illinois to adjudicate an Illinois employee's claim, is against public policy, void to the extent it denies an employee or prospective employee a substantive or procedural right or remedy related to alleged unlawful employment practices, and severable from an otherwise valid and enforceable contract under this Act." *820 ILCS 96/1-25(b).* <https://www.ilga.gov/documents/legislation/ilcs/documents/082000960K1-25.htm>
+
+[^elite-nopoach]: **State ex rel. Raoul v. Elite Staffing, Inc.** — "We hold that the Illinois Antitrust Act does not exempt from antitrust scrutiny all agreements between competitors to hold down wages and to limit employment opportunities for their employees." *State ex rel. Raoul v. Elite Staffing, Inc., 2024 IL 128763.* <https://www.courtlistener.com/opinion/9467526/state-ex-rel-raoul-v-elite-staffing-inc/#:~:text=We%20hold%20that%20the%20Illinois,employment%20opportunities%20for%20their%20employees.>

--- a/skills/non-compete-contract-explainer/content/india.md
+++ b/skills/non-compete-contract-explainer/content/india.md
@@ -1,0 +1,269 @@
+---
+jurisdiction: "India"
+slug: india
+countryCode: IN
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-03"
+canonicalUrl: https://openagreements.org/legal/non-compete/india
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/india · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in India[^about]
+
+India voids post-employment non-compete agreements under Section 27 of the Indian Contract Act, 1872 — no matter how reasonable in time, area, or scope — leaving only a narrow sale-of-goodwill exception, in-term covenants, confidentiality, targeted non-solicitation, garden leave during notice, and cost-based employment bonds.
+
+
+## At a glance
+
+| Question | India |
+| --- | --- |
+| **Are non-competes enforceable?** | Banned |
+| **Bottom line** | Post-employment non-competes are void under Section 27 of the Indian Contract Act, 1872 regardless of how reasonable they are, and Indian law offers no reasonableness saving for post-term restraints — leaving only the sale-of-goodwill exception, in-term covenants, confidentiality, non-solicitation, garden leave during the notice period, and cost-based employment bonds. |
+| **Main law or case** | Indian Contract Act, 1872, § 27 |
+| **Main exceptions** | Sale of business goodwill (Exception 1 to § 27); partnership carve-outs (§§ 11(2), 36(2), 54); in-term exclusive-service covenants |
+| **When the ban took effect** | Longstanding — Section 27 has been in force since 1872 |
+| **Can a court narrow it?** | No |
+| **Applies to contractors?** | Yes |
+| **Restriction extended during a breach?** | Not applicable — the post-term covenant is void |
+| **Maximum length set by law** | Not applicable — void |
+
+## Are post-employment non-compete agreements enforceable in India? {#post-employment-noncompetes}
+
+**Short answer.** No. India voids post-employment non-compete agreements by statute. Section 27 of the Indian Contract Act, 1872 makes any agreement that restrains someone from exercising a lawful profession, trade, or business void *to that extent*, and the Supreme Court has held that a service covenant operating after employment ends is void — a position it calls *completely settled* [^stat-s27-void][^krishan-murgai-void][^percept-settled].
+
+This makes India fundamentally different from a *reasonableness* jurisdiction such as England or Singapore. India codified the rule in 1872, so an Indian court does not weigh a post-employment covenant's duration or geography against the employer's interest — a clause that restrains a former employee from competing is simply void under Section 27 [^stat-s27-void].
+
+"Every agreement by which any one is restrained from exercising a lawful profession, trade or business of any kind, is to that extent void."[^stat-s27-void]
+
+The Supreme Court settled the post-employment position decades ago. In *Superintendence Co. of India v. Krishan Murgai*, it held that a covenant extended past the end of the service is void under Section 27 [^krishan-murgai-void].
+
+"Under Section 27 of the Contract Act, a service covenant extended beyond the termination of the service is void."[^krishan-murgai-void]
+
+The Court reaffirmed and generalized that rule in *Percept D'Mark (India) v. Zaheer Khan*, describing the law on post-contractual restraints as fixed [^percept-settled].
+
+"The legal position with regard to post-contractual covenants or restrictions has been consistent, unchanging and completely settled in our country."[^percept-settled]
+
+The narrow things an Indian employer *can* protect — the goodwill it buys in an acquisition, its genuine confidential information, in-term exclusivity, and cost-based training bonds — are each addressed in the questions below.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not paper an Indian employee with a US- or UK-style non-compete form and assume a court will enforce or narrow it because it looks *reasonable*. India treats a post-employment non-compete as void rather than reforming it, so a covenant copied from a reasonableness jurisdiction gives an Indian employer no enforceable restraint at all [^stat-s27-void][^krishan-murgai-void].
+
+## Does it matter if an Indian non-compete is short, narrow, or paid for? {#reasonable-noncompete}
+
+**Short answer.** No. A post-employment non-compete does not become enforceable in India because it is limited to a few months, a small area, or supported by a payment. Unlike England's *reasonableness* doctrine, Section 27 admits no reasonableness or *partial restraint* saving for a post-term covenant unless it fits a statutory exception, and the Delhi High Court reaffirmed in 2025 that a restraint on post-employment work is void [^krishan-murgai-no-reasonableness][^q2-percept-s27][^varun-tyagi-void].
+
+In *Krishan Murgai*, the Supreme Court drew the line that separates Indian law from the English approach: the *reasonableness* test that rescues a narrowly tailored covenant elsewhere does not apply to a Section 27 case at all, except within the sale-of-goodwill exception [^krishan-murgai-no-reasonableness].
+
+"Neither the test of reasonableness nor the principle of that the restraint being partial was reasonable are applicable to a case governed by Section 27 of the Contract Act, unless it falls within Exception 1."[^krishan-murgai-no-reasonableness]
+
+*Percept* states the operative rule directly: a covenant reaching past the term of the contract is void and unenforceable [^q2-percept-s27].
+
+"Under Section 27 of the Contract Act (a) a restrictive covenant extending beyond the term of the contract is void and not enforceable."[^q2-percept-s27]
+
+This is not a fading doctrine. In *Varun Tyagi v. Daffodil Software*, decided in June 2025, the Delhi High Court held that an employment-contract term restricting a worker's right to take up employment after the contract ends is void under Section 27 [^varun-tyagi-void].
+
+"In view of the above, it is clear that any terms of the employment contract that imposes a restriction on right of the employee to get employed post-termination of the contract of employment shall be void being contrary to Section 27 of the ICA."[^varun-tyagi-void]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not try to save a post-employment non-compete by trimming its duration, shrinking its territory, or attaching a payment. None of those moves brings an Indian covenant within Section 27, because the statute has no reasonableness gateway for post-term restraints — the covenant is void either way [^krishan-murgai-no-reasonableness][^q2-percept-s27].
+
+## Can an Indian employer restrict competition during employment? {#during-employment}
+
+**Short answer.** Yes. A negative covenant that binds an employee to serve the employer exclusively *during* the employment is not treated as a restraint of trade and does not fall under Section 27, and a court may, in its discretion, enjoin breach of that negative promise under Section 42 of the Specific Relief Act, 1963 [^golikari-in-term][^sra-s42].
+
+The Supreme Court drew the during- versus post-employment line in *Niranjan Shankar Golikari v. Century Spinning & Mfg. Co.*, holding that an in-term exclusive-service covenant is outside Section 27 [^golikari-in-term].
+
+"Negative covenants operative during the period of the contract of employment when the employee is bound to serve his employer exclusively are generally not regarded as restraint of trade and therefore do not fall under section 27 of the Contract Act."[^golikari-in-term]
+
+The Court was explicit that timing is what changes the analysis — the objections that defeat a covenant after employment ends do not apply while the contract is still running [^q3-golikari-distinction].
+
+"The result of the above discussion is that considerations against restrictive covenants are different in cases where the restriction is to apply during the period after the termination of the contract than those in cases where it is to operate during the period of the contract."[^q3-golikari-distinction]
+
+The same distinction reaches beyond employment. In *Gujarat Bottling Co. v. Coca Cola Co.*, the Supreme Court upheld an in-term exclusive-dealing covenant in a commercial franchise, reasoning that a restriction confined to the life of the contract is not a restraint of trade — and *Percept* confirms the doctrine is not limited to employment contracts [^gujarat-in-term][^q3-percept-not-confined].
+
+"As held by this Court in Gujarat Bottling vs. Coca Cola (supra), this doctrine is not confined only to contracts of employment, but is also applicable to all other contracts."[^q3-percept-not-confined]
+
+The procedural mechanism is Section 42 of the Specific Relief Act, which lets a court enjoin breach of a negative covenant even though it cannot order the affirmative service to be performed — though that relief is discretionary and conditioned on the plaintiff's own performance of the contract [^sra-s42].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> An in-term exclusivity or *whole-time service* covenant is enforceable, but it must be confined to the period the employment or contract is actually running — the moment it purports to operate after the relationship ends, it crosses into Section 27 and is void. Draft the obligation to expire with the contract, and rely on Section 42 of the Specific Relief Act for an injunction during the term [^golikari-in-term][^sra-s42].
+
+## Are customer and employee non-solicitation clauses enforceable in India? {#non-solicitation}
+
+**Short answer.** Sometimes — a targeted non-solicitation clause is more defensible than a non-compete, but the outcome is fact-sensitive. Indian courts have upheld a non-solicitation-of-employees clause as a restriction on the contracting *parties* rather than on the employees, and have granted only narrow injunctions against soliciting a former employer's customers — but they will not let a *confidentiality* or non-solicitation theory become a monopoly over the departing worker's clients [^wipro-not-hit][^desiccant-injunction][^amex-monopoly].
+
+On employee non-solicitation, the Delhi High Court in *Wipro Ltd. v. Beckman Coulter International* treated a clause barring one company from soliciting the other's staff as a restriction on the companies, not on the employees, so it fell outside Section 27 [^wipro-parties][^wipro-not-hit].
+
+"In my view, therefore, the non-solicitation clause does not amount to a restraint of trade, business or profession and would not be hit by Section 27 of the Indian Contract Act, 1872 as being void."[^wipro-not-hit]
+
+Critically, the remedy is a claim against the contracting party, not an order preventing the employees themselves from being hired [^wipro-remedy].
+
+"The remedy lies in the claim for damages and an injunction against solicitation in future."[^wipro-remedy]
+
+The setting matters: *Wipro* arose between two contracting *companies*, so it most directly supports a business-to-business non-solicitation clause. An employer's clause aimed at its *own* departing employee is on weaker ground and is read against the right-to-livelihood limit below.
+
+On customer non-solicitation, the relief Indian courts will grant is narrow. In *Desiccant Rotors International v. Bappaditya Sarkar*, the Delhi High Court refused to bar a former employee from working for a competitor at all; the only restraint it imposed was an injunction against approaching the plaintiff's own suppliers and customers [^desiccant-injunction], and even then it stressed that the employee's right to livelihood prevails over the employer's wish to be free of competition [^desiccant-livelihood].
+
+"It is this attempt to protect themselves from competition which clashes with the right of the employees to seek employment where so ever they choose and in a clash like this, it is clear that the right of livelihood of the latter must prevail."[^desiccant-livelihood]
+
+The outer limit is set by *American Express Bank v. Priya Puri*, where the Delhi High Court rejected the idea that an employer can lock up its customer base through a former employee [^amex-monopoly].
+
+"In my opinion no Bank should be allowed to create monopolies on the ground that they have developed exhaustive data of their clients/customers."[^amex-monopoly]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> A *narrowly drawn* non-solicitation clause is the more defensible cousin of a non-compete in India, but do not over-read it. An employee non-solicitation clause is enforced against the contracting party as damages or an anti-solicitation injunction, never as a no-hire bar on the workers; and a customer non-solicitation clause cannot be stretched into a *de facto* non-compete that fences off the former employee's livelihood [^wipro-remedy][^desiccant-livelihood].
+
+## Is garden leave enforceable in India? {#garden-leave}
+
+**Short answer.** Only during the notice period, while the employee is still on the rolls. Garden leave inside the notice period works as an *in-term* exclusive-service covenant, which Section 27 does not reach [^q5-golikari-in-term]; but a *garden leave* clause that operates after the employee has ceased employment is prima facie in restraint of trade and hit by Section 27 — even though the employer keeps paying — because it stops the former employee from working elsewhere [^vfs-garden-leave][^vfs-obstruct].
+
+In *VFS Global Services v. Suprit Roy*, the Bombay High Court considered a clause requiring a departed employee to sit out a period after leaving, with pay, and held it to be a post-cessation restraint that Section 27 voids [^vfs-garden-leave].
+
+"The Garden Leave Clause is therefore, prima facie in restraint of trade and is hit by Section 27 of the Contract Act."[^vfs-garden-leave]
+
+The court's reasoning was that paying a former employee to stay idle is still an obstruction of their ability to earn a living elsewhere [^vfs-obstruct].
+
+"To obstruct on employee who has left service from obtaining gainful employment elsewhere is not fair or proper."[^vfs-obstruct]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Structure garden leave as part of the *notice period* — the employee remains employed, on payroll, and bound by in-term duties — rather than as a sit-out that begins after employment ends. A garden-leave obligation that runs after cessation functions as a post-term non-compete and is void under Section 27, and adding a salary does not cure it [^vfs-garden-leave][^vfs-obstruct].
+
+## Are employment bonds and minimum-service clauses enforceable in India? {#employment-bonds}
+
+**Short answer.** Yes, when they recover a genuine cost rather than penalize departure. A minimum-service clause backed by liquidated damages is not a restraint of trade under Section 27 — the Supreme Court held in 2025 that such a clause furthers the employment relationship instead of restraining future work — and any recovery is capped at *reasonable compensation* under Section 74 of the Contract Act [^vijaya-furtherance][^stat-s74].
+
+In *Vijaya Bank v. Prashant B. Narnaware*, decided in May 2025, the Supreme Court upheld a clause requiring an employee either to serve a minimum term or pay a fixed sum, reasoning that the obligation operated within the employment rather than restricting later employment [^vijaya-furtherance].
+
+"The object of the restrictive covenant was in furtherance of the employment contract and not to restrain future employment."[^vijaya-furtherance]
+
+The Court concluded that the bond was neither a restraint of trade nor contrary to public policy [^vijaya-holding].
+
+"In light of the aforesaid discussion, we are of the view the restrictive covenant in clause 11(k) of the appointment letter does not amount to restraint of trade nor is it opposed to public policy."[^vijaya-holding]
+
+The clause in *Vijaya Bank* arose in a public-sector bank and required either a three-year minimum service or payment of a fixed sum; the Court treated that sum as reasonable compensation for the employer's retention interest and the real cost and burden of fresh recruitment, not as a penalty calibrated to deter resignation.
+
+A bond is a damages mechanism, not a penalty, and Section 74 limits what the employer can actually recover to reasonable compensation not exceeding the stipulated sum [^stat-s74].
+
+"the party complaining of the breach is entitled, whether or not actual damage or loss is proved to have been caused thereby, to receive from the party who has broken the contract reasonable compensation not exceeding the amount so named or, as the case may be, the penalty stipulated for."[^stat-s74]
+
+> [!NOTE]
+> **Practice note.**
+>
+> Tie an employment bond to a legitimate, documented interest — recruitment, replacement, or training expense the employer actually incurred — and keep the stipulated sum proportionate and amortized over the service period, so that leaving early is not made illusory. A bond pegged to a real pre-estimated expense recovers reasonable compensation under Section 74; a round-number *penalty* set only to deter resignation, untethered from any cost, is liable to be cut down or struck as unreasonable. Because *Vijaya Bank* arose in a public-sector setting, a private employer should be ready to evidence the cost or operational loss its bond recovers [^vijaya-furtherance][^stat-s74].
+
+## Is there a sale-of-business or goodwill exception to India's non-compete ban? {#sale-of-business}
+
+**Short answer.** Yes, but it is narrow. Exception 1 to Section 27 lets someone who sells the *goodwill* of a business agree not to compete within reasonable local limits while the buyer carries on a like business, and the Indian Partnership Act, 1932 adds express *notwithstanding Section 27* carve-outs for partners — covering both an outgoing partner's restraint and restraints made on dissolution. A purely financial or minority-investor exit, with no goodwill transferred, does not qualify [^stat-s27-exception1][^partnership-s36][^partnership-s54].
+
+Exception 1 is the one statutory escape from the Section 27 ban, and it exists so a buyer can protect the goodwill it pays for [^stat-s27-exception1].
+
+"One who sells the good-will of a business may agree with the buyer to refrain from carrying on a similar business, within specified local limits, so long as the buyer, or any person deriving title to the good-will from him, carries on a like business therein, provided that such limits appear to the Court reasonable, regard being had to the nature of the business."[^stat-s27-exception1]
+
+Parliament added parallel exceptions for partnerships, which underscores how the rule works: a restraint is valid only where the statute expressly says so. The Partnership Act validates a restraint on an *outgoing* partner — the closest analogue to a departing stakeholder — where the limits are reasonable [^partnership-s36], and a like restraint among partners on dissolution [^partnership-s54].
+
+"Partners may, upon or in anticipation of the dissolution of the firm, make an agreement that some or all of them will not carry on a business similar to that of the firm within a specified period or within specified local limits; and notwithstanding anything contained in section 27 of the Indian Contract Act, 1872 (9 of 1872), such agreement shall be valid if the restrictions imposed are reasonable."[^partnership-s54]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Tie a sale-of-business non-compete to the goodwill actually sold, keep it within reasonable local limits, and place it in the purchase agreement — not the seller's employment contract. A covenant bootstrapped onto continued employment, or imposed on a founder who keeps only a minority financial stake without transferring goodwill, falls outside Exception 1 and is void under Section 27 [^stat-s27-exception1][^partnership-s54].
+
+## What can an Indian employer protect instead of a non-compete? {#what-to-protect}
+
+**Short answer.** Genuine confidential information, targeted non-solicitation, in-term exclusivity, garden leave during notice, and cost-based bonds — applied to employees and to independent contractors alike, because Section 27 reaches non-employment contracts too. A confidentiality clause that protects real trade secrets is enforceable, but it cannot be written so broadly that it bars the former employee from working in their field [^vfs-confidentiality][^amex-freedom].
+
+India has no standalone trade-secrets statute, so protection is built from contract and the equitable action for breach of confidence. The Bombay High Court confirmed in *VFS Global* that a clause protecting genuine commercial or trade secrets is not a restraint of trade [^vfs-confidentiality].
+
+"A clause prohibiting an employee from disclosing commercial or trade secrets is not in restraint of trade."[^vfs-confidentiality]
+
+The boundary is that confidentiality cannot be used as a back-door non-compete. *American Express Bank v. Priya Puri* held that an employee's freedom to move for a better position is a vital right that an employer cannot curtail by labelling ordinary customer information *confidential* [^amex-freedom].
+
+"Freedom of changing employment for improving service conditions is a vital and important right of an employee which cannot be restricted or curtailed on the ground that the employee has employer's data and confidential information of customers which is capable of ascertainment on behalf of defendant or any one else, by an independent canvass at a small expense and in a very limited period of time."[^amex-freedom]
+
+Because Section 27 applies to all contracts, not just employment, an employer cannot escape the ban by engaging a worker as a consultant or independent contractor — the same rules govern, as Section 27's reach in *Percept* (an agency contract) and *Gujarat Bottling* (a franchise) confirms [^q8-percept-not-confined]. These freedoms are reinforced by the constitutional right to practise any profession or carry on any trade or business [^const-art19].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Build the protection program around what Indian law actually enforces: a confidentiality clause tied to identifiable trade secrets, a narrow non-solicitation clause, in-term exclusivity, garden leave inside the notice period, and a cost-based bond — used consistently for employees and contractors. Do not define *confidential information* so broadly that it sweeps in the worker's general skill and experience, which would make the clause a *de facto* non-compete and void under Section 27 [^vfs-confidentiality][^amex-freedom].
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-03. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not India. This article synthesizes India primary law and is not legal advice from a India-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^stat-s27-void]: **Indian Contract Act, 1872, § 27** — "Every agreement by which any one is restrained from exercising a lawful profession, trade or business of any kind, is to that extent void." *Indian Contract Act, 1872, § 27.* <https://www.indiacode.nic.in/bitstream/123456789/2187/2/A187209.pdf>
+
+[^krishan-murgai-void]: **Superintendence Co. of India (P) Ltd. v. Krishan Murgai** — "Under Section 27 of the Contract Act, a service covenant extended beyond the termination of the service is void." *Superintendence Co. of India (P) Ltd. v. Krishan Murgai, (1981) 2 SCC 246.* <https://indiankanoon.org/doc/1186410/>
+
+[^percept-settled]: **Percept D'Mark (India) Pvt. Ltd. v. Zaheer Khan** — "The legal position with regard to post-contractual covenants or restrictions has been consistent, unchanging and completely settled in our country." *Percept D'Mark (India) Pvt. Ltd. v. Zaheer Khan, (2006) 4 SCC 227.* <https://indiankanoon.org/doc/571375/>
+
+[^krishan-murgai-no-reasonableness]: **Superintendence Co. of India (P) Ltd. v. Krishan Murgai** — "Neither the test of reasonableness nor the principle of that the restraint being partial was reasonable are applicable to a case governed by Section 27 of the Contract Act, unless it falls within Exception 1." *Superintendence Co. of India (P) Ltd. v. Krishan Murgai, (1981) 2 SCC 246.* <https://indiankanoon.org/doc/1186410/>
+
+[^q2-percept-s27]: **Percept D'Mark (India) Pvt. Ltd. v. Zaheer Khan** — "Under Section 27 of the Contract Act (a) a restrictive covenant extending beyond the term of the contract is void and not enforceable." *Percept D'Mark (India) Pvt. Ltd. v. Zaheer Khan, (2006) 4 SCC 227.* <https://indiankanoon.org/doc/571375/>
+
+[^varun-tyagi-void]: **Varun Tyagi v. Daffodil Software Pvt. Ltd.** — "In view of the above, it is clear that any terms of the employment contract that imposes a restriction on right of the employee to get employed post-termination of the contract of employment shall be void being contrary to Section 27 of the ICA." *Varun Tyagi v. Daffodil Software Pvt. Ltd., FAO 167/2025 (Delhi High Court, June 25, 2025).* <https://indiankanoon.org/doc/187332526/>
+
+[^golikari-in-term]: **Niranjan Shankar Golikari v. Century Spinning & Mfg. Co.** — "Negative covenants operative during the period of the contract of employment when the employee is bound to serve his employer exclusively are generally not regarded as restraint of trade and therefore do not fall under section 27 of the Contract Act." *Niranjan Shankar Golikari v. Century Spinning & Mfg. Co., AIR 1967 SC 1098.* <https://indiankanoon.org/doc/452434/>
+
+[^sra-s42]: **Specific Relief Act, 1963, § 42** — "Notwithstanding anything contained in clause (e) of section 41, where a contract comprises an affirmative agreement to do a certain act, coupled with a negative agreement, express or implied, not to do a certain act, the circumstance that the court is unable to compel specific performance of the affirmative agreement shall not preclude it from granting an injunction to perform the negative agreement: Provided that the plaintiff has not failed to perform the contract so far as it is binding on him." *Specific Relief Act, 1963, § 42.* <https://www.indiacode.nic.in/bitstream/123456789/1583/7/A1963-47.pdf>
+
+[^q3-golikari-distinction]: **Niranjan Shankar Golikari v. Century Spinning & Mfg. Co.** — "The result of the above discussion is that considerations against restrictive covenants are different in cases where the restriction is to apply during the period after the termination of the contract than those in cases where it is to operate during the period of the contract." *Niranjan Shankar Golikari v. Century Spinning & Mfg. Co., AIR 1967 SC 1098.* <https://indiankanoon.org/doc/452434/>
+
+[^gujarat-in-term]: **Gujarat Bottling Co. Ltd. v. Coca Cola Co.** — "Since the negatice stipulation in paragraph 14 of the 1993 Agreement is confined in its application to the period of subsistence of the agreement and the restriction imposed therein is operative only during the period the 1993 Agreement is subsisting, the said stipulation cannot be held to be in restraint of trade so as to attract the bar of section 27 of the Contract Act." *Gujarat Bottling Co. Ltd. v. Coca Cola Co., (1995) 5 SCC 545.* <https://indiankanoon.org/doc/104935066/>
+
+[^q3-percept-not-confined]: **Percept D'Mark (India) Pvt. Ltd. v. Zaheer Khan** — "As held by this Court in Gujarat Bottling vs. Coca Cola (supra), this doctrine is not confined only to contracts of employment, but is also applicable to all other contracts." *Percept D'Mark (India) Pvt. Ltd. v. Zaheer Khan, (2006) 4 SCC 227.* <https://indiankanoon.org/doc/571375/>
+
+[^wipro-not-hit]: **Wipro Ltd. v. Beckman Coulter International S.A.** — "In my view, therefore, the non-solicitation clause does not amount to a restraint of trade, business or profession and would not be hit by Section 27 of the Indian Contract Act, 1872 as being void." *Wipro Ltd. v. Beckman Coulter International S.A., 131 (2006) DLT 681 (Delhi HC).* <https://indiankanoon.org/doc/647033/>
+
+[^desiccant-injunction]: **Desiccant Rotors International Pvt. Ltd. v. Bappaditya Sarkar** — "The injunction only restrains Defendant No. 1 from approaching the plaintiff‟s suppliers and customers for soliciting business which is in direct competition with the business of the plaintiff." *Desiccant Rotors International Pvt. Ltd. v. Bappaditya Sarkar, CS(OS) No. 337/2008 (Delhi HC, 2009).* <https://indiankanoon.org/doc/175180860/>
+
+[^amex-monopoly]: **American Express Bank Ltd. v. Priya Puri** — "In my opinion no Bank should be allowed to create monopolies on the ground that they have developed exhaustive data of their clients/customers." *American Express Bank Ltd. v. Priya Puri, (2006) III LLJ 540 (Delhi HC).* <https://indiankanoon.org/doc/445135/>
+
+[^wipro-parties]: **Wipro Ltd. v. Beckman Coulter International S.A.** — "It is a restriction cast upon the contracting parties and not on the employees." *Wipro Ltd. v. Beckman Coulter International S.A., 131 (2006) DLT 681 (Delhi HC).* <https://indiankanoon.org/doc/647033/>
+
+[^wipro-remedy]: **Wipro Ltd. v. Beckman Coulter International S.A.** — "The remedy lies in the claim for damages and an injunction against solicitation in future." *Wipro Ltd. v. Beckman Coulter International S.A., 131 (2006) DLT 681 (Delhi HC).* <https://indiankanoon.org/doc/647033/>
+
+[^desiccant-livelihood]: **Desiccant Rotors International Pvt. Ltd. v. Bappaditya Sarkar** — "It is this attempt to protect themselves from competition which clashes with the right of the employees to seek employment where so ever they choose and in a clash like this, it is clear that the right of livelihood of the latter must prevail." *Desiccant Rotors International Pvt. Ltd. v. Bappaditya Sarkar, CS(OS) No. 337/2008 (Delhi HC, 2009).* <https://indiankanoon.org/doc/175180860/>
+
+[^q5-golikari-in-term]: **Niranjan Shankar Golikari v. Century Spinning & Mfg. Co.** — "Negative covenants operative during the period of the contract of employment when the employee is bound to serve his employer exclusively are generally not regarded as restraint of trade and therefore do not fall under section 27 of the Contract Act." *Niranjan Shankar Golikari v. Century Spinning & Mfg. Co., AIR 1967 SC 1098.* <https://indiankanoon.org/doc/452434/>
+
+[^vfs-garden-leave]: **VFS Global Services Pvt. Ltd. v. Suprit Roy** — "The Garden Leave Clause is therefore, prima facie in restraint of trade and is hit by Section 27 of the Contract Act." *VFS Global Services Pvt. Ltd. v. Suprit Roy, 2008 (2) Bom CR 446 (Bombay HC).* <https://indiankanoon.org/doc/1547420/>
+
+[^vfs-obstruct]: **VFS Global Services Pvt. Ltd. v. Suprit Roy** — "To obstruct on employee who has left service from obtaining gainful employment elsewhere is not fair or proper." *VFS Global Services Pvt. Ltd. v. Suprit Roy, 2008 (2) Bom CR 446 (Bombay HC).* <https://indiankanoon.org/doc/1547420/>
+
+[^vijaya-furtherance]: **Vijaya Bank v. Prashant B. Narnaware** — "The object of the restrictive covenant was in furtherance of the employment contract and not to restrain future employment." *Vijaya Bank v. Prashant B. Narnaware, 2025 INSC 691.* <https://indiankanoon.org/doc/42763766/>
+
+[^stat-s74]: **Indian Contract Act, 1872, § 74** — "the party complaining of the breach is entitled, whether or not actual damage or loss is proved to have been caused thereby, to receive from the party who has broken the contract reasonable compensation not exceeding the amount so named or, as the case may be, the penalty stipulated for." *Indian Contract Act, 1872, § 74.* <https://www.indiacode.nic.in/bitstream/123456789/2187/2/A187209.pdf>
+
+[^vijaya-holding]: **Vijaya Bank v. Prashant B. Narnaware** — "In light of the aforesaid discussion, we are of the view the restrictive covenant in clause 11(k) of the appointment letter does not amount to restraint of trade nor is it opposed to public policy." *Vijaya Bank v. Prashant B. Narnaware, 2025 INSC 691.* <https://indiankanoon.org/doc/42763766/>
+
+[^stat-s27-exception1]: **Indian Contract Act, 1872, § 27 (Exception 1)** — "One who sells the good-will of a business may agree with the buyer to refrain from carrying on a similar business, within specified local limits, so long as the buyer, or any person deriving title to the good-will from him, carries on a like business therein, provided that such limits appear to the Court reasonable, regard being had to the nature of the business." *Indian Contract Act, 1872, § 27, Exception 1.* <https://www.indiacode.nic.in/bitstream/123456789/2187/2/A187209.pdf>
+
+[^partnership-s36]: **Indian Partnership Act, 1932, § 36(2)** — "A partner may make an agreement with his partners that on ceasing to be a partner he will not carry on any business similar to that of the firm within a specified period or within specified local limits; and, notwithstanding anything contained in section 27 of the Indian Contract Act, 1872 (9 of 1872), such agreement shall be valid if the restrictions imposed are reasonable." *Indian Partnership Act, 1932, § 36(2).* <https://www.indiacode.nic.in/bitstream/123456789/19863/1/indian_partnership_act_1932.pdf>
+
+[^partnership-s54]: **Indian Partnership Act, 1932, § 54** — "Partners may, upon or in anticipation of the dissolution of the firm, make an agreement that some or all of them will not carry on a business similar to that of the firm within a specified period or within specified local limits; and notwithstanding anything contained in section 27 of the Indian Contract Act, 1872 (9 of 1872), such agreement shall be valid if the restrictions imposed are reasonable." *Indian Partnership Act, 1932, § 54.* <https://www.indiacode.nic.in/bitstream/123456789/19863/1/indian_partnership_act_1932.pdf>
+
+[^vfs-confidentiality]: **VFS Global Services Pvt. Ltd. v. Suprit Roy** — "A clause prohibiting an employee from disclosing commercial or trade secrets is not in restraint of trade." *VFS Global Services Pvt. Ltd. v. Suprit Roy, 2008 (2) Bom CR 446 (Bombay HC).* <https://indiankanoon.org/doc/1547420/>
+
+[^amex-freedom]: **American Express Bank Ltd. v. Priya Puri** — "Freedom of changing employment for improving service conditions is a vital and important right of an employee which cannot be restricted or curtailed on the ground that the employee has employer's data and confidential information of customers which is capable of ascertainment on behalf of defendant or any one else, by an independent canvass at a small expense and in a very limited period of time." *American Express Bank Ltd. v. Priya Puri, (2006) III LLJ 540 (Delhi HC).* <https://indiankanoon.org/doc/445135/>
+
+[^q8-percept-not-confined]: **Percept D'Mark (India) Pvt. Ltd. v. Zaheer Khan** — "As held by this Court in Gujarat Bottling vs. Coca Cola (supra), this doctrine is not confined only to contracts of employment, but is also applicable to all other contracts." *Percept D'Mark (India) Pvt. Ltd. v. Zaheer Khan, (2006) 4 SCC 227.* <https://indiankanoon.org/doc/571375/>
+
+[^const-art19]: **Constitution of India, art. 19(1)(g)** — "All citizens shall have the right— (g) to practise any profession, or to carry on any occupation, trade or business." *Constitution of India, art. 19(1)(g).* <https://www.indiacode.nic.in/bitstream/123456789/16124/1/the_constitution_of_india.pdf>

--- a/skills/non-compete-contract-explainer/content/indiana.md
+++ b/skills/non-compete-contract-explainer/content/indiana.md
@@ -1,0 +1,253 @@
+---
+jurisdiction: "Indiana"
+slug: indiana
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-03"
+canonicalUrl: https://openagreements.org/legal/non-compete/indiana
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/indiana · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in Indiana[^about]
+
+Indiana enforces non-competes only when they are reasonable and protect a legitimate interest, applies a strict eraser-style blue pencil, and bans most physician-hospital covenants by statute.
+
+
+## At a glance
+
+| Question | Indiana |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed if reasonable |
+| **Bottom line** | Indiana enforces a non-compete only if the employer proves it is reasonable in time, activity, and geography and protects a legitimate interest; courts disfavor them and use a strict eraser blue pencil. |
+| **Main law or case** | common law (Central Indiana Podiatry, P.C. v. Krueger, 882 N.E.2d 723 (Ind. 2008)) |
+| **Main exceptions** | Physician-hospital covenants banned (SEA 475, 2025); primary-care physician non-competes banned (SEA 7, 2023); physician covenants must meet HEA 1004 |
+| **Can a court narrow it?** | Only strikes wording |
+| **Applies to contractors?** | Unclear |
+| **Restriction extended during a breach?** | Unsettled |
+| **Maximum length set by law** | No statutory limit |
+
+## Are employee non-compete agreements enforceable in Indiana? {#employee-noncompetes}
+
+**Short answer.** Yes, sometimes. Indiana is a reasonableness state, not a general ban state for the ordinary workforce. Courts disfavor non-competes as restraints of trade, construe them strictly against the employer, and enforce them only when the restraint is reasonable and protects a legitimate business interest [^krueger-strict-construction][^dicen-disfavored].
+
+There is no general Indiana statute governing non-competes for most employees; the enforceability analysis is judge-made. The Indiana Supreme Court has long treated these covenants as disfavored and read them narrowly, placing the burden on the employer to justify every restriction [^krueger-strict-construction]. The one large statutory exception — a layered set of restrictions on physician covenants — is covered later in this note.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not assume an Indiana covenant is enforceable just because the employee signed it. The employer carries the burden, courts construe the restraint strictly against the drafter, and an unreasonable restriction will not be enforced [^krueger-strict-construction].
+
+## What legitimate business interests can support an Indiana non-compete? {#protectable-interests}
+
+**Short answer.** Customer goodwill, established customer relationships, trade secrets, and confidential information are the recognized interests that can justify a tailored Indiana restraint. The employer must first prove it has such an interest before any restriction will be tested for reasonableness [^krueger-legitimate-interest].
+
+A covenant cannot exist only to insulate the employer from ordinary competition. An employee's general skills and routine industry knowledge are not protectable, so a restraint that simply keeps a former worker out of the market is void as against public policy. The protectable interest must be something the employer is entitled to guard — typically goodwill, customer relationships, or confidential information [^krueger-legitimate-interest].
+
+Indiana's Uniform Trade Secrets Act supplies a statutory overlay that runs alongside any covenant. It defines a trade secret by the twin tests of independent economic value from secrecy and reasonable efforts to keep it secret, and it displaces conflicting common law except contract law — so trade-secret remedies coexist with a contractual restraint or NDA rather than replacing it [^iutsa-trade-secret]. A confidentiality and trade-secret strategy is often the more durable protection, especially where a non-compete is unenforceable or, for hospital-employed physicians, statutorily void.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not draft an Indiana non-compete around a general wish to avoid competition. Identify the specific goodwill, customer relationship, or confidential information at stake, because the employer must prove a legitimate protectable interest before a court will even reach the reasonableness of time, activity, or geography [^krueger-legitimate-interest].
+
+## Is continued at-will employment enough consideration for an Indiana non-compete? {#consideration}
+
+**Short answer.** Yes. In Indiana, an employer's promise to continue an at-will employee's job is valid consideration for a non-compete signed during employment — even when the employee is told to sign the new covenant or be fired [^med1-consideration].
+
+The Indiana Court of Appeals settled this point in *Med-1 Solutions, LLC v. Taylor* (2024), confirming a longstanding rule: continued employment of an at-will worker supplies the consideration needed for a mid-employment restrictive covenant. No separate bonus, raise, or promotion is required [^med1-consideration]. This is a meaningful contrast with neighboring states that require new, independent consideration when an incumbent signs.
+
+Even so, consideration is only the threshold. In *Med-1 Solutions* itself the court still affirmed the denial of an injunction because the employer could not show the restraint was reasonable — so a covenant supported by continued employment can still fail on overbreadth.
+
+## What duration, geography, and activity scope are reasonable for an Indiana non-compete? {#duration-geography-scope}
+
+**Short answer.** There is no fixed cap. The employer bears the burden of proving the covenant is reasonable in time, activity, and geographic scope, and a restraint that bars working for a competitor in *any capacity* is routinely struck down as too broad [^krueger-scope-burden][^med1-any-capacity].
+
+Indiana courts evaluate the three dimensions together against the employer's real footprint and the employee's actual role. Duration should match the time needed to protect the interest; geography should track where the employer does business or where the employee held influence; and the restricted activity must relate to the work the employee actually performed [^krueger-scope-burden].
+
+The activity dimension is where covenants most often fail. In *Med-1 Solutions*, a clause that would have barred the employee from working for a competitor in *any capacity* — including roles unrelated to any protectable interest — was held unreasonably broad [^med1-any-capacity].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not bar a former employee from a competitor in *any capacity* or across business lines they never touched. Tie the restricted activity to the employee's actual role and the protected interest, because an Indiana court placed the burden on the employer and found exactly that kind of all-capacity restraint unreasonably broad [^med1-any-capacity].
+
+## Will an Indiana court blue-pencil or reform an overbroad non-compete? {#court-narrowing}
+
+**Short answer.** Only by deleting, never by rewriting. Indiana's blue-pencil doctrine is a strict eraser: a court may strike grammatically divisible unreasonable language, but it cannot add, change, or rearrange terms to save a covenant — even if the contract contains a clause inviting the court to do so [^heraeus-eraser][^heraeus-reformation-clause].
+
+The Indiana Supreme Court reaffirmed this in *Heraeus Medical, LLC v. Zimmer, Inc.* (2019). A court may excise offending words from a divisible covenant, but it may not rewrite the agreement, and a contractual reformation or modification clause does not expand that power [^heraeus-reformation-clause]. The blue pencil is available only where the covenant is *clearly divisible* and a reasonable restriction survives after the unreasonable parts are removed [^heraeus-divisibility].
+
+That divisibility requirement is decisive. In *Clark's Sales and Service, Inc. v. Smith*, an overbroad restriction that was written as an interconnected whole could not be saved, because there was no severable language a court could strike to leave a reasonable covenant behind [^clarks-indivisible].
+
+"The doctrine, however, does not allow a court to rewrite a noncompetition agreement by adding, changing, or rearranging terms."[^heraeus-eraser]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not rely on a reformation or savings clause to rescue an aggressive Indiana covenant — it is a dead letter. Draft narrow, severable restrictions from the start, because an Indiana court will only erase divisible offending language and will void an indivisible overbroad covenant entirely [^heraeus-reformation-clause][^clarks-indivisible].
+
+## Are customer non-solicitation and employee no-hire clauses enforceable in Indiana? {#non-solicitation}
+
+**Short answer.** They are analyzed under the same reasonableness and eraser rules as non-competes. A no-hire clause barring solicitation of *all* of the former employer's workers is overbroad and unenforceable; it must be narrowed to employees in whom the company has a genuine protectable interest [^heraeus-nosolicit-overbroad].
+
+In *Heraeus*, an employee non-solicitation covenant failed because it reached every company employee, not just those tied to a protectable interest [^heraeus-nosolicit-overbroad]. The same reasonableness analysis governs customer non-solicitation. Because any restraint must be tied to a legitimate protectable interest, a customer restriction is on firmer ground when limited to customers the employee actually served or about whom the employee held confidential information, and weaker when it sweeps in all customers regardless of contact [^q6-krueger-interest].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not draft a no-hire clause that covers *any* or *all* employees of the company. Limit it to workers who hold confidential information or specialized value, because Indiana voided a blanket employee non-solicitation covenant as overbroad and the eraser rule will not rewrite it for you [^heraeus-nosolicit-overbroad].
+
+## Are liquidated-damages clauses in Indiana non-competes enforceable? {#liquidated-damages}
+
+**Short answer.** Only if they are a reasonable measure of anticipated loss. Indiana courts will treat a liquidated-damages provision as an unenforceable penalty when the stipulated sum is grossly disproportionate to the loss from the breach or sweeps in too much conduct [^amconsulting-penalty].
+
+In *American Consulting, Inc. v. Hannum Wagle & Cline Engineering, Inc.* (2019), the Indiana Supreme Court struck the liquidated-damages provisions at issue as penalties, finding them too broad to function as a reasonable estimate of damages [^amconsulting-penalty][^amconsulting-holding]. Because injunctive relief can be hard to obtain when a covenant's reasonableness is contested, employers often lean on liquidated damages — but an aggressive number that bears no relation to actual loss is itself a litigation risk.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not set a flat, oversized liquidated-damages figure as a non-compete enforcement substitute. Tie any stipulated sum to a reasonable estimate of anticipated loss, because Indiana struck liquidated-damages provisions that were grossly disproportionate and captured too much conduct as unenforceable penalties [^amconsulting-penalty].
+
+## Can an employer use a choice-of-law clause or fee-shifting to strengthen an Indiana covenant? {#choice-of-law-and-fees}
+
+**Short answer.** Only within limits. Indiana generally honors a forum or choice-of-law clause, but a contract for the improvement of Indiana real estate may not be made subject to another state's law or require out-of-state dispute resolution, and attorney's fees are available mainly for bad-faith or groundless litigation [^forum-void-construction][^fees-bad-faith].
+
+Employers sometimes try to escape Indiana's strict eraser rule by routing disputes to a more covenant-friendly state through a choice-of-law or forum clause. That tactic has a statutory limit in the construction context: for a contract to improve Indiana real estate, a provision making the contract subject to another state's law — or requiring litigation, arbitration, or other dispute resolution to occur in another state — is void [^forum-void-construction].
+
+On costs, Indiana follows the American Rule. A court may shift attorney's fees to the prevailing party only when the opponent's claim or defense was frivolous, unreasonable, or groundless, or was litigated in bad faith [^fees-bad-faith]. In practice, parties contract around the default with a prevailing-party fee clause, which Indiana courts routinely enforce.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not assume a foreign choice-of-law or forum clause will carry an Indiana covenant dispute. For a contract to improve Indiana real estate the clause is void by statute, and absent a contractual fee provision, attorney's fees are recoverable only for frivolous or bad-faith litigation [^forum-void-construction][^fees-bad-faith].
+
+## Does an Indiana non-compete toll or extend during breach or litigation? {#tolling-extension}
+
+**Short answer.** This is an open Indiana question. No Indiana statute or precedential appellate decision squarely endorses automatically tolling or extending the restricted period while the former employee is in breach or while litigation is pending [^q8-krueger-reasonableness][^q8-heraeus-eraser].
+
+Two features of Indiana law cut against assuming an extension will be enforced. First, any clause that lengthens the restricted period is still part of the covenant and must satisfy the same reasonableness test, with the burden on the employer; an automatic, open-ended extension risks being found unreasonable [^q8-krueger-reasonableness]. Second, because Indiana courts may only erase divisible language and cannot rewrite a covenant, a court is unlikely to manufacture extra time that the contract did not clearly and reasonably provide [^q8-heraeus-eraser].
+
+A contractual extension-on-breach clause is therefore unsettled and fact-dependent in Indiana. It is most defensible when drafted as a separate, reasonable provision tied to the duration of an actual breach, rather than as an automatic or indefinite tolling of the clock.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Open question: Indiana law is unsettled on whether a tolling or extension-on-breach clause is enforceable after the original period expires. Draft any such clause narrowly and tie it to the actual breach, and do not assume an Indiana court will add time to an expired covenant, because the courts can only erase — not rewrite — covenant language [^q8-heraeus-eraser].
+
+## Are non-competes tied to the sale of a business treated differently in Indiana? {#sale-of-business}
+
+**Short answer.** Yes. A covenant ancillary to the sale of a business — or to an owner's sale of an equity interest — is judged under a more liberal standard than an ordinary employment covenant, because the buyer is paying for goodwill that the seller could otherwise destroy [^dicen-sale-liberal][^zollinger-sale-standard].
+
+Indiana applies the skeptical, employer-disfavoring standard to employment covenants but a more lenient one to sale-ancillary restraints [^zollinger-sale-standard]. The Indiana Supreme Court explained in *Dicen* that sale-of-business promises are enforced on a more liberal basis than employment covenants [^dicen-sale-liberal], and the Court of Appeals applied that lenient standard in *Zollinger v. Wagner-Meinert Engineering, LLC* to an owner who sold his interest. The reason is goodwill: the Seventh Circuit, applying Indiana law in *E.T. Products, LLC v. D.E. Miller Holdings, Inc.*, upheld a broad sale covenant precisely to protect the goodwill the buyer purchased [^etproducts-goodwill].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not analyze a sale-of-business or equity-sale covenant under the strict employment standard, in either direction. The seller faces a more liberal, buyer-favoring standard that tolerates broader restraints, so a covenant that would fail as an employment clause may well be enforced when it is ancillary to a sale [^zollinger-sale-standard][^etproducts-goodwill].
+
+## What special non-compete rules apply to Indiana physicians? {#physicians}
+
+**Short answer.** Indiana regulates physician non-competes by statute in three layers, each keyed to when the agreement was entered. For agreements entered on or after July 1, 2020, an enforceable physician covenant must include specified provisions, including a buyout option at a reasonable price; primary care physician non-competes entered on or after July 1, 2023 are banned outright; and physician-hospital non-competes entered on or after July 1, 2025 are void [^hea1004-requirements][^sea7-primary-care-ban][^sea475-hospital-ban].
+
+The 2020 baseline (House Enrolled Act 1004) created Indiana Code chapter 25-22.5-5.5, which applies to physician noncompetes entered on or after July 1, 2020 and makes every such covenant conditional on mandatory contract terms [^hea1004-requirements]. Among those terms, the physician must be given the option to purchase a complete and final release from the covenant at a reasonable price — a term the statute does not define, which has become a recurring point of dispute [^sea7-buyout].
+
+The 2023 amendments (Senate Enrolled Act 7) went further. They banned non-competes for primary care physicians entered on or after July 1, 2023 [^sea7-primary-care-ban], and made other physician covenants within the chapter unenforceable when, for example, the employer terminates the physician without cause [^sea7-without-cause].
+
+The 2025 amendment (Senate Enrolled Act 475) is the most sweeping. Effective July 1, 2025, a physician and a hospital, a parent company of a hospital, an affiliated manager of a hospital, or a hospital system may not enter a non-compete, and any agreement that violates the ban is void and unenforceable [^sea475-hospital-ban]. The ban reaches new agreements only — it does not invalidate covenants originally entered before July 1, 2025 — and it preserves trade-secret NDAs, a narrow non-solicitation of current employees lasting no more than one year (which may not restrict patient interactions, patient referrals, clinical collaboration, or the physician's professional relationships), and covenants tied to a physician's sale of a practice they majority-owned.
+
+"Any agreement in violation of this section is void and unenforceable."[^sea475-hospital-ban]
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not assume the 2025 ban covers every Indiana doctor. Senate Enrolled Act 475 reaches physicians employed by hospitals and hospital systems entering new covenants on or after July 1, 2025; private-practice groups remain subject instead to the 2020 requirements and the 2023 primary-care ban, so the rule depends on the execution date, the physician type, and the employer entity [^sea475-hospital-ban][^sea7-primary-care-ban].
+
+## Do low-wage or hourly Indiana workers have a special non-compete exemption? {#other-workers}
+
+**Short answer.** No. Indiana has not enacted any wage-threshold or hourly-worker exemption. Outside the physician statutes, every employee — regardless of income — is governed by the common-law reasonableness and protectable-interest analysis [^q11-dicen-common-law].
+
+A persistent online myth claims that Indiana Code 22-5-8-1 exempts low-wage workers from non-competes. That is false: section 22-5-8-1 is part of the chapter prohibiting the forced implantation of devices (microchips) in employees and has nothing to do with restrictive covenants. No enacted Indiana law protects low-wage workers from non-competes [^q11-dicen-common-law].
+
+Reform has been proposed but not enacted. In the 2026 session, Senate Bill 132 would have voided non-competes for employees earning less than $150,000 a year, and House Bill 1054 targeted certain plumbing-trade covenants — but both received only a first reading and did not advance out of committee before the session adjourned. They signal possible future direction, not current law; recheck the Indiana General Assembly each session.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not tell an Indiana worker or employer that low-wage employees are statutorily exempt from non-competes. No such exemption exists; the often-cited Indiana Code 22-5-8-1 is the device-implantation statute, and the 2026 wage-threshold bill did not pass, so ordinary workers remain under the common-law reasonableness test [^q11-dicen-common-law].
+
+## Did the FTC's federal non-compete rule change Indiana non-compete law? {#federal-ftc-overlay}
+
+**Short answer.** No. The FTC's 2024 nationwide Non-Compete Rule was set aside by a federal court before it took effect, so Indiana non-competes remain governed by Indiana common law and the physician statutes [^ryan-ftc-set-aside].
+
+In *Ryan LLC v. Federal Trade Commission*, a federal court set the rule aside with nationwide effect, holding it would not be enforced or take effect [^ryan-ftc-set-aside]. The FTC has since signaled a shift toward case-by-case enforcement against specific covenants rather than a blanket rule, but that does not change Indiana's governing standards. The outcome leaves Indiana's reasonableness analysis, eraser-style blue pencil, and physician restrictions in control, and does not make any particular Indiana covenant enforceable.
+
+"The Non-Compete Rule, 16 C.F.R. § 910.1–.6, is hereby SET ASIDE and shall not be enforced or otherwise take effect on September 4, 2024, or thereafter."[^ryan-ftc-set-aside]
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-03. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not Indiana. This article synthesizes Indiana primary law and is not legal advice from a Indiana-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^krueger-strict-construction]: **Central Indiana Podiatry, P.C. v. Krueger** — "We construe these covenants strictly against the employer and will not enforce an unreasonable restriction." *Central Indiana Podiatry, P.C. v. Krueger, 882 N.E.2d 723 (Ind. 2008).* <https://www.courtlistener.com/opinion/852486/central-indiana-podiatry-pc-v-krueger/#:~:text=We%20construe%20these%20covenants%20strictly,not%20enforce%20an%20unreasonable%20restriction.>
+
+[^dicen-disfavored]: **Dicen v. New Sesco, Inc.** — "Covenants not to compete are not favored in the law." *Dicen v. New Sesco, Inc., 839 N.E.2d 684 (Ind. 2005).* <https://www.courtlistener.com/opinion/852724/dicen-v-new-sesco-inc/#:~:text=Covenants%20not%20to%20compete%20are,not%20favored%20in%20the%20law.>
+
+[^krueger-legitimate-interest]: **Central Indiana Podiatry, P.C. v. Krueger** — "In arguing the reasonableness of a non-competition agreement, the employer must first show that it has a legitimate interest to be protected by the agreement." *Central Indiana Podiatry, P.C. v. Krueger, 882 N.E.2d 723 (Ind. 2008).* <https://www.courtlistener.com/opinion/852486/central-indiana-podiatry-pc-v-krueger/#:~:text=In%20arguing%20the%20reasonableness%20of,be%20protected%20by%20the%20agreement.>
+
+[^iutsa-trade-secret]: **Indiana Uniform Trade Secrets Act, Ind. Code § 24-2-3** — "‘Trade secret’ means information, including a formula, pattern, compilation, program, device, method, technique, or process, that: (1) derives independent economic value, actual or potential, from not being generally known to, and not being readily ascertainable by proper means by, other persons who can obtain economic value from its disclosure or use; and (2) is the subject of efforts that are reasonable under the circumstances to maintain its secrecy." *Ind. Code § 24-2-3-2.* <https://iga.in.gov/laws/2025/ic/titles/24>
+
+[^med1-consideration]: **Med-1 Solutions, LLC v. Taylor** — "We hold that, where an at-will employee signs a non-competition agreement as a condition of their hiring and is later told to sign a new non-competition agreement or they will be fired, the employee's continued employment can serve as consideration for the latter agreement." *Med-1 Solutions, LLC v. Taylor, No. 24A-PL-450 (Ind. Ct. App. Nov. 25, 2024).* <https://www.courtlistener.com/opinion/10283022/med-1-solutions-llc-v-jennifer-taylor/#:~:text=We%20hold%20that%2C%20where%20an,consideration%20for%20the%20latter%20agreement.>
+
+[^krueger-scope-burden]: **Central Indiana Podiatry, P.C. v. Krueger** — "The employer also bears the burden of establishing that the agreement is reasonable in scope as to the time, activity, and geographic area restricted." *Central Indiana Podiatry, P.C. v. Krueger, 882 N.E.2d 723 (Ind. 2008).* <https://www.courtlistener.com/opinion/852486/central-indiana-podiatry-pc-v-krueger/#:~:text=The%20employer%20also%20bears%20the,activity%2C%20and%20geographic%20area%20restricted.>
+
+[^med1-any-capacity]: **Med-1 Solutions, LLC v. Taylor** — "We find that the scope of activity restricted by the covenant is unreasonably broad." *Med-1 Solutions, LLC v. Taylor, No. 24A-PL-450 (Ind. Ct. App. Nov. 25, 2024).* <https://www.courtlistener.com/opinion/10283022/med-1-solutions-llc-v-jennifer-taylor/#:~:text=We%20find%20that%20the%20scope,the%20covenant%20is%20unreasonably%20broad.>
+
+[^heraeus-eraser]: **Heraeus Medical, LLC v. Zimmer, Inc.** — "The doctrine, however, does not allow a court to rewrite a noncompetition agreement by adding, changing, or rearranging terms." *Heraeus Medical, LLC v. Zimmer, Inc., 135 N.E.3d 150 (Ind. 2019).* <https://www.courtlistener.com/opinion/4683524/heraeus-medical-llc-v-zimmer-inc/#:~:text=The%20doctrine%2C%20however%2C%20does%20not,adding%2C%20changing%2C%20or%20rearranging%20terms.>
+
+[^heraeus-reformation-clause]: **Heraeus Medical, LLC v. Zimmer, Inc.** — "Consistent with the history and purpose of Indiana's blue pencil doctrine, courts cannot add terms to an unenforceable restrictive covenant in a noncompetition agreement—even when that agreement contains language purporting to give a court the power to do so." *Heraeus Medical, LLC v. Zimmer, Inc., 135 N.E.3d 150 (Ind. 2019).* <https://www.courtlistener.com/opinion/4683524/heraeus-medical-llc-v-zimmer-inc/#:~:text=Consistent%20with%20the%20history%20and,the%20power%20to%20do%20so.>
+
+[^heraeus-divisibility]: **Heraeus Medical, LLC v. Zimmer, Inc.** — "A court can blue-pencil unreasonable provisions from a restrictive covenant if the covenant is clearly divisible into parts and if a reasonable restriction remains to be enforced after the unreasonable portions have been eliminated." *Heraeus Medical, LLC v. Zimmer, Inc., 135 N.E.3d 150 (Ind. 2019).* <https://www.courtlistener.com/opinion/4683524/heraeus-medical-llc-v-zimmer-inc/#:~:text=A%20court%20can%20blue%2Dpencil%20unreasonable,unreasonable%20portions%20have%20been%20eliminated.>
+
+[^clarks-indivisible]: **Clark's Sales and Service, Inc. v. Smith** — "Paragraph 7(C) is indivisible and unreasonable as a whole, and the blue pencil doctrine is inapplicable." *Clark's Sales and Service, Inc. v. Smith, 4 N.E.3d 772 (Ind. Ct. App. 2014).* <https://www.courtlistener.com/opinion/2725543/clarks-sales-and-service-inc-v-john-d-smith-and-ferguson-enterprises/#:~:text=Paragraph%207(C)%20is%20indivisible%20and,blue%20pencil%20doctrine%20is%20inapplicable.>
+
+[^heraeus-nosolicit-overbroad]: **Heraeus Medical, LLC v. Zimmer, Inc.** — "As written, the Kolbe Agreement's employee nonsolicitation covenant is overbroad because it applies to all Zimmer employees." *Heraeus Medical, LLC v. Zimmer, Inc., 135 N.E.3d 150 (Ind. 2019).* <https://www.courtlistener.com/opinion/4683524/heraeus-medical-llc-v-zimmer-inc/#:~:text=As%20written%2C%20the%20Kolbe%20Agreement's,applies%20to%20all%20Zimmer%20employees.>
+
+[^q6-krueger-interest]: **Central Indiana Podiatry, P.C. v. Krueger** — "In arguing the reasonableness of a non-competition agreement, the employer must first show that it has a legitimate interest to be protected by the agreement." *Central Indiana Podiatry, P.C. v. Krueger, 882 N.E.2d 723 (Ind. 2008).* <https://www.courtlistener.com/opinion/852486/central-indiana-podiatry-pc-v-krueger/#:~:text=In%20arguing%20the%20reasonableness%20of,be%20protected%20by%20the%20agreement.>
+
+[^amconsulting-penalty]: **American Consulting, Inc. v. Hannum Wagle & Cline Engineering, Inc.** — "When liquidated damages are grossly disproportionate to the loss that results from the breach or are unconscionably in excess of the loss sought to be asserted, appellate courts will treat the sum as an unenforceable penalty rather than as liquidated damages." *American Consulting, Inc. v. Hannum Wagle & Cline Eng'g, Inc., 136 N.E.3d 208 (Ind. 2019).* <https://www.courtlistener.com/opinion/4688172/american-consulting-inc-dba-american-structurepoint-inc-v-hannum/#:~:text=When%20liquidated%20damages%20are%20grossly,rather%20than%20as%20liquidated%20damages.>
+
+[^amconsulting-holding]: **American Consulting, Inc. v. Hannum Wagle & Cline Engineering, Inc.** — "In sum, we find that all of the liquidated damages provisions at issue are unenforceable penalties." *American Consulting, Inc. v. Hannum Wagle & Cline Eng'g, Inc., 136 N.E.3d 208 (Ind. 2019).* <https://www.courtlistener.com/opinion/4688172/american-consulting-inc-dba-american-structurepoint-inc-v-hannum/#:~:text=In%20sum%2C%20we%20find%20that,at%20issue%20are%20unenforceable%20penalties.>
+
+[^forum-void-construction]: **Ind. Code § 32-28-3-17** — "A provision in a contract for the improvement of real estate in Indiana is void if the provision: (1) makes the contract subject to the laws of another state; or (2) requires litigation, arbitration, or other dispute resolution process on the contract occur in another state." *Ind. Code § 32-28-3-17.* <https://iga.in.gov/laws/2025/ic/titles/32>
+
+[^fees-bad-faith]: **Ind. Code § 34-52-1-1** — "In any civil action, the court may award attorney's fees as part of the cost to the prevailing party, if the court finds that either party: (1) brought the action or defense on a claim or defense that is frivolous, unreasonable, or groundless; (2) continued to litigate the action or defense after the party's claim or defense clearly became frivolous, unreasonable, or groundless; or (3) litigated the action in bad faith." *Ind. Code § 34-52-1-1(b).* <https://iga.in.gov/laws/2025/ic/titles/34>
+
+[^q8-krueger-reasonableness]: **Central Indiana Podiatry, P.C. v. Krueger** — "The employer also bears the burden of establishing that the agreement is reasonable in scope as to the time, activity, and geographic area restricted." *Central Indiana Podiatry, P.C. v. Krueger, 882 N.E.2d 723 (Ind. 2008).* <https://www.courtlistener.com/opinion/852486/central-indiana-podiatry-pc-v-krueger/#:~:text=The%20employer%20also%20bears%20the,activity%2C%20and%20geographic%20area%20restricted.>
+
+[^q8-heraeus-eraser]: **Heraeus Medical, LLC v. Zimmer, Inc.** — "The doctrine, however, does not allow a court to rewrite a noncompetition agreement by adding, changing, or rearranging terms." *Heraeus Medical, LLC v. Zimmer, Inc., 135 N.E.3d 150 (Ind. 2019).* <https://www.courtlistener.com/opinion/4683524/heraeus-medical-llc-v-zimmer-inc/#:~:text=The%20doctrine%2C%20however%2C%20does%20not,adding%2C%20changing%2C%20or%20rearranging%20terms.>
+
+[^dicen-sale-liberal]: **Dicen v. New Sesco, Inc.** — "We hold that such promises not to compete should be enforced on a more liberal basis than the skeptical one courts use regarding contracts between employer and employee." *Dicen v. New Sesco, Inc., 839 N.E.2d 684 (Ind. 2005).* <https://www.courtlistener.com/opinion/852724/dicen-v-new-sesco-inc/#:~:text=We%20hold%20that%20such%20promises,contracts%20between%20employer%20and%20employee.>
+
+[^zollinger-sale-standard]: **Zollinger v. Wagner-Meinert Engineering, LLC** — "Covenants in typical employment contracts are reviewed under a ‘skeptical’ standard, while covenants that arise ancillary to the sale of a business are subject to a more liberal standard." *Zollinger v. Wagner-Meinert Eng'g, LLC, 146 N.E.3d 1060 (Ind. Ct. App. 2020).* <https://www.courtlistener.com/opinion/4747784/wayne-doug-zollinger-v-wagner-meinert-engineering-llc/#:~:text=Covenants%20in%20typical%20employment%20contracts,to%20a%20more%20liberal%20standard.>
+
+[^etproducts-goodwill]: **E.T. Products, LLC v. D.E. Miller Holdings, Inc.** — "Indiana courts recognize that in a business sale, ‘a broad noncompetition agreement may be necessary to assure that the buyer receives that which he purchased.’" *E.T. Products, LLC v. D.E. Miller Holdings, Inc., 872 F.3d 464 (7th Cir. 2017).* <https://www.courtlistener.com/opinion/4427509/et-products-llc-v-de-miller-holdings-inc/#:~:text=Indiana%20courts%20recognize%20that%20in,receives%20that%20which%20he%20purchased.%22>
+
+[^hea1004-requirements]: **House Enrolled Act 1004 (2020), Ind. Code § 25-22.5-5.5-2** — "To be enforceable, a physician noncompete agreement must include all of the following provisions:" *Ind. Code § 25-22.5-5.5-2 (House Enrolled Act 1004, P.L. 93-2020).* <https://iga.in.gov/pdf-documents/121/2020/house/bills/HB1004/HB1004.05.ENRS.pdf>
+
+[^sea7-primary-care-ban]: **Senate Enrolled Act 7 (2023), Ind. Code § 25-22.5-5.5-2.5** — "Notwithstanding any other law, a primary care physician and an employer may not enter into a noncompete agreement." *Ind. Code § 25-22.5-5.5-2.5(b) (Senate Enrolled Act 7, P.L. 165-2023).* <https://iga.in.gov/pdf-documents/123/2023/senate/bills/SB0007/SB0007.05.ENRH.pdf>
+
+[^sea475-hospital-ban]: **Senate Enrolled Act 475 (2025), Ind. Code § 25-22.5-5.5-2.3** — "Any agreement in violation of this section is void and unenforceable." *Ind. Code § 25-22.5-5.5-2.3(c) (Senate Enrolled Act 475, P.L. 207-2025).* <https://iga.in.gov/pdf-documents/124/2025/senate/bills/SB0475/SB0475.04.ENRH.pdf>
+
+[^sea7-buyout]: **Senate Enrolled Act 7 (2023), Ind. Code § 25-22.5-5.5-2** — "(4) A provision that provides the physician whose employment has terminated or whose contract has expired with the option to purchase a complete and final release from the terms of the enforceable physician noncompete agreement at a reasonable price." *Ind. Code § 25-22.5-5.5-2(a)(4) (Senate Enrolled Act 7, P.L. 165-2023).* <https://iga.in.gov/pdf-documents/123/2023/senate/bills/SB0007/SB0007.05.ENRH.pdf>
+
+[^sea7-without-cause]: **Senate Enrolled Act 7 (2023), Ind. Code § 25-22.5-5.5-2** — "The employer terminates the physician's employment without cause." *Ind. Code § 25-22.5-5.5-2(b)(1) (Senate Enrolled Act 7, P.L. 165-2023).* <https://iga.in.gov/pdf-documents/123/2023/senate/bills/SB0007/SB0007.05.ENRH.pdf>
+
+[^q11-dicen-common-law]: **Dicen v. New Sesco, Inc.** — "Covenants not to compete are not favored in the law." *Dicen v. New Sesco, Inc., 839 N.E.2d 684 (Ind. 2005).* <https://www.courtlistener.com/opinion/852724/dicen-v-new-sesco-inc/#:~:text=Covenants%20not%20to%20compete%20are,not%20favored%20in%20the%20law.>
+
+[^ryan-ftc-set-aside]: **Ryan LLC v. Federal Trade Commission** — "The Non-Compete Rule, 16 C.F.R. § 910.1–.6, is hereby SET ASIDE and shall not be enforced or otherwise take effect on September 4, 2024, or thereafter." *Ryan LLC v. Fed. Trade Comm'n, 746 F. Supp. 3d 369 (N.D. Tex. 2024).* <https://www.courtlistener.com/opinion/10205745/ryan-llc-v-federal-trade-commission/#:~:text=The%20Non%2DCompete%20Rule%2C%2016%20C.F.R.,September%204%2C%202024%2C%20or%20thereafter.>

--- a/skills/non-compete-contract-explainer/content/iowa.md
+++ b/skills/non-compete-contract-explainer/content/iowa.md
@@ -1,0 +1,232 @@
+---
+jurisdiction: "Iowa"
+slug: iowa
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-02"
+canonicalUrl: https://openagreements.org/legal/non-compete/iowa
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/iowa · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in Iowa[^about]
+
+Iowa non-compete law uses a three-prong common-law reasonableness test, permits judicial reformation through a 'purple pencil' approach, leaves tolling unresolved, carves out narrow industry bans for mental health, health-care staffing, franchise, and UIHC clinical roles, and preserves trade-secret alternatives under chapter 550.
+
+
+## At a glance
+
+| Question | Iowa |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed if reasonable |
+| **Bottom line** | Iowa enforces an employee non-compete only if it satisfies a three-prong reasonableness test, with the employer bearing the burden; courts may reform an overbroad covenant rather than void it. |
+| **Main law or case** | common law (Revere Transducers, Inc. v. Deere & Co., 595 N.W.2d 751 (Iowa 1999)) |
+| **Main exceptions** | Mental-health professionals (§ 147.161); health-care staffing workers (§ 135Q.2); franchise nonrenewal (§ 537A.10); UIHC clinical roles (HF 2254, 2026) |
+| **Can a court narrow it?** | Yes — rewrites to reasonable |
+| **Applies to contractors?** | Yes |
+| **Restriction extended during a breach?** | Unsettled |
+| **Maximum length set by law** | No statutory safe harbor (case by case) |
+
+## Are employee non-compete agreements enforceable in Iowa? {#employee-noncompetes}
+
+**Short answer.** Yes, when they are reasonable. Iowa has no general employee non-compete statute, so ordinary employment covenants are governed by a common-law reasonableness test that asks whether the restraint protects the employer without overburdening the employee or the public [^q1-revere-three-prong].
+
+Iowa courts do not treat employee non-competes as void per se. The starting point is the Iowa Supreme Court rule restated in *Revere Transducers*: an employment restrictive covenant can be enforced only if it satisfies the three Iowa reasonableness prongs:
+
+"(1) Is the restriction reasonably necessary for the protection of the employer’s business; (2) is it unreasonably restrictive of the employee’s rights; and (3) is it prejudicial to the public interest?"[^q1-revere-three-prong]
+
+That common-law baseline matters because Iowa has enacted several narrow profession or industry restrictions, but not a statewide ban for all employees.
+
+## What reasonableness test do Iowa courts apply to non-competes? {#reasonableness-test}
+
+**Short answer.** Iowa applies a three-prong test, and the employer bears the burden. The covenant must be reasonably necessary to protect the business, not unreasonably restrictive of the employee, and not prejudicial to the public interest [^q2-lamp-three-prong][^q2-iowa-glass-burden].
+
+The Iowa Supreme Court stated the test directly in *Lamp v. American Prosthetics*, an employee covenant case involving a prosthetics business.
+
+"Because this case was tried in equity, our review is de novo. Iowa R.App.P. 4. In deciding whether to enforce a restrictive covenant, the court will apply a three-pronged test: (1) Is the restriction reasonably necessary for the protection of the employer’s business; (2) is it unreasonably restrictive of the employee’s rights; and (3) is it prejudicial to the public interest?"[^q2-lamp-three-prong]
+
+The burden does not shift to the former employee. *Iowa Glass Depot* places reasonableness on the party seeking enforcement, and it also frames the analysis as a balance between fair protection for the employer and unnecessary interference with the employee [^q2-iowa-glass-burden].
+
+## What legitimate business interests can an Iowa non-compete protect? {#legitimate-business-interest}
+
+**Short answer.** Customer relationships, employer-specific information, and specialized training can matter, but ordinary competition is not enough. Iowa courts look at customer proximity, information peculiar to the employer, the nature of the business, and the restrained occupation [^q3-revere-factors].
+
+The protectable-interest inquiry is practical. A route salesperson, account manager, specialist, or consultant with close customer ties may present a stronger case than an employee whose work involves common skills, public information, or little customer influence.
+
+"Factors we consider in determining the enforceability of a noncompete agreement include the employee’s close proximity to customers, the nature of the business, accessibility to information peculiar to the employer’s business, and the nature of the occupation which is restrained."[^q3-revere-factors]
+
+The other side of that rule is equally important. Iowa does not let a covenant suppress the employee's general skill and experience. In *Iowa Glass Depot*, the covenant failed in part because the employee had little specialized training and no trade secrets or exclusive customer list to take [^q3-iowa-glass-general-skill].
+
+*AG Spectrum* shows the same limit in an independent-contractor setting. The Eighth Circuit, applying Iowa law, treated the company's ordinary reseller support and training as not entitled to special protection [^q3-ag-spectrum-support].
+
+## How long or geographically broad can an Iowa non-compete be? {#time-and-geography}
+
+**Short answer.** There is no statutory safe harbor. Iowa evaluates duration, geography, and activity limits case by case, and the Eighth Circuit, applying Iowa law, has predicted that Iowa treats the ultimate enforceability question as one for the court [^q4-ag-spectrum-court-question][^q4-pro-edge-one-year].
+
+The examples are fact-specific. In *Pro Edge*, a federal court applying Iowa law enforced a one-year, 250-mile restriction against a veterinarian whose customer relationships were central to the employer's Montana embryo-transfer business.
+
+"Further, the court finds that the covenant not to compete is not unreasonably restrictive in time or area. The non-compete clause does not prevent Dr. Gue from practicing in the field of veterinary medicine, nor even in the specialty of embryo transfer in livestock. It merely prevents him from doing so within 250-miles of a Trans Ova facility, and for only 1 year following his separation from employment."[^q4-pro-edge-one-year]
+
+By contrast, *AG Spectrum* held a three-year restraint unreasonable on a record where the independent contractor developed his own customer base and received minimal support from the company [^q4-ag-spectrum-unreasonable]. The same case predicted that Iowa would leave enforceability to the court rather than a jury [^q4-ag-spectrum-court-question].
+
+## Will an Iowa court fix an overbroad non-compete or void it? {#court-reformation}
+
+**Short answer.** Usually it may reform. Iowa rejected a strict all-or-nothing approach and allows partial enforcement to the extent reasonably necessary to protect legitimate interests, unless the facts show bad faith or oppression [^q5-ehlers-reform].
+
+This is Iowa's version of a *purple pencil* rule. In *Ehlers*, the Iowa Supreme Court overruled the prior all-or-nothing rule and adopted partial enforcement for employment covenants.
+
+"I. In view of the position we take here, it is unnecessary to discuss these propositions separately. We now overrule Brecher v. Brown (1945), 235 Iowa 627 , 17 N.W.2d 377 , and adopt the rule that unless the facts and circumstances indicate bad faith on the part of the employer, we will enforce noncompetitive covenants to the extent they are reasonably necessary to protect his legitimate interests without imposing undue hardship on the employee when the public interest is not adversely affected."[^q5-ehlers-reform]
+
+*Farm Bureau* then applied the rule, narrowing a petroleum delivery covenant to the activities and six-township territory the employee actually served [^q5-farm-bureau-partial].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not draft an intentionally oppressive covenant and assume a court will rescue it. *Ehlers* expressly preserves a bad-faith limit, and no covenant inserted for reasons other than protecting legitimate employer interests should be enforced in equity [^q5-ehlers-bad-faith].
+
+## Does an Iowa non-compete period toll or extend during breach or litigation? {#tolling-during-breach}
+
+**Short answer.** Iowa has no controlling appellate authority squarely deciding that a non-compete period tolls during breach or enforcement litigation. The closest Iowa doctrine is reformation, which reshapes an overbroad covenant to a reasonable scope; it is not a tolling rule [^q6-ehlers-reform].
+
+A drafted extension-on-breach clause would still have to survive Iowa's ordinary reasonableness test. That means the clause should be analyzed as part of the restraint's duration and practical burden, not assumed valid because Iowa courts can narrow overbroad covenants.
+
+*Farm Bureau* illustrates the difference. The court narrowed a covenant to activities, territory, and a fixed two-year period measured from employment termination; it did not announce any rule adding time back for breach or litigation delay [^q6-farm-bureau-fixed-period].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Treat tolling as an open Iowa issue. A clause that extends the restricted period during breach or litigation should be drafted as a defined, reasonable term and defended under the three-prong test, because Iowa reformation cases support narrowing unreasonable restraints, not automatically extending them [^q6-ehlers-reform][^q6-farm-bureau-fixed-period].
+
+## Are Iowa non-solicitation and no-business covenants treated like non-competes? {#non-solicitation-no-business}
+
+**Short answer.** Generally yes. Iowa analyzes non-solicitation, no-business, and similar post-employment restraints under the same reasonableness framework, scrutinizing whether the restricted activities and territory exceed what is necessary to protect the employer [^q7-farm-bureau-activities].
+
+Iowa cases often involve covenants that combine competition bans, customer-contact limits, and solicitation limits. The court's task is to identify what protection is reasonably necessary and what overreaches.
+
+"First it appears the activities restricted were more than were necessary for plaintiff’s protection. Defendant was restricted from any ‘ * * * business activity competitive to that of the company * * It would be ample protection for the plaintiff in this case to restrict a former employee only from those activities he undertook during his employment. Similarly defendant was restricted from activity throughout a two county area. It would have sufficed to restrict him from the six townships he worked in. The trial court rightly held the covenant too broad both as to scope and area."[^q7-farm-bureau-activities]
+
+So a customer non-solicit or no-business covenant may be easier to defend than a broad no-work covenant, but only when its scope tracks the employer's actual protectable relationships and does not suppress unrelated work.
+
+## Is continued employment enough consideration for an Iowa non-compete? {#consideration}
+
+**Short answer.** Generally yes. Iowa decisions treat continued employment for an indefinite period as sufficient consideration to support a covenant not to compete, even when the covenant is signed after employment begins [^q8-farm-bureau-consideration].
+
+This consideration rule does not make the covenant enforceable by itself. It only answers contract formation; the covenant still must satisfy the three-prong reasonableness test.
+
+"In Ehlers the contract was not executed until sometime after the employee went to work. The case might be distinguished by the concession in Ehlers that the matter was discussed when the job was undertaken. Ehlers is however authority for the proposition continuing employment for an indefinite period is sufficient consideration to support a covenant not to compete."[^q8-farm-bureau-consideration]
+
+*Iowa Glass Depot* says the same thing and then refuses enforcement on reasonableness grounds, showing why consideration and enforceability should be kept separate [^q8-iowa-glass-consideration].
+
+## Are there Iowa industry-specific non-compete bans? {#industry-specific-bans}
+
+**Short answer.** Yes, but they are narrow. Iowa has no general employee non-compete ban, but statutes restrict covenants for licensed mental health professionals, health-care employment agency workers, certain franchise nonrenewal situations, and 2026 UIHC clinical employment contracts [^q9-mental-health-ban][^q9-health-agency-ban][^q9-franchise-nonrenewal][^q9-hf2254-uihc].
+
+The mental-health statute prohibits employers from entering agreements that limit practice location, former-patient contact, or time of practice for licensed mental health professionals, and any provision contrary to the statute is void and unenforceable [^q9-mental-health-ban][^q9-mh-void]. Chapter 135Q bars health-care employment agencies from using noncompetes to restrict agency workers and from charging conversion fees when an agency worker is later hired directly [^q9-health-agency-ban].
+
+Iowa's franchise statute is not a general employee rule. In a market-withdrawal nonrenewal, the franchisor must agree not to enforce a non-compete against the nonrenewed franchisee [^q9-franchise-nonrenewal].
+
+H.F. 2254 is enacted 2026 law of limited reach. It directs the Board of Regents to adopt a policy barring the University of Iowa Hospitals and Clinics from including noncompetes in employment contracts with listed clinical roles; it is not a statewide physician non-compete ban.
+
+"Develop a policy that prohibits the university of Iowa hospitals and clinics from including a noncompete clause in an employment contract with an advanced registered nurse practitioner, a licensed practical nurse, a pharmacist, a physician, a physician assistant, or a registered nurse."[^q9-hf2254-uihc]
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not overstate the 2026 UIHC law. H.F. 2254 is limited to specified clinical employment contracts with the university of Iowa hospitals and clinics entered into, extended, or renewed on or after the Act's effective date; it does not ban non-competes for every Iowa physician or health-care employer [^q9-hf2254-effective].
+
+## How are sale-of-business non-competes treated in Iowa? {#sale-of-business}
+
+**Short answer.** More leniently than ordinary employee covenants. Iowa recognizes that a buyer of business goodwill may need broader protection than an employer restraining a wage earner, though the restraint still must be reasonable [^q10-baker-sale-goodwill].
+
+The Iowa Supreme Court drew that distinction in *Baker v. Starkey*. The reason is economic: in a sale of goodwill, the restriction helps preserve what the buyer purchased, and the seller and buyer are usually closer to parity than employer and employee.
+
+"In determining the question of reasonableness as to area and time, restrictive stipulations in agreements between employer and employee are not viewed with the same indulgence as such stipulations are between a vendor and vendee of a business and its good will."[^q10-baker-sale-goodwill]
+
+The distinction does not eliminate reasonableness review. *Baker* still refused to partially enforce the employee covenant before Iowa later adopted reformation in *Ehlers*, and its core point remains that employee restraints receive closer scrutiny than sale-of-business restraints.
+
+## What trade-secret and NDA tools exist alongside Iowa non-competes? {#trade-secrets-confidentiality}
+
+**Short answer.** Iowa chapter 550 remains available for trade secrets, and confidentiality covenants can operate alongside non-competes. Chapter 550 defines trade secrets, authorizes injunctions and damages, allows attorney fees in specified cases, and does not preempt all common-law tort theories involving trade secrets [^q11-trade-secret-definition][^q11-injunctive-relief][^q11-damages][^q11-fees][^q11-brandow-nonpreemption].
+
+The statutory definition focuses on economic value from secrecy and reasonable efforts to maintain secrecy.
+
+"‘Trade secret’ means information, including but not limited to a formula, pattern, compilation, program, device, method, technique, or process that is both of the following: a. Derives independent economic value, actual or potential, from not being generally known to, and not being readily ascertainable by proper means by a person able to obtain economic value from its disclosure or use. b. Is the subject of efforts that are reasonable under the circumstances to maintain its secrecy."[^q11-trade-secret-definition]
+
+Chapter 550 also provides injunctive relief for actual or threatened misappropriation, damages for actual loss and unjust enrichment, and fee shifting for bad-faith claims, bad-faith injunction termination fights, or willful and malicious misappropriation [^q11-injunctive-relief][^q11-damages][^q11-fees].
+
+Unlike some states, Iowa has not made its trade-secret statute the exclusive route for all related tort claims. In *205 Corp. v. Brandow*, the Iowa Supreme Court held that chapter 550 did not preempt all tort theories involving trade secrets.
+
+"Chapter 550 has not preempted all tort theories involving trade secrets."[^q11-brandow-nonpreemption]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not use a non-compete as the only confidentiality tool. If the real concern is secrecy, draft targeted NDA, invention-assignment, and trade-secret provisions, then use chapter 550 remedies where the information meets the statutory definition and secrecy efforts can be proved [^q11-trade-secret-definition][^q11-injunctive-relief].
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-02. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not Iowa. This article synthesizes Iowa primary law and is not legal advice from a Iowa-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^q1-revere-three-prong]: **Revere Transducers, Inc. v. Deere & Co.** — "(1) Is the restriction reasonably necessary for the protection of the employer’s business; (2) is it unreasonably restrictive of the employee’s rights; and (3) is it prejudicial to the public interest?" *Revere Transducers, Inc. v. Deere & Co., 595 N.W.2d 751 (Iowa 1999).* <https://www.courtlistener.com/opinion/1989929/revere-transducers-inc-v-deere-co/#:~:text=(1)%20Is%20the%20restriction%20reasonably,prejudicial%20to%20the%20public%20interest%3F>
+
+[^q2-lamp-three-prong]: **Lamp v. American Prosthetics, Inc.** — "Because this case was tried in equity, our review is de novo. Iowa R.App.P. 4. In deciding whether to enforce a restrictive covenant, the court will apply a three-pronged test: (1) Is the restriction reasonably necessary for the protection of the employer’s business; (2) is it unreasonably restrictive of the employee’s rights; and (3) is it prejudicial to the public interest?" *Lamp v. American Prosthetics, Inc., 379 N.W.2d 909 (Iowa 1986).* <https://www.courtlistener.com/opinion/1601399/lamp-v-american-prosthetics-inc/#:~:text=Because%20this%20case%20was%20tried,prejudicial%20to%20the%20public%20interest%3F>
+
+[^q2-iowa-glass-burden]: **Iowa Glass Depot, Inc. v. Jindrich** — "The burden of proving reasonableness is upon the employer who seeks to enforce such a covenant." *Iowa Glass Depot, Inc. v. Jindrich, 338 N.W.2d 376 (Iowa 1983).* <https://www.courtlistener.com/opinion/2223795/iowa-glass-depot-inc-v-jindrich/#:~:text=The%20burden%20of%20proving%20reasonableness,to%20enforce%20such%20a%20covenant.>
+
+[^q3-revere-factors]: **Revere Transducers, Inc. v. Deere & Co.** — "Factors we consider in determining the enforceability of a noncompete agreement include the employee’s close proximity to customers, the nature of the business, accessibility to information peculiar to the employer’s business, and the nature of the occupation which is restrained." *Revere Transducers, Inc. v. Deere & Co., 595 N.W.2d 751 (Iowa 1999).* <https://www.courtlistener.com/opinion/1989929/revere-transducers-inc-v-deere-co/#:~:text=Factors%20we%20consider%20in%20determining,the%20occupation%20which%20is%20restrained.>
+
+[^q3-iowa-glass-general-skill]: **Iowa Glass Depot, Inc. v. Jindrich** — "An employee cannot be precluded from exercising the skill and general knowledge he has acquired or increased through experience or even instruction while in the employment." *Iowa Glass Depot, Inc. v. Jindrich, 338 N.W.2d 376 (Iowa 1983).* <https://www.courtlistener.com/opinion/2223795/iowa-glass-depot-inc-v-jindrich/#:~:text=An%20employee%20cannot%20be%20precluded,instruction%20while%20in%20the%20employment.>
+
+[^q3-ag-spectrum-support]: **AG Spectrum Co. v. Elder** — "In this context, Ag Spectrum’s support resembles the type of support that any reseller would expect to receive. Thus, like ordinary on-the-job training, Ag Spectrum’s training and support is not entitled to special protection." *AG Spectrum Co. v. Elder, 865 F.3d 1088 (8th Cir. 2017).* <https://www.courtlistener.com/opinion/4414551/ag-spectrum-company-v-vaughn-elder/#:~:text=In%20this%20context%2C%20Ag%20Spectrum%E2%80%99s,not%20entitled%20to%20special%20protection.>
+
+[^q4-ag-spectrum-court-question]: **AG Spectrum Co. v. Elder** — "For two reasons, we think that the Iowa Supreme Court would hold that the enforceability of a noncompete provision is a question for the court." *AG Spectrum Co. v. Elder, 865 F.3d 1088 (8th Cir. 2017).* <https://www.courtlistener.com/opinion/4414551/ag-spectrum-company-v-vaughn-elder/#:~:text=For%20two%20reasons%2C%20we%20think,a%20question%20for%20the%20court.>
+
+[^q4-pro-edge-one-year]: **Pro Edge, L.P. v. Gue** — "Further, the court finds that the covenant not to compete is not unreasonably restrictive in time or area. The non-compete clause does not prevent Dr. Gue from practicing in the field of veterinary medicine, nor even in the specialty of embryo transfer in livestock. It merely prevents him from doing so within 250-miles of a Trans Ova facility, and for only 1 year following his separation from employment." *Pro Edge, L.P. v. Gue, 374 F. Supp. 2d 711 (N.D. Iowa 2005).* <https://www.courtlistener.com/opinion/2397219/pro-edge-lp-v-gue/#:~:text=Further%2C%20the%20court%20finds%20that,following%20his%20separation%20from%20employment.>
+
+[^q4-ag-spectrum-unreasonable]: **AG Spectrum Co. v. Elder** — "Because requiring Elder to forsake the customers that he brought to Ag Spectrum as an independent contractor is unreasonable in the circumstances, we hold that the noncompete provision demanding this result is unenforceable." *AG Spectrum Co. v. Elder, 865 F.3d 1088 (8th Cir. 2017).* <https://www.courtlistener.com/opinion/4414551/ag-spectrum-company-v-vaughn-elder/#:~:text=Because%20requiring%20Elder%20to%20forsake,demanding%20this%20result%20is%20unenforceable.>
+
+[^q5-ehlers-reform]: **Ehlers v. Iowa Warehouse Co.** — "I. In view of the position we take here, it is unnecessary to discuss these propositions separately. We now overrule Brecher v. Brown (1945), 235 Iowa 627 , 17 N.W.2d 377 , and adopt the rule that unless the facts and circumstances indicate bad faith on the part of the employer, we will enforce noncompetitive covenants to the extent they are reasonably necessary to protect his legitimate interests without imposing undue hardship on the employee when the public interest is not adversely affected." *Ehlers v. Iowa Warehouse Co., 188 N.W.2d 368 (Iowa 1971).* <https://www.courtlistener.com/opinion/2117830/ehlers-v-iowa-warehouse-company/#:~:text=I.%20In%20view%20of%20the,interest%20is%20not%20adversely%20affected.>
+
+[^q5-farm-bureau-partial]: **Farm Bureau Serv. Co. of Maynard v. Kohls** — "The cause is remanded for entry of a decree properly restraining the defendant from competing with plaintiff as provided herein. Said injunction shall restrain defendant from activity competitive to plaintiff in the six townships he served in plaintiff’s employment, shall embrace only the activities defendant undertook in plaintiff’s employment and shall be for a period of two years from the date that employment was terminated." *Farm Bureau Serv. Co. of Maynard v. Kohls, 203 N.W.2d 209 (Iowa 1972).* <https://www.courtlistener.com/opinion/1935888/farm-bureau-service-co-of-maynard-v-kohls/#:~:text=The%20cause%20is%20remanded%20for,date%20that%20employment%20was%20terminated.>
+
+[^q5-ehlers-bad-faith]: **Ehlers v. Iowa Warehouse Co.** — "No covenant placed in the contract for reasons other than an attempt to protect the employer's legitimate interests should be enforced in equity." *Ehlers v. Iowa Warehouse Co., 188 N.W.2d 368 (Iowa 1971).* <https://www.courtlistener.com/opinion/2117830/ehlers-v-iowa-warehouse-company/#:~:text=No%20covenant%20placed%20in%20the,should%20be%20enforced%20in%20equity.>
+
+[^q6-ehlers-reform]: **Ehlers v. Iowa Warehouse Co.** — "I. In view of the position we take here, it is unnecessary to discuss these propositions separately. We now overrule Brecher v. Brown (1945), 235 Iowa 627 , 17 N.W.2d 377 , and adopt the rule that unless the facts and circumstances indicate bad faith on the part of the employer, we will enforce noncompetitive covenants to the extent they are reasonably necessary to protect his legitimate interests without imposing undue hardship on the employee when the public interest is not adversely affected." *Ehlers v. Iowa Warehouse Co., 188 N.W.2d 368 (Iowa 1971).* <https://www.courtlistener.com/opinion/2117830/ehlers-v-iowa-warehouse-company/#:~:text=I.%20In%20view%20of%20the,interest%20is%20not%20adversely%20affected.>
+
+[^q6-farm-bureau-fixed-period]: **Farm Bureau Serv. Co. of Maynard v. Kohls** — "The cause is remanded for entry of a decree properly restraining the defendant from competing with plaintiff as provided herein. Said injunction shall restrain defendant from activity competitive to plaintiff in the six townships he served in plaintiff’s employment, shall embrace only the activities defendant undertook in plaintiff’s employment and shall be for a period of two years from the date that employment was terminated." *Farm Bureau Serv. Co. of Maynard v. Kohls, 203 N.W.2d 209 (Iowa 1972).* <https://www.courtlistener.com/opinion/1935888/farm-bureau-service-co-of-maynard-v-kohls/#:~:text=The%20cause%20is%20remanded%20for,date%20that%20employment%20was%20terminated.>
+
+[^q7-farm-bureau-activities]: **Farm Bureau Serv. Co. of Maynard v. Kohls** — "First it appears the activities restricted were more than were necessary for plaintiff’s protection. Defendant was restricted from any ‘ * * * business activity competitive to that of the company * * It would be ample protection for the plaintiff in this case to restrict a former employee only from those activities he undertook during his employment. Similarly defendant was restricted from activity throughout a two county area. It would have sufficed to restrict him from the six townships he worked in. The trial court rightly held the covenant too broad both as to scope and area." *Farm Bureau Serv. Co. of Maynard v. Kohls, 203 N.W.2d 209 (Iowa 1972).* <https://www.courtlistener.com/opinion/1935888/farm-bureau-service-co-of-maynard-v-kohls/#:~:text=First%20it%20appears%20the%20activities,as%20to%20scope%20and%20area.>
+
+[^q8-farm-bureau-consideration]: **Farm Bureau Serv. Co. of Maynard v. Kohls** — "In Ehlers the contract was not executed until sometime after the employee went to work. The case might be distinguished by the concession in Ehlers that the matter was discussed when the job was undertaken. Ehlers is however authority for the proposition continuing employment for an indefinite period is sufficient consideration to support a covenant not to compete." *Farm Bureau Serv. Co. of Maynard v. Kohls, 203 N.W.2d 209 (Iowa 1972).* <https://www.courtlistener.com/opinion/1935888/farm-bureau-service-co-of-maynard-v-kohls/#:~:text=In%20Ehlers%20the%20contract%20was,a%20covenant%20not%20to%20compete.>
+
+[^q8-iowa-glass-consideration]: **Iowa Glass Depot, Inc. v. Jindrich** — "Thus, while his continued employment served as sufficient consideration for the restrictive covenant, we view Jindrich's gain from the contract to be grossly disproportionate to the injury he would sustain from enforcement of the restrictive covenant." *Iowa Glass Depot, Inc. v. Jindrich, 338 N.W.2d 376 (Iowa 1983).* <https://www.courtlistener.com/opinion/2223795/iowa-glass-depot-inc-v-jindrich/#:~:text=Thus%2C%20while%20his%20continued%20employment,enforcement%20of%20the%20restrictive%20covenant.>
+
+[^q9-mental-health-ban]: **Iowa Code § 147.161** — "An employer shall not enter into an agreement with a licensed mental health professional that limits the location at which the licensee may practice, prohibits the licensee from contacting for professional services a person previously treated by the licensee, or imposes a time restriction on the practice of the licensee." *Iowa Code § 147.161.* <https://www.legis.iowa.gov/docs/code/2025/147.161.pdf>
+
+[^q9-health-agency-ban]: **Iowa Code § 135Q.2** — "A health care employment agency shall not do any of the following: (1) Restrict in any manner the employment opportunities of an agency worker by including a noncompete clause in any contract with an agency worker or health care entity. (2) In any contract with an agency worker or health care entity, require payment of liquidated damages, employment fees, or other compensation if the agency worker is subsequently hired as a permanent employee of the health care entity." *Iowa Code § 135Q.2.* <https://www.legis.iowa.gov/docs/code/2025/135Q.2.pdf>
+
+[^q9-franchise-nonrenewal]: **Iowa Code § 537A.10** — "The franchisor completely withdraws from directly or indirectly distributing its products or services in the geographic market served by the franchisee, provided that upon expiration of the franchise, the franchisor agrees not to seek to enforce any covenant of the nonrenewed franchisee not to compete with the franchisor or franchisees of the franchisor." *Iowa Code § 537A.10.* <https://www.legis.iowa.gov/docs/code/2025/537A.10.pdf>
+
+[^q9-hf2254-uihc]: **2026 Iowa Acts, House File 2254** — "Develop a policy that prohibits the university of Iowa hospitals and clinics from including a noncompete clause in an employment contract with an advanced registered nurse practitioner, a licensed practical nurse, a pharmacist, a physician, a physician assistant, or a registered nurse." *2026 Iowa Acts, House File 2254 (codified at Iowa Code § 262.9(43)).* <https://www.legis.iowa.gov/docs/publications/LGE/91/HF2254.pdf>
+
+[^q9-mh-void]: **Iowa Code § 147.161** — "A provision of an agreement entered into between an employer and a licensed mental health professional prior to, on, or after June 1, 2023, that is contrary to this section shall be void and unenforceable." *Iowa Code § 147.161.* <https://www.legis.iowa.gov/docs/code/2025/147.161.pdf>
+
+[^q9-hf2254-effective]: **2026 Iowa Acts, House File 2254** — "This subsection applies to all employment contracts between an advanced registered nurse practitioner, a licensed practical nurse, a pharmacist, a physician, a physician assistant, or a registered nurse and the university of Iowa hospitals and clinics entered into, extended, or renewed on or after the effective date of this Act." *2026 Iowa Acts, House File 2254 (codified at Iowa Code § 262.9(43)).* <https://www.legis.iowa.gov/docs/publications/LGE/91/HF2254.pdf>
+
+[^q10-baker-sale-goodwill]: **Baker v. Starkey** — "In determining the question of reasonableness as to area and time, restrictive stipulations in agreements between employer and employee are not viewed with the same indulgence as such stipulations are between a vendor and vendee of a business and its good will." *Baker v. Starkey, 144 N.W.2d 889 (Iowa 1966).* <https://www.courtlistener.com/opinion/2202172/baker-v-starkey/#:~:text=In%20determining%20the%20question%20of,business%20and%20its%20good%20will.>
+
+[^q11-trade-secret-definition]: **Iowa Code § 550.2** — "‘Trade secret’ means information, including but not limited to a formula, pattern, compilation, program, device, method, technique, or process that is both of the following: a. Derives independent economic value, actual or potential, from not being generally known to, and not being readily ascertainable by proper means by a person able to obtain economic value from its disclosure or use. b. Is the subject of efforts that are reasonable under the circumstances to maintain its secrecy." *Iowa Code § 550.2.* <https://www.legis.iowa.gov/docs/code/2025/550.2.pdf>
+
+[^q11-injunctive-relief]: **Iowa Code § 550.3** — "The owner of a trade secret may petition the district court to enjoin an actual or threatened misappropriation." *Iowa Code § 550.3.* <https://www.legis.iowa.gov/docs/code/2025/550.3.pdf>
+
+[^q11-damages]: **Iowa Code § 550.4** — "Damages may include the actual loss caused by the misappropriation, and the unjust enrichment caused by the misappropriation which is not taken into account in computing the actual loss." *Iowa Code § 550.4.* <https://www.legis.iowa.gov/docs/code/2025/550.4.pdf>
+
+[^q11-fees]: **Iowa Code § 550.6** — "The court may award actual and reasonable attorney fees to the prevailing party in an action under this chapter if any of the following is applicable: 1. A claim of misappropriation is made in bad faith. 2. A motion to terminate an injunction is made or resisted in bad faith. 3. A person acts willfully and maliciously in the misappropriation." *Iowa Code § 550.6.* <https://www.legis.iowa.gov/docs/code/2025/550.6.pdf>
+
+[^q11-brandow-nonpreemption]: **205 Corp. v. Brandow** — "Chapter 550 has not preempted all tort theories involving trade secrets." *205 Corp. v. Brandow, 517 N.W.2d 548 (Iowa 1994).* <https://www.courtlistener.com/opinion/1312295/205-corp-v-brandow/#:~:text=Chapter%20550%20has%20not%20preempted,tort%20theories%20involving%20trade%20secrets.>

--- a/skills/non-compete-contract-explainer/content/kansas.md
+++ b/skills/non-compete-contract-explainer/content/kansas.md
@@ -1,0 +1,227 @@
+---
+jurisdiction: "Kansas"
+slug: kansas
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-02"
+canonicalUrl: https://openagreements.org/legal/non-compete/kansas
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/kansas · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in Kansas[^about]
+
+A question-by-question summary of Kansas non-compete law, including the Weber reasonableness test, judicial reformation of overbroad covenants, tolling-during-breach clauses, the SB 241 amendments to K.S.A. 50-163, non-solicitation safe harbors, healthcare covenants, and trade-secret alternatives.
+
+
+## At a glance
+
+| Question | Kansas |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed if reasonable |
+| **Bottom line** | Kansas enforces an employee non-compete that is ancillary, reasonable under the four-factor Weber test, and not adverse to the public welfare, and is one of the more employer-friendly states; courts will narrow an overbroad restraint. |
+| **Main law or case** | common law (Weber v. Tillman, 913 P.2d 84 (Kan. 1996)) |
+| **Main exceptions** | Non-competes excluded from K.S.A. 50-163 Restraint of Trade Act; non-solicit & owner safe harbors; no physician/healthcare ban |
+| **Can a court narrow it?** | Yes — rewrites to reasonable |
+| **Applies to contractors?** | Unclear |
+| **Restriction extended during a breach?** | No — Doan declined an indefinite tolling-during-breach clause |
+| **Maximum length set by law** | No statutory limit for non-competes |
+
+## Are employee non-compete agreements enforceable in Kansas? {#employee-noncompetes}
+
+**Short answer.** Yes, when they are reasonable. Kansas enforces an employee non-compete that is ancillary to a lawful contract, reasonable under the circumstances, and not adverse to the public welfare [^weber-governing-standard].
+
+Kansas is a reasonableness state, and it is one of the more employer-friendly jurisdictions in the country. The starting point is not a statute but the common law: a covenant is judged by whether the restraint is reasonable and the employer carries the burden of showing it [^weber-governing-standard].
+
+The Kansas Supreme Court framed the governing rule in *Weber v. Tillman*, a physician case that remains the leading authority on employee covenants.
+
+"A noncompetition covenant ancillary to an employment contract is valid and enforceable if the restraint is reasonable under the circumstances and not adverse to the public welfare."[^weber-governing-standard]
+
+## What reasonableness test do Kansas courts apply to non-competes? {#reasonableness-test}
+
+**Short answer.** A four-factor test. Kansas courts ask whether the covenant protects a legitimate business interest, whether it imposes an undue burden on the employee, whether it injures the public welfare, and whether its time and territory limits are reasonable [^q2-weber-four-factor].
+
+The four factors come from *Weber* and are restated in later cases.
+
+"The analysis of whether the noncompetition clause is reasonable evaluates these factors: (1) Does the covenant protect a legitimate business interest of the employer? (2) Does the covenant create an undue burden on the employee? (3) Is the covenant injurious to the public welfare? (4) Are the time and territorial limitations contained in the covenant reasonable?"[^q2-weber-four-factor]
+
+Enforceability is a question Kansas appellate courts decide without deference to the trial court, so a covenant that reads as reasonable on its face can still be tested fully on appeal [^doan-de-novo].
+
+The public-welfare factor is a real limit, not a formality. In *Caring Hearts*, the Kansas Court of Appeals applied the same four questions to home-health workers and found no public-welfare problem on the facts [^caring-hearts-public-welfare].
+
+## Will a Kansas court narrow an overbroad non-compete instead of voiding it? {#modification-blue-pencil}
+
+**Short answer.** Usually it narrows. Kansas courts have long used their equitable power to reduce an overbroad restraint and enforce it as reduced, rather than striking the whole covenant [^eastern-equitable-reduction].
+
+The modern rule has a common-law root. In *Eastern Distributing*, the Kansas Supreme Court affirmed a trial court that cut an excessive territory down to what was reasonably necessary and enforced the covenant to that extent.
+
+"We think the trial court in the exercise of its equitable powers fairly and reasonably reduced the area restriction to only that which was necessary to protect plaintiff's interest."[^eastern-equitable-reduction]
+
+Reformation has a ceiling, though. A court reforms an *unreasonable* term; it may not rewrite a term that was already reasonable. In *Doan*, the Court of Appeals held the trial court erred when it cut a reasonable two-year term down to one year [^doan-no-rewrite].
+
+The 2025 statutory amendments add a separate, mandatory reformation command, but it is aimed at the covenants the Kansas Restraint of Trade Act actually governs. K.S.A. 50-163 directs a court to modify and enforce an overbroad covenant that is *not* conclusively presumed enforceable [^q3-ksa-50-163-reform], yet the same statute excludes covenants not to compete from the Act altogether [^q3-ksa-50-163-noncompete-exclusion]. For a traditional non-compete, the operative reformation authority remains the common-law equity power recognized in *Eastern Distributing*, not the statute. No published Kansas decision has yet construed that exclusion as applied to a non-compete, so this reading rests on the statute's plain text.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not rely on reformation as a license to overreach. Kansas will narrow an unreasonable restraint, but *Doan* shows a court will refuse to rewrite a term that is already reasonable, and an employer that drafts too broadly risks getting only the minimum relief a court considers necessary [^doan-no-rewrite][^eastern-equitable-reduction].
+
+## Does a tolling or extension-during-breach clause extend a Kansas non-compete? {#tolling-during-breach}
+
+**Short answer.** Probably not as written. The only Kansas appellate decision on point refused to enforce a clause that tolled the restricted period during breach and during enforcement litigation, treating the resulting open-ended restraint as unreasonable [^doan-tolling-declined].
+
+Many templates add a tolling or extension clause so the employer gets the full benefit of the restricted period even if the former employee competes during it. In *Doan*, the agreement did exactly that, and the Kansas Court of Appeals affirmed the district court's refusal to enforce the tolling provision.
+
+"The district court did not err, however, when it declined to enforce the noncompete clause's tolling provision."[^doan-tolling-declined]
+
+The court's reasoning was about reasonableness, not a technicality. A fixed two-year term was reasonable, but an open-ended extension tied to breach and litigation was not.
+
+"While a two-year period is a reasonable restriction under these facts, an indefinite extension of that period is not a reasonable restraint on Arnberger."[^doan-tolling-indefinite]
+
+No Kansas case approves judicial or equitable extension of a covenant period either, and there is no Kansas Supreme Court decision on tolling. So an employer should treat the drafted, indefinite tolling clause as a serious enforcement risk and should not assume a Kansas court will add lost time back to the restricted period.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Avoid an open-ended tolling-during-breach-and-litigation clause in a Kansas non-compete. *Doan* refused to enforce one as an unreasonable, potentially indefinite restraint, so a defined and reasonable fixed term is the safer drafting choice [^doan-tolling-declined][^doan-tolling-indefinite].
+
+## How did the 2025 SB 241 amendments change Kansas restrictive-covenant law? {#sb-241-changes}
+
+**Short answer.** They created statutory safe harbors for non-solicitation and owner covenants, not for traditional non-competes. K.S.A. 50-163, as amended in 2025, conclusively presumes certain solicitation covenants enforceable, but it also excludes covenants not to compete from the Kansas Restraint of Trade Act [^q5-ksa-50-163-reasonable][^q5-ksa-50-163-exclusion].
+
+SB 241 (2025 Kan. Sess. Laws ch. 74, effective July 1, 2025) amended K.S.A. 50-163. The amendments matter most for non-solicitation and owner covenants, which now get conclusive presumptions of enforceability inside defined limits. The statute frames the baseline as a reasonableness standard.
+
+"An arrangement, contract, agreement, trust, understanding or combination is a reasonable restraint of trade or commerce if such restraint is reasonable in view of all of the facts and circumstances of the particular case and does not contravene public welfare."[^q5-ksa-50-163-reasonable]
+
+For overbroad covenants that the Act does govern, K.S.A. 50-163 now requires reformation rather than voiding [^q5-ksa-50-163-reform]. But the statute carves traditional non-competes out of the Act entirely, alongside franchise agreements [^q5-ksa-50-163-exclusion]. The practical result is that SB 241 did not rewrite Kansas non-compete law; ordinary employee non-competes are still governed by the common-law *Weber* test.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not overstate SB 241 as a non-compete statute. Its conclusive presumptions and statutory reformation command run to non-solicitation and owner covenants, while K.S.A. 50-163 expressly excludes covenants not to compete from the Act, leaving them to the common-law reasonableness analysis [^q5-ksa-50-163-exclusion][^q5-ksa-50-163-reform].
+
+## Are Kansas non-solicitation covenants conclusively presumed enforceable? {#non-solicitation}
+
+**Short answer.** Yes, inside the statutory limits. A written employee customer non-solicit is conclusively presumed enforceable if it is limited to material contact customers and lasts no more than two years [^ksa-50-163-customer-nonsolicit].
+
+K.S.A. 50-163 sets durational and scope limits that, if met, make the covenant conclusively presumed enforceable and not a restraint of trade. For an employee customer non-solicit, the limits are a two-year cap and a material-contact-customer scope.
+
+The statute defines who counts as a material contact customer, which is the key scope concept for these covenants.
+
+"‘Material contact customer’ means any customer or prospective customer that is solicited, produced or serviced, directly or indirectly, by the employee or owner at issue or any customer or prospective customer about whom the employee or owner, directly or indirectly, had confidential business or proprietary information or trade secrets in the course of the employee's or owner's relationship with the customer."[^ksa-50-163-material-contact]
+
+Owner covenants get a longer runway. A written covenant by an owner not to solicit the entity's customers is conclusively presumed enforceable if it is limited to material contact customers and does not run more than four years after the owner's relationship with the business ends [^ksa-50-163-owner-nonsolicit].
+
+The presumption is strong but not absolute. Even for a covenant inside a safe harbor, the statute lets the employee or owner raise any available legal or equitable defense for the court to consider [^ksa-50-163-defenses].
+
+## What consideration supports a Kansas non-compete? {#consideration}
+
+**Short answer.** Continued employment is enough. Kansas does not treat continued employment of an existing at-will employee as inadequate consideration for a covenant signed after hire [^puritan-bennett-consideration].
+
+This matters for covenants rolled out mid-employment. In *Puritan-Bennett*, the Court of Appeals held that an employee's continued employment could support a covenant not to compete and reversed a contrary ruling.
+
+"After reviewing these authorities, we hold that continued employment should not as a matter of law be disregarded as consideration sufficient to uphold a covenant not to compete."[^puritan-bennett-consideration]
+
+That gives Kansas employers more flexibility than states requiring new, independent consideration such as a bonus or promotion. The covenant still has to be reasonable under *Weber*; sufficient consideration does not cure an overbroad restraint.
+
+## Do special rules apply to Kansas physician and healthcare non-competes? {#healthcare}
+
+**Short answer.** No special ban. Kansas evaluates physician covenants under the ordinary reasonableness test, and it recognizes referral sources as a legitimate interest a medical practice may protect [^idbeis-referral-sources].
+
+Kansas has no statute banning healthcare non-competes. Both of the state's leading covenant cases, *Weber* and *Idbeis*, arose in medical practices and enforced the covenants. *Idbeis* is the clearest statement that a medical group may protect referral relationships.
+
+"In Kansas, however, the law is clear that referral sources are a legitimate interest which can be protected by a restrictive covenant even in the context of a medical practice."[^idbeis-referral-sources]
+
+A 2026 bill, SB 504, would have banned most post-employment non-competes for physicians and mid-level practitioners, but it died in the 2025 to 2026 legislative session without advancing. It signals legislative interest, not a change in the law, so physician covenants in Kansas are still analyzed under the reasonableness test today.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not assume Kansas has adopted a healthcare non-compete ban. The 2026 proposal did not pass, and current law still enforces a reasonable physician covenant, including protection of referral sources [^idbeis-referral-sources].
+
+## Are trade-secret and confidentiality protections still available in Kansas? {#trade-secrets}
+
+**Short answer.** Yes. The Kansas Uniform Trade Secrets Act protects trade secrets, and a contractual confidentiality covenant remains available for information that is not a trade secret [^ksa-60-3320-trade-secret][^ksa-60-3326-contract].
+
+The Kansas Uniform Trade Secrets Act, K.S.A. 60-3320 et seq., defines a trade secret in terms of independent economic value and reasonable secrecy efforts.
+
+"‘Trade secret’ means information, including a formula, pattern, compilation, program, device, method, technique, or process, that: (i) derives independent economic value, actual or potential, from not being generally known to, and not being readily ascertainable by proper means by, other persons who can obtain economic value from its disclosure or use, and (ii) is the subject of efforts that are reasonable under the circumstances to maintain its secrecy."[^ksa-60-3320-trade-secret]
+
+The Act is the exclusive route for trade-secret recovery. In *Wolfe Electric*, the Kansas Supreme Court held that a tort claim cannot be used to recover for trade-secret misappropriation because the Act preempts it [^wolfe-kutsa-exclusive]. But the Act reaches only trade secrets, and it preserves contractual remedies, so a confidentiality covenant is the tool for protecting valuable information that does not qualify as a trade secret [^ksa-60-3326-contract].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not rely on the trade-secret statute to protect ordinary confidential information. *Wolfe Electric* confirms the Act is the exclusive remedy for trade-secret misappropriation, so non-trade-secret information should be protected by a separate, reasonable confidentiality covenant [^wolfe-kutsa-exclusive][^ksa-60-3326-contract].
+
+## How are Kansas sale-of-business and owner covenants treated? {#sale-of-business}
+
+**Short answer.** More favorably than employee covenants. Owner and seller non-solicitation covenants get a four-year statutory safe harbor, covering both no-recruit and customer non-solicitation terms, while a sale-related non-compete is still tested under the common-law reasonableness standard [^q10-ksa-50-163-owner][^q10-ksa-50-163-owner-customer].
+
+K.S.A. 50-163 treats owners and sellers differently from rank-and-file employees. An owner who agrees not to recruit the entity's employees or owners is conclusively presumed enforceable for up to four years.
+
+"A covenant in writing in which an owner agrees to not solicit, recruit, induce, persuade, encourage, direct or otherwise interfere with, directly or indirectly, one or more employees or owners of a business entity for the purpose of interfering with the employment or ownership relationship of such employees or owners shall be conclusively presumed to be enforceable and not a restraint of trade if the covenant is between a business entity and an owner of the business entity and the covenant does not continue for more than four years following the end of the owner's business relationship with the business entity."[^q10-ksa-50-163-owner]
+
+The statute defines owner broadly to include sellers of business assets and equity interests, so a buyer protecting purchased goodwill can use the longer owner runway for solicitation covenants [^q10-ksa-50-163-owner-def]. A pure non-compete tied to a sale still falls outside the Act and is judged under *Weber*, where courts generally give sale-of-business restraints more latitude than employee restraints.
+
+A 2026 bill, HB 2650, would have voided non-competes on the sale or change in control of an employer, but it also died in the 2025 to 2026 session and is not law.
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-02. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not Kansas. This article synthesizes Kansas primary law and is not legal advice from a Kansas-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^weber-governing-standard]: **Weber v. Tillman** — "A noncompetition covenant ancillary to an employment contract is valid and enforceable if the restraint is reasonable under the circumstances and not adverse to the public welfare." *Weber v. Tillman, 259 Kan. 457, 913 P.2d 84 (1996).* <https://www.courtlistener.com/opinion/7969238/weber-v-tillman/#:~:text=A%20noncompetition%20covenant%20ancillary%20to,adverse%20to%20the%20public%20welfare.>
+
+[^q2-weber-four-factor]: **Weber v. Tillman** — "The analysis of whether the noncompetition clause is reasonable evaluates these factors: (1) Does the covenant protect a legitimate business interest of the employer? (2) Does the covenant create an undue burden on the employee? (3) Is the covenant injurious to the public welfare? (4) Are the time and territorial limitations contained in the covenant reasonable?" *Weber v. Tillman, 259 Kan. 457, 913 P.2d 84 (1996).* <https://www.courtlistener.com/opinion/7969238/weber-v-tillman/#:~:text=The%20analysis%20of%20whether%20the,contained%20in%20the%20covenant%20reasonable%3F>
+
+[^doan-de-novo]: **Doan Family Corp. v. Arnberger** — "Kansas appellate courts exercise unlimited review when determining whether a noncompete clause in an employment contract is enforceable as written." *Doan Family Corp. v. Arnberger, 522 P.3d 364 (Kan. Ct. App. 2022).* <https://www.courtlistener.com/opinion/9367497/doan-family-corp-v-arnberger/#:~:text=Kansas%20appellate%20courts%20exercise%20unlimited,contract%20is%20enforceable%20as%20written.>
+
+[^caring-hearts-public-welfare]: **Caring Hearts Personal Home Services, Inc. v. Hobley** — "There is no evidence that enforcement of the noncompete agreement is injurious to the public welfare." *Caring Hearts Personal Home Servs., Inc. v. Hobley, 35 Kan. App. 2d 345, 130 P.3d 1215 (2006).* <https://www.courtlistener.com/opinion/7213041/caring-hearts-personal-home-services-inc-v-hobley/#:~:text=There%20is%20no%20evidence%20that%20enforcement,injurious%20to%20the%20public%20welfare.>
+
+[^eastern-equitable-reduction]: **Eastern Distributing Co. v. Flynn** — "We think the trial court in the exercise of its equitable powers fairly and reasonably reduced the area restriction to only that which was necessary to protect plaintiff's interest." *Eastern Distributing Co. v. Flynn, 222 Kan. 666, 567 P.2d 1371 (1977).* <https://www.courtlistener.com/opinion/1195583/eastern-distributing-co-inc-v-flynn/#:~:text=We%20think%20the%20trial%20court,necessary%20to%20protect%20plaintiff's%20interest.>
+
+[^doan-no-rewrite]: **Doan Family Corp. v. Arnberger** — "Because the two-year term was reasonable, the court did not have the discretion to rewrite that term of the agreement." *Doan Family Corp. v. Arnberger, 522 P.3d 364 (Kan. Ct. App. 2022).* <https://www.courtlistener.com/opinion/9367497/doan-family-corp-v-arnberger/#:~:text=Because%20the%20two%2Dyear%20term%20was,that%20term%20of%20the%20agreement.>
+
+[^q3-ksa-50-163-reform]: **K.S.A. 50-163** — "If a covenant that is not presumed to be enforceable pursuant to subsection (c) is determined to be overbroad or otherwise not reasonably necessary to protect a business interest of the business entity seeking enforcement of the covenant, the court shall modify the covenant, enforce the covenant as modified and grant only the relief reasonably necessary to protect such interests." *K.S.A. 50-163(b).* <https://ksrevisor.gov/statutes/chapters/ch50/050_001_0063.html>
+
+[^q3-ksa-50-163-noncompete-exclusion]: **K.S.A. 50-163** — "any franchise agreements or covenants not to compete" *K.S.A. 50-163(e)(6).* <https://ksrevisor.gov/statutes/chapters/ch50/050_001_0063.html>
+
+[^doan-tolling-declined]: **Doan Family Corp. v. Arnberger** — "The district court did not err, however, when it declined to enforce the noncompete clause's tolling provision." *Doan Family Corp. v. Arnberger, 522 P.3d 364 (Kan. Ct. App. 2022).* <https://www.courtlistener.com/opinion/9367497/doan-family-corp-v-arnberger/#:~:text=The%20district%20court%20did%20not,the%20noncompete%20clause's%20tolling%20provision.>
+
+[^doan-tolling-indefinite]: **Doan Family Corp. v. Arnberger** — "While a two-year period is a reasonable restriction under these facts, an indefinite extension of that period is not a reasonable restraint on Arnberger." *Doan Family Corp. v. Arnberger, 522 P.3d 364 (Kan. Ct. App. 2022).* <https://www.courtlistener.com/opinion/9367497/doan-family-corp-v-arnberger/#:~:text=While%20a%20two%2Dyear%20period%20is,a%20reasonable%20restraint%20on%20Arnberger.>
+
+[^q5-ksa-50-163-reasonable]: **K.S.A. 50-163** — "An arrangement, contract, agreement, trust, understanding or combination is a reasonable restraint of trade or commerce if such restraint is reasonable in view of all of the facts and circumstances of the particular case and does not contravene public welfare." *K.S.A. 50-163(c)(1).* <https://ksrevisor.gov/statutes/chapters/ch50/050_001_0063.html>
+
+[^q5-ksa-50-163-exclusion]: **K.S.A. 50-163** — "any franchise agreements or covenants not to compete" *K.S.A. 50-163(e)(6).* <https://ksrevisor.gov/statutes/chapters/ch50/050_001_0063.html>
+
+[^q5-ksa-50-163-reform]: **K.S.A. 50-163** — "If a covenant that is not presumed to be enforceable pursuant to subsection (c) is determined to be overbroad or otherwise not reasonably necessary to protect a business interest of the business entity seeking enforcement of the covenant, the court shall modify the covenant, enforce the covenant as modified and grant only the relief reasonably necessary to protect such interests." *K.S.A. 50-163(b).* <https://ksrevisor.gov/statutes/chapters/ch50/050_001_0063.html>
+
+[^ksa-50-163-customer-nonsolicit]: **K.S.A. 50-163** — "A covenant in writing in which an employee agrees not to solicit, recruit, induce, persuade, encourage, direct or otherwise interfere with, directly or indirectly, a business entity's customers, including any reduction, termination, acceptance or transfer of any customer's business, in whole or in part, for the purpose of providing any product or service that is competitive with those provided by the employer shall be conclusively presumed to be enforceable and not a restraint of trade if the covenant is limited to material contact customers and the covenant is between an employer and an employee and does not continue for more than two years following the end of the employee's employment with the employer." *K.S.A. 50-163(c)(5).* <https://ksrevisor.gov/statutes/chapters/ch50/050_001_0063.html>
+
+[^ksa-50-163-material-contact]: **K.S.A. 50-163** — "‘Material contact customer’ means any customer or prospective customer that is solicited, produced or serviced, directly or indirectly, by the employee or owner at issue or any customer or prospective customer about whom the employee or owner, directly or indirectly, had confidential business or proprietary information or trade secrets in the course of the employee's or owner's relationship with the customer." *K.S.A. 50-163(g)(2).* <https://ksrevisor.gov/statutes/chapters/ch50/050_001_0063.html>
+
+[^ksa-50-163-owner-nonsolicit]: **K.S.A. 50-163** — "A covenant in writing in which an owner agrees to not solicit, induce, persuade, encourage, service, direct or otherwise interfere with, directly or indirectly, a business entity's customers, including any reduction, termination, acceptance or transfer of any customer's business, in whole or in part, for the purpose of providing any product or service that is competitive with those provided by the business entity shall be conclusively presumed to be enforceable and not a restraint of trade if the covenant is limited to material contact customers and the covenant does not continue for more than four years following the end of the owner's business relationship with the business entity." *K.S.A. 50-163(c)(3).* <https://ksrevisor.gov/statutes/chapters/ch50/050_001_0063.html>
+
+[^ksa-50-163-defenses]: **K.S.A. 50-163** — "Notwithstanding the presumption of enforceability provided in subsections (c)(2) through (c)(5), an employee or owner shall be permitted to assert any applicable defense available at law or in equity for the court's consideration in a dispute regarding a written covenant." *K.S.A. 50-163(c)(7).* <https://ksrevisor.gov/statutes/chapters/ch50/050_001_0063.html>
+
+[^puritan-bennett-consideration]: **Puritan-Bennett Corp. v. Richter** — "After reviewing these authorities, we hold that continued employment should not as a matter of law be disregarded as consideration sufficient to uphold a covenant not to compete." *Puritan-Bennett Corp. v. Richter, 8 Kan. App. 2d 311, 657 P.2d 589 (1983).* <https://www.courtlistener.com/opinion/1159191/puritan-bennett-corp-v-richter/#:~:text=After%20reviewing%20these%20authorities%2C%20we,a%20covenant%20not%20to%20compete.>
+
+[^idbeis-referral-sources]: **Idbeis v. Wichita Surgical Specialists, P.A.** — "In Kansas, however, the law is clear that referral sources are a legitimate interest which can be protected by a restrictive covenant even in the context of a medical practice." *Idbeis v. Wichita Surgical Specialists, P.A., 279 Kan. 755, 112 P.3d 81 (2005).* <https://www.courtlistener.com/opinion/7970031/idbeis-v-wichita-surgical-specialists-pa/#:~:text=In%20Kansas%2C%20however%2C%20the%20law,context%20of%20a%20medical%20practice.>
+
+[^ksa-60-3320-trade-secret]: **K.S.A. 60-3320** — "‘Trade secret’ means information, including a formula, pattern, compilation, program, device, method, technique, or process, that: (i) derives independent economic value, actual or potential, from not being generally known to, and not being readily ascertainable by proper means by, other persons who can obtain economic value from its disclosure or use, and (ii) is the subject of efforts that are reasonable under the circumstances to maintain its secrecy." *K.S.A. 60-3320(4).* <https://ksrevisor.gov/statutes/chapters/ch60/060_033_0020.html>
+
+[^ksa-60-3326-contract]: **K.S.A. 60-3326** — "This act does not affect: (1) Contractual remedies, whether or not based upon misappropriation of a trade secret;" *K.S.A. 60-3326(b)(1).* <https://ksrevisor.gov/statutes/chapters/ch60/060_033_0026.html>
+
+[^wolfe-kutsa-exclusive]: **Wolfe Electric, Inc. v. Duckworth** — "This is error because tort causes of action cannot include a claim to recover for trade secrets; KUTSA is the exclusive remedy." *Wolfe Electric, Inc. v. Duckworth, 293 Kan. 375, 266 P.3d 516 (2011).* <https://www.courtlistener.com/opinion/7970813/wolfe-electric-inc-v-duckworth/#:~:text=This%20is%20error%20because%20tort,KUTSA%20is%20the%20exclusive%20remedy.>
+
+[^q10-ksa-50-163-owner]: **K.S.A. 50-163** — "A covenant in writing in which an owner agrees to not solicit, recruit, induce, persuade, encourage, direct or otherwise interfere with, directly or indirectly, one or more employees or owners of a business entity for the purpose of interfering with the employment or ownership relationship of such employees or owners shall be conclusively presumed to be enforceable and not a restraint of trade if the covenant is between a business entity and an owner of the business entity and the covenant does not continue for more than four years following the end of the owner's business relationship with the business entity." *K.S.A. 50-163(c)(2).* <https://ksrevisor.gov/statutes/chapters/ch50/050_001_0063.html>
+
+[^q10-ksa-50-163-owner-customer]: **K.S.A. 50-163** — "A covenant in writing in which an owner agrees to not solicit, induce, persuade, encourage, service, direct or otherwise interfere with, directly or indirectly, a business entity's customers, including any reduction, termination, acceptance or transfer of any customer's business, in whole or in part, for the purpose of providing any product or service that is competitive with those provided by the business entity shall be conclusively presumed to be enforceable and not a restraint of trade if the covenant is limited to material contact customers and the covenant does not continue for more than four years following the end of the owner's business relationship with the business entity." *K.S.A. 50-163(c)(3).* <https://ksrevisor.gov/statutes/chapters/ch50/050_001_0063.html>
+
+[^q10-ksa-50-163-owner-def]: **K.S.A. 50-163** — "‘Owner’ means a current or former owner or seller of all or any part of the assets of a business entity or any interest in a business entity, including, but not limited to, a partnership interest, a membership interest in a limited liability company or a series limited liability company or any other equity interest or ownership interest." *K.S.A. 50-163(g)(3).* <https://ksrevisor.gov/statutes/chapters/ch50/050_001_0063.html>

--- a/skills/non-compete-contract-explainer/content/kentucky.md
+++ b/skills/non-compete-contract-explainer/content/kentucky.md
@@ -1,0 +1,201 @@
+---
+jurisdiction: "Kentucky"
+slug: kentucky
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-03"
+canonicalUrl: https://openagreements.org/legal/non-compete/kentucky
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/kentucky · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in Kentucky[^about]
+
+Kentucky enforces non-competes only when the restraint is reasonable under common law and supported by valid consideration, with a narrow statutory ban for temporary health care staffing.
+
+
+## At a glance
+
+| Question | Kentucky |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed if reasonable |
+| **Bottom line** | Kentucky enforces a non-compete only if it is supported by valid consideration and reasonable in scope; existing employees must get new consideration, and courts may blue-pencil overbroad terms. |
+| **Main law or case** | common law (Kegel v. Tillotson, 297 S.W.3d 908 (Ky. App. 2009); Charles T. Creech, Inc. v. Brown, 433 S.W.3d 345 (Ky. 2014)) |
+| **Main exceptions** | Temporary health-care staffing ban (KRS 216.724) |
+| **Can a court narrow it?** | Yes — rewrites to reasonable |
+| **Applies to contractors?** | Unclear |
+| **Restriction extended during a breach?** | Unsettled |
+| **Maximum length set by law** | No statutory cap |
+
+## Are employee non-compete agreements enforceable in Kentucky? {#employee-noncompetes}
+
+**Short answer.** Yes, sometimes. Kentucky is a reasonableness state, not a general ban state. A non-compete is enforceable only if it is supported by valid consideration and is reasonable — affording fair protection to a legitimate employer interest without being so broad as to harm the public or impose undue hardship on the employee [^kegel-reasonableness-test].
+
+The common-law standard traces to *Ceresia v. Mitchell* and is restated in later cases such as *Kegel v. Tillotson*. In practice the recurring questions are duration, geography, the employer's protectable interest, the burden on the employee, and the effect on the public [^kegel-reasonableness-test].
+
+Kentucky has not enacted a general non-compete statute for the ordinary workforce. The enforceability analysis is judge-made, with one narrow statutory exception for temporary health care staffing covered later in this note.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not treat Kentucky as either a free-for-all or a ban state. Confirm there is valid consideration first, then test the restraint for reasonableness in time, territory, and scope before assuming a Kentucky covenant is enforceable [^kegel-reasonableness-test].
+
+## Is continued at-will employment enough consideration for a Kentucky non-compete? {#consideration}
+
+**Short answer.** No, not by itself, for an existing employee. Since *Charles T. Creech, Inc. v. Brown*, requiring a current employee to sign a non-compete without giving anything new — no raise, promotion, or other benefit — fails for lack of consideration [^creech-no-consideration][^creech-existing-employee-nothing].
+
+In *Creech*, a sixteen-year employee was asked to sign a conflicts-of-interest agreement containing a non-compete and received nothing in exchange. The Kentucky Supreme Court held the covenant unenforceable because the employer gave up no legal right and the employee gained no new benefit, so there was no mutuality of obligation [^creech-no-consideration].
+
+The practical rule that emerges is a split between new hires and incumbents. An offer of employment at the outset of the relationship is itself adequate consideration, but an employer that introduces a covenant mid-employment must provide independent, new consideration such as a bonus, a raise, a promotion, or specialized training [^creech-existing-employee-nothing].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not rely on continued at-will employment alone when an existing Kentucky employee signs a new covenant. Tie the signature to identifiable new consideration and document it, because a bare recital of consideration did not save the agreement in *Creech* [^creech-no-consideration][^creech-existing-employee-nothing].
+
+## What legitimate business interests can support a Kentucky non-compete? {#protectable-interests}
+
+**Short answer.** Trade secrets, confidential information, and customer goodwill are the core interests that can justify a tailored Kentucky restraint, and the Kentucky Uniform Trade Secrets Act supplies the statutory trade-secret overlay [^kutsa-trade-secret-definition].
+
+A covenant cannot exist only to suppress ordinary competition. It must protect something the employer is entitled to guard, such as trade secrets, confidential business information, or customer goodwill, rather than a general wish to keep a former employee out of the market [^kutsa-trade-secret-definition].
+
+The Kentucky Uniform Trade Secrets Act, codified at KRS 365.880 through 365.900, runs alongside contractual restraints. It defines a trade secret by the twin tests of independent economic value from secrecy and reasonable efforts to keep the information secret [^kutsa-trade-secret-definition]. A non-solicitation covenant is often easier to enforce than a trade-secret claim, because it requires proving contact with protected customers rather than meeting the statutory trade-secret threshold.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not use a Kentucky non-compete to block competition disconnected from a protectable interest. Tie the restraint to specific confidential information, trade secrets, or customer goodwill, and keep trade-secret remedies in a separate confidentiality and KUTSA strategy [^kutsa-trade-secret-definition].
+
+## What duration and geographic scope are reasonable for a Kentucky non-compete? {#duration-geography}
+
+**Short answer.** There is no statutory cap. Kentucky courts weigh duration, geography, the employer's protectable interest, the burden on the employee, and the public effect as a whole, rather than applying fixed numbers [^q4-kegel-reasonableness].
+
+During the *Creech* litigation, the Kentucky Court of Appeals proposed a six-factor reasonableness test — covering the nature of the industry, the employer's characteristics, the history of the employment relationship, the protectable interest, the hardship on the employee, and the effect on the public [^creech-six-factor-proposed]. Trial courts often look to that framework, but its status is limited: the Kentucky Supreme Court resolved *Creech* on consideration grounds alone and expressly addressed only that issue, so it never adopted the six-factor test [^creech-consideration-only-issue].
+
+Because the standard is holistic, geography and duration are evaluated together against the employer's actual footprint. A restraint limited to the area where the employer does business and to a duration that matches the time needed to protect the relationship is far easier to defend than a long, open-ended, statewide ban [^q4-kegel-reasonableness].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not copy a fixed term or radius from another form. Match the duration and territory to the employee's role and the employer's real market, because a Kentucky court evaluates the restraint as a whole and there is no safe-harbor number [^q4-kegel-reasonableness][^creech-consideration-only-issue].
+
+## Will a Kentucky court blue-pencil or reform an overbroad non-compete? {#court-narrowing}
+
+**Short answer.** Often, yes. Kentucky is a reformation jurisdiction: its courts have a blue-pencil power to reform or amend overly broad restrictions, and in some cases to supply a missing reasonable limit, rather than voiding the covenant outright [^kegel-blue-pencil][^hodges-reformation-geography].
+
+*Kegel v. Tillotson* states the rule directly: Kentucky courts are empowered to reform or amend restrictions in a non-compete clause when the initial terms are overly broad or burdensome [^kegel-blue-pencil]. *Hodges v. Todd* shows how far that power can reach — there, in the sale-of-a-business context, the court held that a trial court could enforce a covenant that omitted any geographic limit by establishing a reasonable one based on the parties' intent [^hodges-reformation-geography].
+
+That equitable power is not a license to overreach. Reformation is discretionary, and an employer that drafts an abusively broad covenant cannot assume a court will simply rewrite it into something enforceable.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not rely on Kentucky's blue-pencil power as a safety net for an aggressive covenant. Draft tiered, severable, reasonable restraints, because reformation is discretionary and a court may decline to rescue a covenant it views as overreaching [^kegel-blue-pencil][^hodges-reformation-geography].
+
+## Does a Kentucky non-compete toll or extend during breach or litigation? {#tolling-extension}
+
+**Short answer.** This is an open Kentucky question. No staged Kentucky statute or appellate decision squarely endorses automatically tolling or extending the restricted period while the former employee is in breach or while litigation is pending [^q6-kegel-reasonableness-backdrop][^q6-kegel-blue-pencil].
+
+Kentucky law gives two signals rather than a rule. First, any clause that extends the restricted period must still satisfy the ordinary reasonableness standard, so an extension that turns a fixed covenant into an open-ended restraint risks being found unreasonable [^q6-kegel-reasonableness-backdrop]. Second, Kentucky courts reform restraints toward reasonableness rather than mechanically enlarging them, which cuts against assuming a court will tack on extra time for a breach [^q6-kegel-blue-pencil].
+
+A contractual extension-on-breach clause is therefore unsettled and fact-dependent in Kentucky. It is most defensible when it is tied to the duration of an actual breach and a legitimate interest, rather than written as an automatic, indefinite extension.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Open question: Kentucky law is unsettled on whether an extension-on-breach or tolling clause is enforceable after the original restricted period expires. Draft any such clause as a separate, reasonable restraint tied to the breach, and do not assume a Kentucky court will automatically extend an expired covenant [^q6-kegel-reasonableness-backdrop][^q6-kegel-blue-pencil].
+
+## Which Kentucky workers have special non-compete limits? {#industry-specific-limits}
+
+**Short answer.** Kentucky's one categorical statutory ban targets temporary health care staffing. KRS 216.724 voids non-compete and contract buy-out provisions between a health care services agency and its temporary direct care staff [^krs-216-724-healthcare-ban][^krs-216-724-void].
+
+The statute bars a health care services agency from restricting the employment opportunities of temporary direct care staff, including through non-compete or buy-out clauses [^krs-216-724-healthcare-ban]. A contract that violates the rule is treated as an unfair trade practice and is void [^krs-216-724-void]. A 2023 amendment narrowed the ban so it does not reach the placement of permanent direct care staff.
+
+Outside that carve-out, Kentucky has no broad occupational exemptions for non-competes. Ordinary employees — including most professionals — fall back on the common-law reasonableness and consideration analysis described above rather than an industry-specific statute.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not use ordinary reasonableness analysis to rescue a covenant that KRS 216.724 voids. For a temporary direct care staffer at a health care services agency, the statutory ban controls and the covenant is void regardless of how reasonable it looks [^krs-216-724-healthcare-ban][^krs-216-724-void].
+
+## Will a choice-of-law clause selecting Kentucky law be enforced? {#choice-of-law}
+
+**Short answer.** Often, yes. Kentucky's moderate reformation approach makes Kentucky law a common pick for multi-state covenants, and courts — even in states that reject blue-penciling — have applied a contractual Kentucky choice-of-law clause and found Kentucky's rule not contrary to the forum's public policy [^senture-applies-kentucky-law][^edwards-public-policy-not-repugnant].
+
+In *Senture, LLC v. Dietrich*, a Virginia federal court applied Kentucky law to a non-compete pursuant to the agreement's choice-of-law and forum-selection clause [^senture-applies-kentucky-law]. In *Edwards Moving & Rigging, Inc. v. W.O. Grubb Steel Erection, Inc.*, another Virginia federal court enforced a Kentucky choice-of-law clause and held that applying Kentucky law — which allows blue-penciling, unlike Virginia — was not repugnant enough to Virginia public policy to override the parties' choice [^edwards-public-policy-not-repugnant].
+
+The limit is public policy. A court applies the chosen law only when doing so does not offend the forum's own public policy, and both decisions are federal trial-court rulings rather than binding Kentucky Supreme Court authority.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not treat a Kentucky choice-of-law clause as automatically dispositive. It is strongest when paired with a real connection to Kentucky and a covenant that is reasonable on its own terms, because a forum court will still test the clause against its own public policy before applying Kentucky law [^senture-applies-kentucky-law][^edwards-public-policy-not-repugnant].
+
+## Did the FTC's federal non-compete rule change Kentucky non-compete law? {#federal-ftc-overlay}
+
+**Short answer.** No. The FTC's 2024 nationwide Non-Compete Rule was set aside by a federal court before it took effect, so Kentucky non-competes remain governed by Kentucky common law and the state's narrow statutory carve-out [^ryan-ftc-rule-set-aside].
+
+*Ryan LLC v. FTC* held that the FTC lacked statutory authority to issue the rule and that the rule was arbitrary and capricious [^ryan-ftc-unlawful]. The court set the rule aside with nationwide effect so that it would not be enforced or take effect [^ryan-ftc-rule-set-aside].
+
+That outcome does not make every Kentucky covenant enforceable. It simply removes the FTC rule as a nationwide overlay and leaves Kentucky's reasonableness and consideration requirements in control.
+
+"The Non-Compete Rule, 16 C.F.R. § 910.1–.6, is hereby SET ASIDE and shall not be enforced or otherwise take effect on September 4, 2024, or thereafter."[^ryan-ftc-rule-set-aside]
+
+## What recent Kentucky non-compete reform efforts should employers watch? {#pending-reform}
+
+**Short answer.** None is currently law. Kentucky's most recent reform efforts, House Bill 690 and Senate Bill 234 in the 2025 session, would have restricted non-competes for lower-wage and other workers, but both died without enactment [^hb690-wage-threshold].
+
+House Bill 690 would have barred non-competes against a *covered employee* — defined as a worker earning less than two thousand dollars per week — and let affected workers sue [^hb690-wage-threshold]. A broader companion proposal, Senate Bill 234, also failed that session. Neither bill passed before the 2025 session adjourned, and the 2026 session likewise ended without enacting a general non-compete restriction.
+
+The enacted baseline therefore remains common-law reasonableness and consideration, plus the narrow health care staffing ban. These bills matter as a signal of likely future direction, not as current law.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Treat House Bill 690 and Senate Bill 234 as monitoring items, not present Kentucky law. Recheck the Kentucky General Assembly bill status each session before changing forms or telling workers that Kentucky has enacted a wage-threshold or general non-compete ban [^hb690-wage-threshold].
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-03. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not Kentucky. This article synthesizes Kentucky primary law and is not legal advice from a Kentucky-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^kegel-reasonableness-test]: **Kegel v. Tillotson** — "agreements on restraint of trade are reasonable if, ‘on consideration of the subject, nature of the business, situation of the parties and circumstances of the particular case, the restriction is such only as to afford fair protection to the interests of the covenan-tee and is not so large as to interfere with the public interests or impose undue hardship on the party restricted." *Kegel v. Tillotson, 297 S.W.3d 908 (Ky. App. 2009).* <https://www.courtlistener.com/opinion/2169063/kegel-v-tillotson/#:~:text=agreements%20on%20restraint%20of%20trade,hardship%20on%20the%20party%20restricted.>
+
+[^creech-no-consideration]: **Charles T. Creech, Inc. v. Brown** — "Because the Agreement did not require Creech to forbear the exercise of some legal right or otherwise result in some detriment to Creech, there was no consideration." *Charles T. Creech, Inc. v. Brown, 433 S.W.3d 345 (Ky. 2014).* <https://www.courtlistener.com/opinion/5444327/charles-t-creech-inc-v-brown/#:~:text=Because%20the%20Agreement%20did%20not,Creech%2C%20there%20was%20no%20consideration.>
+
+[^creech-existing-employee-nothing]: **Charles T. Creech, Inc. v. Brown** — "In short, Brown received no consideration from Creech in exchange for signing the Agreement or after he signed the Agreement." *Charles T. Creech, Inc. v. Brown, 433 S.W.3d 345 (Ky. 2014).* <https://www.courtlistener.com/opinion/5444327/charles-t-creech-inc-v-brown/#:~:text=In%20short%2C%20Brown%20received%20no,after%20he%20signed%20the%20Agreement.>
+
+[^kutsa-trade-secret-definition]: **Ky. Rev. Stat. § 365.880** — "‘Trade secret’ means information, including a formula, pattern, compilation, program, data, device, method, technique, or process, that: (a) Derives independent economic value, actual or potential, from not being generally known to, and not being readily ascertainable by proper means by, other persons who can obtain economic value from its disclosure or use, and (b) Is the subject of efforts that are reasonable under the circumstances to maintain its secrecy." *Ky. Rev. Stat. § 365.880(4).* <https://apps.legislature.ky.gov/law/statutes/statute.aspx?id=34868>
+
+[^q4-kegel-reasonableness]: **Kegel v. Tillotson** — "agreements on restraint of trade are reasonable if, ‘on consideration of the subject, nature of the business, situation of the parties and circumstances of the particular case, the restriction is such only as to afford fair protection to the interests of the covenan-tee and is not so large as to interfere with the public interests or impose undue hardship on the party restricted." *Kegel v. Tillotson, 297 S.W.3d 908 (Ky. App. 2009).* <https://www.courtlistener.com/opinion/2169063/kegel-v-tillotson/#:~:text=agreements%20on%20restraint%20of%20trade,hardship%20on%20the%20party%20restricted.>
+
+[^creech-six-factor-proposed]: **Charles T. Creech, Inc. v. Brown** — "In doing so, the Court proposed a six factor test that should be applied by the trial court in determining whether the non-compete portion of the Agreement is enforceable." *Charles T. Creech, Inc. v. Brown, 433 S.W.3d 345 (Ky. 2014).* <https://www.courtlistener.com/opinion/5444327/charles-t-creech-inc-v-brown/#:~:text=In%20doing%20so%2C%20the%20Court%20proposed,of%20the%20Agreement%20is%20enforceable.>
+
+[^creech-consideration-only-issue]: **Charles T. Creech, Inc. v. Brown** — "Because we hold that this Agreement was not supported by adequate consideration, that is the only issue we address." *Charles T. Creech, Inc. v. Brown, 433 S.W.3d 345 (Ky. 2014).* <https://www.courtlistener.com/opinion/5444327/charles-t-creech-inc-v-brown/#:~:text=Because%20we%20hold%20that%20this,the%20only%20issue%20we%20address.>
+
+[^kegel-blue-pencil]: **Kegel v. Tillotson** — "our courts have adopted a ‘blue pencil’ rule, whereby we are empowered to reform or amend restrictions in a non-compete clause if the initial restrictions are overly broad or burdensome." *Kegel v. Tillotson, 297 S.W.3d 908 (Ky. App. 2009).* <https://www.courtlistener.com/opinion/2169063/kegel-v-tillotson/#:~:text=our%20courts%20have%20adopted%20a,are%20overly%20broad%20or%20burdensome.>
+
+[^hodges-reformation-geography]: **Hodges v. Todd** — "we hold that the trial court had the authority to enforce the covenant by establishing a reasonable geographical limitation based on the intention of the parties at the time the contract was executed." *Hodges v. Todd, 698 S.W.2d 317 (Ky. App. 1985).* <https://www.courtlistener.com/opinion/1781513/hodges-v-todd/#:~:text=we%20hold%20that%20the%20trial,time%20the%20contract%20was%20executed.>
+
+[^q6-kegel-reasonableness-backdrop]: **Kegel v. Tillotson** — "agreements on restraint of trade are reasonable if, ‘on consideration of the subject, nature of the business, situation of the parties and circumstances of the particular case, the restriction is such only as to afford fair protection to the interests of the covenan-tee and is not so large as to interfere with the public interests or impose undue hardship on the party restricted." *Kegel v. Tillotson, 297 S.W.3d 908 (Ky. App. 2009).* <https://www.courtlistener.com/opinion/2169063/kegel-v-tillotson/#:~:text=agreements%20on%20restraint%20of%20trade,hardship%20on%20the%20party%20restricted.>
+
+[^q6-kegel-blue-pencil]: **Kegel v. Tillotson** — "our courts have adopted a ‘blue pencil’ rule, whereby we are empowered to reform or amend restrictions in a non-compete clause if the initial restrictions are overly broad or burdensome." *Kegel v. Tillotson, 297 S.W.3d 908 (Ky. App. 2009).* <https://www.courtlistener.com/opinion/2169063/kegel-v-tillotson/#:~:text=our%20courts%20have%20adopted%20a,are%20overly%20broad%20or%20burdensome.>
+
+[^krs-216-724-healthcare-ban]: **Ky. Rev. Stat. § 216.724** — "Restrict in any manner the employment opportunities of any temporary direct care staff that is contracted with or employed by the agency, including but not limited to contract buy-out provisions or contract non-compete clauses;" *Ky. Rev. Stat. § 216.724(1)(a).* <https://apps.legislature.ky.gov/law/statutes/statute.aspx?id=53778>
+
+[^krs-216-724-void]: **Ky. Rev. Stat. § 216.724** — "Any contract between a health care services agency and temporary direct care staff that does not comply with subsection (1) of this section shall be considered an unfair trade practice and be void pursuant to KRS 365.060." *Ky. Rev. Stat. § 216.724(2).* <https://apps.legislature.ky.gov/law/statutes/statute.aspx?id=53778>
+
+[^senture-applies-kentucky-law]: **Senture, LLC v. Dietrich** — "With respect to the first issue, this Court will apply Kentucky law to this case." *Senture, LLC v. Dietrich, 575 F. Supp. 2d 724 (E.D. Va. 2008).* <https://www.courtlistener.com/opinion/2465686/senture-llc-v-dietrich/#:~:text=With%20respect%20to%20the%20first,Kentucky%20law%20to%20this%20case.>
+
+[^edwards-public-policy-not-repugnant]: **Edwards Moving & Rigging, Inc. v. W.O. Grubb Steel Erection, Inc.** — "Applying the law of a state that allows ‘blue penciling’ is not so repugnant to Virginia public policy as to overcome Virginia's preference for enforcing choice-of-law and forum-selection clauses." *Edwards Moving & Rigging, Inc. v. W.O. Grubb Steel Erection, Inc., No. 3:12CV146-HEH (E.D. Va. Apr. 23, 2012).* <https://www.casemine.com/judgement/us/5914ae80add7b04934747bf6>
+
+[^ryan-ftc-rule-set-aside]: **Ryan LLC v. Federal Trade Commission** — "The Non-Compete Rule, 16 C.F.R. § 910.1–.6, is hereby SET ASIDE and shall not be enforced or otherwise take effect on September 4, 2024, or thereafter." *Ryan LLC v. Fed. Trade Comm'n, 746 F. Supp. 3d 369 (N.D. Tex. 2024).* <https://www.courtlistener.com/opinion/10205745/ryan-llc-v-federal-trade-commission/#:~:text=The%20Non%2DCompete%20Rule%2C%2016%20C.F.R.,September%204%2C%202024%2C%20or%20thereafter.>
+
+[^ryan-ftc-unlawful]: **Ryan LLC v. Federal Trade Commission** — "In sum, the Court concludes that the FTC lacks statutory authority to promulgate the Non- Compete Rule, and that the Rule is arbitrary and capricious." *Ryan LLC v. Fed. Trade Comm'n, 746 F. Supp. 3d 369 (N.D. Tex. 2024).* <https://www.courtlistener.com/opinion/10205745/ryan-llc-v-federal-trade-commission/#:~:text=In%20sum%2C%20the%20Court%20concludes%20that,Rule%20is%20arbitrary%20and%20capricious.>
+
+[^hb690-wage-threshold]: **An Act relating to contracts (H.B. 690)** — "No employer shall enter into, enforce, or threaten to enforce a covenant not to compete with any covered employee." *H.B. 690, 2025 Reg. Sess. (Ky. 2025).* <https://apps.legislature.ky.gov/recorddocuments/bill/25RS/hb690/orig_bill.pdf>

--- a/skills/non-compete-contract-explainer/content/louisiana.md
+++ b/skills/non-compete-contract-explainer/content/louisiana.md
@@ -1,0 +1,272 @@
+---
+jurisdiction: "Louisiana"
+slug: louisiana
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-03"
+canonicalUrl: https://openagreements.org/legal/non-compete/louisiana
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/louisiana · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in Louisiana[^about]
+
+A question-by-question summary of Louisiana non-compete law under La. R.S. 23:921, including the default rule of nullity, the parish-naming geographic requirement, the two-year cap, the bar on judicial reformation, the prospective-employee timing trap, employee non-solicitation after Brown & Root v. Farris, the void choice-of-law rule, the 2025 physician burn-off limits, the 2026 intern and apprentice ban, and trade-secret alternatives.
+
+
+## At a glance
+
+| Question | Louisiana |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed if reasonable |
+| **Bottom line** | Louisiana voids every non-compete by default and enforces one only if it fits a narrow statutory exception with named parishes and a two-year cap, so most out-of-state templates fail. |
+| **Main law or case** | La. R.S. 23:921 |
+| **Main exceptions** | Employee exception (subsection C, 2-yr/named parishes); sale of business; physician burn-off limits; automobile salesmen banned; intern/apprentice ban (Aug 1, 2026) |
+| **Can a court narrow it?** | Only strikes wording |
+| **Applies to contractors?** | Unclear |
+| **Restriction extended during a breach?** | Silent — likely barred by 2-year cap |
+| **Maximum length set by law** | 2 years from termination (employee covenant) |
+
+## Are employee non-compete agreements enforceable in Louisiana? {#employee-noncompetes}
+
+**Short answer.** Only inside a narrow statutory lane. Louisiana starts from the position that any agreement restraining a lawful profession, trade, or business is null and void, and it enforces a non-compete only when the agreement fits one of the relationship-based exceptions the statute spells out [^rs-23921-a1].
+
+Louisiana is not a reasonableness state. Unlike most jurisdictions, it does not ask whether a restraint is fair under the circumstances; it asks whether the agreement complies with the exact text of a single statute, La. R.S. 23:921. The statute opens with a flat declaration of nullity, subject only to the exceptions it then lists.
+
+"Every contract or agreement, or provision thereof, by which anyone is restrained from exercising a lawful profession, trade, or business of any kind, except as provided in this Section, shall be null and void."[^rs-23921-a1]
+
+Because the covenant is a statutory exception to a public-policy rule, Louisiana courts construe it strictly against the employer. The Louisiana Supreme Court made that the governing posture in *SWAT 24 Shreveport Bossier, Inc. v. Bond* [^swat24-strict-construction].
+
+"Because such covenants are in derogation of the common right, they must be strictly construed against the party seeking their enforcement."[^swat24-strict-construction]
+
+The practical consequence is that an out-of-state template will almost never survive in Louisiana. A covenant that reads as perfectly reasonable elsewhere is void here if it misses a statutory requirement, because reasonableness is not the test.
+
+## What geographic and durational limits must a Louisiana non-compete meet? {#geography-duration}
+
+**Short answer.** Named parishes and no more than two years. An employee non-compete must identify the specific parishes or municipalities where it applies and may not run longer than two years from the end of employment [^rs-23921-c]. A mileage radius does not satisfy the parish-naming requirement [^amcom-radius].
+
+The employee exception in subsection C is the most litigated part of the statute. It permits a covenant only within named geography where the employer actually does business, and only for a capped period.
+
+"Any person, including a corporation and the individual shareholders of such corporation, who is employed as an agent, servant, or employee may agree with his employer to refrain from carrying on or engaging in a business similar to that of the employer and/or from soliciting customers of the employer within a specified parish or parishes, municipality or municipalities, or parts thereof, so long as the employer carries on a like business therein, not to exceed a period of two years from termination of employment."[^rs-23921-c]
+
+The geographic rule is the single most common drafting trap. Louisiana requires the agreement to list parishes or municipalities by name; a radius around an office does not count. In *AMCOM of Louisiana, Inc. v. Battson*, the court rejected a restriction defined by a seventy-five-mile radius as overly broad [^amcom-radius].
+
+"We agree with the trial court's factual finding that the geographical area encompassed within a 75-mile radius of Shreveport or Bossier City makes this employment agreement overly broad."[^amcom-radius]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not define the restricted territory by a mileage radius or a generic catch-all such as *any parish where the employer does business*. Louisiana requires named parishes or municipalities, and a radius was struck down as overly broad in *AMCOM* [^amcom-radius][^rs-23921-c].
+
+## Does a tolling or extension-during-breach clause extend a Louisiana non-compete? {#tolling-during-breach}
+
+**Short answer.** It should not be relied on. The statute caps the restraint at two years from termination, and Louisiana's strict-construction and no-reformation rules leave no room for a clause that pushes the restriction past that ceiling by adding back time spent in breach or litigation [^q3-rs-23921-c][^q3-teamenv-no-reform].
+
+Many national templates add a tolling or extension clause so the employer gets the full benefit of the restricted period even if the former employee competes during it. Louisiana law is not friendly to that device. The statutory cap is fixed: the restraint may run for no more than two years measured from termination [^q3-rs-23921-c], not from the date competition stops or a judgment issues.
+
+Because the two-year ceiling is statutory and the covenant is strictly construed, a Louisiana court has no general power to lengthen the restriction. The federal Fifth Circuit, applying Louisiana law in *Team Environmental Services, Inc. v. Addison*, vacated an injunction on a covenant that violated the statute and held that the agreement could not be rewritten to comply [^q3-teamenv-no-reform].
+
+"Finding that the agreement violates the controlling Louisiana statute and may not be reformed, we vacate the injunction and render judgment for the defendants."[^q3-teamenv-no-reform]
+
+No Louisiana statute or appellate decision authorizes judicial tolling of the period, so the safest reading is that an extension-on-breach clause that would carry the restraint beyond two years from termination is unenforceable to that extent. There is no Louisiana Supreme Court decision squarely approving or rejecting a contractual tolling clause, so this conclusion rests on the statutory cap and the strict-construction rule rather than a case directly on tolling.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not assume a Louisiana court will add time back to a non-compete for a period of breach or litigation. The statute fixes a two-year ceiling measured from termination, and courts will not reform a covenant to extend it [^q3-rs-23921-c][^q3-teamenv-no-reform].
+
+## Will a Louisiana court narrow an overbroad non-compete instead of voiding it? {#reformation}
+
+**Short answer.** Only by severing, never by rewriting. A court will not add or substitute language to save a defective covenant; at most it may strike an offending portion under a severability clause and enforce what independently complies with the statute [^q4-teamenv-no-reform][^brock-severance].
+
+Louisiana courts have far less blue-pencil power than courts in reasonableness states. The starting point is that a non-compete violating the statute cannot be reformed into compliance, as the Fifth Circuit held in *Team Environmental* [^q4-teamenv-no-reform].
+
+There is a limited exception. Where the agreement contains a severability clause, a court may delete an invalid component and enforce the remainder, provided the surviving terms independently satisfy the statute. In *Brock Services, L.L.C. v. Rogillio*, the Fifth Circuit applied Louisiana law to enforce a covenant whose territory had been narrowed to comply, while restating that such covenants are disfavored and strictly construed [^brock-severance].
+
+A note on vocabulary: some Louisiana opinions use the word *reform* to describe this permitted excision of offending language under a severability clause, while others, like *Team Environmental*, use *reform* to mean rewriting a covenant into compliance, which is not allowed. The distinction that matters is functional rather than verbal: a court may strike an invalid term, but it may not add or substitute language to manufacture a compliant restraint.
+
+"Restrictive covenants are unfavored in Louisiana and are narrowly and strictly construed."[^brock-severance]
+
+The drafting lesson is the opposite of the strategy that works in reformation states. Casting a wide net in the hope a judge will trim it down is a high-risk approach in Louisiana, where the more likely outcome is total nullity of the non-compliant provision.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not draft an intentionally broad Louisiana covenant expecting a court to narrow it. A court will not rewrite a defective restraint; severance helps only when the surviving terms already comply with the statute [^q4-teamenv-no-reform][^brock-severance].
+
+## Must the employment relationship already exist when a Louisiana non-compete is signed? {#prospective-employee}
+
+**Short answer.** Yes, or the agreement must be carefully dated. A non-compete signed before the employment relationship exists is unenforceable, though a Louisiana appellate court has allowed one signed pre-start when it carries an effective date on or after the first day of work [^rouses-prospective][^annison-effective-date].
+
+The statute's employee exception applies to a person who *is employed* by the employer. The Fifth Circuit took that text seriously in *Rouses Enterprises, L.L.C. v. Clapp*, refusing to enforce a covenant a worker signed before he was actually employed [^rouses-prospective].
+
+"Because Clapp was not employed by Rouses when he signed the agreement, it is unenforceable under Louisiana law."[^rouses-prospective]
+
+A later Louisiana First Circuit decision, *Arthur J. Gallagher & Co. v. Annison*, distinguished *Rouses* and supplied a drafting fix. There the employees signed before starting, but each agreement fixed an effective date equal to the employee's first day of work [^annison-effective-date].
+
+"But Annison and Cates expressly agreed with Gallagher that the effective date of their employment agreements was the date each commenced their respective employment."[^annison-effective-date]
+
+Because the employment relationship existed as of that effective date, the timing of the signature did not void the covenants, which is the opposite of the result in *Rouses*.
+
+On consideration, Louisiana is a civil-law state, so the question is framed as lawful cause rather than common-law consideration. Continued at-will employment generally suffices, as in *Cellular One, Inc. v. Boyd*, where the covenant the court analyzed was signed as a condition of continued employment [^cellone-continued-employment], so an employer ordinarily need not pay a separate bonus to bind an existing employee.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not have a candidate sign a Louisiana non-compete during the interview or application stage. *Rouses* held a pre-employment covenant unenforceable; if a prospective employee must sign before the start date, the agreement should state an effective date on or after the first day of work [^rouses-prospective][^annison-effective-date].
+
+## Are employee non-solicitation (anti-poaching) clauses governed by La. R.S. 23:921? {#employee-nonsolicitation}
+
+**Short answer.** No, but they still need a durational limit. A 2024 Louisiana appellate decision held that an employee non-solicitation, or anti-poaching, clause is not governed by the non-compete statute, yet must be reasonable in scope and duration, and a clause with no end date can fail [^farris-not-governed].
+
+Louisiana practice historically treated solicitation restrictions as subject to the same strict statutory rules as non-competes. The First Circuit changed that for *employee* anti-poaching clauses in *Brown & Root Industrial Services, LLC v. Farris*, reasoning that restricting whom a former employee may recruit does not restrain that worker's own trade.
+
+"However, a contract by a former employee not to solicit employees of his former employer, like Promise Number 9, is not governed by La. R.S. 23:921."[^farris-not-governed]
+
+Falling outside the statute is not a free pass. The *Farris* court held that such clauses must still satisfy a common-law reasonableness standard.
+
+"Nevertheless, a review of the limited cases analyzing employee non-solicitation provisions reflects that courts have required that these non-solicitation provisions be reasonable in scope and duration, which we also find to be a necessary requirement and therefore applicable to our analysis of Promise Number 9."[^farris-reasonable]
+
+Applying that requirement, the court refused to enforce the clause because the agreement fixed no end date for the restriction at all.
+
+"In fact, the entire Agreement is devoid of any language, wording, or indication as to the duration of the terms of the contract."[^farris-no-duration]
+
+This distinction matters in drafting. A *customer* non-solicit still operates as a restraint on the former employee's trade and is generally treated under the strict 23:921 framework, while an *employee* anti-poaching clause is judged for reasonableness but must carry a clear end date.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not leave a Louisiana employee anti-poaching clause open-ended. Even though *Farris* placed such clauses outside La. R.S. 23:921, it refused to enforce one whose agreement was devoid of any durational limit [^farris-not-governed][^farris-no-duration].
+
+## Can an out-of-state choice-of-law or forum clause sidestep Louisiana non-compete law? {#choice-of-law}
+
+**Short answer.** No. A choice-of-forum or choice-of-law clause in a Louisiana employee's contract is null and void unless the employee ratifies it after the dispute has already arisen [^rs-23921-a2].
+
+A common strategy for multistate employers is to choose the law of a more employer-friendly state. Louisiana closed that door directly in the statute. Subsection A(2) voids forum and choice-of-law clauses in employment contracts except in a narrow ratification scenario.
+
+"(2) The provisions of every employment contract or agreement...shall be null and void except where the choice of forum clause or choice of law clause is expressly, knowingly, and voluntarily agreed to and ratified by the employee after the occurrence of the incident which is the subject of the civil or administrative action."[^rs-23921-a2]
+
+The ratification exception is rarely available in practice, because an employee almost never agrees, after a dispute has begun, to be governed by another state's more restrictive law. For a Louisiana resident, the realistic planning assumption is that Louisiana law will apply regardless of the contract's choice-of-law clause.
+
+## Do special rules apply to Louisiana physician non-competes? {#physician-noncompetes}
+
+**Short answer.** Yes, since 2025. A physician non-compete now runs from the date the contract is signed, not from termination, and it is capped at three years for primary care physicians and five years for other physicians [^rs-23921-m][^rs-23921-n].
+
+Act 273 of 2024 added physician-specific limits to La. R.S. 23:921, effective January 1, 2025. These rules differ structurally from the ordinary employee covenant: the clock starts at contract execution, a so-called burn-off period, rather than at the end of employment. For a primary care physician, the cap is three years.
+
+"Any provision in a contract or agreement which restrains a primary care physician from practicing medicine shall not exceed three years from the effective date of the initial contract or agreement."[^rs-23921-m]
+
+For any other physician, the cap is five years from the same starting point.
+
+"For any physician other than a primary care physician as defined in Subsection M of this Section, any provision in a contract or agreement which restrains the physician from practicing medicine shall not exceed five years from the effective date of the initial contract or agreement."[^rs-23921-n]
+
+The statute also narrows the geography for physician covenants and exempts certain rural and federally qualified health-center arrangements. Because the burn-off period runs from signing rather than separation, a physician who stays past the burn-off window may no longer be subject to any enforceable restraint, which is the opposite of the ordinary post-termination model.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not apply the ordinary two-year, post-termination model to a Louisiana physician covenant. Since January 1, 2025, the period runs from the contract's effective date and is capped at three years for primary care and five years for other physicians [^rs-23921-m][^rs-23921-n].
+
+## Which Louisiana professions have their own non-compete carve-outs? {#profession-carveouts}
+
+**Short answer.** Several. Automobile salesmen cannot be subject to a non-compete at all, real estate licensees get a three-day rescission right, and as of August 1, 2026, interns and apprentices are protected by a new statutory ban [^rs-23921-i][^rs-37-1448][^act150-intern].
+
+Beyond the general framework, the legislature has carved out specific occupations. Automobile salesmen are protected by a categorical bar inside the statute itself.
+
+"There shall be no contract or agreement or provision entered into by an automobile salesman and his employer restraining him from selling automobiles."[^rs-23921-i]
+
+Real estate brokers and licensees are governed by a separate statute that makes a non-compete an absolute nullity unless the licensee receives a short rescission window.
+
+"A non-compete agreement between a real estate broker and licensee...shall be unenforceable and an absolute nullity unless the licensee shall have the right to rescind the non-compete agreement until midnight of the third business day following the execution of the non-compete agreement or the delivery of the agreement to the licensee, whichever is later."[^rs-37-1448]
+
+The newest carve-out covers interns and apprentices. Act 150 of 2026, enacting La. R.S. 23:921(P) effective August 1, 2026, bars non-competes for interns and apprentices outright [^act150-intern].
+
+"There shall be no contract or agreement or provision entered into by an intern, whether paid or unpaid, or apprentice and his employer restraining the intern or apprentice from engaging in a business or an employment similar to that of the employer."[^act150-intern]
+
+Lawyers are separately constrained by the Louisiana Rules of Professional Conduct, which generally bar agreements restricting a lawyer's right to practice after the relationship ends.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not use a standard non-compete for an automobile salesman, a real estate licensee, an intern, or an apprentice. Each has a specific statutory rule: salesmen and, as of August 1, 2026, interns and apprentices cannot be restrained at all, and a real estate licensee must receive a third-business-day rescission right [^rs-23921-i][^act150-intern][^rs-37-1448].
+
+## How are Louisiana sale-of-business covenants treated? {#sale-of-business}
+
+**Short answer.** Under the same statute, on a separate track. The buyer of a business's goodwill may restrain the seller from competing within named parishes for up to two years from the sale [^rs-23921-b].
+
+The sale-of-goodwill exception sits in subsection B and mirrors the employee rule's structure: named geography, a like-business requirement, and a two-year cap, but measured from the date of sale rather than termination of employment.
+
+"Any person, including a corporation and the individual shareholders of such corporation, who sells the goodwill of a business may agree with the buyer that the seller or other interested party in the transaction, will refrain from carrying on or engaging in a business similar to the business being sold or from soliciting customers of the business being sold within a specified parish or parishes, or municipality or municipalities, or parts thereof, so long as the buyer, or any person deriving title to the goodwill from him, carries on a like business therein, not to exceed a period of two years from the date of sale."[^rs-23921-b]
+
+Because these covenants are negotiated between commercial parties rather than imposed on an individual worker, they are often easier to enforce in practice, but they still must satisfy the same parish-naming and two-year requirements. Louisiana has also extended comparable treatment to partners, corporate shareholders, and LLC members, each capped at two years from the end of the ownership relationship.
+
+## Are trade-secret and confidentiality protections available in Louisiana? {#trade-secrets}
+
+**Short answer.** Yes. The Louisiana Uniform Trade Secrets Act allows a court to enjoin actual or threatened misappropriation, and a confidentiality agreement remains available because it does not restrain a person from working [^rs-51-1432].
+
+Because non-competes are so hard to enforce, Louisiana employers frequently rely on trade-secret and confidentiality protections instead. The Louisiana Uniform Trade Secrets Act provides injunctive relief independent of any covenant.
+
+"Actual or threatened misappropriation may be enjoined."[^rs-51-1432]
+
+A confidentiality or non-disclosure agreement is not subject to the parish-naming and two-year limits of La. R.S. 23:921 because it restricts the use of information rather than the right to work. The important caveat is that an employer cannot use a confidentiality clause as a disguised non-compete; if an agreement is so broad that it effectively prevents the former employee from working in the field, a court is likely to treat it as a non-compete and apply the statute.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not draft a confidentiality agreement so broadly that it functions as a disguised non-compete. The trade-secret statute protects information and supports an injunction against misappropriation, but a confidentiality clause that effectively bars the employee from working risks being treated as a non-compete under La. R.S. 23:921 [^rs-51-1432][^q11-rs-23921-a1].
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-03. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not Louisiana. This article synthesizes Louisiana primary law and is not legal advice from a Louisiana-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^rs-23921-a1]: **La. R.S. 23:921** — "Every contract or agreement, or provision thereof, by which anyone is restrained from exercising a lawful profession, trade, or business of any kind, except as provided in this Section, shall be null and void." *La. R.S. 23:921(A)(1).* <https://legis.la.gov/Legis/Law.aspx?d=84015>
+
+[^swat24-strict-construction]: **SWAT 24 Shreveport Bossier, Inc. v. Bond** — "Because such covenants are in derogation of the common right, they must be strictly construed against the party seeking their enforcement." *SWAT 24 Shreveport Bossier, Inc. v. Bond, 808 So. 2d 294 (La. 2001).* <https://www.courtlistener.com/opinion/1860745/swat-24-shreveport-bossier-inc-v-bond/#:~:text=Because%20such%20covenants%20are%20in,the%20party%20seeking%20their%20enforcement.>
+
+[^rs-23921-c]: **La. R.S. 23:921** — "Any person, including a corporation and the individual shareholders of such corporation, who is employed as an agent, servant, or employee may agree with his employer to refrain from carrying on or engaging in a business similar to that of the employer and/or from soliciting customers of the employer within a specified parish or parishes, municipality or municipalities, or parts thereof, so long as the employer carries on a like business therein, not to exceed a period of two years from termination of employment." *La. R.S. 23:921(C).* <https://legis.la.gov/Legis/Law.aspx?d=84015>
+
+[^amcom-radius]: **AMCOM of Louisiana, Inc. v. Battson** — "We agree with the trial court's factual finding that the geographical area encompassed within a 75-mile radius of Shreveport or Bossier City makes this employment agreement overly broad." *AMCOM of La., Inc. v. Battson, 666 So. 2d 1227 (La. Ct. App. 1996).* <https://www.courtlistener.com/opinion/1094717/amcom-of-louisiana-inc-v-battson/#:~:text=We%20agree%20with%20the%20trial,this%20employment%20agreement%20overly%20broad.>
+
+[^q3-rs-23921-c]: **La. R.S. 23:921** — "within a specified parish or parishes, municipality or municipalities, or parts thereof, so long as the employer carries on a like business therein, not to exceed a period of two years from termination of employment." *La. R.S. 23:921(C).* <https://legis.la.gov/Legis/Law.aspx?d=84015>
+
+[^q3-teamenv-no-reform]: **Team Environmental Services, Inc. v. Addison** — "Finding that the agreement violates the controlling Louisiana statute and may not be reformed, we vacate the injunction and render judgment for the defendants." *Team Envtl. Servs., Inc. v. Addison, 2 F.3d 124 (5th Cir. 1993).* <https://www.courtlistener.com/opinion/5925/team-environmental-services-inc-v-addison/#:~:text=Finding%20that%20the%20agreement%20violates,render%20judgment%20for%20the%20defendants.>
+
+[^q4-teamenv-no-reform]: **Team Environmental Services, Inc. v. Addison** — "Finding that the agreement violates the controlling Louisiana statute and may not be reformed, we vacate the injunction and render judgment for the defendants." *Team Envtl. Servs., Inc. v. Addison, 2 F.3d 124 (5th Cir. 1993).* <https://www.courtlistener.com/opinion/5925/team-environmental-services-inc-v-addison/#:~:text=Finding%20that%20the%20agreement%20violates,render%20judgment%20for%20the%20defendants.>
+
+[^brock-severance]: **Brock Services, L.L.C. v. Rogillio** — "Restrictive covenants are unfavored in Louisiana and are narrowly and strictly construed." *Brock Servs., L.L.C. v. Rogillio, 936 F.3d 290 (5th Cir. 2019).* <https://www.courtlistener.com/opinion/4656603/brock-services-llc-v-richard-rogillio/#:~:text=Restrictive%20covenants%20are%20unfavored%20in,are%20narrowly%20and%20strictly%20construed.>
+
+[^rouses-prospective]: **Rouses Enterprises, L.L.C. v. Clapp** — "Because Clapp was not employed by Rouses when he signed the agreement, it is unenforceable under Louisiana law." *Rouses Enters., L.L.C. v. Clapp, No. 21-30293 (5th Cir. Mar. 8, 2022).* <https://www.ca5.uscourts.gov/opinions/unpub/21/21-30293.0.pdf>
+
+[^annison-effective-date]: **Arthur J. Gallagher & Co. v. Annison** — "But Annison and Cates expressly agreed with Gallagher that the effective date of their employment agreements was the date each commenced their respective employment." *Arthur J. Gallagher & Co. v. Annison, 391 So. 3d 1089 (La. Ct. App. 2024).* <https://caselaw.findlaw.com/court/la-court-of-appeal/116265798.html>
+
+[^cellone-continued-employment]: **Cellular One, Inc. v. Boyd** — "Defendants signed these agreements as a condition of their continued employment." *Cellular One, Inc. v. Boyd, 653 So. 2d 30 (La. Ct. App. 1995).* <https://www.courtlistener.com/opinion/1154814/cellular-one-inc-v-boyd/#:~:text=Defendants%20signed%20these%20agreements%20as,condition%20of%20their%20continued%20employment.>
+
+[^farris-not-governed]: **Brown & Root Industrial Services, LLC v. Farris** — "However, a contract by a former employee not to solicit employees of his former employer, like Promise Number 9, is not governed by La. R.S. 23:921." *Brown & Root Indus. Servs., LLC v. Farris, 392 So. 3d 424 (La. Ct. App. 2024).* <https://caselaw.findlaw.com/court/la-court-of-appeal/116318576.html>
+
+[^farris-reasonable]: **Brown & Root Industrial Services, LLC v. Farris** — "Nevertheless, a review of the limited cases analyzing employee non-solicitation provisions reflects that courts have required that these non-solicitation provisions be reasonable in scope and duration, which we also find to be a necessary requirement and therefore applicable to our analysis of Promise Number 9." *Brown & Root Indus. Servs., LLC v. Farris, 392 So. 3d 424 (La. Ct. App. 2024).* <https://caselaw.findlaw.com/court/la-court-of-appeal/116318576.html>
+
+[^farris-no-duration]: **Brown & Root Industrial Services, LLC v. Farris** — "In fact, the entire Agreement is devoid of any language, wording, or indication as to the duration of the terms of the contract." *Brown & Root Indus. Servs., LLC v. Farris, 392 So. 3d 424 (La. Ct. App. 2024).* <https://caselaw.findlaw.com/court/la-court-of-appeal/116318576.html>
+
+[^rs-23921-a2]: **La. R.S. 23:921** — "(2) The provisions of every employment contract or agreement...shall be null and void except where the choice of forum clause or choice of law clause is expressly, knowingly, and voluntarily agreed to and ratified by the employee after the occurrence of the incident which is the subject of the civil or administrative action." *La. R.S. 23:921(A)(2).* <https://legis.la.gov/Legis/Law.aspx?d=84015>
+
+[^rs-23921-m]: **La. R.S. 23:921** — "Any provision in a contract or agreement which restrains a primary care physician from practicing medicine shall not exceed three years from the effective date of the initial contract or agreement." *La. R.S. 23:921(M)(1).* <https://legis.la.gov/Legis/Law.aspx?d=84015>
+
+[^rs-23921-n]: **La. R.S. 23:921** — "For any physician other than a primary care physician as defined in Subsection M of this Section, any provision in a contract or agreement which restrains the physician from practicing medicine shall not exceed five years from the effective date of the initial contract or agreement." *La. R.S. 23:921(N)(1).* <https://legis.la.gov/Legis/Law.aspx?d=84015>
+
+[^rs-23921-i]: **La. R.S. 23:921** — "There shall be no contract or agreement or provision entered into by an automobile salesman and his employer restraining him from selling automobiles." *La. R.S. 23:921(I)(1).* <https://legis.la.gov/Legis/Law.aspx?d=84015>
+
+[^rs-37-1448]: **La. R.S. 37:1448.1** — "A non-compete agreement between a real estate broker and licensee...shall be unenforceable and an absolute nullity unless the licensee shall have the right to rescind the non-compete agreement until midnight of the third business day following the execution of the non-compete agreement or the delivery of the agreement to the licensee, whichever is later." *La. R.S. 37:1448.1(A).* <https://legis.la.gov/Legis/Law.aspx?d=93285>
+
+[^act150-intern]: **La. Acts 2026, No. 150 (H.B. 315)** — "There shall be no contract or agreement or provision entered into by an intern, whether paid or unpaid, or apprentice and his employer restraining the intern or apprentice from engaging in a business or an employment similar to that of the employer." *La. Acts 2026, No. 150 (enacting La. R.S. 23:921(P)), eff. Aug. 1, 2026.* <https://legis.la.gov/legis/ViewDocument.aspx?d=1475140>
+
+[^rs-23921-b]: **La. R.S. 23:921** — "Any person, including a corporation and the individual shareholders of such corporation, who sells the goodwill of a business may agree with the buyer that the seller or other interested party in the transaction, will refrain from carrying on or engaging in a business similar to the business being sold or from soliciting customers of the business being sold within a specified parish or parishes, or municipality or municipalities, or parts thereof, so long as the buyer, or any person deriving title to the goodwill from him, carries on a like business therein, not to exceed a period of two years from the date of sale." *La. R.S. 23:921(B).* <https://legis.la.gov/Legis/Law.aspx?d=84015>
+
+[^rs-51-1432]: **La. R.S. 51:1432** — "Actual or threatened misappropriation may be enjoined." *La. R.S. 51:1432(A).* <https://legis.la.gov/Legis/Law.aspx?d=104049>
+
+[^q11-rs-23921-a1]: **La. R.S. 23:921** — "Every contract or agreement, or provision thereof, by which anyone is restrained from exercising a lawful profession, trade, or business of any kind, except as provided in this Section, shall be null and void." *La. R.S. 23:921(A)(1).* <https://legis.la.gov/Legis/Law.aspx?d=84015>

--- a/skills/non-compete-contract-explainer/content/maine.md
+++ b/skills/non-compete-contract-explainer/content/maine.md
@@ -1,0 +1,178 @@
+---
+jurisdiction: "Maine"
+slug: maine
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-02"
+canonicalUrl: https://openagreements.org/legal/non-compete/maine
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/maine · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in Maine[^about]
+
+Maine regulates employee non-competes through 26 M.R.S. § 599-A, using statutory bright-line limits plus Maine common-law reasonableness and as-applied review.
+
+
+## At a glance
+
+| Question | Maine |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed above a pay level |
+| **Bottom line** | Maine treats non-competes as contrary to public policy and enforces them only when reasonable, and bans them entirely for employees earning at or below 400% of the federal poverty level (and for non-owner veterinarians). |
+| **Main law or case** | 26 M.R.S. § 599-A |
+| **Main exceptions** | Veterinarian (non-owner) ban; health-care-practitioner restriction (L.D. 2200, eff. July 13, 2026); employer no-poach ban (§ 599-B) |
+| **When the ban took effect** | Wage-floor ban (threshold indexed; $62,600 in 2025) |
+| **Can a court narrow it?** | Unsettled |
+| **Applies to contractors?** | Unclear |
+| **Restriction extended during a breach?** | Not addressed |
+| **Maximum length set by law** | No statutory maximum (reasonable duration) |
+
+## Are employee non-compete agreements enforceable in Maine? {#employee-noncompetes}
+
+**Short answer.** Sometimes, but Maine starts from a statutory anti-restraint rule: 26 M.R.S. § 599-A says non-competes are contrary to public policy[^maine-599a-public-policy-narrow-interests] and enforceable only if reasonable and no broader than necessary to protect specified employer interests.
+
+The statute limits those interests to trade secrets, confidential information that is not a trade secret, and goodwill. A covenant aimed only at ordinary competition is outside that statutory frame.
+
+Maine common law points in the same direction. *Lord* says the covenant must sweep no wider than needed to protect the business interest, and *Sisters of Charity* treats duration, geography, and the nature of the protected interest as fact-intensive reasonableness questions [^lord-no-wider-than-necessary][^sisters-duration-geography-interest].
+
+## Which Maine workers cannot be bound by non-competes? {#protected-workers}
+
+**Short answer.** Maine bars non-competes for employees earning at or below 400 percent of the federal poverty level and for non-owner licensed veterinarians in covered veterinary facilities [^maine-599a-prohibited-workers][^maine-599a-veterinarian-prior-agreements].
+
+The wage floor moves with the federal poverty level. Foley reports that Maine updated its threshold from $60,240 in 2024 to $62,600 in 2025 [^foley-2025-maine-threshold].
+
+The veterinarian rule is stronger than ordinary non-enforcement. The current statutory text also tells courts not to enforce earlier or renewed veterinarian non-competes unless the veterinarian has an ownership interest in the facility [^maine-599a-veterinarian-prior-agreements].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not treat the physician delayed-effect carve-out as a healthcare-wide permission rule. A separate health-care-practitioner restriction is now law: Governor Mills signed L.D. 2200 on April 15, 2026, and it applies to agreements entered into or renewed on or after its July 13, 2026 effective date [^ebg-ld2200-enacted][^maine-599a-prohibited-workers].
+
+## What notice and timing rules apply to Maine non-competes? {#notice-timing}
+
+**Short answer.** Maine requires pre-offer disclosure, a copy at least 3 business days before signing, and delayed effectiveness until the later of one year of employment or 6 months after signing, except for allopathic and osteopathic physician agreements [^maine-599a-disclosure-notice][^maine-599a-delayed-effectiveness].
+
+The notice rule has two parts. First, if the job will require a non-compete, the employer must disclose that requirement before making the offer. Second, the employer must provide the agreement at least 3 business days before the required signing date.
+
+The delayed-effectiveness rule is separate from the signing rule. A compliant agreement can be signed before it takes effect. For most employees, the restriction does not ripen until both the statutory waiting period and the employment-duration rule are satisfied.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Build the notice and delay rules into onboarding workflows. A signature collected on time is not enough if the pre-offer disclosure or 3-business-day copy requirement was missed [^maine-599a-disclosure-notice].
+
+## Will Maine courts narrow or reform an overbroad non-compete? {#court-narrowing}
+
+**Short answer.** Often they evaluate the restraint as applied, not only as drafted. *Brignull* says Maine assesses a non-compete only as the employer sought to apply it[^brignull-as-applied-review].
+
+That makes Maine different from a strict red-pencil jurisdiction and from a mechanical blue-pencil state. The court can focus on the actual enforcement request, but the requested restraint still must be reasonable in duration, geography, and protected interest.
+
+*Lord* gives the limiting principle. The court may require specificity about what goodwill or business value needs protection before imposing or enforcing a severe restraint [^lord-specificity-goodwill-restraint].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not draft broadly just because Maine recognizes as-applied review. *Lord* still requires a record showing that the scope is reasonably necessary to protect the specific goodwill or business value at issue [^lord-specificity-goodwill-restraint].
+
+## Are employer no-poach or no-hire agreements allowed in Maine? {#employer-no-poach}
+
+**Short answer.** No. 26 M.R.S. § 599-B prohibits employer-to-employer restrictive employment agreements that restrict one employer from soliciting or hiring another employer's employees or former employees [^maine-599b-no-poach-definition-ban].
+
+The statute reaches agreements between two or more employers, including through franchise, contractor, and subcontractor arrangements. It separately bars entering into the agreement, enforcing it, or threatening enforcement.
+
+Violations carry a civil fine of at least $5,000, and the Maine Department of Labor enforces the section [^maine-599b-penalty-enforcement].
+
+## Are non-solicitation and confidentiality agreements safer alternatives in Maine? {#alternatives}
+
+**Short answer.** Often yes. Section 599-A itself points to nonsolicitation, nondisclosure, and confidentiality agreements as alternatives, and a non-compete may be presumed necessary only when those alternatives cannot adequately protect the interest [^maine-599a-alternative-covenants].
+
+That does not make every alternative covenant low risk. A confidentiality covenant can protect information beyond trade secrets, but it cannot bar use of general skill or knowledge. *Bernier* upheld a nondisclosure clause because it protected specialized original work without stopping the employee from using general skill and knowledge [^bernier-confidential-not-general-skill].
+
+Maine also has a separate employment NDA statute. Section 599-C protects reporting, testimony, evidence, and law-enforcement communications in discrimination-related contexts, while preserving ordinary protections for proprietary information, trade secrets, and information confidential by law [^maine-599c-discrimination-reporting][^maine-599c-proprietary-info-saved].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not make a confidentiality clause do non-compete work. Maine allows protection for specialized confidential information, but *Bernier* distinguishes that from blocking general skill and knowledge [^bernier-confidential-not-general-skill].
+
+## What trade-secret remedies are available in Maine? {#trade-secrets}
+
+**Short answer.** Maine trade-secret law gives employers remedies that can substitute for or sit beside narrow restrictive covenants, including injunctions, damages, exemplary damages, and attorney-fee awards [^maine-utsa-injunctions][^maine-utsa-damages][^maine-utsa-fees].
+
+The definition matters because § 599-A cross-references Title 10, section 1542 for trade secrets. Maine defines a trade secret as information that derives independent economic value from not being generally known or readily ascertainable and is subject to reasonable secrecy efforts [^maine-utsa-trade-secret-definition].
+
+The remedies are practical. Courts may restrain actual or threatened misappropriation, award actual loss and unjust enrichment, use a reasonable royalty measure, and award exemplary damages for willful and malicious misappropriation [^maine-utsa-injunctions][^maine-utsa-damages].
+
+## What recent Maine non-compete developments should employers track? {#recent-developments}
+
+**Short answer.** Track three moving points: the annually indexed wage threshold, the 2024 veto of L.D. 1496, and the newly enacted L.D. 2200 health-care-practitioner restriction effective July 13, 2026 [^foley-2025-threshold-recent][^bernstein-ld1496-veto-sustained][^ebg-ld2200-effective].
+
+The 2024 veto means Maine did not move to a near-total employee non-compete ban then. Bernstein Shur reports that the veto was sustained on April 2, 2024, so employers continued to draft under the existing L.D. 733 framework [^bernstein-ld1496-veto-sustained].
+
+The 2026 healthcare development is now law. Governor Mills signed L.D. 2200 on April 15, 2026, and it applies to non-compete agreements entered into or renewed on or after its July 13, 2026 effective date [^ebg-ld2200-effective].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Confirm the codified text before relying on the § 599-A page alone for healthcare covenants. L.D. 2200 was signed on April 15, 2026 but does not take effect until July 13, 2026, so the Revisor's current § 599-A text may still show only the wage-floor and veterinarian prohibitions until the amendment is codified [^maine-599a-current-prohibited-workers][^ebg-ld2200-effective].
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-02. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not Maine. This article synthesizes Maine primary law and is not legal advice from a Maine-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^maine-599a-public-policy-narrow-interests]: **26 M.R.S. § 599-A — Noncompete agreements** — "Noncompete agreements are contrary to public policy and are enforceable only to the extent that they are reasonable and are no broader than necessary to protect one or more of the following legitimate business interests of the employer:" *26 M.R.S. § 599-A(2).* <https://legislature.maine.gov/statutes/26/title26sec599-A.html>
+
+[^lord-no-wider-than-necessary]: **Lord v. Lord** — "We have long recognized that non-competition agreements are contrary to public policy and will be enforced only to the extent that they are reasonable and sweep no wider than necessary to protect the business interests in issue." *Lord v. Lord, 454 A.2d 830, 834 (Me. 1983).* <https://www.courtlistener.com/opinion/2367150/lord-v-lord/#:~:text=We%20have%20long%20recognized%20that,the%20business%20interests%20in%20issue.>
+
+[^sisters-duration-geography-interest]: **Sisters of Charity Health System, Inc. v. Farrago** — "Although reasonableness is a question of law, the inquiry is fact-intensive, and it depends on the specific circumstances of the case: the covenant’s duration, the scope of the specified geographic area, and the nature of the interest to be protected." *Sisters of Charity Health Sys., Inc. v. Farrago, 2011 ME 62, ¶ 10, 21 A.3d 110.* <https://www.courtlistener.com/opinion/2444708/sisters-of-charity-health-system-inc-v-farrago/#:~:text=Although%20reasonableness%20is%20a%20question,the%20interest%20to%20be%20protected.>
+
+[^maine-599a-prohibited-workers]: **26 M.R.S. § 599-A — Noncompete agreements** — "The employee is earning wages at or below 400% of the federal poverty level; or" *26 M.R.S. § 599-A(3)(A).* <https://legislature.maine.gov/statutes/26/title26sec599-A.html>
+
+[^maine-599a-veterinarian-prior-agreements]: **26 M.R.S. § 599-A — Noncompete agreements** — "A court may not enforce a noncompete agreement entered into or renewed with an employee who is a veterinarian licensed under Title 32, chapter 71‑A before the effective date of this paragraph unless the employee is working in a veterinary facility in which the employee has an ownership interest." *26 M.R.S. § 599-A(3).* <https://legislature.maine.gov/statutes/26/title26sec599-A.html>
+
+[^foley-2025-maine-threshold]: **Noncompete Agreements: Updated Income Thresholds for 2025** — "Accordingly, Maine is updating its $60,240 threshold from 2024 to $62,600 in 2025." *Foley & Lardner, Noncompete Agreements: Updated Income Thresholds for 2025 (2025).* <https://www.foley.com/insights/publications/2025/01/noncompete-agreements-updated-income-thresholds-for-2025/>
+
+[^ebg-ld2200-enacted]: **Maine Restricts Noncompetes for Health Care Practitioners** — "On April 15, 2026, Governor Janet T. Mills signed into law ‘An Act Relating to Noncompete Agreements Between Employers and Health Care Practitioners,’ L.D. 2200 (the ‘Amendments’)." *Epstein Becker Green, Maine Restricts Noncompetes for Health Care Practitioners (2026).* <https://www.tradesecretsandemployeemobility.com/maine-restricts-noncompetes-for-health-care-practitioners>
+
+[^maine-599a-disclosure-notice]: **26 M.R.S. § 599-A — Noncompete agreements** — "An employer shall notify an employee or prospective employee of a noncompete agreement requirement and provide a copy of the noncompete agreement not less than 3 business days before the employer requires the agreement to be signed to allow time for the employee or prospective employee to review the agreement and negotiate the terms of the agreement or employment with the employer if the employee or prospective employee wishes to do so." *26 M.R.S. § 599-A(4).* <https://legislature.maine.gov/statutes/26/title26sec599-A.html>
+
+[^maine-599a-delayed-effectiveness]: **26 M.R.S. § 599-A — Noncompete agreements** — "Except for a noncompete agreement between an employer and an allopathic physician or an osteopathic physician licensed under Title 32, chapter 48 or chapter 36, respectively, the terms of a noncompete agreement do not take effect until after one year of the employee's employment with the employer or a period of 6 months from the date the agreement was signed, whichever is later." *26 M.R.S. § 599-A(5).* <https://legislature.maine.gov/statutes/26/title26sec599-A.html>
+
+[^brignull-as-applied-review]: **Brignull v. Albert** — "Finally, because the reasonableness of a noncompetition agreement depends on the specific facts of the case, we assess the agreement only as Brignull has sought to apply it and not as it might have been enforced on its terms." *Brignull v. Albert, 666 A.2d 82, 84 (Me. 1995).* <https://www.courtlistener.com/opinion/2381411/brignull-v-albert/#:~:text=Finally%2C%20because%20the%20reasonableness%20of,been%20enforced%20on%20its%20terms.>
+
+[^lord-specificity-goodwill-restraint]: **Lord v. Lord** — "Upon remand, on the basis of the existing record and any further evidence received, the presiding justice should first define the nature and components of the good will included in the determination of value and then proceed to determine the scope of any restraint which may be reasonably necessary to protect the value of the asset." *Lord v. Lord, 454 A.2d 830, 835 (Me. 1983).* <https://www.courtlistener.com/opinion/2367150/lord-v-lord/#:~:text=Upon%20remand%2C%20on%20the%20basis,the%20value%20of%20the%20asset.>
+
+[^maine-599b-no-poach-definition-ban]: **26 M.R.S. § 599-B — Restrictive employment agreements** — "An employer may not:" *26 M.R.S. § 599-B(2).* <https://legislature.maine.gov/statutes/26/title26sec599-B.html>
+
+[^maine-599b-penalty-enforcement]: **26 M.R.S. § 599-B — Restrictive employment agreements** — "An employer that violates subsection 2 commits a civil violation for which a fine of not less than $5,000 may be adjudged. The Department of Labor is responsible for enforcement of this section." *26 M.R.S. § 599-B(3).* <https://legislature.maine.gov/statutes/26/title26sec599-B.html>
+
+[^maine-599a-alternative-covenants]: **26 M.R.S. § 599-A — Noncompete agreements** — "A noncompete agreement may be presumed necessary if the legitimate business interest cannot be adequately protected through an alternative restrictive covenant, including but not limited to a nonsolicitation agreement or a nondisclosure or confidentiality agreement." *26 M.R.S. § 599-A(2).* <https://legislature.maine.gov/statutes/26/title26sec599-A.html>
+
+[^bernier-confidential-not-general-skill]: **Bernier v. Merrill Air Engineers** — "The nondisclosure clause does not prohibit Bernier from using the general skill and knowledge he acquired during his employment with Merrill." *Bernier v. Merrill Air Eng'rs, 2001 ME 17, ¶ 18, 770 A.2d 97.* <https://www.courtlistener.com/opinion/2361851/bernier-v-merrill-air-engineers/#:~:text=The%20nondisclosure%20clause%20does%20not,during%20his%20employment%20with%20Merrill.>
+
+[^maine-599c-discrimination-reporting]: **26 M.R.S. § 599-C — Nondisclosure agreements** — "An employer may not require an employee, intern or applicant for employment to enter into a contract or agreement that waives or limits any right to report or discuss unlawful employment discrimination, as defined and limited by Title 5, chapter 337, subchapter 3, occurring in the workplace or at work-related events." *26 M.R.S. § 599-C(2).* <https://legislature.maine.gov/statutes/26/title26sec599-C.html>
+
+[^maine-599c-proprietary-info-saved]: **26 M.R.S. § 599-C — Nondisclosure agreements** — "Nothing in this section may be construed as limiting the use of nondisclosure agreements to protect the confidentiality of proprietary information, trade secrets or information that is otherwise confidential by law, rule or regulation." *26 M.R.S. § 599-C(4).* <https://legislature.maine.gov/statutes/26/title26sec599-C.html>
+
+[^maine-utsa-injunctions]: **10 M.R.S. § 1543 — Uniform Trade Secrets Act (Injunctive relief)** — "Actual or threatened misappropriation may be restrained or enjoined." *10 M.R.S. § 1543(1).* <https://legislature.maine.gov/statutes/10/title10sec1543.html>
+
+[^maine-utsa-damages]: **10 M.R.S. § 1544 — Uniform Trade Secrets Act (Damages)** — "Damages may include both the actual loss caused by misappropriation and the unjust enrichment caused by misappropriation that is not taken into account in computing actual loss. In lieu of damages measured by any other methods, the damages caused by misappropriation may be measured by imposition of liability for a reasonable royalty for a misappropriator's unauthorized disclosure or use of a trade secret." *10 M.R.S. § 1544(1).* <https://legislature.maine.gov/statutes/10/title10sec1544.html>
+
+[^maine-utsa-fees]: **10 M.R.S. § 1545 — Uniform Trade Secrets Act (Attorney's fees)** — "If a claim of misappropriation is made in bad faith, a motion to terminate an injunction is made or resisted in bad faith or willful and malicious misappropriation exists, the court may award reasonable attorneys fees to the prevailing party." *10 M.R.S. § 1545.* <https://legislature.maine.gov/statutes/10/title10sec1545.html>
+
+[^maine-utsa-trade-secret-definition]: **10 M.R.S. § 1542 — Uniform Trade Secrets Act (Definitions)** — "‘Trade secret’ means information, including, but not limited to, a formula, pattern, compilation, program, device, method, technique or process, that:" *10 M.R.S. § 1542(4).* <https://legislature.maine.gov/statutes/10/title10sec1542.html>
+
+[^foley-2025-threshold-recent]: **Noncompete Agreements: Updated Income Thresholds for 2025** — "Specifically, thresholds in Washington, Colorado, Maine, Rhode Island, Oregon, Virginia, and Washington, D.C. increase each year." *Foley & Lardner, Noncompete Agreements: Updated Income Thresholds for 2025 (2025).* <https://www.foley.com/insights/publications/2025/01/noncompete-agreements-updated-income-thresholds-for-2025/>
+
+[^bernstein-ld1496-veto-sustained]: **Governor Mills Vetoes L.D. 1496: What Maine Employers Need to Know** — "Because L.D. 1496 was vetoed and that veto was sustained by the Maine State Legislature, Maine employers should continue to reference L.D. 733 when drafting and negotiating noncompete agreements." *Bernstein Shur, Governor Mills Vetoes L.D. 1496: What Maine Employers Need to Know (2024).* <https://www.bernsteinshur.com/insights-events/governor-mills-vetoes-l-d-1496-an-act-to-prohibit-noncompete-clauses-what-maine-employers-need-to-know/>
+
+[^ebg-ld2200-effective]: **Maine Restricts Noncompetes for Health Care Practitioners** — "The Amendments apply to all noncompete agreements entered into, or renewed on or after, the Amendments’ effective date of July 13, 2026 (the ‘Effective Date’)." *Epstein Becker Green, Maine Restricts Noncompetes for Health Care Practitioners (2026).* <https://www.tradesecretsandemployeemobility.com/maine-restricts-noncompetes-for-health-care-practitioners>
+
+[^maine-599a-current-prohibited-workers]: **26 M.R.S. § 599-A — Noncompete agreements** — "The employee is earning wages at or below 400% of the federal poverty level; or" *26 M.R.S. § 599-A(3)(A).* <https://legislature.maine.gov/statutes/26/title26sec599-A.html>

--- a/skills/non-compete-contract-explainer/content/maryland.md
+++ b/skills/non-compete-contract-explainer/content/maryland.md
@@ -1,0 +1,244 @@
+---
+jurisdiction: "Maryland"
+slug: maryland
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-03"
+canonicalUrl: https://openagreements.org/legal/non-compete/maryland
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/maryland · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in Maryland[^about]
+
+Maryland enforces non-competes only when the restraint is reasonable under common law, and a statute voids them outright for low-wage, veterinary, and many health care workers.
+
+
+## At a glance
+
+| Question | Maryland |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed if reasonable |
+| **Bottom line** | Maryland enforces an ordinary employee non-compete only if it is reasonable under the Becker common-law test, but a statute voids covenants outright for low-wage, veterinary, and many health care workers. |
+| **Main law or case** | Becker v. Bailey, 268 Md. 93 (1973); Md. Code, Lab. & Empl. § 3-716 |
+| **Main exceptions** | Low-wage ban (≤150% min wage); veterinary ban; health-care ≤$350k ban; high-earner clinician cap (1 yr/10 mi); client/patient-list carve-out |
+| **Can a court narrow it?** | Only strikes wording |
+| **Applies to contractors?** | Unclear |
+| **Restriction extended during a breach?** | Unsettled |
+| **Maximum length set by law** | No fixed cap for ordinary employees; 1 year for covered health-care |
+
+## Are employee non-compete agreements enforceable in Maryland? {#employee-noncompetes}
+
+**Short answer.** Yes, sometimes. Maryland is a reasonableness state, not a general ban state, so an ordinary employee non-compete is enforceable only if the employer has a legally protected interest, the restraint is no wider in scope and duration than reasonably necessary, it does not impose undue hardship on the employee, and it does not violate public policy [^seneca-four-part-test][^becker-general-rule].
+
+The common-law test traces to *Becker v. Bailey* and is restated in modern federal decisions applying Maryland law. In practice the recurring questions are protectable interest, scope and duration, hardship on the employee, and the public interest [^seneca-four-part-test][^becker-general-rule].
+
+Maryland layers a statute on top of that common-law test. Labor and Employment § 3-716 makes a covenant null and void for whole categories of workers — low-wage employees, veterinary professionals, and many health care workers — before ordinary reasonableness balancing ever applies [^statute-3716-null-void].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not treat Maryland as a pure reasonableness state or as a total-ban state. Start with the worker's wage and occupation, apply § 3-716 if the worker is covered, and only then run the common-law reasonableness test on any covenant that survives [^statute-3716-null-void][^seneca-four-part-test].
+
+## Which Maryland workers are automatically protected from non-competes? {#statutory-voids}
+
+**Short answer.** Section 3-716 voids non-competes outright for employees who earn 150% or less of the State minimum wage, for veterinary practitioners and technicians, and for many licensed health care workers who provide direct patient care and earn $350,000 or less [^statute-150-threshold][^statute-vet-ban][^statute-healthcare-void].
+
+The wage line is keyed to the State minimum wage in § 3-413, which has been $15.00 per hour since January 1, 2024, so the covered ceiling is $22.50 per hour [^statute-minimum-wage]. A covenant against any employee at or below that 150% line is void [^statute-150-threshold].
+
+The 2024 amendment in House Bill 1388 added two occupation-based bans. The veterinary ban applies retroactively to agreements entered into on or before its effective date [^hb1388-vet-retroactive]. The statute also voids covenants for licensed health-occupations employees who provide direct patient care and earn $350,000 or less, and that health care expansion applies only to agreements executed on or after July 1, 2025 [^statute-healthcare-void][^hb1388-health-prospective].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not rely on a § 3-716 covenant for a low-wage, veterinary, or covered health care worker. For those workers the covenant is void by statute, so the employer's protection has to come from confidentiality terms and trade-secret law, not from the non-compete [^statute-150-threshold][^statute-healthcare-void].
+
+## How are non-competes capped for high-earning Maryland health care workers? {#healthcare-high-earners}
+
+**Short answer.** For a direct-patient-care health care employee who earns more than $350,000, a covenant is not void but is capped: it cannot run longer than one year or reach more than ten miles from the primary place of employment [^statute-highearner-bucket][^statute-cap-duration][^statute-cap-geography].
+
+The statute draws a line at $350,000 in total annual compensation. At or below that figure the covenant is void; above it, the high-earner bucket applies and the employer may use a covenant only within the statutory one-year and ten-mile limits [^statute-highearner-bucket][^statute-cap-duration][^statute-cap-geography].
+
+Staying inside the cap is necessary, not sufficient. Section 3-716(b) sets outer limits; it does not guarantee enforceability, so a covenant within the cap still has to satisfy the ordinary common-law reasonableness test [^becker-highearner-reasonableness].
+
+There is also a patient-notice duty. On a patient's request, the employer must tell the patient where the departing clinician will be practicing [^statute-patient-notice].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not copy a longer term or wider radius into a Maryland high-earner clinician covenant. Anything beyond one year or ten miles from the primary practice site exceeds the statutory cap, and pair the covenant with the required patient-notice process [^statute-cap-duration][^statute-patient-notice].
+
+## What legitimate business interests can support a Maryland non-compete? {#protectable-interests}
+
+**Short answer.** Maryland enforces a covenant only to protect genuine interests such as unique services, trade secrets, customer routes or lists, and customer goodwill — not to prevent ordinary competition [^becker-protectable-interests][^fowler-no-broader-than-necessary].
+
+*Becker* describes the categories Maryland courts recognize: covenants are enforced against employees who provide unique services, or to prevent misuse of trade secrets, routes, or client lists, or solicitation of customers [^becker-protectable-interests]. Even when a legitimate interest exists, the restraint can be no broader than necessary to protect it [^fowler-no-broader-than-necessary].
+
+Section 3-716 reinforces that focus. Section 3-716(a)'s void rule carves out provisions aimed at the taking or use of a client or patient list or other proprietary client information — signaling that protecting customer data is treated differently from blocking competition outright [^statute-client-list-carveout].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not use a Maryland non-compete to block ordinary competition unconnected to a protectable interest. Tie the restraint to specific unique services, trade secrets, customer lists, or goodwill, and handle confidential-information protection through separate confidentiality and trade-secret terms [^becker-protectable-interests][^statute-client-list-carveout].
+
+## What duration and geographic scope are reasonable for a Maryland non-compete? {#duration-geography}
+
+**Short answer.** Outside the § 3-716 categories there is no fixed cap for ordinary employees. Maryland courts judge time and territory case by case, asking whether the restraint is reasonable on the specific facts [^ruhl-no-yardstick][^seneca-overbroad].
+
+*Ruhl* makes the fact-specific nature explicit: there is no arbitrary yardstick for what protection is reasonably necessary, no fixed measure of undue hardship, and no precise scale for the public interest [^ruhl-no-yardstick]. A covenant is overbroad when it exceeds what is reasonably necessary to protect the employer's interest [^seneca-overbroad].
+
+Scope of the prohibited activity matters as much as miles and months. In *Medispec*, a federal court applying Maryland law held a covenant unenforceable on its face because it barred the former employee from working in essentially any capacity, far beyond his prior sales role [^medispec-facially-overbroad].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not copy a duration or radius from another Maryland form without matching the worker's role and customer exposure. A broad activity ban that sweeps in work unrelated to the employee's actual job is the kind of facial overbreadth that sinks a Maryland covenant [^medispec-facially-overbroad][^seneca-overbroad].
+
+## Is continued at-will employment enough consideration for a Maryland non-compete? {#continued-employment-consideration}
+
+**Short answer.** Yes. Maryland treats an employer's agreement to continue an at-will employee as sufficient consideration for a covenant signed after employment begins [^simko-mutuality][^simko-minority-view].
+
+*Simko* is the anchor. The court reasoned that because the at-will relationship is mutual, the employer's promise not to terminate in exchange for the covenant is just as good as the employee's promise to keep working [^simko-mutuality]. The court treated the contrary view — that continued at-will employment is not consideration — as the distinct minority position [^simko-minority-view].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not assume a bare recital cures a consideration problem. Maryland accepts continued employment as consideration, but the record is cleaner when the agreement and the surrounding documents show that signing was connected to the employee's continued employment [^simko-mutuality].
+
+## Will a Maryland court blue-pencil or rewrite an overbroad non-compete? {#court-narrowing}
+
+**Short answer.** Maryland courts blue-pencil rather than rewrite. A court may strike an offending, severable portion of a covenant and enforce what remains, but if the unreasonable language is not severable the whole covenant fails — and employers cannot count on a court redrafting an indivisible overbroad term into a new, enforceable one [^holloway-blue-pencil][^holloway-mechanical-rule].
+
+*Holloway* describes the typical Maryland response to an invalid portion of a covenant: blue-pencil the violative words and, if what is excised is severable, enforce the rest; otherwise the entire agreement is void [^holloway-blue-pencil]. The traditional, strict version of that rule is mechanical — a court strikes words and enforces what is left only if the remainder still stands as a complete, valid contract [^holloway-mechanical-rule]. Maryland's focus is therefore on severability: the *Holloway* litigation, affirmed in part by the Maryland Supreme Court, turned on whether the covenant could be severed (there, on a client-by-client basis) rather than on a court rewriting the bargain.
+
+*Hebb v. Stump, Harvey & Cook* shows the partial-enforcement side in practice. Where an overbroad restriction is not so interwoven as to be logically inseparable from the rest of the contract, a Maryland court will sever it and enforce the lawful remainder when partial enforcement works no injury to the public and no injustice to the parties [^hebb-severable-partial-enforcement].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Draft severable, tiered restrictions rather than relying on a savings clause that asks a court to invent a narrower Maryland radius or duration. Whether a court applies a strict blue pencil or a more granular severance, an indivisible overbroad term gives it nothing to enforce [^holloway-blue-pencil][^holloway-mechanical-rule].
+
+## How does the Maryland Uniform Trade Secrets Act protect employers when a covenant is void? {#trade-secrets-mutsa}
+
+**Short answer.** The Maryland Uniform Trade Secrets Act gives employers a separate remedy that does not depend on a non-compete. It defines what counts as a trade secret, authorizes injunctions against misappropriation, and allows damages including exemplary damages for willful, malicious conduct [^mutsa-trade-secret-definition][^mutsa-injunction][^mutsa-exemplary-damages].
+
+A trade secret is information that derives independent economic value from not being generally known and is the subject of reasonable secrecy efforts [^mutsa-trade-secret-definition]. Actual or threatened misappropriation may be enjoined, and for willful and malicious misappropriation a court may award exemplary damages of up to twice the damages awarded under the statute's compensatory-damages provision [^mutsa-injunction][^mutsa-exemplary-damages].
+
+Trade-secret remedies can also outrun a contract's damages cap. In *Ingram v. Cantwell-Cleary*, the court declined to enforce a non-compete's liquidated-damages provisions because they did not bar a separate recovery for trade-secret misappropriation, and it upheld findings that customer lists and pricing data were misappropriated trade secrets [^ingram-liquidated-not-bar][^ingram-trade-secret-finding].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Where § 3-716 voids the covenant, build the protection plan around confidentiality and the trade-secret statute instead. Identify the actual trade secrets, document reasonable secrecy measures, and preserve the statutory injunction and damages remedies that do not depend on an enforceable non-compete [^mutsa-trade-secret-definition][^mutsa-injunction].
+
+## Does a Maryland non-compete toll or extend during breach or litigation? {#tolling-extension}
+
+**Short answer.** This is an open Maryland question. No staged Maryland statute or appellate decision squarely endorses automatic judicial tolling or enforcement of an extension-on-breach clause after the stated restricted period expires [^ruhl-reasonableness-backdrop][^becker-reasonableness-backdrop].
+
+Maryland law on pausing the clock during a violation, or extending a covenant for the length of litigation, is unsettled. The safest reading is that any such extension still has to satisfy the same reasonableness test that governs the covenant itself [^ruhl-reasonableness-backdrop]. If an extension-on-breach clause turns a fixed one-year restraint into an open-ended one, a court could find it unreasonable on the facts [^becker-reasonableness-backdrop].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Open question: Maryland authority does not settle whether an extension-on-breach or tolling clause is enforceable after the original period expires. Draft any tolling clause as a separate, reasonable restraint tied to the duration of the breach, and do not assume a Maryland court will automatically extend an expired covenant [^ruhl-reasonableness-backdrop][^becker-reasonableness-backdrop].
+
+## Did the FTC's federal non-compete rule change Maryland non-compete law? {#federal-ftc-overlay}
+
+**Short answer.** No. A federal court set aside the FTC's 2024 nationwide Non-Compete Rule, so Maryland non-competes remain governed by Maryland's statute, Maryland common law, and the state's trade-secret act [^ryan-rule-set-aside].
+
+In *Ryan LLC v. FTC*, the court held the rule unlawful and set it aside, stating that the rule would not be enforced or take effect on its September 4, 2024 effective date [^ryan-rule-set-aside]. That removes the FTC rule as a nationwide overlay but does not make every Maryland covenant enforceable — § 3-716 and Maryland common law still control.
+
+"The Rule shall not be enforced or otherwise take effect on its effective date of September 4, 2024, or thereafter."[^ryan-rule-set-aside]
+
+## What recent Maryland non-compete changes should employers watch? {#recent-amendments}
+
+**Short answer.** The most recent enacted change is House Bill 1016 (2026), now Chapter 301. It is enacted but not yet effective: beginning October 1, 2026, it extends § 3-716's void rule to a new, narrow category — employees of a licensed architect whose employer, after employing more than 30 workers based mainly in Maryland, relocates the majority of that workforce out of state or no longer has its principal place of business in Maryland [^hb1016-architect-out-of-state].
+
+This is the fourth wave of § 3-716 amendments, after the 2019 low-wage ban, the 2023 amendment altering the application of the prohibition (Senate Bill 591, Chapter 266, effective October 1, 2023 — the change that keyed the low-wage threshold to the State minimum wage), and the 2024 veterinary and health care expansion [^sb591-2023-threshold]. Mechanically, the new law inserts the architect category as a new § 3-716(a)(1)(i)3 and renumbers the existing veterinary category to (a)(1)(i)4, effective October 1, 2026 — so the subsection numbers used throughout this note reflect the statute as it reads before that date. The provision is narrow and prospective: it applies only to agreements executed on or after the effective date [^hb1016-architect-out-of-state].
+
+A broader 2025 effort to clarify that § 3-716 reaches only post-separation restrictions died in committee, so the active-employment reach of the statute's conflict-of-interest language remains unsettled.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Treat the § 3-716 categories as a moving target. Re-check the worker's wage band and occupation against the current statute each session, and remember the architect provision is enacted but does not begin until agreements executed on or after October 1, 2026 [^hb1016-architect-out-of-state].
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-03. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not Maryland. This article synthesizes Maryland primary law and is not legal advice from a Maryland-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^seneca-four-part-test]: **Seneca One Finance, Inc. v. Bloshuk** — "In Maryland, a restrictive employment covenant will only be enforced if it meets four requirements: ‘(1) the employer must have a legally protected interest, (2) the restrictive covenant must be no wider in scope and duration than is reasonably necessary to protect the employer’s interest, (3) the covenant cannot impose an undue hardship on the employee, and (4) the covenant cannot violate public policy.’" *Seneca One Fin., Inc. v. Bloshuk, 214 F. Supp. 3d 457 (D. Md. 2016).* <https://www.courtlistener.com/opinion/7322313/seneca-one-finance-inc-v-bloshuk/#:~:text=In%20Maryland%2C%20a%20restrictive%20employment,covenant%20cannot%20violate%20public%20policy.%E2%80%9D>
+
+[^becker-general-rule]: **Becker v. Bailey** — "The general rule in Maryland is that if a restrictive covenant in an employment contract is supported by adequate consideration and is ancillary to the employment contract, an employee’s agreement not to compete with his employer upon leaving the employment will be upheld ‘if the restraint is confined within limits which are no wider as to area and duration than are reasonably necessary for the protection of the business of the employer and do not impose undue hardship on the employee or disregard the interests of the public.’" *Becker v. Bailey, 268 Md. 93 (1973).* <https://www.courtlistener.com/opinion/2322561/becker-v-bailey/#:~:text=The%20general%20rule%20in%20Maryland,the%20interests%20of%20the%20public.%E2%80%9D>
+
+[^statute-3716-null-void]: **Md. Code, Lab. & Empl. § 3-716** — "A noncompete or conflict of interest provision in an employment contract or a similar document or agreement that restricts the ability of an employee to enter into employment with a new employer or to become self–employed in the same or similar business or trade shall be null and void as being against the public policy of the State." *Md. Code, Lab. & Empl. § 3-716(a)(3).* <https://mgaleg.maryland.gov/mgawebsite/Laws/StatuteText?article=gle&section=3-716>
+
+[^statute-150-threshold]: **Md. Code, Lab. & Empl. § 3-716** — "an employee who earns equal to or less than 150% of the State minimum wage rate established under § 3–413 of this title" *Md. Code, Lab. & Empl. § 3-716(a)(1)(i)1.* <https://mgaleg.maryland.gov/mgawebsite/Laws/StatuteText?article=gle&section=3-716>
+
+[^statute-vet-ban]: **Md. Code, Lab. & Empl. § 3-716** — "an employee licensed as a veterinary practitioner or veterinary technician under Title 2, Subtitle 3 of the Agriculture Article" *Md. Code, Lab. & Empl. § 3-716(a)(1)(i)3.* <https://mgaleg.maryland.gov/mgawebsite/Laws/StatuteText?article=gle&section=3-716>
+
+[^statute-healthcare-void]: **Md. Code, Lab. & Empl. § 3-716** — "employment in a position for which the employee: A. is required to be licensed under the Health Occupations Article; B. is employed in a position that provides direct patient care; and C. earns equal to or less than $350,000 in total annual compensation" *Md. Code, Lab. & Empl. § 3-716(a)(1)(i)2.* <https://mgaleg.maryland.gov/mgawebsite/Laws/StatuteText?article=gle&section=3-716>
+
+[^statute-minimum-wage]: **Md. Code, Lab. & Empl. § 3-413** — "the State minimum wage rate is: (i) for the 12–month period beginning January 1, 2023, $13.25 per hour; and (ii) beginning January 1, 2024, $15.00 per hour." *Md. Code, Lab. & Empl. § 3-413(c)(1).* <https://mgaleg.maryland.gov/mgawebsite/Laws/StatuteText?article=gle&section=3-413>
+
+[^hb1388-vet-retroactive]: **2024 Md. Laws ch. 378 (H.B. 1388)** — "That this Act shall be construed to apply retroactively and shall be applied to and interpreted to affect an employment contract or a similar contract or agreement entered into on or before the effective date of this Act." *2024 Md. Laws ch. 378, § 2 (H.B. 1388).* <https://mgaleg.maryland.gov/2024rs/Chapters_noln/CH_378_hb1388e.pdf>
+
+[^hb1388-health-prospective]: **2024 Md. Laws ch. 378 (H.B. 1388)** — "That § 3–716(a)(1)(i)2 and (b) of the Labor and Employment Article, as enacted by Section 1 of this Act, shall be construed to apply only to employment contracts or similar documents or agreements for employment executed on or after July 1, 2025." *2024 Md. Laws ch. 378, § 3 (H.B. 1388).* <https://mgaleg.maryland.gov/2024rs/Chapters_noln/CH_378_hb1388e.pdf>
+
+[^statute-highearner-bucket]: **Md. Code, Lab. & Empl. § 3-716** — "This subsection applies only to an employment contract or similar document or agreement concerning employment in a position for which the employee: (i) is required to be licensed under the Health Occupations Article; (ii) is employed in a position that provides direct patient care; and (iii) earns more than $350,000 in total annual compensation." *Md. Code, Lab. & Empl. § 3-716(b)(1).* <https://mgaleg.maryland.gov/mgawebsite/Laws/StatuteText?article=gle&section=3-716>
+
+[^statute-cap-duration]: **Md. Code, Lab. & Empl. § 3-716** — "The period for which a noncompete or conflict of interest provision in an employment contract or similar document or agreement is in effect may not exceed 1 year from the last day of employment." *Md. Code, Lab. & Empl. § 3-716(b)(2)(i).* <https://mgaleg.maryland.gov/mgawebsite/Laws/StatuteText?article=gle&section=3-716>
+
+[^statute-cap-geography]: **Md. Code, Lab. & Empl. § 3-716** — "The geographical restriction in a noncompete or conflict of interest provision in an employment contract or similar document or agreement may not exceed 10 miles from the primary place of employment." *Md. Code, Lab. & Empl. § 3-716(b)(2)(ii).* <https://mgaleg.maryland.gov/mgawebsite/Laws/StatuteText?article=gle&section=3-716>
+
+[^becker-highearner-reasonableness]: **Becker v. Bailey** — "The general rule in Maryland is that if a restrictive covenant in an employment contract is supported by adequate consideration and is ancillary to the employment contract, an employee’s agreement not to compete with his employer upon leaving the employment will be upheld ‘if the restraint is confined within limits which are no wider as to area and duration than are reasonably necessary for the protection of the business of the employer and do not impose undue hardship on the employee or disregard the interests of the public.’" *Becker v. Bailey, 268 Md. 93 (1973).* <https://www.courtlistener.com/opinion/2322561/becker-v-bailey/#:~:text=The%20general%20rule%20in%20Maryland,the%20interests%20of%20the%20public.%E2%80%9D>
+
+[^statute-patient-notice]: **Md. Code, Lab. & Empl. § 3-716** — "On request of a patient, an employer of an employee described in paragraph (1) of this subsection shall provide notice to a patient of the new location where a former employee will be practicing." *Md. Code, Lab. & Empl. § 3-716(b)(3).* <https://mgaleg.maryland.gov/mgawebsite/Laws/StatuteText?article=gle&section=3-716>
+
+[^becker-protectable-interests]: **Becker v. Bailey** — "These decisions demonstrate that Maryland follows the general rule that restrictive covenants may be applied and enforced only against those employees who provide unique services, or to prevent the future misuse of trade secrets, routes or lists of clients, or solicitation of customers." *Becker v. Bailey, 268 Md. 93 (1973).* <https://www.courtlistener.com/opinion/2322561/becker-v-bailey/#:~:text=These%20decisions%20demonstrate%20that%20Maryland,clients%2C%20or%20solicitation%20of%20customers.>
+
+[^fowler-no-broader-than-necessary]: **Fowler v. Printers II, Inc.** — "Of course, even a restrictive covenant that serves an employer’s ‘legitimate interest’ can be no broader, or more restrictive, than necessary to effectuate that interest." *Fowler v. Printers II, Inc., 89 Md. App. 448 (1991).* <https://www.courtlistener.com/opinion/1930228/fowler-v-printers-ii-inc/#:~:text=Of%20course%2C%20even%20a%20restrictive,necessary%20to%20effectuate%20that%20interest.>
+
+[^statute-client-list-carveout]: **Md. Code, Lab. & Empl. § 3-716** — "This subsection does not apply to an employment contract or a similar document or agreement with respect to the taking or use of a client or patient list or other proprietary client–related or patient–related information." *Md. Code, Lab. & Empl. § 3-716(a)(2).* <https://mgaleg.maryland.gov/mgawebsite/Laws/StatuteText?article=gle&section=3-716>
+
+[^ruhl-no-yardstick]: **Ruhl v. F. A. Bartlett Tree Expert Co.** — "There is no arbitrary yardstick as to what protection of the business of the employer is reasonably necessary, no categorical measurement of what constitutes undue hardship on the employee, no precise scales to weigh the interest of the public." *Ruhl v. F. A. Bartlett Tree Expert Co., 245 Md. 118 (1967).* <https://www.courtlistener.com/opinion/2292892/ruhl-v-f-a-bartlett-tree-expert-co/#:~:text=There%20is%20no%20arbitrary%20yardstick,the%20interest%20of%20the%20public.>
+
+[^seneca-overbroad]: **Seneca One Finance, Inc. v. Bloshuk** — "A restrictive covenant is overbroad if it exceeds the limits of what is reasonably necessary to protect the employer’s legally protected interest." *Seneca One Fin., Inc. v. Bloshuk, 214 F. Supp. 3d 457 (D. Md. 2016).* <https://www.courtlistener.com/opinion/7322313/seneca-one-finance-inc-v-bloshuk/#:~:text=A%20restrictive%20covenant%20is%20overbroad,the%20employer%E2%80%99s%20legally%20protected%20interest.>
+
+[^medispec-facially-overbroad]: **Medispec, Ltd. v. Chouinard** — "Here, an examination of the particular facts is not necessary because the clause is overly broad on its face." *Medispec, Ltd. v. Chouinard, 133 F. Supp. 3d 771 (D. Md. 2015).* <https://www.courtlistener.com/opinion/7315898/medispec-ltd-v-chouinard/#:~:text=Here%2C%20an%20examination%20of%20the,overly%20broad%20on%20its%20face.>
+
+[^simko-mutuality]: **Simko, Inc. v. Graymar Co.** — "Given the inherent mutuality, we see no basis for distinguishing the employee’s consent to continue from the flip side of the coin — the employer’s consent not to terminate." *Simko, Inc. v. Graymar Co., 55 Md. App. 561 (1983).* <https://www.courtlistener.com/opinion/1983736/simko-inc-v-graymar-co/#:~:text=Given%20the%20inherent%20mutuality%2C%20we,employer%E2%80%99s%20consent%20not%20to%20terminate.>
+
+[^simko-minority-view]: **Simko, Inc. v. Graymar Co.** — "the viewpoint which holds that continuation of an at-will employee is not sufficient consideration for a covenant not to compete represents the distinct minority." *Simko, Inc. v. Graymar Co., 55 Md. App. 561 (1983).* <https://www.courtlistener.com/opinion/1983736/simko-inc-v-graymar-co/#:~:text=the%20viewpoint%20which%20holds%20that,compete%20represents%20the%20distinct%20minority.>
+
+[^holloway-blue-pencil]: **Holloway v. Faw, Casson & Co.** — "The typical response in the reported appellate decisions in this State, in which the Courts have ruled a portion of an employee noncompetition agreement invalid, has been to ‘blue pencil’ (cross out) the violative portions of the agreement and, if the excised portions of the agreement are severable, to permit the agreement to stand minus the unenforceable wording; otherwise the entire agreement is void." *Holloway v. Faw, Casson & Co., 78 Md. App. 205 (1989), aff'd in part & rev'd in part, 319 Md. 324 (1990).* <https://www.courtlistener.com/opinion/1991703/holloway-v-faw-casson-co/#:~:text=The%20typical%20response%20in%20the,the%20entire%20agreement%20is%20void.>
+
+[^holloway-mechanical-rule]: **Holloway v. Faw, Casson & Co.** — "By this rule, the divisibility of a promise in excessive restraint of trade is determined by purely mechanical means: if the promise is so worded that the excessive restraint can be eliminated by crossing out a few of the words with a ‘blue pencil,’ while at the same time the remaining words constitute a complete and valid contract, the contract as thus ‘blue penciled’ will be enforced." *Holloway v. Faw, Casson & Co., 78 Md. App. 205 (1989), aff'd in part & rev'd in part, 319 Md. 324 (1990).* <https://www.courtlistener.com/opinion/1991703/holloway-v-faw-casson-co/#:~:text=By%20this%20rule%2C%20the%20divisibility,%E2%80%9Cblue%20penciled%E2%80%9D%20will%20be%20enforced.>
+
+[^hebb-severable-partial-enforcement]: **Hebb v. Stump, Harvey & Cook, Inc.** — "In the instant case the partial enforcement of the restrictions works no injury to the public and creates no injustice to the parties, thus the restrictions are severable and thus partially enforceable." *Hebb v. Stump, Harvey & Cook, Inc., 25 Md. App. 478 (1975).* <https://www.courtlistener.com/opinion/2195970/hebb-v-stump-harvey-cook-inc/#:~:text=In%20the%20instant%20case%20the,severable%20and%20thus%20partially%20enforceable.>
+
+[^mutsa-trade-secret-definition]: **Md. Code, Com. Law § 11-1201** — "‘Trade secret’ means information, including a formula, pattern, compilation, program, device, method, technique, or process, that: (1) Derives independent economic value, actual or potential, from not being generally known to, and not being readily ascertainable by proper means by, other persons who can obtain economic value from its disclosure or use; and (2) Is the subject of efforts that are reasonable under the circumstances to maintain its secrecy." *Md. Code, Com. Law § 11-1201(e).* <https://mgaleg.maryland.gov/mgawebsite/Laws/StatuteText?article=gcl&section=11-1201>
+
+[^mutsa-injunction]: **Md. Code, Com. Law § 11-1202** — "Actual or threatened misappropriation may be enjoined." *Md. Code, Com. Law § 11-1202(a).* <https://mgaleg.maryland.gov/mgawebsite/Laws/StatuteText?article=gcl&section=11-1202>
+
+[^mutsa-exemplary-damages]: **Md. Code, Com. Law § 11-1203** — "If willful and malicious misappropriation exists, the court may award exemplary damages in an amount not exceeding twice any award made under subsection (a) of this section." *Md. Code, Com. Law § 11-1203(d).* <https://mgaleg.maryland.gov/mgawebsite/Laws/StatuteText?article=gcl&section=11-1203>
+
+[^ingram-liquidated-not-bar]: **Ingram v. Cantwell-Cleary Co.** — "We hold that the court did not err in declining to enforce the liquidated damages provisions contained in Appellants’ Non-Compete Agreements because they did not bar Cantwell-Cleary from recovering damages under its separate claims for misappropriation" *Ingram v. Cantwell-Cleary Co., 259 Md. App. 102 (2023).* <https://www.courtlistener.com/opinion/9454756/ingram-v-cantwell-cleary-co/#:~:text=We%20hold%20that%20the%20court,its%20separate%20claims%20for%20misappropriation>
+
+[^ingram-trade-secret-finding]: **Ingram v. Cantwell-Cleary Co.** — "We also hold that the court did not err in finding that Cantwell-Cleary’s confidential customer lists and pricing information constituted trade secrets and that Appellants had misappropriated that information." *Ingram v. Cantwell-Cleary Co., 259 Md. App. 102 (2023).* <https://www.courtlistener.com/opinion/9454756/ingram-v-cantwell-cleary-co/#:~:text=We%20also%20hold%20that%20the,Appellants%20had%20misappropriated%20that%20information.>
+
+[^ruhl-reasonableness-backdrop]: **Ruhl v. F. A. Bartlett Tree Expert Co.** — "Covenants of this nature are in restraint of trade; the test is whether the particular restraint is reasonable on the specific facts." *Ruhl v. F. A. Bartlett Tree Expert Co., 245 Md. 118 (1967).* <https://www.courtlistener.com/opinion/2292892/ruhl-v-f-a-bartlett-tree-expert-co/#:~:text=Covenants%20of%20this%20nature%20are,reasonable%20on%20the%20specific%20facts.>
+
+[^becker-reasonableness-backdrop]: **Becker v. Bailey** — "The general rule in Maryland is that if a restrictive covenant in an employment contract is supported by adequate consideration and is ancillary to the employment contract, an employee’s agreement not to compete with his employer upon leaving the employment will be upheld ‘if the restraint is confined within limits which are no wider as to area and duration than are reasonably necessary for the protection of the business of the employer and do not impose undue hardship on the employee or disregard the interests of the public.’" *Becker v. Bailey, 268 Md. 93 (1973).* <https://www.courtlistener.com/opinion/2322561/becker-v-bailey/#:~:text=The%20general%20rule%20in%20Maryland,the%20interests%20of%20the%20public.%E2%80%9D>
+
+[^ryan-rule-set-aside]: **Ryan LLC v. Federal Trade Commission** — "The Rule shall not be enforced or otherwise take effect on its effective date of September 4, 2024, or thereafter." *Ryan LLC v. Fed. Trade Comm'n, 746 F. Supp. 3d 369 (N.D. Tex. 2024).* <https://www.courtlistener.com/opinion/10205745/ryan-llc-v-federal-trade-commission/#:~:text=The%20Rule%20shall%20not%20be%20enforced%20or%20otherwise%20take%20effect%20on%20its%20effective%20date%20of%20September%204%2C%202024%2C%20or%20thereafter.>
+
+[^hb1016-architect-out-of-state]: **2026 Md. Laws ch. 301 (H.B. 1016)** — "That § 3–716(a)(1)(i)3 of the Labor and Employment Article, as enacted by Section 1 of this Act, shall be construed to apply only to employment contracts or similar documents or agreements for employment executed on or after the effective date of this Act." *2026 Md. Laws ch. 301, § 2 (H.B. 1016).* <https://mgaleg.maryland.gov/2026rs/Chapters_noln/CH_301_hb1016e.pdf>
+
+[^sb591-2023-threshold]: **2023 Md. Laws ch. 266 (S.B. 591)** — "FOR the purpose of altering the application of the prohibition on including a noncompete or conflict of interest provision in an employment contract or similar document or agreement" *2023 Md. Laws ch. 266 (S.B. 591).* <https://mgaleg.maryland.gov/2023rs/Chapters_noln/CH_266_sb0591t.pdf>

--- a/skills/non-compete-contract-explainer/content/massachusetts.md
+++ b/skills/non-compete-contract-explainer/content/massachusetts.md
@@ -1,0 +1,272 @@
+---
+jurisdiction: "Massachusetts"
+slug: massachusetts
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-03"
+canonicalUrl: https://openagreements.org/legal/non-compete/massachusetts
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/massachusetts · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in Massachusetts[^about]
+
+Massachusetts enforces employee non-competes only when they meet the Noncompetition Agreement Act — a garden-leave or other agreed consideration, a 12-month cap, and strict notice rules — and voids them entirely for physicians, nurses, psychologists, social workers, and most of the broadcasting industry.
+
+
+## At a glance
+
+| Question | Massachusetts |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed if reasonable |
+| **Bottom line** | Massachusetts enforces an employee non-compete only if it meets the 2018 Noncompetition Agreement Act — paid garden leave or agreed consideration, a 12-month cap, and strict notice — and voids them entirely for physicians, nurses, psychologists, social workers, and most broadcasters. |
+| **Main law or case** | Mass. Gen. Laws ch. 149, § 24L |
+| **Main exceptions** | Physician, nurse, psychologist, social-worker, broadcaster bans; excluded workers (FLSA-nonexempt, interns, laid-off/no-cause, age ≤18); sale-of-business & non-solicit/NDA carve-outs |
+| **Can a court narrow it?** | Yes — rewrites to reasonable |
+| **Applies to contractors?** | Yes |
+| **Restriction extended during a breach?** | No automatic extension; statutory misconduct trigger (up to 2 yrs) or express tolling clause |
+| **Maximum length set by law** | 12 months (up to 2 years on breach of fiduciary duty/taking property) |
+| **Must the employer pay to enforce?** | Yes — required for any non-compete |
+
+## Are employee non-compete agreements enforceable in Massachusetts? {#enforceability}
+
+**Short answer.** Sometimes, and only on strict terms. For agreements entered into on or after October 1, 2018, the Massachusetts Noncompetition Agreement Act makes an employee non-compete enforceable only if it satisfies a list of statutory requirements — including paid garden leave or other agreed consideration, a 12-month cap, and advance written notice [^mnaa-validity][^nuvasive-effective-date].
+
+The governing statute is G.L. c. 149, § 24L. Subsection (b) provides that a noncompetition agreement is valid and enforceable only if it meets eight minimum requirements, which are described in the questions below [^mnaa-validity]. The act applies only to agreements entered into on or after October 1, 2018; the First Circuit, applying the statute, confirmed that limited reach [^nuvasive-effective-date].
+
+Watch the statute's reach: for purposes of § 24L, an *employee* includes independent contractors, so the act's protections are not limited to W-2 workers [^mnaa-employee-scope].
+
+Underlying the statute is a long common-law tradition that still frames how Massachusetts courts evaluate restraints. A covenant is enforceable only if it is necessary to protect a legitimate business interest, reasonably limited in time and space, and consonant with the public interest [^boulanger-reasonableness].
+
+"To be valid and enforceable, a noncompetition agreement must meet the minimum requirements of paragraphs (i) through (viii)."[^mnaa-validity]
+
+## What notice and signing rules apply to a Massachusetts non-compete? {#formation-notice}
+
+**Short answer.** Strict, and they differ for new hires versus current employees. A new hire's non-compete must be in writing, signed, expressly state the right to consult counsel, and be delivered by the earlier of a formal offer or 10 business days before the start date [^formation-newhire][^formation-newhire-timing].
+
+For a non-compete signed after employment begins but not at separation, the statute adds a consideration requirement: the agreement must be supported by fair and reasonable consideration independent from continued employment, with at least 10 business days' notice before it takes effect [^formation-midemployment]. That abrogates the older Massachusetts rule that continued at-will employment alone could support a mid-employment covenant.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not present a Massachusetts non-compete for immediate signature on the first day of work. For a new hire, deliver it by the earlier of the formal offer or 10 business days before the start date and tell the employee in the document that they may consult counsel; for a current employee, give 10 business days' notice and provide separate consideration beyond keeping the job [^formation-newhire-timing][^formation-midemployment].
+
+## Does Massachusetts require garden leave or extra pay for a non-compete? {#garden-leave}
+
+**Short answer.** Yes — a non-compete must be bought. Section 24L requires that the agreement be supported by a garden leave clause or other mutually-agreed consideration that is specified in the agreement [^consideration-requirement].
+
+A qualifying garden leave clause means paying the former employee, on a pro-rata basis during the restricted period, at least 50% of their highest annualized base salary over the two years before termination [^garden-leave-fifty-percent]. The statute's alternative — *other mutually-agreed upon consideration* — is left undefined, which is the single biggest open drafting question under the act: whether a small fixed payment can substitute for garden leave remains unsettled.
+
+"The noncompetition agreement shall be supported by a garden leave clause or other mutually-agreed upon consideration between the employer and the employee, provided that such consideration is specified in the noncompetition agreement."[^consideration-requirement]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not rely on a token payment as *other mutually-agreed upon consideration* without analysis. The only consideration the statute defines is a garden leave clause paying at least 50% of the employee's highest base salary across the restricted period; the enforceability of a smaller fixed sum is unsettled, so size the consideration conservatively and specify it in the agreement [^consideration-requirement][^garden-leave-fifty-percent].
+
+## How long can a Massachusetts non-compete last? {#duration}
+
+**Short answer.** Twelve months, with one narrow exception. The restricted period may not exceed 12 months from the end of employment, unless the employee breached a fiduciary duty or unlawfully took employer property — in which case it may run up to 2 years [^duration-cap].
+
+The 12-month default is a hard statutory ceiling, not a starting point for negotiation. The only way to a longer restraint is the misconduct trigger: a breach of fiduciary duty to the employer, or the unlawful taking of property, physically or electronically [^duration-cap].
+
+"In no event may the stated restricted period exceed 12 months from the date of cessation of employment, unless the employee has breached his or her fiduciary duty to the employer or the employee has unlawfully taken, physically or electronically, property belonging to the employer, in which case the duration may not exceed 2 years from the date of cessation of employment."[^duration-cap]
+
+## What business interests can a Massachusetts non-compete protect? {#legitimate-interests}
+
+**Short answer.** Only trade secrets, other confidential information, and goodwill — and no more than necessary. Section 24L permits a non-compete only where it is no broader than necessary to protect the employer's trade secrets, confidential information that is not a trade secret, or goodwill [^legitimate-interests-statute].
+
+This codifies a long-standing common-law limit. Massachusetts courts had already held that legitimate business interests are confined to trade secrets, confidential information, and goodwill [^boulanger-interests]. Protection from ordinary competition has never qualified — a former employer is not entitled by contract to restrain ordinary competition [^allstainless-ordinary-competition].
+
+"A former employer is not entitled by contract to restrain ordinary competition."[^allstainless-ordinary-competition]
+
+## Which Massachusetts workers cannot be bound by a non-compete? {#excluded-workers}
+
+**Short answer.** Four categories, regardless of pay. Section 24L makes a non-compete unenforceable against employees who are nonexempt under the Fair Labor Standards Act, student interns, employees terminated without cause or laid off, and employees age 18 or younger [^excluded-workers].
+
+The termination trigger is the one that surprises employers most: an employee who is laid off or fired without cause cannot be held to a non-compete at all. The statute does not define *without cause*, so the line between a for-cause termination and one that frees the employee is itself a litigation risk.
+
+"A noncompetition agreement shall not be enforceable against the following types of workers: (i) an employee who is classified as nonexempt under the Fair Labor Standards Act, 29 U.S.C. 201-219; (ii) undergraduate or graduate students that partake in an internship or otherwise enter a short-term employment relationship with an employer, whether paid or unpaid, while enrolled in a full-time or part-time undergraduate or graduate educational institution; (iii) employees that have been terminated without cause or laid off; or (iv) employees age 18 or younger."[^excluded-workers]
+
+> [!NOTE]
+> **Practice note.**
+>
+> A non-compete is unenforceable against an employee who was laid off or terminated without cause, so an employer that ends the relationship on its own initiative generally cannot then enforce the covenant. Because *without cause* is undefined, treat any non-misconduct separation as likely freeing the employee, and do not count on a non-compete after a reduction in force [^excluded-workers].
+
+## What restrictive covenants fall outside the Massachusetts Noncompetition Agreement Act? {#covered-agreements}
+
+**Short answer.** Most of the others. The act defines a noncompetition agreement to include forfeiture-for-competition agreements but to exclude employee and customer non-solicits, nondisclosure agreements, invention-assignment agreements, qualifying sale-of-business covenants, and separation agreements that give the employee seven business days to rescind [^noncompete-exclusions-solicit][^noncompete-exclusions-sale][^noncompete-exclusions-other].
+
+The sale-of-business carve-out is itself limited: it reaches a covenant signed in connection with a sale or disposition only where the restricted party is a significant owner, member, or partner who will receive significant consideration or benefit from the deal [^noncompete-exclusions-sale].
+
+That boundary matters because covenants outside the act escape its garden-leave, duration, and notice rules and are instead governed by ordinary common-law reasonableness. In 2025, the Supreme Judicial Court confirmed the boundary is read by the statute's plain terms: a forfeiture clause triggered by breach of a non-solicit is not a *forfeiture for competition agreement* and so falls outside the act entirely [^miele-forfeiture][^miele-plain-language].
+
+"Under the plain language of the Massachusetts Noncompetition Agreement Act, (1) noncompetition agreements do not include nonsolicitation agreements, and (2) forfeiture for competition agreements are a subset of noncompetition agreements."[^miele-plain-language]
+
+## Which Massachusetts professions cannot be subject to a non-compete at all? {#profession-bans}
+
+**Short answer.** Several, under their own statutes. Separate from the Noncompetition Agreement Act, Massachusetts voids non-competes restricting the practice of physicians, nurses, psychologists, and social workers, and voids most broadcasting-industry non-competes [^ban-physicians][^ban-nurses][^ban-broadcasting].
+
+These bans predate the 2018 act and operate independently of it. A contract restricting a registered physician's right to practice medicine is void and unenforceable as to that restriction [^ban-physicians], and the same is true for registered and practical nurses [^ban-nurses], licensed psychologists [^ban-psychologists], and licensed social workers [^ban-social-workers]. In the broadcasting industry, a covenant restricting an employee's right to obtain later employment is void where the employer ended the employment, the parties ended it by mutual agreement, or the contract expired, and a violator is liable for the affected employee's reasonable attorneys' fees and costs [^ban-broadcasting].
+
+"Any contract or agreement which creates or establishes the terms of a partnership, employment, or any other form of professional relationship with a physician registered to practice medicine pursuant to section two, which includes any restriction of the right of such physician to practice medicine in any geographic area for any period of time after the termination of such partnership, employment or professional relationship shall be void and unenforceable with respect to said restriction; provided, however, that nothing herein shall render void or unenforceable the remaining provisions of any such contract or agreement."[^ban-physicians]
+
+## Can another state's law govern a Massachusetts worker's non-compete? {#choice-of-law}
+
+**Short answer.** Not if it is used to evade the act. Section 24L makes a choice-of-law provision unenforceable, where it would have the effect of avoiding the statute, for an employee who has been a Massachusetts resident or employed in Massachusetts for at least 30 days before leaving [^choice-of-law-statute].
+
+The statutory bar is reinforced by Massachusetts common-law choice-of-law analysis, which can cut against a Massachusetts clause too. The Supreme Judicial Court refused to enforce a Massachusetts choice-of-law clause where applying Massachusetts law would violate the fundamental public policy of another state — California — that favors employee mobility [^oxford-choice-of-law]. Civil actions over a covered non-compete must be brought in the employee's county of residence or, by mutual agreement, in Suffolk County [^venue-statute].
+
+## Will a Massachusetts court reform an overbroad non-compete? {#reformation}
+
+**Short answer.** It can, at its discretion. Section 24L expressly authorizes a court to reform or otherwise revise a noncompetition agreement to make it valid and enforceable to the extent necessary to protect the employer's legitimate business interests [^reformation-statute].
+
+This is a discretionary power, not a guarantee. The statute lets a court rewrite an overbroad covenant, but an employer should not draft to the outer edge on the assumption that a judge will trim the agreement into shape rather than decline to enforce it.
+
+"A court may, in its discretion, reform or otherwise revise a noncompetition agreement so as to render it valid and enforceable to the extent necessary to protect the applicable legitimate business interests."[^reformation-statute]
+
+## Does a promotion or change in role void an older Massachusetts non-compete? {#material-change}
+
+**Short answer.** It can, under the material-change doctrine. Massachusetts courts have long held that far-reaching changes to the employment relationship can show the parties abandoned the old agreement and formed a new one — voiding a covenant signed under the earlier terms [^bartlett-abandonment][^bartlett-newcontract].
+
+In *F.A. Bartlett Tree Expert Co. v. Barrington*, the Supreme Judicial Court treated successive material changes in pay and position as evidence that the original contract — and its non-compete — had been abandoned and replaced [^bartlett-newcontract]. The doctrine's force after the 2018 act is unsettled, so the conservative practice is to have the employee sign a fresh, statute-compliant covenant on each material promotion or change in terms rather than rely on an old one.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not assume a non-compete signed years ago still binds an employee who has since been promoted or had a material change in pay or duties. Under the material-change doctrine a court may treat the original covenant as abandoned, so re-paper the non-compete — in compliance with the current statute — whenever the role materially changes [^bartlett-abandonment][^bartlett-newcontract].
+
+## Does a Massachusetts non-compete toll or extend during a breach or litigation? {#tolling-extension}
+
+**Short answer.** Only as the statute allows, and a court will not extend it for you. The act itself extends the restricted period to up to 2 years when the employee breached a fiduciary duty or unlawfully took employer property; outside that, and absent an express tolling clause, a Massachusetts court will not equitably extend a non-compete past its stated term [^duration-extension][^emc-no-extension].
+
+The First Circuit, applying Massachusetts law, held that once a restraint period has expired, specific relief is inappropriate and the employer is left to a damages remedy [^emc-expired]. The court pointedly noted that the employer could have contracted for tolling the term of the restriction during litigation, or for the restriction to begin on a preliminary finding of breach — but it had not [^emc-no-extension].
+
+The Supreme Judicial Court takes the same view of judicial extension. In *Automile Holdings, LLC v. McGovern*, it held that a trial judge's equitable extension of a covenant beyond its plain terms was an abuse of discretion, and that such extensions are strongly disfavored absent a finding that damages would be inadequate [^automile-extension].
+
+"Being forewarned, EMC could have contracted, as the district judge noted, for tolling the term of the restriction during litigation, or for a period of restriction to commence upon preliminary finding of breach."[^emc-no-extension]
+
+"As a matter of public policy, we strongly disfavor restrictive covenants, and the use of an equitable remedy to extend such a restriction beyond the plain terms of the contract, even in the context of a sale of a business, was not warranted without a finding that damages would be inadequate."[^automile-extension]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not assume a Massachusetts court will pause the clock while the former employee competes or while litigation drags on. The only built-in extension is the statute's misconduct trigger; if you want the restricted period tolled during a breach or suit, you must draft an express tolling or extension clause — and even then keep the total restraint within the statutory cap [^duration-extension][^emc-no-extension].
+
+## Can a parent or affiliated company enforce a Massachusetts non-compete? {#parent-company-enforcement}
+
+**Short answer.** Risky — the agreement should be with the direct employer. The Noncompetition Agreement Act governs an agreement between an *employer* and an *employee*, and a Massachusetts Superior Court has declined to enforce a non-compete signed with a parent holding company rather than the employee's actual employer [^anaplan-employer].
+
+In *Anaplan Parent, LP v. Brennan*, the Business Litigation Session denied a preliminary injunction on a non-compete contained in equity-grant agreements signed with the employee's parent company, reasoning that the term *employer* has not been read to include a parent corporation [^anaplan-employer]. The decision is a trial-court order on a preliminary injunction — persuasive rather than binding — but it flags a concrete drafting risk.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Have the entity that actually employs the worker — not a parent, holding company, or affiliate — be the named counterparty on a Massachusetts non-compete. A covenant signed only with a parent company risks being unenforceable because the parent may not be the employee's *employer* under the act [^anaplan-employer].
+
+## If a non-compete is unavailable, what protects a Massachusetts employer? {#trade-secrets}
+
+**Short answer.** Trade-secret law and tailored covenants. The Massachusetts Uniform Trade Secrets Act protects a broadly defined category of trade secrets, and the Noncompetition Agreement Act leaves non-solicitation and confidentiality agreements available without its garden-leave and duration limits [^mutsa-definition][^mutsa-limitations].
+
+Because so many workers and covenants fall outside the act — laid-off employees, nonexempt workers, non-solicits, and NDAs — a confidentiality or non-solicitation agreement backed by trade-secret law is often the more reliable tool. A misappropriation action under the trade-secrets act must be brought within 3 years after the misappropriation is or should have been discovered [^mutsa-limitations].
+
+## What are the key recent developments in Massachusetts non-compete law? {#recent-developments}
+
+**Short answer.** A 2018 statutory overhaul, a clarifying 2025 decision, and continued reform pressure. The Noncompetition Agreement Act reset the rules for agreements entered into on or after October 1, 2018, and the Supreme Judicial Court's 2025 decision in *Miele* drew a firm line keeping non-solicitation agreements — and forfeiture clauses triggered only by breaching them — outside the act [^rd-nuvasive-effective-date][^rd-miele-plain-language].
+
+- 
+- 
+- 
+
+> [!NOTE]
+> **Practice note.**
+>
+> Confirm the current status of pending Massachusetts non-compete legislation before relying on this summary, because reform bills are active in the 2025–2026 session. The settled law remains the 2018 act as interpreted in *Miele*, which keeps non-solicitation and confidentiality covenants outside the act's garden-leave and duration limits [^rd-miele-plain-language].
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-03. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not Massachusetts. This article synthesizes Massachusetts primary law and is not legal advice from a Massachusetts-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^mnaa-validity]: **Mass. Gen. Laws ch. 149, § 24L** — "To be valid and enforceable, a noncompetition agreement must meet the minimum requirements of paragraphs (i) through (viii)." *Mass. Gen. Laws ch. 149, § 24L(b).* <https://malegislature.gov/Laws/GeneralLaws/Chapter149/Section24L>
+
+[^nuvasive-effective-date]: **NuVasive, Inc. v. Day** — "the MNCA ‘only applies to employee noncompetition agreements entered into on or after October 1, 2018,’" *NuVasive, Inc. v. Day, 954 F.3d 439 (1st Cir. 2020).* <https://www.courtlistener.com/opinion/4743298/nuvasive-inc-v-day/#:~:text=the%20MNCA%20%22only%20applies%20to,or%20after%20October%201%2C%202018%2C%22>
+
+[^mnaa-employee-scope]: **Mass. Gen. Laws ch. 149, § 24L** — "provided, however, that the term ''employee'', as used in this section, shall also include independent contractors under section 148B." *Mass. Gen. Laws ch. 149, § 24L(a).* <https://malegislature.gov/Laws/GeneralLaws/Chapter149/Section24L>
+
+[^boulanger-reasonableness]: **Boulanger v. Dunkin' Donuts Inc.** — "A covenant not to compete is enforceable only if it is necessary to protect a legitimate business interest, reasonably limited in time and space, and consonant with the public interest." *Boulanger v. Dunkin' Donuts Inc., 442 Mass. 635 (2004).* <https://www.courtlistener.com/opinion/6579005/boulanger-v-dunkin-donuts-inc/#:~:text=A%20covenant%20not%20to%20compete%20is,consonant%20with%20the%20public%20interest.>
+
+[^formation-newhire]: **Mass. Gen. Laws ch. 149, § 24L** — "If the agreement is entered into in connection with the commencement of employment, it must be in writing and signed by both the employer and employee and expressly state that the employee has the right to consult with counsel prior to signing." *Mass. Gen. Laws ch. 149, § 24L(b)(i).* <https://malegislature.gov/Laws/GeneralLaws/Chapter149/Section24L>
+
+[^formation-newhire-timing]: **Mass. Gen. Laws ch. 149, § 24L** — "The agreement must be provided to the employee by the earlier of a formal offer of employment or 10 business days before the commencement of the employee's employment." *Mass. Gen. Laws ch. 149, § 24L(b)(i).* <https://malegislature.gov/Laws/GeneralLaws/Chapter149/Section24L>
+
+[^formation-midemployment]: **Mass. Gen. Laws ch. 149, § 24L** — "If the agreement is entered into after commencement of employment but not in connection with the separation from employment, it must be supported by fair and reasonable consideration independent from the continuation of employment, and notice of the agreement must be provided at least 10 business days before the agreement is to be effective." *Mass. Gen. Laws ch. 149, § 24L(b)(ii).* <https://malegislature.gov/Laws/GeneralLaws/Chapter149/Section24L>
+
+[^consideration-requirement]: **Mass. Gen. Laws ch. 149, § 24L** — "The noncompetition agreement shall be supported by a garden leave clause or other mutually-agreed upon consideration between the employer and the employee, provided that such consideration is specified in the noncompetition agreement." *Mass. Gen. Laws ch. 149, § 24L(b)(vii).* <https://malegislature.gov/Laws/GeneralLaws/Chapter149/Section24L>
+
+[^garden-leave-fifty-percent]: **Mass. Gen. Laws ch. 149, § 24L** — "To constitute a garden leave clause within the meaning of this section, the agreement must (i) provide for the payment, consistent with the requirements for the payment of wages under section 148 of chapter 149 of the general laws, on a pro-rata basis during the entirety of the restricted period, of at least 50 percent of the employee's highest annualized base salary paid by the employer within the 2 years preceding the employee's termination;" *Mass. Gen. Laws ch. 149, § 24L(b)(vii).* <https://malegislature.gov/Laws/GeneralLaws/Chapter149/Section24L>
+
+[^duration-cap]: **Mass. Gen. Laws ch. 149, § 24L** — "In no event may the stated restricted period exceed 12 months from the date of cessation of employment, unless the employee has breached his or her fiduciary duty to the employer or the employee has unlawfully taken, physically or electronically, property belonging to the employer, in which case the duration may not exceed 2 years from the date of cessation of employment." *Mass. Gen. Laws ch. 149, § 24L(b)(iv).* <https://malegislature.gov/Laws/GeneralLaws/Chapter149/Section24L>
+
+[^legitimate-interests-statute]: **Mass. Gen. Laws ch. 149, § 24L** — "The agreement must be no broader than necessary to protect one or more of the following legitimate business interests of the employer: (A) the employer's trade secrets; (B) the employer's confidential information that otherwise would not qualify as a trade secret; or (C) the employer's goodwill." *Mass. Gen. Laws ch. 149, § 24L(b)(iii).* <https://malegislature.gov/Laws/GeneralLaws/Chapter149/Section24L>
+
+[^boulanger-interests]: **Boulanger v. Dunkin' Donuts Inc.** — "Legitimate business interests include protection of trade secrets, confidential information, and good will." *Boulanger v. Dunkin' Donuts Inc., 442 Mass. 635 (2004).* <https://www.courtlistener.com/opinion/6579005/boulanger-v-dunkin-donuts-inc/#:~:text=Legitimate%20business%20interests%20include%20protection,confidential%20information%2C%20and%20good%20will.>
+
+[^allstainless-ordinary-competition]: **All Stainless, Inc. v. Colby** — "A former employer is not entitled by contract to restrain ordinary competition." *All Stainless, Inc. v. Colby, 364 Mass. 773 (1974).* <https://www.courtlistener.com/opinion/2151844/all-stainless-inc-v-colby/#:~:text=A%20former%20employer%20is%20not,contract%20to%20restrain%20ordinary%20competition.>
+
+[^excluded-workers]: **Mass. Gen. Laws ch. 149, § 24L** — "A noncompetition agreement shall not be enforceable against the following types of workers: (i) an employee who is classified as nonexempt under the Fair Labor Standards Act, 29 U.S.C. 201-219; (ii) undergraduate or graduate students that partake in an internship or otherwise enter a short-term employment relationship with an employer, whether paid or unpaid, while enrolled in a full-time or part-time undergraduate or graduate educational institution; (iii) employees that have been terminated without cause or laid off; or (iv) employees age 18 or younger." *Mass. Gen. Laws ch. 149, § 24L(c).* <https://malegislature.gov/Laws/GeneralLaws/Chapter149/Section24L>
+
+[^noncompete-exclusions-solicit]: **Mass. Gen. Laws ch. 149, § 24L** — "Noncompetition agreements include forfeiture for competition agreements, but do not include: (i) covenants not to solicit or hire employees of the employer; (ii) covenants not to solicit or transact business with customers, clients, or vendors of the employer;" *Mass. Gen. Laws ch. 149, § 24L(a).* <https://malegislature.gov/Laws/GeneralLaws/Chapter149/Section24L>
+
+[^noncompete-exclusions-sale]: **Mass. Gen. Laws ch. 149, § 24L** — "(iii) noncompetition agreements made in connection with the sale of a business entity or substantially all of the operating assets of a business entity or partnership, or otherwise disposing of the ownership interest of a business entity or partnership, or division or subsidiary thereof, when the party restricted by the noncompetition agreement is a significant owner of, or member or partner in, the business entity who will receive significant consideration or benefit from the sale or disposal;" *Mass. Gen. Laws ch. 149, § 24L(a).* <https://malegislature.gov/Laws/GeneralLaws/Chapter149/Section24L>
+
+[^noncompete-exclusions-other]: **Mass. Gen. Laws ch. 149, § 24L** — "(vi) nondisclosure or confidentiality agreements; (vii) invention assignment agreements; (viii) garden leave clauses; (ix) noncompetition agreements made in connection with the cessation of or separation from employment if the employee is expressly given seven business days to rescind acceptance;" *Mass. Gen. Laws ch. 149, § 24L(a).* <https://malegislature.gov/Laws/GeneralLaws/Chapter149/Section24L>
+
+[^miele-forfeiture]: **Miele v. Foundation Medicine, Inc.** — "That is, for the reasons we discuss below, we conclude that a forfeiture clause triggered by a breach of a nonsolicitation agreement does not constitute a ‘forfeiture for competition agreement’ within the meaning of the act." *Miele v. Foundation Medicine, Inc., 496 Mass. 171 (2025).* <https://www.courtlistener.com/opinion/10604382/susan-miele-v-foundation-medicine-inc/#:~:text=That%20is%2C%20for%20the%20reasons,the%20meaning%20of%20the%20act.>
+
+[^miele-plain-language]: **Miele v. Foundation Medicine, Inc.** — "Under the plain language of the Massachusetts Noncompetition Agreement Act, (1) noncompetition agreements do not include nonsolicitation agreements, and (2) forfeiture for competition agreements are a subset of noncompetition agreements." *Miele v. Foundation Medicine, Inc., 496 Mass. 171 (2025).* <https://www.courtlistener.com/opinion/10604382/susan-miele-v-foundation-medicine-inc/#:~:text=Under%20the%20plain%20language%20of,a%20subset%20of%20noncompetition%20agreements.>
+
+[^ban-physicians]: **Mass. Gen. Laws ch. 112, § 12X** — "Any contract or agreement which creates or establishes the terms of a partnership, employment, or any other form of professional relationship with a physician registered to practice medicine pursuant to section two, which includes any restriction of the right of such physician to practice medicine in any geographic area for any period of time after the termination of such partnership, employment or professional relationship shall be void and unenforceable with respect to said restriction; provided, however, that nothing herein shall render void or unenforceable the remaining provisions of any such contract or agreement." *Mass. Gen. Laws ch. 112, § 12X.* <https://malegislature.gov/Laws/GeneralLaws/Chapter112/Section12X>
+
+[^ban-nurses]: **Mass. Gen. Laws ch. 112, § 74D** — "which includes any restriction of the right of such nurse to practice as a nurse in any geographical area for any period of time after the termination of such partnership, employment or professional relationship shall be void and unenforceable with respect to said restriction." *Mass. Gen. Laws ch. 112, § 74D.* <https://malegislature.gov/Laws/GeneralLaws/Chapter112/Section74D>
+
+[^ban-broadcasting]: **Mass. Gen. Laws ch. 149, § 186** — "Any contract or agreement which creates or establishes the terms of employment for an employee or individual in the broadcasting industry, including, television stations, television networks, radio stations, radio networks, or any entities affiliated with the foregoing, and which restricts the right of such employee or individual to obtain employment in a specified geographic area for a specified period of time after termination of employment of the employee by the employer or by termination of the employment relationship by mutual agreement of the employer and the employee or by termination of the employment relationship by the expiration of the contract or agreement, shall be void and unenforceable with respect to such provision." *Mass. Gen. Laws ch. 149, § 186.* <https://malegislature.gov/Laws/GeneralLaws/Chapter149/Section186>
+
+[^ban-psychologists]: **Mass. Gen. Laws ch. 112, § 129B** — "which includes a restriction of the right of the psychologist to practice in any geographic area for any period of time after termination of the partnership, employment or professional relationship shall be void and unenforceable with respect to the restriction;" *Mass. Gen. Laws ch. 112, § 129B.* <https://malegislature.gov/Laws/GeneralLaws/Chapter112/Section129B>
+
+[^ban-social-workers]: **Mass. Gen. Laws ch. 112, § 135C** — "that includes a restriction of the right of the social worker to practice in any geographic area for any period of time after termination of the partnership, employment or professional relationship shall be void and unenforceable with respect to that restriction." *Mass. Gen. Laws ch. 112, § 135C.* <https://malegislature.gov/Laws/GeneralLaws/Chapter112/Section135C>
+
+[^choice-of-law-statute]: **Mass. Gen. Laws ch. 149, § 24L** — "No choice of law provision that would have the effect of avoiding the requirements of this section will be enforceable if the employee is, and has been for at least 30 days immediately preceding his or her cessation of employment, a resident of or employed in Massachusetts at the time of his or her termination of employment." *Mass. Gen. Laws ch. 149, § 24L(e).* <https://malegislature.gov/Laws/GeneralLaws/Chapter149/Section24L>
+
+[^oxford-choice-of-law]: **Oxford Global Res., LLC v. Hernandez** — "We conclude that the Massachusetts choice of law provision in the agreement is not enforceable, where California substantive law would apply under our choice of law principles, and where the application of Massachusetts substantive law would violate the fundamental public policy of California favoring open competition and employee mobility." *Oxford Global Res., LLC v. Hernandez, 480 Mass. 462 (2018).* <https://www.courtlistener.com/opinion/7175264/oxford-global-res-llc-v-hernandez/#:~:text=We%20conclude%20that%20the%20Massachusetts,open%20competition%20and%20employee%20mobility.>
+
+[^venue-statute]: **Mass. Gen. Laws ch. 149, § 24L** — "All civil actions relating to employee noncompetition agreements subject to this section shall be brought in the county where the employee resides or, if mutually agreed upon by the employer and employee, in Suffolk county;" *Mass. Gen. Laws ch. 149, § 24L(f).* <https://malegislature.gov/Laws/GeneralLaws/Chapter149/Section24L>
+
+[^reformation-statute]: **Mass. Gen. Laws ch. 149, § 24L** — "A court may, in its discretion, reform or otherwise revise a noncompetition agreement so as to render it valid and enforceable to the extent necessary to protect the applicable legitimate business interests." *Mass. Gen. Laws ch. 149, § 24L(d).* <https://malegislature.gov/Laws/GeneralLaws/Chapter149/Section24L>
+
+[^bartlett-abandonment]: **F.A. Bartlett Tree Expert Co. v. Barrington** — "Such far reaching changes strongly suggest that the parties had abandoned their old arrangement and had entered into a new relationship." *F.A. Bartlett Tree Expert Co. v. Barrington, 353 Mass. 585 (1968).* <https://www.courtlistener.com/opinion/2013561/f-a-bartlett-tree-expert-co-v-barrington/#:~:text=Such%20far%20reaching%20changes%20strongly,entered%20into%20a%20new%20relationship.>
+
+[^bartlett-newcontract]: **F.A. Bartlett Tree Expert Co. v. Barrington** — "The judge concluded that the conduct of the parties shows a clear new employment contract in both 1960 and 1965 and that the 1948 contract was abandoned and rescinded by mutual consent." *F.A. Bartlett Tree Expert Co. v. Barrington, 353 Mass. 585 (1968).* <https://www.courtlistener.com/opinion/2013561/f-a-bartlett-tree-expert-co-v-barrington/#:~:text=The%20judge%20concluded%20that%20the,and%20rescinded%20by%20mutual%20consent.>
+
+[^duration-extension]: **Mass. Gen. Laws ch. 149, § 24L** — "In no event may the stated restricted period exceed 12 months from the date of cessation of employment, unless the employee has breached his or her fiduciary duty to the employer or the employee has unlawfully taken, physically or electronically, property belonging to the employer, in which case the duration may not exceed 2 years from the date of cessation of employment." *Mass. Gen. Laws ch. 149, § 24L(b)(iv).* <https://malegislature.gov/Laws/GeneralLaws/Chapter149/Section24L>
+
+[^emc-no-extension]: **EMC Corp. v. Arturi** — "Being forewarned, EMC could have contracted, as the district judge noted, for tolling the term of the restriction during litigation, or for a period of restriction to commence upon preliminary finding of breach." *EMC Corp. v. Arturi, 655 F.3d 75 (1st Cir. 2011).* <https://www.courtlistener.com/opinion/612666/emc-corp-v-arturi/#:~:text=Being%20forewarned%2C%20EMC%20could%20have,upon%20preliminary%20finding%20of%20breach.>
+
+[^emc-expired]: **EMC Corp. v. Arturi** — "We explained that ‘when the period of restraint has expired, even when the delay was substantially caused by the time consumed in legal appeals, specific relief is inappropriate and the injured party is left to his damages remedy." *EMC Corp. v. Arturi, 655 F.3d 75 (1st Cir. 2011).* <https://www.courtlistener.com/opinion/612666/emc-corp-v-arturi/#:~:text=We%20explained%20that%20%22when%20the,left%20to%20his%20damages%20remedy.>
+
+[^automile-extension]: **Automile Holdings, LLC v. McGovern** — "As a matter of public policy, we strongly disfavor restrictive covenants, and the use of an equitable remedy to extend such a restriction beyond the plain terms of the contract, even in the context of a sale of a business, was not warranted without a finding that damages would be inadequate." *Automile Holdings, LLC v. McGovern, 483 Mass. 797 (2020).* <https://caselaw.findlaw.com/court/ma-supreme-judicial-court/2042227.html>
+
+[^anaplan-employer]: **Anaplan Parent, LP v. Brennan** — "It has never been held to include a parent corporation as an ‘employer.’" *Anaplan Parent, LP v. Brennan, No. 2584CV02350 (Mass. Super. Ct. 2025).* <https://www.mintz.com/sites/default/files/media/documents/2025-11-07/Anaplan-Parent%2C-LP-v.-Brennan-Noncompete%20Order.pdf>
+
+[^mutsa-definition]: **Mass. Gen. Laws ch. 93, § 42** — "(4) ''Trade secret'', specified or specifiable information, whether or not fixed in tangible form or embodied in any tangible thing, including but not limited to a formula, pattern, compilation, program, device, method, technique, process, business strategy, customer list, invention, or scientific, technical, financial or customer data" *Mass. Gen. Laws ch. 93, § 42(4).* <https://malegislature.gov/Laws/GeneralLaws/Chapter93/Section42>
+
+[^mutsa-limitations]: **Mass. Gen. Laws ch. 93, § 42E** — "An action for misappropriation must be brought within 3 years after the misappropriation is discovered or by the exercise of reasonable diligence should have been discovered." *Mass. Gen. Laws ch. 93, § 42E.* <https://malegislature.gov/Laws/GeneralLaws/Chapter93/Section42E>
+
+[^rd-nuvasive-effective-date]: **NuVasive, Inc. v. Day** — "the MNCA ‘only applies to employee noncompetition agreements entered into on or after October 1, 2018,’" *NuVasive, Inc. v. Day, 954 F.3d 439 (1st Cir. 2020).* <https://www.courtlistener.com/opinion/4743298/nuvasive-inc-v-day/#:~:text=the%20MNCA%20%22only%20applies%20to,or%20after%20October%201%2C%202018%2C%22>
+
+[^rd-miele-plain-language]: **Miele v. Foundation Medicine, Inc.** — "Under the plain language of the Massachusetts Noncompetition Agreement Act, (1) noncompetition agreements do not include nonsolicitation agreements, and (2) forfeiture for competition agreements are a subset of noncompetition agreements." *Miele v. Foundation Medicine, Inc., 496 Mass. 171 (2025).* <https://www.courtlistener.com/opinion/10604382/susan-miele-v-foundation-medicine-inc/#:~:text=Under%20the%20plain%20language%20of,a%20subset%20of%20noncompetition%20agreements.>

--- a/skills/non-compete-contract-explainer/content/michigan.md
+++ b/skills/non-compete-contract-explainer/content/michigan.md
@@ -1,0 +1,222 @@
+---
+jurisdiction: "Michigan"
+slug: michigan
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-03"
+canonicalUrl: https://openagreements.org/legal/non-compete/michigan
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/michigan · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in Michigan[^about]
+
+Michigan enforces employee non-competes only when they are reasonable under MCL 445.774a, judges business-to-business covenants under the antitrust rule of reason, and gives courts discretion to limit overbroad covenants rather than voiding them outright.
+
+
+## At a glance
+
+| Question | Michigan |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed if reasonable |
+| **Bottom line** | Michigan enforces an employee non-compete if it protects a reasonable competitive business interest and is reasonable in duration, geography, and type of employment, with no categorical worker or profession ban. |
+| **Main law or case** | MCL § 445.774a; St. Clair Medical, P.C. v. Borgiel, 270 Mich. App. 260 (2006) |
+| **Main exceptions** | B2B/sale-of-business covenants judged under antitrust rule of reason; no physician or profession ban |
+| **Can a court narrow it?** | Yes — rewrites to reasonable |
+| **Applies to contractors?** | Unclear |
+| **Restriction extended during a breach?** | Unsettled |
+| **Maximum length set by law** | No fixed numeric cap |
+
+## Are employee non-compete agreements enforceable in Michigan? {#employee-noncompetes}
+
+**Short answer.** Yes, sometimes. Michigan is a reasonableness state, not a general-ban state: MCL 445.774a lets an employer enforce a covenant that protects a reasonable competitive business interest and is reasonable in duration, geographic area, and the type of employment restricted [^mcl-774a-employer-may-obtain][^borgiel-unfair-advantage].
+
+The governing statute is part of the Michigan Antitrust Reform Act. A covenant is valid only if it does more than block ordinary competition — under *St. Clair Medical, P.C. v. Borgiel* it must protect against the employee gaining an *unfair* competitive advantage and may not stop the employee from using general knowledge or skill [^borgiel-unfair-advantage].
+
+"To be reasonable in relation to an employer's competitive business interest, a restrictive covenant must protect against the employee's gaining some unfair advantage in competition with the employer, but not prohibit the employee from using general knowledge or skill."[^borgiel-unfair-advantage]
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not treat Michigan as a total-ban state, and do not assume a covenant is enforceable just because the statute permits non-competes. Start with the reasonable-competitive-business-interest test and the duration, geography, and type-of-employment limits, because a covenant that merely suppresses competition fails even though the statute allows non-competes [^mcl-774a-employer-may-obtain][^borgiel-unfair-advantage].
+
+## What legitimate business interests can support a Michigan non-compete? {#protectable-interests}
+
+**Short answer.** Confidential information, customer relationships, and trade secrets are the core interests that justify a Michigan restraint; general skill and knowledge are not protectable [^follmer-confidential-info][^borgiel-general-skill][^mutsa-trade-secret-definition].
+
+In *Follmer, Rudzewicz & Co., P.C. v. Kosco*, the Michigan Supreme Court held that a covenant is enforceable to the extent it reasonably protects the employer's confidential information, and unenforceable to the extent it reaches further [^follmer-confidential-info]. *Borgiel* draws the same line on the employee side: the covenant cannot bar the use of general knowledge or skill [^borgiel-general-skill].
+
+The Michigan Uniform Trade Secrets Act supplies the trade-secret overlay. A trade secret is information that derives independent economic value from not being generally known and is the subject of reasonable secrecy efforts [^mutsa-trade-secret-definition].
+
+"To the extent such an agreement provides reasonable protection for the confidential information of the employer, it does not violate the statute and is enforceable."[^follmer-confidential-info]
+
+## How long and how broad can a Michigan non-compete be? {#duration-geography}
+
+**Short answer.** There is no fixed numeric cap. MCL 445.774a requires the duration, geographic area, and type of employment to be reasonable, and whether a covenant clears that bar is a question of law when the facts are undisputed [^mcl-774a-reasonable-scope][^coates-question-of-law].
+
+Reasonableness is fact-specific, but the outer bounds are clear: in *Mid Michigan Medical Billing Service, Inc. v. Williams*, the Court of Appeals held that a restriction with unlimited duration and geographic reach on working for any past or current client was unreasonable [^mid-michigan-unlimited]. *Coates v. Bastian Brothers, Inc.* confirms a court decides reasonableness as a matter of law when the underlying facts are not in dispute [^coates-question-of-law].
+
+"The reasonableness of a noncompetition provision is a question of law when the relevant facts are undisputed."[^coates-question-of-law]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Tie duration, geography, and covered activity to the specific interest the covenant protects rather than copying a long default term. *Mid Michigan Billing* shows that an unlimited or open-ended client restriction is vulnerable as unreasonable, so a narrower, interest-matched scope is more defensible [^mcl-774a-reasonable-scope][^mid-michigan-unlimited].
+
+## Is continued employment enough consideration for a Michigan non-compete? {#continued-employment-consideration}
+
+**Short answer.** For a genuine at-will employee, usually yes — but it is not automatic. *QIS, Inc. v. Industrial Quality Control, Inc.* states the rule that mere continuation of at-will employment is sufficient consideration, yet *QIS* itself held the covenant void for lack of consideration because the workers were just-cause employees [^qis-continued-employment][^qis-just-cause].
+
+The outcome in *QIS* is the cautionary part. The court agreed the agreement was void because the employees could not be dismissed without just cause, so their continued employment did not supply consideration for signing a new restraint [^qis-just-cause]. The at-will rule it recited (drawn from federal authority applying Michigan law) governs only when employment really is at will.
+
+"Mere continuation of employment is sufficient consideration to support a noncompete agreement in an at-will employment setting."[^qis-continued-employment]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> For a non-at-will or just-cause employee, do not rely on continued employment alone as consideration. *QIS* held a covenant void in that setting because refusing to sign would not have been just cause for termination, so provide separate, identifiable consideration when the worker is not at will [^qis-just-cause].
+
+## Can a Michigan court rewrite or limit an overbroad non-compete? {#court-narrowing}
+
+**Short answer.** Yes. MCL 445.774a expressly lets a court limit a covenant it finds unreasonable and enforce it as limited, so Michigan is a statutory blue-pencil state [^mcl-774a-court-may-limit].
+
+This power is real but discretionary, not guaranteed. In *Mid Michigan Medical Billing Service, Inc. v. Williams*, the court confirmed that MCL 445.774a lets a court modify an unreasonable covenant to render it reasonable and enforceable rather than void it outright [^mid-michigan-limited].
+
+"To the extent any such agreement or covenant is found to be unreasonable in any respect, a court may limit the agreement to render it reasonable in light of the circumstances in which it was made and specifically enforce the agreement as limited."[^mcl-774a-court-may-limit]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Because the statute says a court *may* limit an overbroad covenant, not that it must, do not rely on judicial narrowing as a safety net. Draft scope, geography, and duration to the minimum the protectable interest requires, since a court may decline to save a covenant it views as punitive [^mcl-774a-court-may-limit][^mid-michigan-limited].
+
+## Are Michigan business-to-business or sale-of-business non-competes judged differently? {#business-to-business}
+
+**Short answer.** Yes. The Michigan Supreme Court held in *Innovation Ventures, LLC v. Liquid Manufacturing, LLC* that commercial non-competes between businesses are evaluated under the antitrust rule of reason, not the MCL 445.774a employee test [^innovation-rule-of-reason].
+
+The rule of reason flows from the Michigan Antitrust Reform Act, which makes contracts in restraint of trade in a relevant market unlawful and directs courts to give due deference to federal antitrust interpretations [^mcl-772-restraint][^mcl-784-federal-deference]. That standard is different from the employee test: a true commercial or transaction-ancillary restraint is analyzed for its market context and competitive effect rather than under MCL 445.774a's duration, geography, and type-of-employment framework.
+
+"Commercial noncompete agreements between businesses should be evaluated under the rule of reason, and federal court interpretations of the rule of reason should be given due deference."[^innovation-rule-of-reason]
+
+> [!NOTE]
+> **Practice note.**
+>
+> Identify which framework applies before assessing a covenant. *Innovation Ventures* routes true commercial covenants, including transaction-ancillary covenants, to the antitrust rule of reason, so applying the MCL 445.774a employee duration-geography test to a genuine business-to-business covenant analyzes it under the wrong standard [^innovation-rule-of-reason][^mcl-772-restraint].
+
+## What special non-compete issues affect Michigan physicians? {#physician-rules}
+
+**Short answer.** Michigan does not categorically ban physician non-competes — they are analyzed under the ordinary MCL 445.774a reasonableness test, and *Borgiel* itself upheld a physician covenant [^borgiel-physician-upheld]. The distinctive problem is evidentiary, not categorical.
+
+In *Isidore Steiner, DPM, PC v. Bonanni*, the Court of Appeals held that Michigan's physician-patient privilege is more protective than HIPAA and blocks discovery of nonparty patient information, which can make it harder for a medical employer to prove diversion of patients [^steiner-patient-privilege].
+
+"Because Michigan law is more protective of patients' privacy interests in the context of this litigation, Michigan law applies to plaintiff's attempted discovery of defendant's patient information."[^steiner-patient-privilege]
+
+> [!NOTE]
+> **Practice note.**
+>
+> A physician non-solicitation or non-compete can be valid yet hard to enforce in practice. *Steiner* shows that patient-privilege limits on discovery can deprive a medical employer of the nonparty-patient evidence it needs to prove a breach, so build the enforcement case on non-privileged proof [^steiner-patient-privilege].
+
+## How does Michigan's trade-secret act interact with non-competes? {#trade-secret-overlay}
+
+**Short answer.** The Michigan Uniform Trade Secrets Act runs alongside a non-compete: it displaces conflicting common-law tort remedies for misappropriation but preserves contract remedies, so a confidentiality and trade-secret strategy can backstop or substitute for a covenant [^mutsa-displacement].
+
+MUTSA has its own timing and fee rules that a non-compete does not. A misappropriation claim must be brought within three years of discovery [^mutsa-limitations], and a court may award attorney fees for bad-faith claims or willful and malicious misappropriation — relief the non-compete statute itself does not provide [^mutsa-fees].
+
+"Except as provided in subsection (2), this act displaces conflicting tort, restitutionary, and other law of this state providing civil remedies for misappropriation of a trade secret."[^mutsa-displacement]
+
+## Will Michigan enforce a non-compete's choice-of-law or forum-selection clause? {#choice-of-law-forum}
+
+**Short answer.** Often yes. In the *Stryker Corp. v. Ridgeway* litigation (the *Stone Surgical* dispute), the Sixth Circuit held that a non-compete's Michigan forum-selection clause was valid and enforceable under Michigan law [^stryker-michigan-clauses].
+
+But the clause type matters. In *Barshaw v. Allegheny Performance Plastics, LLC*, the Court of Appeals held that a Michigan court applies Michigan law to decide the effect of a forum-selection clause, even when the contract chooses another state's law for the merits [^barshaw-michigan-forum-law].
+
+"Under Michigan law, the Michigan forum-selection clause is valid and enforceable."[^stryker-michigan-clauses]
+
+## Does a Michigan non-compete toll or extend during breach or litigation? {#tolling-extension}
+
+**Short answer.** This is an open Michigan question. No Michigan statute or appellate decision surfaced here squarely endorses automatic judicial tolling, or enforcement of an extension-on-breach clause after the stated restricted period expires [^mcl-774a-tolling-backdrop][^coates-tolling-backdrop].
+
+The relevant backdrop cuts against assuming an automatic extension. MCL 445.774a authorizes a court to *limit* an unreasonable covenant, not to expand one [^mcl-774a-tolling-backdrop], and any extension still has to satisfy the reasonableness test that *Coates* applies as a question of law [^coates-tolling-backdrop]. A clause that converts a fixed restraint into an open-ended one as litigation drags on raises exactly the reasonableness concern the statute targets.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Open question: Michigan law is unsettled on whether an extension-on-breach clause is enforceable after the original restricted period expires. Draft any tolling clause as a separate, reasonable restraint tied to the duration of the breach and a legitimate interest, and do not assume a Michigan court will extend an expired covenant automatically [^mcl-774a-tolling-backdrop][^coates-tolling-backdrop].
+
+## What Michigan non-compete reform should employers watch? {#pending-reform}
+
+**Short answer.** None is currently law. The bill to watch is House Bill 4040 (2025), which would amend MCL 445.774a to bar nearly all worker non-competes; as of June 3, 2026 it remains in committee and has not been enacted [^hb-4040-worker-ban][^hb-4040-status].
+
+HB 4040 would prohibit a business from entering into, obtaining, or enforcing a non-compete against a worker, reaching beyond employees to independent contractors, interns, and volunteers [^hb-4040-worker-ban]. The official bill record shows it was referred to the House Committee on Economic Competitiveness and has had no further action [^hb-4040-status], so the enacted baseline remains statutory reasonableness under MCL 445.774a, as interpreted by Michigan non-compete cases.
+
+A separate 2025 development affects onboarding paperwork that bundles covenants. In *Rayford v. American House Roseville I, LLC*, the Michigan Supreme Court held that a contractually shortened limitations provision in an adhesion agreement must be examined for reasonableness [^rayford-adhesion-reasonableness].
+
+"Except as otherwise provided in subsection (2), a business shall not do any of the following: (a) Enter into or attempt to enter into a noncompete agreement with a worker. (b) Obtain or attempt to obtain a noncompete agreement from a worker. (c) Enforce or attempt to enforce a noncompete agreement against a worker or former worker."[^hb-4040-worker-ban]
+
+> [!NOTE]
+> **Practice note.**
+>
+> Treat HB 4040 as a monitoring item, not as present Michigan law. Recheck the official Michigan Legislature bill status before changing forms or telling workers that Michigan has enacted a general non-compete ban [^hb-4040-worker-ban].
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-03. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not Michigan. This article synthesizes Michigan primary law and is not legal advice from a Michigan-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^mcl-774a-employer-may-obtain]: **MCL § 445.774a** — "An employer may obtain from an employee an agreement or covenant which protects an employer's reasonable competitive business interests and expressly prohibits an employee from engaging in employment or a line of business after termination of employment if the agreement or covenant is reasonable as to its duration, geographical area, and the type of employment or line of business." *MCL § 445.774a(1).* <https://legislature.mi.gov/Laws/MCL?objectName=mcl-445-774a>
+
+[^borgiel-unfair-advantage]: **St. Clair Medical, P.C. v. Borgiel** — "To be reasonable in relation to an employer's competitive business interest, a restrictive covenant must protect against the employee's gaining some unfair advantage in competition with the employer, but not prohibit the employee from using general knowledge or skill." *St. Clair Med., P.C. v. Borgiel, 270 Mich. App. 260 (2006).* <https://www.courtlistener.com/opinion/2026165/st-clair-medical-pc-v-borgiel/#:~:text=To%20be%20reasonable%20in%20relation,using%20general%20knowledge%20or%20skill.>
+
+[^follmer-confidential-info]: **Follmer, Rudzewicz & Co., P.C. v. Kosco** — "To the extent such an agreement provides reasonable protection for the confidential information of the employer, it does not violate the statute and is enforceable." *Follmer, Rudzewicz & Co., P.C. v. Kosco, 420 Mich. 394 (1984).* <https://www.courtlistener.com/opinion/1708749/follmer-rudzewicz-co-v-kosco/#:~:text=To%20the%20extent%20such%20an,the%20statute%20and%20is%20enforceable.>
+
+[^borgiel-general-skill]: **St. Clair Medical, P.C. v. Borgiel** — "To be reasonable in relation to an employer's competitive business interest, a restrictive covenant must protect against the employee's gaining some unfair advantage in competition with the employer, but not prohibit the employee from using general knowledge or skill." *St. Clair Med., P.C. v. Borgiel, 270 Mich. App. 260 (2006).* <https://www.courtlistener.com/opinion/2026165/st-clair-medical-pc-v-borgiel/#:~:text=To%20be%20reasonable%20in%20relation,using%20general%20knowledge%20or%20skill.>
+
+[^mutsa-trade-secret-definition]: **MCL § 445.1902** — "‘Trade secret’ means information, including a formula, pattern, compilation, program, device, method, technique, or process, that is both of the following: (i) Derives independent economic value, actual or potential, from not being generally known to, and not being readily ascertainable by proper means by, other persons who can obtain economic value from its disclosure or use." *MCL § 445.1902(d).* <https://legislature.mi.gov/Laws/MCL?objectName=mcl-445-1902>
+
+[^mcl-774a-reasonable-scope]: **MCL § 445.774a** — "An employer may obtain from an employee an agreement or covenant which protects an employer's reasonable competitive business interests and expressly prohibits an employee from engaging in employment or a line of business after termination of employment if the agreement or covenant is reasonable as to its duration, geographical area, and the type of employment or line of business." *MCL § 445.774a(1).* <https://legislature.mi.gov/Laws/MCL?objectName=mcl-445-774a>
+
+[^coates-question-of-law]: **Coates v. Bastian Brothers, Inc.** — "The reasonableness of a noncompetition provision is a question of law when the relevant facts are undisputed." *Coates v. Bastian Bros., Inc., 276 Mich. App. 498 (2007).* <https://www.courtlistener.com/opinion/2220514/coates-v-bastian-brothers-inc/#:~:text=The%20reasonableness%20of%20a%20noncompetition,the%20relevant%20facts%20are%20undisputed.>
+
+[^mid-michigan-unlimited]: **Mid Michigan Medical Billing Service, Inc. v. Williams** — "Although plaintiff argues that the expansive restriction is necessary to protect its business interests, plaintiff does not have an unlimited right to restrict the business choices of its clients." *Mid Mich. Med. Billing Serv., Inc. v. Williams, No. 323890 (Mich. Ct. App. Feb. 18, 2016).* <https://www.courts.michigan.gov/siteassets/case-documents/uploads/opinions/final/coa/20160218_c323890_37_323890.opn.pdf>
+
+[^qis-continued-employment]: **QIS, Inc. v. Industrial Quality Control, Inc.** — "Mere continuation of employment is sufficient consideration to support a noncompete agreement in an at-will employment setting." *QIS, Inc. v. Indus. Quality Control, Inc., 262 Mich. App. 592 (2004).* <https://www.courtlistener.com/opinion/1591214/qis-inc-v-industrial-quality-control-inc/#:~:text=Mere%20continuation%20of%20employment%20is,in%20an%20at%2Dwill%20employment%20setting.>
+
+[^qis-just-cause]: **QIS, Inc. v. Industrial Quality Control, Inc.** — "Because defendants were ‘just cause’ employees, however, the issue is whether defendants' refusal to sign the noncompete agreement would amount to ‘just cause’ for their termination." *QIS, Inc. v. Indus. Quality Control, Inc., 262 Mich. App. 592 (2004).* <https://www.courtlistener.com/opinion/1591214/qis-inc-v-industrial-quality-control-inc/#:~:text=Because%20defendants%20were%20%E2%80%9Cjust%20cause%E2%80%9D,%E2%80%9Cjust%20cause%E2%80%9D%20for%20their%20termination.>
+
+[^mcl-774a-court-may-limit]: **MCL § 445.774a** — "To the extent any such agreement or covenant is found to be unreasonable in any respect, a court may limit the agreement to render it reasonable in light of the circumstances in which it was made and specifically enforce the agreement as limited." *MCL § 445.774a(1).* <https://legislature.mi.gov/Laws/MCL?objectName=mcl-445-774a>
+
+[^mid-michigan-limited]: **Mid Michigan Medical Billing Service, Inc. v. Williams** — "If the terms of a noncompetition agreement are unreasonable, MCL 445.774a allows a court to modify the terms of the agreement to render it reasonable and enforceable in light of the circumstances in which it was made." *Mid Mich. Med. Billing Serv., Inc. v. Williams, No. 323890 (Mich. Ct. App. Feb. 18, 2016).* <https://www.courts.michigan.gov/siteassets/case-documents/uploads/opinions/final/coa/20160218_c323890_37_323890.opn.pdf>
+
+[^innovation-rule-of-reason]: **Innovation Ventures, LLC v. Liquid Manufacturing, LLC** — "Commercial noncompete agreements between businesses should be evaluated under the rule of reason, and federal court interpretations of the rule of reason should be given due deference." *Innovation Ventures, LLC v. Liquid Mfg., LLC, 499 Mich. 491 (2016).* <https://www.courtlistener.com/opinion/4239128/innovation-ventures-v-liquid-manufacturing/#:~:text=Commercial%20noncompete%20agreements%20between%20businesses,should%20be%20given%20due%20deference.>
+
+[^mcl-772-restraint]: **MCL § 445.772** — "A contract, combination, or conspiracy between 2 or more persons in restraint of, or to monopolize, trade or commerce in a relevant market is unlawful." *MCL § 445.772.* <https://legislature.mi.gov/Laws/MCL?objectName=mcl-445-772>
+
+[^mcl-784-federal-deference]: **MCL § 445.784** — "It is the intent of the legislature that in construing all sections of this act, the courts shall give due deference to interpretations given by the federal courts to comparable antitrust statutes, including, without limitation, the doctrine of per se violations and the rule of reason." *MCL § 445.784(2).* <https://legislature.mi.gov/Laws/MCL?objectName=mcl-445-784>
+
+[^borgiel-physician-upheld]: **St. Clair Medical, P.C. v. Borgiel** — "We conclude that the covenant protected plaintiff from unfair competition by defendant and therefore protected a reasonable competitive business interest as required by MCL 445.774a(1)." *St. Clair Med., P.C. v. Borgiel, 270 Mich. App. 260 (2006).* <https://www.courtlistener.com/opinion/2026165/st-clair-medical-pc-v-borgiel/#:~:text=We%20conclude%20that%20the%20covenant,as%20required%20by%20MCL%20445.774a(1).>
+
+[^steiner-patient-privilege]: **Isidore Steiner, DPM, PC v. Bonanni** — "Because Michigan law is more protective of patients' privacy interests in the context of this litigation, Michigan law applies to plaintiff's attempted discovery of defendant's patient information." *Isidore Steiner, DPM, PC v. Bonanni, 292 Mich. App. 265 (2011).* <https://www.courtlistener.com/opinion/8006439/isidore-steiner-dpm-pc-v-bonanni/#:~:text=Because%20Michigan%20law%20is%20more,discovery%20of%20defendant's%20patient%20information.>
+
+[^mutsa-displacement]: **MCL § 445.1908** — "Except as provided in subsection (2), this act displaces conflicting tort, restitutionary, and other law of this state providing civil remedies for misappropriation of a trade secret." *MCL § 445.1908(1).* <https://legislature.mi.gov/Laws/MCL?objectName=mcl-445-1908>
+
+[^mutsa-limitations]: **MCL § 445.1907** — "An action for misappropriation must be brought within 3 years after the misappropriation is discovered or by the exercise of reasonable diligence should have been discovered." *MCL § 445.1907.* <https://legislature.mi.gov/Laws/MCL?objectName=mcl-445-1907>
+
+[^mutsa-fees]: **MCL § 445.1905** — "If a claim of misappropriation is made in bad faith, a motion to terminate an injunction is made or resisted in bad faith, or willful and malicious misappropriation exists, the court may award reasonable attorney's fees to the prevailing party." *MCL § 445.1905.* <https://legislature.mi.gov/Laws/MCL?objectName=mcl-445-1905>
+
+[^stryker-michigan-clauses]: **Stryker Corp. v. Ridgeway (Stone Surgical, LLC v. Stryker Corp.)** — "Under Michigan law, the Michigan forum-selection clause is valid and enforceable." *Stryker Corp. v. Ridgeway, 858 F.3d 383 (6th Cir. 2017).* <https://www.courtlistener.com/opinion/4394140/stryker-corporation-v-christopher-ridgeway/#:~:text=Under%20Michigan%20law%2C%20the%20Michigan,clause%20is%20valid%20and%20enforceable.>
+
+[^barshaw-michigan-forum-law]: **Barshaw v. Allegheny Performance Plastics, LLC** — "Hence, in the absence of certain factors not germane to this appeal, a forum-selection clause may be considered separately from any choice-of-law provision that may also be in the contract, and in such cases, the Michigan court in which the action has been filed, shall apply Michigan law in determining the effect of the forum-selection clause." *Barshaw v. Allegheny Performance Plastics, LLC, 334 Mich. App. 741 (2020).* <https://www.courtlistener.com/opinion/4833431/steven-barshaw-v-allegheny-performance-plastics-llc/#:~:text=Hence%2C%20in%20the%20absence%20of,effect%20of%20the%20forum%2Dselection%20clause.>
+
+[^mcl-774a-tolling-backdrop]: **MCL § 445.774a** — "To the extent any such agreement or covenant is found to be unreasonable in any respect, a court may limit the agreement to render it reasonable in light of the circumstances in which it was made and specifically enforce the agreement as limited." *MCL § 445.774a(1).* <https://legislature.mi.gov/Laws/MCL?objectName=mcl-445-774a>
+
+[^coates-tolling-backdrop]: **Coates v. Bastian Brothers, Inc.** — "The reasonableness of a noncompetition provision is a question of law when the relevant facts are undisputed." *Coates v. Bastian Bros., Inc., 276 Mich. App. 498 (2007).* <https://www.courtlistener.com/opinion/2220514/coates-v-bastian-brothers-inc/#:~:text=The%20reasonableness%20of%20a%20noncompetition,the%20relevant%20facts%20are%20undisputed.>
+
+[^hb-4040-worker-ban]: **Michigan House Bill 4040 (2025)** — "Except as otherwise provided in subsection (2), a business shall not do any of the following: (a) Enter into or attempt to enter into a noncompete agreement with a worker. (b) Obtain or attempt to obtain a noncompete agreement from a worker. (c) Enforce or attempt to enforce a noncompete agreement against a worker or former worker." *2025 Mich. H.B. 4040 (introduced Jan. 30, 2025).* <https://www.legislature.mi.gov/documents/2025-2026/billintroduced/House/htm/2025-HIB-4040.htm>
+
+[^hb-4040-status]: **Michigan House Bill 4040 (2025) — bill status** — "referred to Committee on Economic Competitiveness" *2025 Mich. H.B. 4040, Bill Status (Mich. Legislature).* <https://www.legislature.mi.gov/Bills/Bill?ObjectName=2025-HB-4040>
+
+[^rayford-adhesion-reasonableness]: **Rayford v. American House Roseville I, LLC** — "A shortened limitations provision contained in such an agreement must be examined for reasonableness." *Rayford v. American House Roseville I, LLC, ___ Mich. ___ (2025) (Docket No. 163989).* <https://www.courtlistener.com/opinion/10645648/timika-rayford-v-american-house-roseville-i-llc/#:~:text=A%20shortened%20limitations%20provision%20contained,must%20be%20examined%20for%20reasonableness.>

--- a/skills/non-compete-contract-explainer/content/minnesota.md
+++ b/skills/non-compete-contract-explainer/content/minnesota.md
@@ -1,0 +1,171 @@
+---
+jurisdiction: "Minnesota"
+slug: minnesota
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-05-27"
+canonicalUrl: https://openagreements.org/legal/non-compete/minnesota
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/minnesota · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Employment Non-Competes in Minnesota[^about]
+
+A question-by-question summary of Minnesota's 2023 non-compete statute, legacy Minnesota common law, statutory exceptions, nonsolicitation treatment, and choice-of-law limits.
+
+
+## At a glance
+
+| Question | Minnesota |
+| --- | --- |
+| **Are non-competes enforceable?** | Banned |
+| **Bottom line** | Most employee and independent-contractor non-competes signed on or after July 1, 2023 are void and unenforceable, with only sale-of-business and business-dissolution exceptions surviving. |
+| **Main law or case** | Minn. Stat. § 181.988 |
+| **Main exceptions** | Sale of business; dissolution of business; pre-July 1, 2023 agreements under common law; NDAs/nonsolicits excluded |
+| **When the ban took effect** | July 1, 2023 (prospective only) |
+| **Can a court narrow it?** | No |
+| **Applies to contractors?** | Yes |
+
+## Are employee non-compete agreements enforceable in Minnesota? {#employee-noncompetes}
+
+**Short answer.** Usually no, for agreements entered into on or after July 1, 2023. Minn. Stat. § 181.988 makes covered covenants not to compete void and unenforceable[^minn-181-988-voids-employment-noncompetes], unless a sale-of-business or dissolution exception applies.
+
+The statute covers employees and independent contractors. It defines an employee as any individual who performs services for an employer, "including independent contractors"[^minn-181-988-includes-independent-contractors], and commentary treats that scope as broader than wage-threshold statutes in many other states [^cooley-minn-181-988-independent-contractors][^littler-minn-181-988-complete-prohibition].
+
+For a standard post-employment employee non-compete signed on or after July 1, 2023, the practical answer is to remove it rather than revise the duration, territory, or employee class. Those older drafting variables matter mainly for pre-July 1, 2023 agreements and for the statute's narrow business-sale and dissolution exceptions.
+
+## What law governs Minnesota non-compete agreements signed before July 1, 2023? {#pre-2023-agreements}
+
+**Short answer.** Pre-July 1, 2023 agreements are still analyzed under Minnesota common law, not automatically voided by the 2023 statute.
+
+Minnesota-specific commentary reads the statute as prospective: agreements entered before July 1, 2023 continue to be evaluated under the established case-law framework [^cooley-minn-181-988-not-retroactive]. Under that framework, Minnesota courts disfavor employment non-competes, but may enforce them when they protect a legitimate employer interest and are no broader than necessary to protect that interest[^kallok-medtronic-legitimate-interest].
+
+The older common-law analysis is fact-specific. Bennett says the court balances the employer's business protection against the employee's right to work and earn a livelihood [^bennett-storz-fact-specific-balance]. Sanborn adds a separate consideration trap: if the non-compete was not part of the original employment contract, independent consideration is required, and mere continued employment is not enough [^sanborn-currie-independent-consideration].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not treat a pre-July 1, 2023 Minnesota non-compete as automatically enforceable just because the new statute is prospective. The older cases still require a legitimate business interest, reasonable scope, employee hardship balancing, and adequate consideration [^kallok-medtronic-legitimate-interest][^sanborn-currie-independent-consideration].
+
+## What are the statutory exceptions to Minnesota's non-compete ban? {#statutory-exceptions}
+
+**Short answer.** Two statutory exceptions remain: a covenant agreed upon during the sale of a business, and a covenant agreed upon in anticipation of the dissolution of a business.
+
+The sale-of-business exception allows the seller, partners, members, shareholders, and buyer to agree on a temporary and geographically restricted covenant if it is tied to a reasonable area and reasonable length of time "during the sale of a business"[^minn-181-988-sale-business-exception]. The dissolution exception similarly allows partners, members, or shareholders to agree not to carry on a similar business in a reasonable geographic area where the business has operated [^minn-181-988-dissolution-exception].
+
+Those exceptions keep transaction-related restraints available, but they do not convert every seller, founder, member, or shareholder covenant into an enforceable agreement. Commentary flags that the statute does not define what counts as a reasonable geographic territory or duration for the exceptions [^taft-minn-181-988-exception-reasonableness].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Draft sale-of-business and dissolution covenants as transaction restraints, not ordinary employee non-competes repackaged in a purchase agreement or operating-company document. The statutory exception still uses reasonableness limits for geography and time [^minn-181-988-sale-business-exception][^taft-minn-181-988-exception-reasonableness].
+
+## How does Minnesota's non-compete statute treat non-solicitation agreements, customer non-solicits, and NDAs? {#nonsolicits-ndas}
+
+**Short answer.** Minn. Stat. § 181.988 does not define NDAs, trade-secret agreements, customer non-solicits, client-list restrictions, or customer-solicitation restrictions as covenants not to compete.
+
+The statute expressly says a covenant not to compete does not include[^minn-181-988-excludes-ndas-nonsolicits] nondisclosure agreements, agreements designed to protect trade secrets or confidential information, nonsolicitation agreements, client-list restrictions, or customer-solicitation restrictions. Commentary reaches the same basic reading: Minnesota's ban leaves confidentiality and nonsolicitation tools available [^mcdermott-minn-181-988-nonsolicits-valid][^stinson-minn-181-988-nonsolicits-careful-drafting].
+
+That does not mean labels control. A clause called a customer non-solicit can still create non-compete risk if it functionally blocks the worker from performing work for another employer. Employer commentary makes that practical point for templates: preserve legitimate nonsolicit and confidentiality protections, but draft them to protect relationships and information rather than to bar employment [^snell-minn-181-988-functional-noncompete].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> For Minnesota agreements after July 1, 2023, separate permitted confidentiality, trade-secret, customer-list, and nonsolicitation language from any ban on working for a competitor. A nonsolicit that functions like a work ban may be treated as non-compete risk even if the label is different [^snell-minn-181-988-functional-noncompete].
+
+## Can choice-of-law or forum-selection clauses avoid Minnesota's non-compete statute? {#choice-of-law-venue}
+
+**Short answer.** Usually no for employees who primarily reside and work in Minnesota, for claims arising under Minn. Stat. § 181.988.
+
+The statute prohibits requiring a Minnesota-resident-and-worker employee, as a condition of employment, to agree to out-of-state adjudication or to a clause that would deprive the employee of Minnesota substantive protection[^minn-181-988-substantive-minnesota-law] for a controversy arising in Minnesota. If the clause violates that rule, it is voidable at the employee's request, and the dispute is adjudicated in Minnesota under Minnesota law [^minn-181-988-voidable-minnesota-forum].
+
+This is broader than just deleting a non-compete paragraph. Commentary warns that employers with Minnesota employees should review choice-of-law and venue language even in agreement forms that do not currently use non-competes [^stinson-minn-181-988-choice-law-risk][^littler-minn-181-988-foreign-law-templates].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not rely on Delaware, New York, Texas, or another state's law to preserve a Minnesota employee non-compete. For workers who primarily reside and work in Minnesota, use Minnesota forum and Minnesota law for section 181.988 disputes, or expect the employee to challenge the clause [^minn-181-988-substantive-minnesota-law][^stinson-minn-181-988-choice-law-risk].
+
+## Did Minnesota add a separate rule for service-provider no-hire restrictions? {#service-contract-restrictions}
+
+**Short answer.** Yes. Effective July 1, 2024, Minnesota added a separate statute voiding certain service-contract provisions that block a customer from soliciting or hiring a service provider's worker.
+
+Minn. Stat. § 181.9881 is separate from the 2023 employee non-compete statute, but it matters for staffing, consulting, and vendor agreements. It says a service provider may not restrict a customer from soliciting or hiring the service provider's employee, and an existing violating provision is void and unenforceable[^minn-181-9881-service-contract-void].
+
+The statute includes independent contractors in its employee definition and requires notice to affected employees when an existing contract violates the rule [^minn-181-9881-employee-notice]. It also has a software-consulting exemption for workers seeking later permanent employment with the customer [^minn-181-9881-software-consulting-exemption].
+
+## What recent developments changed Minnesota non-compete law? {#recent-developments}
+
+**Short answer.** Minnesota changed from a common-law enforceability regime to a prospective statutory ban in 2023, then added a service-contract restriction in 2024.
+
+**May 24, 2023:** Governor Tim Walz signed SF 3035, adding Minn. Stat. § 181.988 and prohibiting most new employee and independent-contractor non-competes [^stinson-minn-181-988-signed-effective].
+
+**July 1, 2023:** The ban took effect for new agreements. Commentary treats pre-July 1, 2023 agreements as still governed by the preexisting common-law framework [^cooley-minn-181-988-not-retroactive-development][^littler-minn-181-988-existing-agreements].
+
+**July 1, 2024:** The separate service-contract statute, Minn. Stat. § 181.9881, took effect for customer no-hire restrictions in service-provider contracts [^minn-181-9881-service-contract-void-development].
+
+**2025 legislative context:** A 2025 bill proposed additional exceptions to section 181.988 for certain high-compensation employees [^minn-hf1768-proposed-exceptions]; it has not been enacted as of this article's publication.
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-05-27. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not Minnesota. This article synthesizes Minnesota primary law and is not legal advice from a Minnesota-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^minn-181-988-voids-employment-noncompetes]: **Minn. Stat. § 181.988, subd. 2(a)** — "Any covenant not to compete contained in a contract or agreement is void and unenforceable." *Minn. Stat. § 181.988, subd. 2(a) (2025).* <https://www.revisor.mn.gov/statutes/cite/181.988>
+
+[^minn-181-988-includes-independent-contractors]: **Minn. Stat. § 181.988, subd. 1(c)** — "‘Employee’ as used in this section means any individual who performs services for an employer, including independent contractors." *Minn. Stat. § 181.988, subd. 1(c) (2025).* <https://www.revisor.mn.gov/statutes/cite/181.988>
+
+[^cooley-minn-181-988-independent-contractors]: **Cooley commentary** — "SF 3035 is broadly written and bans all noncompetes between an employer and an employee or independent contractor" *Cooley, Minnesota Set to Ban Most Noncompete Agreements Beginning July 1, 2023 (2023).* <https://www.cooley.com/news/insight/2023/2023-06-28-minnesota-set-to-ban-most-noncompete-agreements-beginning-july-1-2023>
+
+[^littler-minn-181-988-complete-prohibition]: **Littler Mendelson commentary** — "the proposed Minnesota law creates a complete prohibition on non-compete agreements between the employer and workers, regardless of the person’s income" *Littler Mendelson, Minnesota Is Poised to Enact a Law Banning Virtually All Non-Compete Agreements (2023).* <https://www.littler.com/news-analysis/asap/minnesota-poised-enact-law-banning-virtually-all-non-compete-agreements>
+
+[^cooley-minn-181-988-not-retroactive]: **Cooley commentary** — "Minnesota’s noncompete statute is not retroactive – any noncompete agreements entered into prior to the July 1, 2023, effective date will continue to be evaluated pursuant to Minnesota common law" *Cooley, Minnesota Set to Ban Most Noncompete Agreements Beginning July 1, 2023 (2023).* <https://www.cooley.com/news/insight/2023/2023-06-28-minnesota-set-to-ban-most-noncompete-agreements-beginning-july-1-2023>
+
+[^kallok-medtronic-legitimate-interest]: **Kallok v. Medtronic, Inc.** — "noncompete agreements are enforceable if they serve a legitimate employer interest and are not broader than necessary to protect this interest." *Kallok v. Medtronic, Inc., 573 N.W.2d 356 (Minn. 1998).* <https://www.courtlistener.com/opinion/1251773/kallok-v-medtronic-inc/#:~:text=noncompete%20agreements%20are%20enforceable%20if,necessary%20to%20protect%20this%20interest.>
+
+[^bennett-storz-fact-specific-balance]: **Bennett v. Storz Broadcasting Co.** — "the court must consider not only the nature of the business and character of the employment but all the circumstances of the case" *Bennett v. Storz Broadcasting Co., 270 Minn. 525, 134 N.W.2d 892 (1965).* <https://www.courtlistener.com/opinion/1689754/bennett-v-storz-broadcasting-co/#:~:text=the%20court%20must%20consider%20not,the%20circumstances%20of%20the%20case>
+
+[^sanborn-currie-independent-consideration]: **Sanborn Manufacturing Co. v. Currie** — "Proof of continued employment is not enough to show sufficient consideration for a noncompetition agreement." *Sanborn Mfg. Co. v. Currie, 500 N.W.2d 161 (Minn. Ct. App. 1993).* <https://www.courtlistener.com/opinion/1625841/sanborn-manufacturing-co-v-currie/#:~:text=Proof%20of%20continued%20employment%20is,consideration%20for%20a%20noncompetition%20agreement.>
+
+[^minn-181-988-sale-business-exception]: **Minn. Stat. § 181.988, subd. 2(b)(1)** — "the covenant not to compete is agreed upon during the sale of a business. The person selling the business and the partners, members, or shareholders, and the buyer of the business may agree on a temporary and geographically restricted covenant not to compete that will prohibit the seller of the business from carrying on a similar business within a reasonable geographic area and for a reasonable length of time" *Minn. Stat. § 181.988, subd. 2(b)(1) (2025).* <https://www.revisor.mn.gov/statutes/cite/181.988>
+
+[^minn-181-988-dissolution-exception]: **Minn. Stat. § 181.988, subd. 2(b)(2)** — "the covenant not to compete is agreed upon in anticipation of the dissolution of a business." *Minn. Stat. § 181.988, subd. 2(b)(2) (2025).* <https://www.revisor.mn.gov/statutes/cite/181.988>
+
+[^taft-minn-181-988-exception-reasonableness]: **Taft commentary** — "the law does not provide guidance as to what constitutes a ‘reasonable’ geographic territory or length of time for a non-competition provision to be permissible." *Taft, Minnesota Becomes Yet Another State To Ban Non-Compete Agreements (2023).* <https://www.taftlaw.com/news-events/law-bulletins/minnesota-becomes-yet-another-state-to-ban-non-compete-agreements/>
+
+[^minn-181-988-excludes-ndas-nonsolicits]: **Minn. Stat. § 181.988, subd. 1(a)** — "A covenant not to compete does not include a nondisclosure agreement, or agreement designed to protect trade secrets or confidential information. A covenant not to compete does not include a nonsolicitation agreement, or agreement restricting the ability to use client or contact lists, or solicit customers of the employer." *Minn. Stat. § 181.988, subd. 1(a) (2025).* <https://www.revisor.mn.gov/statutes/cite/181.988>
+
+[^mcdermott-minn-181-988-nonsolicits-valid]: **McDermott Will & Emery commentary** — "Nondisclosure agreements, or other agreements designed to protect trade secrets or confidential business information" *McDermott Will & Emery, Minnesota Bans Noncompete Agreements with Limited Exceptions (2023).* <https://www.mcdermottlaw.com/insights/minnesota-bans-noncompete-agreements-with-limited-exceptions/>
+
+[^stinson-minn-181-988-nonsolicits-careful-drafting]: **Stinson commentary** — "Nondisclosure (which, as previously mentioned, still must comply with recent NLRB decisions) and nonsolicitation agreements, as well as agreements that restrict an employee’s use of customer or client lists, should be carefully crafted to protect employer’s business needs." *Stinson, Minnesota Non-Compete Ban Signed into Law and Effective July 1, 2023 (2023).* <https://www.stinson.com/newsroom-publications-minnesota-non-compete-ban-signed-into-law-and-effective-july-1-2023>
+
+[^snell-minn-181-988-functional-noncompete]: **Snell & Wilmer commentary** — "Customer non-solicitation and employee non-solicitation agreements are not impacted (but if the provision functions like a noncompete, it will be banned even if it is called a non-solicit)." *Snell & Wilmer, Doing Business in Minnesota? Six Things Employers Should Know About the New Noncompete Ban (2023).* <https://www.swlaw.com/publication/doing-business-in-minnesota-six-things-employers-should-know-about-the-new-noncompete-ban/>
+
+[^minn-181-988-substantive-minnesota-law]: **Minn. Stat. § 181.988, subd. 3(a)** — "deprive the employee of the substantive protection of Minnesota law with respect to a controversy arising in Minnesota." *Minn. Stat. § 181.988, subd. 3(a) (2025).* <https://www.revisor.mn.gov/statutes/cite/181.988>
+
+[^minn-181-988-voidable-minnesota-forum]: **Minn. Stat. § 181.988, subd. 3(b)** — "the matter shall be adjudicated in Minnesota and Minnesota law shall govern the dispute." *Minn. Stat. § 181.988, subd. 3(b) (2025).* <https://www.revisor.mn.gov/statutes/cite/181.988>
+
+[^stinson-minn-181-988-choice-law-risk]: **Stinson commentary** — "employers should consult with their legal counsel to gauge risk in maintaining choice of law and forum selection clauses for outside jurisdictions in agreements for employees who live or work in Minnesota." *Stinson, Minnesota Non-Compete Ban Signed into Law and Effective July 1, 2023 (2023).* <https://www.stinson.com/newsroom-publications-minnesota-non-compete-ban-signed-into-law-and-effective-july-1-2023>
+
+[^littler-minn-181-988-foreign-law-templates]: **Littler Mendelson commentary** — "Many employers in Minnesota that do not currently use non-compete agreements would still need to amend template agreements to comply with this part of the proposed law." *Littler Mendelson, Minnesota Is Poised to Enact a Law Banning Virtually All Non-Compete Agreements (2023).* <https://www.littler.com/news-analysis/asap/minnesota-poised-enact-law-banning-virtually-all-non-compete-agreements>
+
+[^minn-181-9881-service-contract-void]: **Minn. Stat. § 181.9881, subd. 2(a)–(b)** — "Any provision of an existing contract that violates paragraph (a) is void and unenforceable." *Minn. Stat. § 181.9881, subd. 2(a)–(b) (2025).* <https://www.revisor.mn.gov/statutes/cite/181.9881>
+
+[^minn-181-9881-employee-notice]: **Minn. Stat. § 181.9881, subd. 2(c)** — "the service provider must provide notice to their employees of this section and the restrictive covenant in the existing contract that violates this section." *Minn. Stat. § 181.9881, subd. 2(c) (2025).* <https://www.revisor.mn.gov/statutes/cite/181.9881>
+
+[^minn-181-9881-software-consulting-exemption]: **Minn. Stat. § 181.9881, subd. 3** — "This section does not apply to workers providing professional business consulting for computer software development and related services" *Minn. Stat. § 181.9881, subd. 3 (2025).* <https://www.revisor.mn.gov/statutes/cite/181.9881>
+
+[^stinson-minn-181-988-signed-effective]: **Stinson commentary** — "MN SF 3035, signed by Governor Walz on May 24, 2023, restricts employers from entering into noncompetition agreements on or after July 1, 2023" *Stinson, Minnesota Non-Compete Ban Signed into Law and Effective July 1, 2023 (2023).* <https://www.stinson.com/newsroom-publications-minnesota-non-compete-ban-signed-into-law-and-effective-july-1-2023>
+
+[^cooley-minn-181-988-not-retroactive-development]: **Cooley commentary** — "The prohibition on noncompete agreements goes into effect on July 1, 2023." *Cooley, Minnesota Set to Ban Most Noncompete Agreements Beginning July 1, 2023 (2023).* <https://www.cooley.com/news/insight/2023/2023-06-28-minnesota-set-to-ban-most-noncompete-agreements-beginning-july-1-2023>
+
+[^littler-minn-181-988-existing-agreements]: **Littler Mendelson commentary** — "non-compete agreements entered into prior to the effective date of the new law would continue to be evaluated by Minnesota courts based on the established body of case law" *Littler Mendelson, Minnesota Is Poised to Enact a Law Banning Virtually All Non-Compete Agreements (2023).* <https://www.littler.com/news-analysis/asap/minnesota-poised-enact-law-banning-virtually-all-non-compete-agreements>
+
+[^minn-181-9881-service-contract-void-development]: **Minn. Stat. § 181.9881, subd. 2(a)** — "No service provider may restrict, restrain, or prohibit in any way a customer from directly or indirectly soliciting or hiring an employee of a service provider." *Minn. Stat. § 181.9881, subd. 2(a) (2025).* <https://www.revisor.mn.gov/statutes/cite/181.9881>
+
+[^minn-hf1768-proposed-exceptions]: **H.F. 1768, 94th Leg., Reg. Sess. (Minn. 2025)** — "providing additional circumstances under which a covenant not to compete is valid and enforceable" *H.F. 1768, 94th Leg., Reg. Sess. (Minn. 2025).* <https://www.revisor.mn.gov/bills/94/2025/0/HF/1768/versions/latest/pdf/?list=open>

--- a/skills/non-compete-contract-explainer/content/mississippi.md
+++ b/skills/non-compete-contract-explainer/content/mississippi.md
@@ -1,0 +1,237 @@
+---
+jurisdiction: "Mississippi"
+slug: mississippi
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-03"
+canonicalUrl: https://openagreements.org/legal/non-compete/mississippi
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/mississippi · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in Mississippi[^about]
+
+Mississippi enforces non-competes only when the restraint is reasonable under common law, with distinctive rules that void a covenant after a bad-faith firing, reform overbroad terms, and accept continued employment as consideration.
+
+
+## At a glance
+
+| Question | Mississippi |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed if reasonable |
+| **Bottom line** | Mississippi enforces a non-compete only if the employer proves it is reasonable in time, territory, and activity to protect a legitimate interest, and it will not be enforced after a bad-faith firing. |
+| **Main law or case** | common law (Texas Road Boring Co. v. Parker, 194 So. 2d 885 (Miss. 1967)) |
+| **Main exceptions** | Bad-faith-termination defense (Empiregas); minors may disaffirm; lawyers barred (R. 5.6); no health-care statutory ban |
+| **Can a court narrow it?** | Yes — rewrites to reasonable |
+| **Applies to contractors?** | Unclear |
+| **Restriction extended during a breach?** | No judicial tolling (Frierson); express extension clause given effect (Cascio) |
+| **Maximum length set by law** | No statutory limit |
+
+## Are employee non-compete agreements enforceable in Mississippi? {#employee-noncompetes}
+
+**Short answer.** Yes, sometimes. Mississippi is a common-law reasonableness state, not a general ban state and not a statutory-cap state. A non-compete is enforceable only if it is reasonable when the court weighs three competing interests — the employer's, the employee's, and the public's — and the employer carries the burden of proving that reasonableness [^texas-road-boring-three-aspects][^redd-foster-disfavored].
+
+There is no Mississippi non-compete statute. The enforceability analysis is judge-made, rooted in decisions like *Donahoe v. Tatum* and *Texas Road Boring Co. v. Parker*, which frame the inquiry as a balance rather than a checklist [^donahoe-reasonable-balance]. Courts treat these covenants as restraints on trade and individual freedom, so they are disfavored and construed strictly against the drafting employer [^redd-foster-disfavored].
+
+Because the restraint must protect a legitimate business interest — trade secrets, confidential information, customer goodwill, or an employer's investment in specialized training — a covenant that exists only to suppress ordinary competition fails. Mississippi separately protects proprietary information by statute under the Mississippi Uniform Trade Secrets Act, Miss. Code Ann. §§ 75-26-1 to 75-26-19, which supplies injunctive relief and damages independent of any contract.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not treat a Mississippi covenant as automatically valid or automatically void. Confirm that the restraint protects a real business interest and is reasonable in time, territory, and activity, because the employer bears the burden of proving reasonableness and the court will construe ambiguity against the drafter [^texas-road-boring-three-aspects].
+
+## Is continued at-will employment enough consideration for a Mississippi non-compete? {#consideration}
+
+**Short answer.** Yes. Unlike states that demand fresh consideration for a covenant signed after hire, Mississippi treats continued at-will employment as sufficient consideration to support a restrictive covenant [^raines-continued-employment].
+
+The rule traces to *Frierson v. Sheppard Building Supply Co.*, where the Mississippi Supreme Court enforced a two-year covenant against an existing manager, rejecting the argument that retaining an employee in the same position is not enough to support the restraint. The Court of Appeals reaffirmed the point in *Raines v. Bottrell Insurance Agency*, where an agent who signed a covenant when his agency was acquired argued the deal gave him nothing new [^raines-continued-employment].
+
+That said, timing still matters. Mississippi courts have suggested that a covenant extracted just before an imminent, bad-faith discharge stands on weaker ground, which connects to the bad-faith termination defense covered below.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not assume the consideration question disappears in Mississippi just because continued employment can suffice. Document the covenant's tie to the employment relationship, and pair it with new consideration where practical, because Mississippi still construes the agreement strictly and scrutinizes the circumstances of signing [^raines-continued-employment].
+
+## What duration and geographic scope are reasonable for a Mississippi non-compete? {#duration-geography}
+
+**Short answer.** There is no statutory cap. Mississippi courts test duration and territory against the employer's actual footprint and the employee's real influence, so a restraint tied to where the employee worked is far easier to defend than a sweeping statewide ban [^heatherly-statewide-unreasonable][^timber-lake-radius-reasonable].
+
+In *Redd Pest Control Co. v. Heatherly*, the court refused to enforce a statewide pest-control restraint against an employee who only had customer relationships around Tupelo, observing that the company did not need protection across the whole state [^heatherly-statewide-unreasonable]. There is no fixed durational cap either: a restraint matched to the time the employer actually needs to protect the relationship is easier to defend, while the longer terms Mississippi has tolerated tend to appear in executive and sale-of-business deals.
+
+Remote work does not dissolve a geographic limit. In *Timber Lake Foods v. Estess*, a meat broker worked the phones from her home inside a 250-mile radius of Tupelo while serving customers nationwide; the Court of Appeals held the 250-mile restraint reasonable because a nationwide restriction would itself have been justified for that telephonic business [^timber-lake-home-in-radius][^timber-lake-radius-reasonable].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not copy a fixed radius or term from another form. Match the territory to the employer's real market and the employee's actual reach, and remember that a remote worker located inside the restricted area is still bound — geography is measured by where the employee operates, not only where the customers sit [^timber-lake-home-in-radius].
+
+## Will a Mississippi court reform or blue-pencil an overbroad non-compete? {#court-narrowing}
+
+**Short answer.** Often, yes. Mississippi follows an equitable-reformation approach: rather than voiding an overbroad covenant outright, its courts will enforce the agreement to the extent it is reasonable, narrowing scope to the area the employer is entitled to protect [^heatherly-enforce-reasonable-part].
+
+*Redd Pest Control Co. v. Heatherly* is the classic example. The covenant on its face barred competition across the entire state, but the court enforced it only within Tupelo and a fifty-mile radius — the area where the employee actually held customer relationships — and remanded for an injunction limited to that reasonable scope [^heatherly-enforce-reasonable-part]. The court framed the issue as whether a restraint reasonable in part and unreasonable in the rest should be enforced as to the reasonable part, and answered yes [^heatherly-partial-enforcement-issue].
+
+This power is broader than a strict blue pencil that only crosses out severable words, but it is not a safety net for abusive drafting. Reformation rests on the chancellor's equitable discretion, and a grossly overbroad covenant invites a court to decline enforcement rather than rewrite it.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not rely on Mississippi's reformation power to rescue an aggressive covenant. Draft tiered, severable, and genuinely reasonable restraints, because partial enforcement is a discretionary equitable remedy and a chancellor may refuse to narrow a covenant that overreaches [^heatherly-enforce-reasonable-part].
+
+## Can a Mississippi employer enforce a non-compete after a bad-faith termination? {#bad-faith-termination}
+
+**Short answer.** No. Under the *Empiregas* defense, when an employer terminates an employee arbitrarily, capriciously, or in bad faith, the non-competition agreement will not be enforced — an injunction is an equitable remedy, and the employer cannot come to a chancery court with unclean hands [^empiregas-bad-faith][^empiregas-equity].
+
+In *Empiregas, Inc. of Kosciusko v. Bain*, the chancellor found that the employee had been discharged without cause and held the non-compete null and void; the Supreme Court affirmed [^empiregas-bad-faith]. The court explained that when a termination is arbitrary, capricious, or in bad faith, equity will not lend its hand to enforce the covenant [^empiregas-equity].
+
+The defense has a clear limit: it turns on how the employment ended. An employee who voluntarily resigns generally cannot invoke it, and the covenant is then analyzed on ordinary reasonableness grounds.
+
+"Moreover, as we have indicated, when an employer terminates an employee in bad faith, the terms of a non-competition agreement will not be enforced."[^empiregas-bad-faith]
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not fire an employee arbitrarily and expect to enforce the non-compete in Mississippi. Document a legitimate, good-faith basis for any termination before seeking an injunction, because a bad-faith discharge forfeits the equitable enforcement of the covenant [^empiregas-bad-faith].
+
+## How do Mississippi courts read customer non-solicitation clauses? {#non-solicitation}
+
+**Short answer.** Strictly, and against the drafter. A clause that bars an employee from acting to *divert* business does not necessarily stop the employee from passively *accepting* business from former customers who seek the employee out on their own, unless the contract clearly says so [^kennedy-ambiguous-accepting].
+
+In *Kennedy v. Metropolitan Life Insurance Co.*, the covenant barred conduct that would *tend to divert* business from the insurer. The chancellor below found that the agent's participation in clients' coverage changes violated the clause, but the Supreme Court reversed: when former clients followed the agent to a competitor on their own initiative, the language was ambiguous because it did not expressly prohibit *accepting* their business, and the court construed that ambiguity against the employer [^kennedy-ambiguous-accepting]. The court was clear that a properly drafted no-acceptance clause can be enforceable — the problem was the drafting, not the concept [^kennedy-accepting-can-be-valid].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not assume a standard non-solicitation clause stops a former employee from serving customers who come to them. If the goal is to bar servicing former clients regardless of who makes first contact, use explicit non-dealing or no-acceptance language, because Mississippi reads ambiguity against the employer [^kennedy-ambiguous-accepting].
+
+## Does a Mississippi non-compete toll or extend during breach or litigation? {#tolling-extension}
+
+**Short answer.** Two different rules apply. A Mississippi court will not, on its own, extend a covenant beyond the end date the contract sets just because enforcement was delayed — under *Frierson*, the restricted period runs from the contractual termination date, not from a later decree. But where the agreement itself provides for an extension on breach, a court can give that clause effect [^frierson-no-extension][^cascio-extension-effect].
+
+There is no Mississippi rule that a non-compete automatically tolls simply because the former employee is in breach or litigation is pending. *Frierson v. Sheppard Building Supply* points the other way: the court ran the two-year restraint from the contractual termination date and held that, having limited the period that way, a court may not extend the time beyond it [^frierson-no-extension]. So judicial tolling is not the lever — the contract is.
+
+A well-drafted extension clause can do what judicial tolling will not. In *Cascio v. Cascio Investments*, the agreement provided that the non-compete period would be extended by the time the covenantor was in breach, even past the term's ordinary expiration [^cascio-extension-clause]. The trial court enforced that mechanism — extending the covenant and awarding injunctive relief for the covenantor's continuing failure to cancel a protected trade name — and the Supreme Court affirmed the circuit court on the issue [^cascio-extension-effect].
+
+Any such extension still has to satisfy ordinary reasonableness. A clause tied to the duration of an actual breach is far more defensible than an open-ended, automatic extension that could turn a fixed restraint into a perpetual one [^q7-texas-road-boring].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not rely on a Mississippi court to add time to an expired covenant on its own — under *Frierson* it will not. If you need the clock to pause during a breach, draft an explicit extension-on-breach clause tied to the actual period of breach, because that contractual route, not judicial tolling, is what Mississippi courts have enforced [^frierson-no-extension][^cascio-extension-effect].
+
+## Are sale-of-business and ownership covenants treated differently in Mississippi? {#sale-of-business}
+
+**Short answer.** Yes. Covenants tied to the sale of a business or an ownership interest are treated more favorably than ordinary employment restraints, and Mississippi courts have enforced broad ones — including multi-year, multi-state covenants — when reasonable on the facts, to protect the goodwill the buyer paid for [^cooper-general-application][^cascio-extension-clause-x].
+
+In *Cooper v. Gidden*, the seller of a sand-and-gravel business breached a covenant not to compete that he had voluntarily made on the sale; the court treated the restraint as protecting the goodwill conveyed to the buyer and explained that such covenants are given general application unless the contract makes them personal to the original buyer [^cooper-general-application]. The modern high-water mark is *Cascio v. Cascio Investments*, where a five-year covenant covering Mississippi and four other states — arising from a shareholder settlement — was enforced; the trial court found a willful and malicious breach and awarded damages, injunctive relief, and attorney's fees, and the Supreme Court affirmed the circuit court on every issue but a party-joinder point [^cascio-affirmed].
+
+The same favorable treatment reaches modern ownership and buyout disputes. In the 2025 decision *Wiggins v. Southern Securities Group*, an LLC member argued that once his interest was bought out he was no longer bound by the operating agreement's non-compete; the Supreme Court disagreed, holding that the trial court did not err in finding the covenant binding and enjoining him from competing [^wiggins-bound-after-buyout]. Because the seller or departing owner has been paid, the public-policy concern about restraining a livelihood is weaker, and longer terms and wider territories survive that would fail in the pure employment context.
+
+## Can a business buyer enforce an employee's non-compete signed with the seller? {#successor-assignment}
+
+**Short answer.** Not automatically. A buyer that acquires a business by asset purchase may be unable to enforce an employee non-compete signed with the predecessor unless the covenant was properly assigned and the deal documents transfer that contract [^herring-not-enforceable].
+
+In *Herring Gas Co. v. Pine Belt Gas*, the buyer of a propane business tried to enforce a non-compete that an employee had signed with the seller. The Supreme Court held it could not, for two independent reasons: the asset-purchase agreement's plain language did not transfer the employment contract, and a later attempt to assign it failed because it came after the employee had already resigned [^herring-not-enforceable].
+
+This is the mirror image of the sale-of-business rule. A covenant given by the *seller* of a business travels with the goodwill, but a covenant given by an *employee* of the seller is just another contract that must be deliberately assigned in the deal.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not assume an asset purchase sweeps in the seller's employee non-competes. Identify each restrictive covenant in diligence and assign it expressly and before closing, because in *Herring Gas* a post-resignation assignment and silent deal documents left the buyer unable to enforce [^herring-not-enforceable].
+
+## Which Mississippi workers cannot be bound by a non-compete? {#who-is-bound}
+
+**Short answer.** Two categories stand out. A worker who was a minor when signing can disaffirm the agreement, and a lawyer cannot be bound by a practice-restricting non-compete in a partnership or employment agreement: Mississippi Rule of Professional Conduct 5.6 prohibits it [^watercolor-disaffirm][^rule-5-6-ban].
+
+In *Watercolor Salon v. Hixon*, a stylist signed a non-compete at twenty — a minor under Mississippi law at the time — and later disaffirmed it; the Supreme Court agreed the agreement was unenforceable against her [^watercolor-disaffirm]. For lawyers, Rule 5.6 forbids a partnership or employment agreement that restricts a lawyer's right to practice after the relationship ends, except an agreement about retirement benefits [^rule-5-6-ban]; it also does not reach a restriction included in the sale of a law practice under Rule 1.17 [^rule-5-6-sale-exception].
+
+Outside these categories, Mississippi has no statutory wage floor or occupational exemption. Low-wage and entry-level workers are protected only by the general reasonableness analysis — because the employer must prove a legitimate business interest, a restraint on an unskilled, entry-level worker is often hard to justify.
+
+## Has Mississippi banned non-competes for physicians or health care providers? {#healthcare-reform}
+
+**Short answer.** No. Mississippi has no statutory ban on health care or physician non-competes. Bills to void them have been introduced repeatedly — most recently House Bill 500 in 2026 — but each has failed, so physician and health care covenants remain governed by ordinary common-law reasonableness [^hb500-healthcare-void].
+
+House Bill 500, introduced in the 2026 session, would have made any restriction on a licensed health care provider's right to practice after the relationship ends void and unenforceable [^hb500-healthcare-void]. It died in committee on February 3, 2026, as did a materially similar House Bill 806 the year before. An earlier physician-specific measure, Senate Bill 2685 in 2018, would have voided restrictions on a physician's right to practice medicine but failed on the Senate floor [^sb2685-physician-void].
+
+Until one of these proposals becomes law, a Mississippi health care non-compete is tested like any other — for consideration and reasonableness — rather than under a categorical ban. These bills are worth monitoring as a signal of legislative direction, not as current law.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Treat House Bill 500 and its predecessors as monitoring items, not present Mississippi law. Recheck the Mississippi Legislature's bill status each session before telling a physician or health care employer that a statutory non-compete ban applies, because as of this review no such ban has been enacted [^hb500-healthcare-void].
+
+## Did the FTC's federal non-compete rule change Mississippi non-compete law? {#federal-ftc-overlay}
+
+**Short answer.** No. The FTC's 2024 nationwide Non-Compete Rule was set aside by a federal court before it took effect, so Mississippi non-competes remain governed entirely by Mississippi common law [^ryan-ftc-set-aside].
+
+In *Ryan LLC v. FTC*, a federal court held the agency lacked authority to issue the rule and set it aside with nationwide effect, so it never took effect on its scheduled date [^ryan-ftc-set-aside]. That outcome does not make Mississippi covenants more or less enforceable; it simply removes the federal rule as an overlay and leaves the state's reasonableness and good-faith requirements in control.
+
+"The Non-Compete Rule, 16 C.F.R. § 910.1–.6, is hereby SET ASIDE and shall not be enforced or otherwise take effect on September 4, 2024, or thereafter."[^ryan-ftc-set-aside]
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-03. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not Mississippi. This article synthesizes Mississippi primary law and is not legal advice from a Mississippi-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^texas-road-boring-three-aspects]: **Texas Road Boring Co. of Louisiana-Mississippi v. Parker** — "Non-competition agreements are not favored in law and in considering them, courts recognize there are three major aspects to be looked to: the rights of the employer, the rights of the employee, and the rights of the public." *Texas Road Boring Co. of La.-Miss. v. Parker, 194 So. 2d 885 (Miss. 1967).* <https://www.courtlistener.com/opinion/1880375/texas-road-boring-co-of-louisiana-miss-v-parker/#:~:text=Non%2Dcompetition%20agreements%20are%20not%20favored,the%20rights%20of%20the%20public.>
+
+[^redd-foster-disfavored]: **Redd Pest Control Co. v. Foster** — "Contracts which contain non-compete agreements have been viewed by this Court as contracts that restrict trade and individual freedom and are not favored by the law." *Redd Pest Control Co. v. Foster, 761 So. 2d 967 (Miss. Ct. App. 2000).* <https://www.courtlistener.com/opinion/1770475/redd-pest-control-co-inc-v-foster/#:~:text=Contracts%20which%20contain%20non%2Dcompete%20agreements,not%20favored%20by%20the%20law.>
+
+[^donahoe-reasonable-balance]: **Donahoe v. Tatum** — "It is the law's function to maintain a reasonable balance in this area." *Donahoe v. Tatum, 242 Miss. 253, 134 So. 2d 442 (Miss. 1961).* <https://www.courtlistener.com/opinion/1748183/donahoe-v-tatum-dba-personnel-serv/#:~:text=It%20is%20the%20law's%20function,reasonable%20balance%20in%20this%20area.>
+
+[^raines-continued-employment]: **Raines v. Bottrell Insurance Agency, Inc.** — "The supreme court, however, has held that continued employment alone can be sufficient consideration to uphold a contract." *Raines v. Bottrell Ins. Agency, Inc., 992 So. 2d 642 (Miss. Ct. App. 2008).* <https://www.courtlistener.com/opinion/1813535/raines-v-bottrell-ins-agency-inc/#:~:text=The%20supreme%20court%2C%20however%2C%20has,consideration%20to%20uphold%20a%20contract.>
+
+[^heatherly-statewide-unreasonable]: **Redd Pest Control Co. v. Heatherly** — "We are of the opinion that the chancellor was justified in finding that it would be unreasonable as to Heatherly to restrict him from engaging in the pest control business throughout the State of Mississippi for the reason that Heatherly possessed no information that would make his competition with Redd unfair except in the Tupelo area." *Redd Pest Control Co. v. Heatherly, 248 Miss. 34, 157 So. 2d 133 (Miss. 1963).* <https://www.courtlistener.com/opinion/1851641/redd-pest-control-co-v-heatherly/#:~:text=We%20are%20of%20the%20opinion,except%20in%20the%20Tupelo%20area.>
+
+[^timber-lake-radius-reasonable]: **Timber Lake Foods, Inc. v. Estess** — "Since we find that a nationwide geographic restriction would have reasonably protected Timber Lake’s interests, we cannot say that Timber Lake’s effort to balance Stephanie’s interest by reducing that restriction to within a 250-mile radius of Tupelo was unreasonable." *Timber Lake Foods, Inc. v. Estess, 72 So. 3d 521 (Miss. Ct. App. 2011).* <https://www.courtlistener.com/opinion/5053376/timber-lake-foods-inc-v-estess/#:~:text=Since%20we%20find%20that%20a,radius%20of%20Tupelo%20was%20unreasonable.>
+
+[^timber-lake-home-in-radius]: **Timber Lake Foods, Inc. v. Estess** — "She testified that she had worked out of Lawrence’s main office in California and from her home located in Baldwyn, Mississippi, which is within 250 miles of Tupelo." *Timber Lake Foods, Inc. v. Estess, 72 So. 3d 521 (Miss. Ct. App. 2011).* <https://www.courtlistener.com/opinion/5053376/timber-lake-foods-inc-v-estess/#:~:text=She%20testified%20that%20she%20had,within%20250%20miles%20of%20Tupelo.>
+
+[^heatherly-enforce-reasonable-part]: **Redd Pest Control Co. v. Heatherly** — "There is no sound reason why the contract should not be enforced to the extent that it is reasonable since it protects a legitimate business interest." *Redd Pest Control Co. v. Heatherly, 248 Miss. 34, 157 So. 2d 133 (Miss. 1963).* <https://www.courtlistener.com/opinion/1851641/redd-pest-control-co-v-heatherly/#:~:text=There%20is%20no%20sound%20reason,protects%20a%20legitimate%20business%20interest.>
+
+[^heatherly-partial-enforcement-issue]: **Redd Pest Control Co. v. Heatherly** — "The second question raised by appellant is whether an agreement restricting competition which is reasonable as to part of the territory described in the agreement but unreasonable as to the rest should be enforced as to the reasonable part." *Redd Pest Control Co. v. Heatherly, 248 Miss. 34, 157 So. 2d 133 (Miss. 1963).* <https://www.courtlistener.com/opinion/1851641/redd-pest-control-co-v-heatherly/#:~:text=The%20second%20question%20raised%20by,as%20to%20the%20reasonable%20part.>
+
+[^empiregas-bad-faith]: **Empiregas, Inc. of Kosciusko v. Bain** — "Moreover, as we have indicated, when an employer terminates an employee in bad faith, the terms of a non-competition agreement will not be enforced." *Empiregas, Inc. of Kosciusko v. Bain, 599 So. 2d 971 (Miss. 1992).* <https://www.courtlistener.com/opinion/1870077/empiregas-inc-of-kosciusko-v-bain/#:~:text=Moreover%2C%20as%20we%20have%20indicated%2C,agreement%20will%20not%20be%20enforced.>
+
+[^empiregas-equity]: **Empiregas, Inc. of Kosciusko v. Bain** — "However, when the Chancellor finds that the employee's termination was arbitrary, capricious or in bad faith, he can ‘lend the hand of equity’ in refusing to enforce the agreement." *Empiregas, Inc. of Kosciusko v. Bain, 599 So. 2d 971 (Miss. 1992).* <https://www.courtlistener.com/opinion/1870077/empiregas-inc-of-kosciusko-v-bain/#:~:text=However%2C%20when%20the%20Chancellor%20finds,refusing%20to%20enforce%20the%20agreement.>
+
+[^kennedy-ambiguous-accepting]: **Kennedy v. Metropolitan Life Insurance Co.** — "However, this Court concludes that the non-competition provision in the present case is ambiguous in that, unlike the provisions in Kemper and Girard , the provision in the present case does not expressly prohibit Kennedy from ‘accepting’ business with a former employee." *Kennedy v. Metropolitan Life Ins. Co., 759 So. 2d 362 (Miss. 2000).* <https://www.courtlistener.com/opinion/1855498/kennedy-v-metropolitan-life-ins-co/#:~:text=However%2C%20this%20Court%20concludes%20that,business%20with%20a%20former%20employee.>
+
+[^kennedy-accepting-can-be-valid]: **Kennedy v. Metropolitan Life Insurance Co.** — "This Court agrees with Met Life that a non-compete provision which prohibits an ex-employee from accepting business with his former customers may, in appropriate cases, constitute a reasonable and enforceable non-compete provision." *Kennedy v. Metropolitan Life Ins. Co., 759 So. 2d 362 (Miss. 2000).* <https://www.courtlistener.com/opinion/1855498/kennedy-v-metropolitan-life-ins-co/#:~:text=This%20Court%20agrees%20with%20Met,reasonable%20and%20enforceable%20non%2Dcompete%20provision.>
+
+[^frierson-no-extension]: **Frierson v. Sheppard Building Supply Co.** — "Having made the contract limiting the period to two years from the date of termination of employment, the court may not extend the time beyond that date." *Frierson v. Sheppard Bldg. Supply Co., 247 Miss. 157, 154 So. 2d 151 (Miss. 1963).* <https://www.courtlistener.com/opinion/1722477/frierson-v-sheppard-building-supply-co/#:~:text=Having%20made%20the%20contract%20limiting,the%20time%20beyond%20that%20date.>
+
+[^cascio-extension-effect]: **Cascio v. Cascio Investments, LLC** — "Also, injunctive relief was awarded by extending the NCA for Cascio’s failure to cancel the C- Rental trade name." *Cascio v. Cascio Investments, LLC, 327 So. 3d 59 (Miss. 2021).* <https://www.courtlistener.com/opinion/10627857/philip-t-cascio-jr-v-cascio-investments-llc-jackie-cascio-pearson-and/#:~:text=Also%2C%20injunctive%20relief%20was%20awarded,the%20C%2D%20Rental%20trade%20name.>
+
+[^cascio-extension-clause]: **Cascio v. Cascio Investments, LLC** — "Further, in the event of any breach of this agreement, the time period of non-competition shall be extended by the time the undersigned was in breach, even if the time period of non-competition would have otherwise expired according to the terms of this Non-Competition Agreement." *Cascio v. Cascio Investments, LLC, 327 So. 3d 59 (Miss. 2021).* <https://www.courtlistener.com/opinion/10627857/philip-t-cascio-jr-v-cascio-investments-llc-jackie-cascio-pearson-and/#:~:text=Further%2C%20in%20the%20event%20of,terms%20of%20this%20Non%2DCompetition%20Agreement.>
+
+[^q7-texas-road-boring]: **Texas Road Boring Co. of Louisiana-Mississippi v. Parker** — "Non-competition agreements are not favored in law and in considering them, courts recognize there are three major aspects to be looked to: the rights of the employer, the rights of the employee, and the rights of the public." *Texas Road Boring Co. of La.-Miss. v. Parker, 194 So. 2d 885 (Miss. 1967).* <https://www.courtlistener.com/opinion/1880375/texas-road-boring-co-of-louisiana-miss-v-parker/#:~:text=Non%2Dcompetition%20agreements%20are%20not%20favored,the%20rights%20of%20the%20public.>
+
+[^cooper-general-application]: **Cooper v. Gidden** — "A covenant not to compete will be given general application unless, by its own terms, it specifically expresses an intent that it be a personal covenant flowing only to the original obligee." *Cooper v. Gidden, 515 So. 2d 900 (Miss. 1987).* <https://www.courtlistener.com/opinion/1898073/cooper-v-gidden/#:~:text=A%20covenant%20not%20to%20compete%20will,only%20to%20the%20original%20obligee.>
+
+[^cascio-extension-clause-x]: **Cascio v. Cascio Investments, LLC** — "[Cascio] will execute a non-compete agreement with CSW for a period of five years covering Mississippi, Arkansas, Louisiana, Tennessee, and Missouri." *Cascio v. Cascio Investments, LLC, 327 So. 3d 59 (Miss. 2021).* <https://www.courtlistener.com/opinion/10627857/philip-t-cascio-jr-v-cascio-investments-llc-jackie-cascio-pearson-and/#:~:text=%5BCascio%5D%20will%20execute%20a%20non%2Dcompete,Arkansas%2C%20Louisiana%2C%20Tennessee%2C%20and%20Missouri.>
+
+[^cascio-affirmed]: **Cascio v. Cascio Investments, LLC** — "Regarding the direct appeal, we conclude that substantial evidence supports the circuit court’s findings, and the circuit court is affirmed as to all issues except the joinder of the Jackie and Phyllis as plaintiffs." *Cascio v. Cascio Investments, LLC, 327 So. 3d 59 (Miss. 2021).* <https://www.courtlistener.com/opinion/10627857/philip-t-cascio-jr-v-cascio-investments-llc-jackie-cascio-pearson-and/#:~:text=Regarding%20the%20direct%20appeal%2C%20we,Jackie%20and%20Phyllis%20as%20plaintiffs.>
+
+[^wiggins-bound-after-buyout]: **Wiggins v. Southern Securities Group, LLC** — "Thus, based on the evidence presented at the preliminary-injunction hearing, the trial court did not err by finding that the noncompete provision was binding on Wiggins and that Wiggins was enjoined from competing with SSG" *Wiggins v. Southern Securities Group, LLC, No. 2024-CA-00251-SCT (Miss. 2025).* <https://www.courtlistener.com/opinion/10840985/robert-c-wiggins-v-southern-securities-group-llc-and-brandi-hoover/#:~:text=Thus%2C%20based%20on%20the%20evidence,enjoined%20from%20competing%20with%20SSG>
+
+[^herring-not-enforceable]: **Herring Gas Co. v. Pine Belt Gas, Inc.** — "We find that the covenant not to compete contained within Rutland’s employment contract with Broome Gas may not be enforced by Herring Gas against Pine Belt Gas for the following two reasons: (1) the plain language of the asset-purchase agreement precludes enforcement; and (2) the purported assignment of Rutland’s employment contract after the sale of assets was of no effect because it occurred after Rutland’s resignation." *Herring Gas Co. v. Pine Belt Gas, Inc., 2 So. 3d 636 (Miss. 2009).* <https://www.courtlistener.com/opinion/5104773/herring-gas-co-v-pine-belt-gas-inc/#:~:text=We%20find%20that%20the%20covenant,it%20occurred%20after%20Rutland%E2%80%99s%20resignation.>
+
+[^watercolor-disaffirm]: **Watercolor Salon, LLC v. Hixon** — "And because Nealie disaffirmed the contract, it is unenforceable against her." *Watercolor Salon, LLC v. Hixon, No. 2021-IA-01151-SCT (Miss. 2022).* <https://www.courtlistener.com/opinion/10627678/watercolor-salon-llc-v-nealie-hixon/#:~:text=And%20because%20Nealie%20disaffirmed%20the,it%20is%20unenforceable%20against%20her.>
+
+[^rule-5-6-ban]: **Mississippi Rule of Professional Conduct 5.6** — "(a) a partnership or employment agreement that restricts the rights of a lawyer to practice after termination of the relationship, except an agreement concerning benefits upon retirement; or" *Miss. R. Prof'l Conduct 5.6(a).* <https://courts.ms.gov/research/rules/msrulesofcourt/rules_of_professional_conduct.pdf>
+
+[^rule-5-6-sale-exception]: **Mississippi Rule of Professional Conduct 5.6** — "This Rule does not prohibit restrictions that may be included in the terms of the sale of a law practice pursuant to Rule 1.17." *Miss. R. Prof'l Conduct 5.6.* <https://courts.ms.gov/research/rules/msrulesofcourt/rules_of_professional_conduct.pdf>
+
+[^hb500-healthcare-void]: **Mississippi House Bill 500 (2026 Reg. Sess.)** — "Any contract or agreement that creates, establishes or modifies the terms of a partnership, employment or any other form of professional relationship with a health care provider who is licensed in Mississippi, which includes any restriction of the right of the health care provider to practice his or her profession or occupation in any geographic area for any period of time after the termination of such partnership, employment or professional relationship, shall be void and unenforceable with respect to that restriction." *2026 Miss. H.B. 500 (Reg. Sess.).* <https://billstatus.ls.state.ms.us/documents/2026/pdf/HB/0500-0599/HB0500IN.pdf>
+
+[^sb2685-physician-void]: **Mississippi Senate Bill 2685 (2018 Reg. Sess.)** — "If a provision in a contract that creates or establishes the terms of a partnership, employment, or any other form of professional relationship with a physician includes any restriction of the right of the physician to practice medicine, that provision shall be void and unenforceable with respect to the restriction." *2018 Miss. S.B. 2685 (Reg. Sess.).* <https://billstatus.ls.state.ms.us/documents/2018/pdf/SB/2600-2699/SB2685IN.pdf>
+
+[^ryan-ftc-set-aside]: **Ryan LLC v. Federal Trade Commission** — "The Non-Compete Rule, 16 C.F.R. § 910.1–.6, is hereby SET ASIDE and shall not be enforced or otherwise take effect on September 4, 2024, or thereafter." *Ryan LLC v. Fed. Trade Comm'n, 746 F. Supp. 3d 369 (N.D. Tex. 2024).* <https://www.courtlistener.com/opinion/10205745/ryan-llc-v-federal-trade-commission/#:~:text=The%20Non%2DCompete%20Rule%2C%2016%20C.F.R.,September%204%2C%202024%2C%20or%20thereafter.>

--- a/skills/non-compete-contract-explainer/content/missouri.md
+++ b/skills/non-compete-contract-explainer/content/missouri.md
@@ -1,0 +1,219 @@
+---
+jurisdiction: "Missouri"
+slug: missouri
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-03"
+canonicalUrl: https://openagreements.org/legal/non-compete/missouri
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/missouri · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in Missouri[^about]
+
+Missouri enforces non-competes only when the restraint is reasonable and tied to protecting trade secrets or customer contacts, with separate statutory safe harbors for non-solicitation and owner covenants.
+
+
+## At a glance
+
+| Question | Missouri |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed if reasonable |
+| **Bottom line** | Missouri enforces a non-compete only to the extent it is reasonable and protects the employer's trade secrets or customer contacts, not mere competition, with the employer bearing the burden. |
+| **Main law or case** | Healthcare Servs. of the Ozarks, Inc. v. Copeland, 198 S.W.3d 604 (Mo. banc 2006) |
+| **Main exceptions** | Employee no-hire/anti-raiding safe harbor (§ 431.202, ≤1 yr); owner/sale covenants (§ 431.204); no physician statutory cap |
+| **Can a court narrow it?** | Yes — rewrites to reasonable |
+| **Applies to contractors?** | Unclear |
+| **Restriction extended during a breach?** | Not addressed |
+| **Maximum length set by law** | No statutory limit (~2 yrs commonly within range) |
+
+## Are employee non-compete agreements enforceable in Missouri? {#employee-noncompetes}
+
+**Short answer.** Yes, sometimes. Missouri is a reasonableness state, not a general ban state. A non-compete is enforceable only if it is reasonable — no more restrictive than necessary — and only to the extent it protects the employer's trade secrets or customer contacts, not mere competition [^copeland-reasonable-standard][^copeland-mere-competition].
+
+Because covenants not to compete are restraints on trade, Missouri courts treat them as presumptively void and enforce them only to the extent they are demonstrably reasonable, with the employer carrying the burden of proof [^yates-presumptively-void][^whelan-employer-burden]. Every contract in restraint of trade is unlawful as a baseline matter under Missouri's antitrust statute, which is the policy backdrop against which a covenant must be justified [^restraint-of-trade-backdrop].
+
+"In addition, such restrictions are not enforceable to protect an employer from mere competition by a former employee, but only to the extent that the restrictions protect the employer’s trade secrets or customer contacts."[^copeland-mere-competition]
+
+In practice, courts assess duration and geographic scope against the employer's actual operational footprint; restrictions of up to about two years are commonly within the range courts will consider, but reasonableness is always fact-specific [^whelan-employer-burden].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not treat Missouri as a total-ban state, but do not assume any covenant is enforceable either. Start by identifying the trade secret or customer-contact interest the restraint actually protects; a covenant aimed at ordinary competition will not be enforced no matter how it is drafted [^copeland-mere-competition][^yates-presumptively-void].
+
+## What legitimate business interests can support a Missouri non-compete? {#protectable-interests}
+
+**Short answer.** For an ordinary employee non-compete, only two: trade secrets and customer contacts. Missouri courts have carved out these narrow exceptions to the rule against restraints on trade, and the covenant must be tied to one of them [^copeland-two-interests][^paradise-two-interests].
+
+A customer-contacts interest exists where the employee had substantial contact with customers and an opportunity to influence them; the employer need not prove the former employee actually solicited anyone [^osage-customer-contacts][^paradise-no-actual-solicitation].
+
+"If the covenant is lawful and the opportunity for influencing customers exists, enforcement is appropriate."[^osage-customer-contacts]
+
+The trade-secret interest is defined by the Missouri Uniform Trade Secrets Act, which protects information that derives independent economic value from secrecy and is subject to reasonable secrecy efforts [^mutsa-trade-secret-definition].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not write a covenant to block ordinary competition disconnected from a protectable interest. Tie the restraint to specific trade secrets or to customers the employee actually serviced, and keep a separate trade-secret strategy under the Uniform Trade Secrets Act [^copeland-two-interests][^mutsa-trade-secret-definition].
+
+## How does Missouri treat employee no-hire and customer non-solicitation covenants? {#non-solicitation-431-202}
+
+**Short answer.** They follow two different tracks. Covenants not to solicit, recruit, or hire the employer's own workforce have a statutory safe harbor under section 431.202 — conclusively presumed reasonable if their post-employment duration is no more than one year — while covenants not to solicit customers are judged under the common-law reasonableness test [^section-431-202-presumption][^whelan-customer-overbroad].
+
+Section 431.202 reaches a covenant promising not to solicit, recruit, hire, or otherwise interfere with the employment of one or more of the employer's employees — an anti-raiding or no-hire covenant, not a customer restriction. Such a covenant is enforceable when it protects the employer's confidential information or its customer or supplier relationships, goodwill, or loyalty, or even without one of those interests if it runs no more than one year — except that the one-year route does not apply to employees who provide only secretarial or clerical services [^section-431-202-clerical]. Section 431.202 is not a general non-compete statute; it expressly does not create or affect the enforceability of employer-employee covenants not to compete, which remain governed by the common-law reasonableness test [^section-431-202-presumption].
+
+"Whether a covenant covered by this section is reasonable shall be determined based upon the facts and circumstances pertaining to such covenant, but a covenant covered exclusively by subdivision (3) or (4) of subsection 1 of this section shall be conclusively presumed to be reasonable if its postemployment duration is no more than one year."[^section-431-202-presumption]
+
+Customer non-solicitation is a separate, common-law inquiry. In *Whelan*, the Missouri Supreme Court found a customer non-solicitation clause overbroad as written because it reached customers regardless of the employee's relationship with them — including prospective customers — beyond the employer's legitimate customer-contacts interest [^whelan-customer-overbroad].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Draft an employee no-hire or anti-raiding covenant to one year or less to capture the section 431.202 conclusive presumption, and do not rely on the one-year route for purely secretarial or clerical staff. For a customer non-solicit — which section 431.202 does not cover — the safest course is to limit it to customers the employee actually serviced, the group *Whelan* left enforceable after striking the overbroad reach [^section-431-202-presumption][^section-431-202-clerical][^whelan-customer-overbroad].
+
+## What consideration is required to support a Missouri non-compete? {#consideration}
+
+**Short answer.** This is unsettled. Missouri appellate cases have treated continued at-will employment plus access to the employer's customers or trade secrets as adequate consideration, but the Missouri Supreme Court's reasoning that an at-will promise is illusory — and a federal court applying it to a non-compete — has cast real doubt on relying on continued employment alone [^jumbosack-consideration][^baker-illusory][^durrell-at-will].
+
+In *JumboSack*, the court of appeals recognized continued employment as consideration where the employee also received access to protectable assets and relationships [^jumbosack-consideration]. But in *Baker v. Bristol Care*, the Missouri Supreme Court held that a promise of continued at-will employment is not valid consideration because the employer promises nothing it is not already free to do [^baker-illusory]. A federal court then applied that reasoning directly to a non-compete in *Durrell*, concluding that at-will employment is not a source of consideration under Missouri contract law [^durrell-at-will].
+
+"An offer of at-will employment, or the continuation of at-will employment, is simply not a source of consideration under Missouri contract law."[^durrell-at-will]
+
+Because *Baker* arose in the arbitration context and the Missouri Supreme Court has not squarely resolved the question for non-competes, lower courts are not bound to follow *Durrell*, and the law remains divided.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not rely on continued at-will employment as the only consideration for a Missouri non-compete. Support the covenant with independent consideration — a signing bonus, a raise, specialized training, or another concrete benefit — and document it, because *Baker* and *Durrell* make bare continued-employment consideration a litigation risk [^baker-illusory][^durrell-at-will][^jumbosack-consideration].
+
+## Will a Missouri court modify (blue-pencil) an overbroad non-compete? {#court-modification}
+
+**Short answer.** It can, but it does not have to. Missouri courts have authority to refuse to enforce unreasonable terms or to modify an overbroad covenant to make it reasonable, yet modification is discretionary — a court may instead decline to enforce the covenant at all [^whelan-modification][^sigma-refused-modification].
+
+In *Sigma-Aldrich*, the court of appeals affirmed both the trial court's refusal to enforce a covenant that lacked any geographic or other non-temporal limit and its discretionary decision not to rewrite it [^sigma-refused-modification]. There is also a litigation-economics trap: an employer that needs the court to blue-pencil its overbroad agreement may not qualify as the prevailing party and can lose its contractual right to attorney's fees [^paradise-prevailing-party].
+
+"Accordingly, when the provisions of a non-compete clause impose a restraint that is unreasonably broad, appellate courts still can give effect to its purpose by refusing to give effect to the unreasonable terms or modifying the terms of the contract to be reasonable."[^whelan-modification]
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not rely on a court to rewrite an overbroad covenant. Drafting to the outer edge risks both non-enforcement, if the court declines to modify, and forfeiture of a contractual attorney's-fee award even when the covenant is ultimately enforced as modified [^sigma-refused-modification][^paradise-prevailing-party].
+
+## Does a Missouri non-compete period toll or extend during a breach or litigation? {#tolling}
+
+**Short answer.** Missouri law does not squarely answer this. Neither the non-solicitation safe harbor nor the owner-covenant statute addresses whether a restricted period pauses (tolls) while a former employee is violating the covenant or while litigation is pending, and Missouri appellate courts have not laid down a clear rule on judicial or contractual tolling for non-competes [^tolling-431-202-duration][^tolling-whelan-time].
+
+This is an open question, so treat it conservatively. The statutory presumptions in section 431.202 are framed around a fixed post-employment duration, and *Whelan* measures reasonableness against the covenant's stated time and geographic terms — so a clause that effectively lengthens the restraint by tolling could be tested against those same reasonableness and safe-harbor limits [^tolling-431-202-duration][^tolling-whelan-time].
+
+> [!NOTE]
+> **Practice note.**
+>
+> If you want the restricted period to extend during a breach, say so expressly in the covenant rather than assuming a court will toll it — Missouri has no clear authority requiring judicial tolling. But keep the total potential restraint within a reasonable duration: an extension that pushes a one-year non-solicit past the section 431.202 safe harbor, or a non-compete past what *Whelan* would consider reasonable in time, may invite a reasonableness challenge [^tolling-431-202-duration][^tolling-whelan-time].
+
+## What rules apply to owner and sale-of-business covenants under section 431.204? {#owner-sale-of-business-431-204}
+
+**Short answer.** A separate statute governs them. Section 431.204, effective August 28, 2023, presumes certain covenants between a business entity and an owner enforceable: an owner's covenant not to solicit, recruit, hire, or interfere with the entity's employees or owners for up to two years, and an owner's customer non-solicitation covenant of up to five years limited to customers the owner dealt with [^section-431-204-employee][^section-431-204-customer].
+
+Section 431.204 also imposes a mandatory reformation rule that differs sharply from the discretionary blue-penciling used for ordinary employment covenants: if an owner covenant is overbroad, a court *shall* modify it and enforce it as modified [^section-431-204-modify]. Like section 431.202, it is not a general non-compete statute and does not change the enforceability of covenants not to compete except as the section provides [^section-431-204-not-noncompete].
+
+"If a covenant is overbroad, overlong, or otherwise not reasonably necessary to protect the protectable business interests of the business entity seeking enforcement of the covenant, a court shall modify the covenant, enforce the covenant as modified, and grant only the relief reasonably necessary to protect such interests."[^section-431-204-modify]
+
+> [!NOTE]
+> **Practice note.**
+>
+> Confirm the covenant is actually between a business entity and an owner before relying on section 431.204 — its caps and its mandatory-modification rule apply to owner covenants, not to ordinary employee non-competes. Because the section does not define owner, make sure the covenanting party genuinely holds an ownership interest rather than a nominal equity stake [^section-431-204-modify][^section-431-204-not-noncompete].
+
+## Are physician and healthcare non-competes restricted in Missouri? {#healthcare-physician}
+
+**Short answer.** Not yet by statute. Physician non-competes in Missouri are still governed by the common-law reasonableness test, and repeated legislative attempts to cap them have not become law [^physician-copeland][^hb-2979-physician-bill].
+
+Missouri legislators have repeatedly introduced bills to cap physician covenants in recent sessions. The most recent, the 2026 Missouri Rural Doctors Act (HB 2979), would make a physician non-compete with a nonprofit employer enforceable only in a clinical setting and only within 365 days and five miles, with a carve-out for research university hospitals [^hb-2979-physician-bill]. As of this review none of these bills had been enacted, so physician covenants remain governed by the common-law reasonableness standard [^physician-copeland].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not assume Missouri has a physician non-compete cap; healthcare covenants are still tested under the *Copeland* reasonableness standard. Watch the legislature, because the 365-day, five-mile framework in HB 2979 could re-emerge in a future session [^physician-copeland][^hb-2979-physician-bill].
+
+## What remedies are available when a Missouri non-compete is breached? {#remedies}
+
+**Short answer.** Damages, injunctive relief, and a parallel trade-secret track. A liquidated-damages clause is enforceable if it is a reasonable forecast of damages rather than a penalty, and the Uniform Trade Secrets Act separately authorizes injunctions against actual or threatened trade-secret misappropriation [^mayer-liquidated-damages][^mutsa-injunction].
+
+A liquidated-damages provision is valid in Missouri when the amount is a reasonable forecast of the harm and the harm is difficult to estimate; the Eighth Circuit, applying Missouri law in *Mayer Hoffman McCann*, upheld a large award measured by the fees from diverted clients [^mayer-liquidated-damages]. The Missouri Uniform Trade Secrets Act supplies an independent path to relief: it authorizes injunctions for actual or threatened misappropriation and expressly preserves contractual remedies, so a trade-secret claim can stand even where a covenant is narrow or unenforceable [^mutsa-injunction][^mutsa-contractual-remedies].
+
+"If both requirements are met, the liquidated damages provision is valid."[^mayer-liquidated-damages]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Draft any liquidated-damages clause as a genuine, reasonable forecast of hard-to-measure harm, not a deterrent penalty, or it will not be enforced. Keep a separate confidentiality and trade-secret strategy under the Uniform Trade Secrets Act so relief does not depend solely on the covenant [^mayer-liquidated-damages][^mutsa-contractual-remedies].
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-03. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not Missouri. This article synthesizes Missouri primary law and is not legal advice from a Missouri-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^copeland-reasonable-standard]: **Healthcare Services of the Ozarks, Inc. v. Copeland** — "In practical terms, a non-compete agreement is reasonable if it is no more restrictive than is necessary to protect the legitimate interests of the employer." *Healthcare Servs. of the Ozarks, Inc. v. Copeland, 198 S.W.3d 604 (Mo. banc 2006).* <https://www.courtlistener.com/opinion/1654936/healthcare-services-of-the-ozarks-inc-v-copeland/#:~:text=In%20practical%20terms%2C%20a%20non%2Dcompete,legitimate%20interests%20of%20the%20employer.>
+
+[^copeland-mere-competition]: **Healthcare Services of the Ozarks, Inc. v. Copeland** — "In addition, such restrictions are not enforceable to protect an employer from mere competition by a former employee, but only to the extent that the restrictions protect the employer’s trade secrets or customer contacts." *Healthcare Servs. of the Ozarks, Inc. v. Copeland, 198 S.W.3d 604 (Mo. banc 2006).* <https://www.courtlistener.com/opinion/1654936/healthcare-services-of-the-ozarks-inc-v-copeland/#:~:text=In%20addition%2C%20such%20restrictions%20are,trade%20secrets%20or%20customer%20contacts.>
+
+[^yates-presumptively-void]: **Payroll Advance, Inc. v. Yates** — "Generally, because covenants not to compete are considered to be restraints on trade, they are presumptively void and are enforceable only to the extent that they are demonstratively reasonable." *Payroll Advance, Inc. v. Yates, 270 S.W.3d 428 (Mo. App. S.D. 2008).* <https://www.courtlistener.com/opinion/1590178/payroll-advance-inc-v-yates/#:~:text=Generally%2C%20because%20covenants%20not%20to,that%20they%20are%20demonstratively%20reasonable.>
+
+[^whelan-employer-burden]: **Whelan Security Co. v. Kennebrew** — "The employer has the burden to prove that the non-compete agreement protects its legitimate interests in trade secrets or customer contacts and that the agreement is reasonable as to time and geographic space." *Whelan Sec. Co. v. Kennebrew, 379 S.W.3d 835 (Mo. banc 2012).* <https://www.courtlistener.com/opinion/5283000/whelan-security-co-v-kennebrew/#:~:text=The%20employer%20has%20the%20burden,to%20time%20and%20geographic%20space.>
+
+[^restraint-of-trade-backdrop]: **Mo. Rev. Stat. § 416.031** — "Every contract, combination or conspiracy in restraint of trade or commerce in this state is unlawful." *Mo. Rev. Stat. § 416.031(1).* <https://revisor.mo.gov/main/OneSection.aspx?section=416.031>
+
+[^copeland-two-interests]: **Healthcare Services of the Ozarks, Inc. v. Copeland** — "Missouri courts have carved out narrow exceptions for trade secrets and customer contacts." *Healthcare Servs. of the Ozarks, Inc. v. Copeland, 198 S.W.3d 604 (Mo. banc 2006).* <https://www.courtlistener.com/opinion/1654936/healthcare-services-of-the-ozarks-inc-v-copeland/#:~:text=Missouri%20courts%20have%20carved%20out,trade%20secrets%20and%20customer%20contacts.>
+
+[^paradise-two-interests]: **Paradise v. Midwest Asphalt Coatings, Inc.** — "Missouri recognizes two legitimate business interests: trade secrets and customer contacts." *Paradise v. Midwest Asphalt Coatings, Inc., 316 S.W.3d 327 (Mo. App. W.D. 2010).* <https://www.courtlistener.com/opinion/1873853/paradise-v-midwest-asphalt-coatings-inc/#:~:text=Missouri%20recognizes%20two%20legitimate%20business,trade%20secrets%20and%20customer%20contacts.>
+
+[^osage-customer-contacts]: **Osage Glass, Inc. v. Donovan** — "If the covenant is lawful and the opportunity for influencing customers exists, enforcement is appropriate." *Osage Glass, Inc. v. Donovan, 693 S.W.2d 71 (Mo. banc 1985).* <https://www.courtlistener.com/opinion/1781769/osage-glass-inc-v-donovan/#:~:text=If%20the%20covenant%20is%20lawful,customers%20exists%2C%20enforcement%20is%20appropriate.>
+
+[^paradise-no-actual-solicitation]: **Paradise v. Midwest Asphalt Coatings, Inc.** — "An employer is not required to show actual solicitation or a willful violation of the non-compete agreement." *Paradise v. Midwest Asphalt Coatings, Inc., 316 S.W.3d 327 (Mo. App. W.D. 2010).* <https://www.courtlistener.com/opinion/1873853/paradise-v-midwest-asphalt-coatings-inc/#:~:text=An%20employer%20is%20not%20required,violation%20of%20the%20non%2Dcompete%20agreement.>
+
+[^mutsa-trade-secret-definition]: **Mo. Rev. Stat. § 417.453** — "Derives independent economic value, actual or potential, from not being generally known to, and not being readily ascertainable by proper means by other persons who can obtain economic value from its disclosure or use; and (b) Is the subject of efforts that are reasonable under the circumstances to maintain its secrecy." *Mo. Rev. Stat. § 417.453(4).* <https://revisor.mo.gov/main/OneSection.aspx?section=417.453>
+
+[^section-431-202-presumption]: **Mo. Rev. Stat. § 431.202** — "Whether a covenant covered by this section is reasonable shall be determined based upon the facts and circumstances pertaining to such covenant, but a covenant covered exclusively by subdivision (3) or (4) of subsection 1 of this section shall be conclusively presumed to be reasonable if its postemployment duration is no more than one year." *Mo. Rev. Stat. § 431.202.2.* <https://revisor.mo.gov/main/OneSection.aspx?section=431.202>
+
+[^whelan-customer-overbroad]: **Whelan Security Co. v. Kennebrew** — "As written, the customer non-solicitation clauses are more broad than necessary to protect Whelan’s legitimate interest in customer contacts." *Whelan Sec. Co. v. Kennebrew, 379 S.W.3d 835 (Mo. banc 2012).* <https://www.courtlistener.com/opinion/5283000/whelan-security-co-v-kennebrew/#:~:text=As%20written%2C%20the%20customer%20non%2Dsolicitation,legitimate%20interest%20in%20customer%20contacts.>
+
+[^section-431-202-clerical]: **Mo. Rev. Stat. § 431.202** — "Between an employer and one or more employees, notwithstanding the absence of the protectable interests described in subdivision (3) of this subsection, so long as such covenant does not continue for more than one year following the employee's employment; provided, however, that this subdivision shall not apply to covenants signed by employees who provide only secretarial or clerical services." *Mo. Rev. Stat. § 431.202.1(4).* <https://revisor.mo.gov/main/OneSection.aspx?section=431.202>
+
+[^jumbosack-consideration]: **JumboSack Corp. v. Buyck** — "In the instant case, Employee received in consideration for his covenant not to compete, access to Employer’s new and existing customers, as well as continued at-will employment, salary, and commissions." *JumboSack Corp. v. Buyck, 407 S.W.3d 51 (Mo. App. E.D. 2013).* <https://www.courtlistener.com/opinion/5285458/jumbosack-corp-v-buyck/#:~:text=In%20the%20instant%20case%2C%20Employee,at%2Dwill%20employment%2C%20salary%2C%20and%20commissions.>
+
+[^baker-illusory]: **Baker v. Bristol Care, Inc.** — "An offer of continued at-will employment is not valid consideration because the employer makes no legally enforceable promise to do or refrain from doing anything it is not already entitled to do." *Baker v. Bristol Care, Inc., 450 S.W.3d 770 (Mo. banc 2014).* <https://www.courtlistener.com/opinion/2718919/carla-baker-v-bristol-care-inc-dba-bristol-manor-and-david-furnell/#:~:text=An%20offer%20of%20continued%20at%2Dwill,not%20already%20entitled%20to%20do.>
+
+[^durrell-at-will]: **Durrell v. Tech Electronics, Inc.** — "An offer of at-will employment, or the continuation of at-will employment, is simply not a source of consideration under Missouri contract law." *Durrell v. Tech Elecs., Inc., No. 4:16-cv-01367, 2016 WL 6833956 (E.D. Mo. Nov. 15, 2016).* <https://www.govinfo.gov/app/details/USCOURTS-moed-4_16-cv-01367>
+
+[^whelan-modification]: **Whelan Security Co. v. Kennebrew** — "Accordingly, when the provisions of a non-compete clause impose a restraint that is unreasonably broad, appellate courts still can give effect to its purpose by refusing to give effect to the unreasonable terms or modifying the terms of the contract to be reasonable." *Whelan Sec. Co. v. Kennebrew, 379 S.W.3d 835 (Mo. banc 2012).* <https://www.courtlistener.com/opinion/5283000/whelan-security-co-v-kennebrew/#:~:text=Accordingly%2C%20when%20the%20provisions%20of,the%20contract%20to%20be%20reasonable.>
+
+[^sigma-refused-modification]: **Sigma-Aldrich Corp. v. Vikin** — "The trial court also did not err by using its discretion and refusing to modify the Agreement." *Sigma-Aldrich Corp. v. Vikin, 451 S.W.3d 767 (Mo. App. E.D. 2014).* <https://www.courtlistener.com/opinion/2741957/sigma-aldrich-corporation-v-omar-vikin/#:~:text=The%20trial%20court%20also%20did,refusing%20to%20modify%20the%20Agreement.>
+
+[^paradise-prevailing-party]: **Paradise v. Midwest Asphalt Coatings, Inc.** — "Notwithstanding any affirmative defense, a party requesting payment of contractual attorney fees must be the prevailing party." *Paradise v. Midwest Asphalt Coatings, Inc., 316 S.W.3d 327 (Mo. App. W.D. 2010).* <https://www.courtlistener.com/opinion/1873853/paradise-v-midwest-asphalt-coatings-inc/#:~:text=Notwithstanding%20any%20affirmative%20defense%2C%20a,must%20be%20the%20prevailing%20party.>
+
+[^tolling-431-202-duration]: **Mo. Rev. Stat. § 431.202** — "Whether a covenant covered by this section is reasonable shall be determined based upon the facts and circumstances pertaining to such covenant, but a covenant covered exclusively by subdivision (3) or (4) of subsection 1 of this section shall be conclusively presumed to be reasonable if its postemployment duration is no more than one year." *Mo. Rev. Stat. § 431.202.2.* <https://revisor.mo.gov/main/OneSection.aspx?section=431.202>
+
+[^tolling-whelan-time]: **Whelan Security Co. v. Kennebrew** — "The employer has the burden to prove that the non-compete agreement protects its legitimate interests in trade secrets or customer contacts and that the agreement is reasonable as to time and geographic space." *Whelan Sec. Co. v. Kennebrew, 379 S.W.3d 835 (Mo. banc 2012).* <https://www.courtlistener.com/opinion/5283000/whelan-security-co-v-kennebrew/#:~:text=The%20employer%20has%20the%20burden,to%20time%20and%20geographic%20space.>
+
+[^section-431-204-employee]: **Mo. Rev. Stat. § 431.204** — "A reasonable covenant in writing promising not to solicit, recruit, hire, induce, persuade, encourage, or otherwise interfere with, directly or indirectly, the employment of one or more employees or owners of a business entity shall be presumed to be enforceable and not a restraint of trade pursuant to subsection 1 of section 416.031 if it is between a business entity and the owner of the business entity and does not continue for more than two years following the end of the owner's business relationship with the business entity." *Mo. Rev. Stat. § 431.204.1.* <https://revisor.mo.gov/main/OneSection.aspx?section=431.204>
+
+[^section-431-204-customer]: **Mo. Rev. Stat. § 431.204** — "A reasonable covenant in writing promising not to solicit, induce, direct, or otherwise interfere with, directly or indirectly, a business entity's customers, including any reduction, termination, or transfer of any customer's business, in whole or in part, for the purposes of providing any product or any service that is competitive with those provided by the business entity shall be presumed to be enforceable and not a restraint of trade pursuant to subsection 1 of section 416.031 if the covenant is limited to customers with whom the owner dealt and if the covenant is between a business entity and an owner, so long as the covenant does not continue for more than five years following the end of the owner's business relationship with the business entity." *Mo. Rev. Stat. § 431.204.2.* <https://revisor.mo.gov/main/OneSection.aspx?section=431.204>
+
+[^section-431-204-modify]: **Mo. Rev. Stat. § 431.204** — "If a covenant is overbroad, overlong, or otherwise not reasonably necessary to protect the protectable business interests of the business entity seeking enforcement of the covenant, a court shall modify the covenant, enforce the covenant as modified, and grant only the relief reasonably necessary to protect such interests." *Mo. Rev. Stat. § 431.204.4.* <https://revisor.mo.gov/main/OneSection.aspx?section=431.204>
+
+[^section-431-204-not-noncompete]: **Mo. Rev. Stat. § 431.204** — "Nothing in this section is intended to create or to affect the validity or enforceability of covenants not to compete, other types of covenants, or nondisclosure or confidentiality agreements, except as expressly provided in this section." *Mo. Rev. Stat. § 431.204.5.* <https://revisor.mo.gov/main/OneSection.aspx?section=431.204>
+
+[^physician-copeland]: **Healthcare Services of the Ozarks, Inc. v. Copeland** — "In practical terms, a non-compete agreement is reasonable if it is no more restrictive than is necessary to protect the legitimate interests of the employer." *Healthcare Servs. of the Ozarks, Inc. v. Copeland, 198 S.W.3d 604 (Mo. banc 2006).* <https://www.courtlistener.com/opinion/1654936/healthcare-services-of-the-ozarks-inc-v-copeland/#:~:text=In%20practical%20terms%2C%20a%20non%2Dcompete,legitimate%20interests%20of%20the%20employer.>
+
+[^hb-2979-physician-bill]: **Mo. H.B. 2979 (2026) — Missouri Rural Doctors Act** — "A covenant not to compete between a physician and a nonprofit employer shall be valid and enforceable only if: (1) The physician is providing health care services in a clinical setting; (2) The covenant not to compete does not restrict the physician's competitive activities for a period of more than three hundred sixty-five days; and (3) The covenant not to compete does not restrict the physician's competitive activities in a geographic area of more than five miles from the address of the office or facility in which the physician provides health care services in a clinical setting." *Mo. H.B. 2979, 103d Gen. Assemb., 2d Reg. Sess. (2026) (as introduced).* <https://documents.house.mo.gov/billtracking/bills261/hlrbillspdf/6359H.02I.pdf>
+
+[^mayer-liquidated-damages]: **Mayer Hoffman McCann, P.C. v. Barton** — "If both requirements are met, the liquidated damages provision is valid." *Mayer Hoffman McCann, P.C. v. Barton, 614 F.3d 893 (8th Cir. 2010).* <https://www.courtlistener.com/opinion/152690/mayer-hoffman-mccann-pc-v-barton/#:~:text=If%20both%20requirements%20are%20met%2C,liquidated%20damages%20provision%20is%20valid.>
+
+[^mutsa-injunction]: **Mo. Rev. Stat. § 417.455** — "Actual or threatened misappropriation may be enjoined." *Mo. Rev. Stat. § 417.455.1.* <https://revisor.mo.gov/main/OneSection.aspx?section=417.455>
+
+[^mutsa-contractual-remedies]: **Mo. Rev. Stat. § 417.463** — "Sections 417.450 to 417.467 shall not affect: (1) Contractual remedies, whether or not based upon misappropriation of a trade secret; or" *Mo. Rev. Stat. § 417.463.2(1).* <https://revisor.mo.gov/main/OneSection.aspx?section=417.463>

--- a/skills/non-compete-contract-explainer/content/montana.md
+++ b/skills/non-compete-contract-explainer/content/montana.md
@@ -1,0 +1,202 @@
+---
+jurisdiction: "Montana"
+slug: montana
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-02"
+canonicalUrl: https://openagreements.org/legal/non-compete/montana
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/montana · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in Montana[^about]
+
+Montana starts from § 28-2-703's restraint-of-trade rule, but the Dobbins partial-restraint rule of reason leaves narrow covenants enforceable, while § 28-2-724 now bans many health-care provider non-competes in 2025 and 2026.
+
+
+## At a glance
+
+| Question | Montana |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed if reasonable |
+| **Bottom line** | Montana's restraint-of-trade statute voids absolute restraints, but reasonable partial restraints survive under the Dobbins rule of reason, and covered health-care provider non-competes are now banned. |
+| **Main law or case** | Mont. Code Ann. § 28-2-703 (Dobbins, DeGuire & Tucker, P.C. v. Rutherford, 708 P.2d 577 (Mont. 1985)) |
+| **Main exceptions** | Health-care provider ban (§ 28-2-724, HB 198/HB 620, all physicians Jan 1, 2026); sale-of-goodwill (§ 28-2-704); partnership dissolution (§ 28-2-705); employer-initiated termination usually defeats enforcement (Wrigg) |
+| **Can a court narrow it?** | No |
+| **Applies to contractors?** | Unclear |
+| **Restriction extended during a breach?** | Not addressed |
+| **Maximum length set by law** | No general statutory limit |
+
+## Are employee non-compete agreements enforceable in Montana? {#employee-noncompetes}
+
+**Short answer.** Sometimes. Montana Code § 28-2-703 makes restraints on a lawful profession, trade, or business void, but Montana is not a California-style total-ban state because *Dobbins* preserves reasonable partial restraints [^montana-restraint-baseline][^dobbins-partial-restraint].
+
+The key distinction is absolute versus partial restraint. A covenant that effectively blocks the worker from practicing a trade is in serious danger. A covenant that leaves the worker free to practice, but regulates a limited client, territory, time, or fee consequence, can be tested under Montana's reasonableness framework.
+
+That means the first drafting question is not simply whether the agreement is called a non-compete. It is whether the clause actually restrains work, whether it is absolute or partial, and whether the employer can prove the *Dobbins* elements.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not summarize Montana as a blanket-ban jurisdiction. The statute is broad, but *Dobbins* and later cases treat partial restraints differently from absolute restraints [^montana-restraint-baseline][^dobbins-partial-restraint].
+
+## What is the Dobbins test for Montana non-competes? {#dobbins-test}
+
+**Short answer.** For a partial restraint, Montana asks whether the covenant is limited as to time or place, supported by good consideration, and reasonably protects the employer without imposing an unreasonable burden on the employee or the public [^dobbins-three-part-test].
+
+The first element is phrased as time *or* place, not necessarily both. That still does not make open-ended drafting safe. The third element requires balancing, so a covenant that technically has a time or territory limit can still fail if the employer's protection is disproportionate to the worker or public burden.
+
+*Alborn* later applied the same framework to a shareholder accounting-firm covenant, explaining that partial restraints require a reasonableness determination rather than automatic invalidation [^alborn-dobbins-partial].
+
+## Is continued employment enough consideration for a Montana non-compete signed after hire? {#consideration-after-hire}
+
+**Short answer.** Usually no for an at-will employee. *Access Organics* held that simple continued employment did not supply good consideration for a non-compete signed more than four months after hiring [^access-continued-employment].
+
+Montana treats post-hire covenants as afterthought agreements. They are not automatically invalid, but the employer needs independent consideration, such as a raise, promotion, access to trade secrets, or another real benefit tied to the new restriction [^access-independent-consideration].
+
+The practical rule is timing-sensitive. A covenant presented as part of pre-employment negotiations can use the job offer as the exchange. A covenant presented later needs a new exchange, and past raises or prior employment are not enough.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> For an existing Montana employee, do not rely on continued at-will employment alone. Tie the covenant to new consideration and document the exchange at the time the covenant is signed [^access-continued-employment][^access-independent-consideration].
+
+## Can a Montana employer enforce a non-compete after terminating the employee without cause? {#termination-without-cause}
+
+**Short answer.** Generally no. *Wrigg* held that an employer normally lacks a legitimate business interest in enforcing a covenant when the employer chooses to end the employment relationship [^wrigg-employer-termination].
+
+The reason is practical and equitable. If the employer could avoid competition by keeping the worker employed, then firing the worker and still blocking the worker's livelihood looks like ordinary competition prevention rather than legitimate protection.
+
+*Wrigg* leaves room for a different result when the employee's conduct gives the employer a real protective interest. Trade-secret misuse, customer-relationship misuse, or proprietary-information misuse can change the analysis, but the employer must prove the risk [^wrigg-misconduct-exception][^wrigg-trade-secret-analysis].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Before sending an enforcement letter after a layoff, nonrenewal, or termination without cause, identify a Montana-specific legitimate interest beyond ordinary competition. *Wrigg* makes employer-initiated separation a major enforcement problem [^wrigg-employer-termination].
+
+## Are fee-for-service and customer-fee clauses enforceable in Montana? {#customer-fee-restraints}
+
+**Short answer.** They can be. Montana courts have treated customer-linked fee provisions as partial restraints when the worker remains free to compete and serve the customer, subject to a contract payment [^alborn-partial-customer-fee][^jccs-client-payment].
+
+The accounting-firm cases are the strongest pattern. In the 2016 *Alborn* appeal, the Montana Supreme Court held that a fee provision requiring payment for servicing former firm clients was not an absolute prohibition. In the 2020 appeal, the court affirmed a $2,353,463.27 judgment tied to that fee structure and recognized the employer's protectable interest in its client base [^jccs-legitimate-client-base][^jccs-damages-amount].
+
+This does not make all customer restrictions safe. The covenant still needs time or place limits, good consideration, and a reasonable burden. But Montana's leading cases show that fee-for-service provisions are often a better fit than a no-work ban.
+
+A pure customer non-solicitation clause is different from the fee-for-service provisions these cases enforced. Because § 28-2-703 voids contracts restraining a business of any kind, a customer or employee non-solicit is best treated as a restraint on trade tested under the same *Dobbins* partial-restraint analysis, but no Montana Supreme Court decision squarely fixes the permissible duration or scope of a stand-alone non-solicit [^q5-montana-restraint-baseline].
+
+## What kinds of non-compete restraints are void in Montana? {#absolute-restraints}
+
+**Short answer.** Absolute restraints are void. A covenant that leaves the worker with no realistic way to practice the trade in the relevant market is likely an unlawful restraint under § 28-2-703 [^curl-unreasonable-restraint][^mungas-absolute-prohibition].
+
+*Montana Mountain Products v. Curl* is the practical warning case. The worker's local trade depended on working for a subcontractor of Montana Silversmiths, and the covenant prohibited exactly that. The court held the covenant unreasonable and void.
+
+*Mungas* shows a related sale-of-goodwill boundary. A covenant does not fit the goodwill exception merely because a partnership document says so. The court looked for an actual sale of property for pecuniary consideration and held that the goodwill exception did not apply where no sale occurred [^mungas-no-goodwill-sale].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Montana's partial-restraint cases are not permission to draft a broad no-work clause. If the restraint functions as an absolute prohibition in the worker's actual market, *Curl* and *Mungas* point toward invalidity [^curl-unreasonable-restraint][^mungas-absolute-prohibition].
+
+## What are the sale-of-business and partnership exceptions in Montana? {#sale-partnership-exceptions}
+
+**Short answer.** Montana has two classic statutory exceptions: sale of business goodwill under § 28-2-704 and dissolution of partnership under § 28-2-705 [^montana-goodwill-sale][^montana-partnership-dissolution].
+
+The sale-of-goodwill exception lets a seller agree with the buyer not to carry on a similar business in specified areas while the buyer or successor carries on a like business there. The geographic menu is statutory: the principal-office city or county, adjacent cities or counties, or a combination of those areas [^montana-goodwill-areas].
+
+The partnership exception is narrower and tracks the same geographic areas. It applies when partners dissolve the partnership and agree that one or more partners may not carry on a similar business within the § 28-2-704 territory.
+
+## What special non-compete rules apply to Montana health-care providers? {#health-care-providers}
+
+**Short answer.** Section 28-2-724 bars covered health-care provider contracts from restricting post-relationship practice, services, patient treatment, patient relationships, or patient solicitation, subject to a narrow sale-of-practice exception and a physician-only decreasing-repayment exception [^montana-healthcare-practice-ban][^montana-healthcare-covered-providers][^montana-healthcare-exceptions].
+
+The current consolidated statute covers physicians, psychologists, naturopathic physicians, social workers, professional counselors, addiction counselors, marriage and family therapists, behavioral health peer support specialists, registered professional nurses, advanced practice registered nurses, and physician assistants.
+
+The 2025 amendments matter for timing. HB 198 added naturopathic physicians, RNs, APRNs, and PAs and took effect on passage and approval, applying to contracts made or renewed on or after its effective date [^hb198-effective]. HB 620 added all physicians licensed under Title 37, chapter 3 on a delayed effective date of January 1, 2026, applying to contracts made or renewed on or after that date [^hb620-effective]. The practical takeaway is that the covered-provider analysis turns on when the contract was made or renewed, not only on when the dispute arises [^hb198-effective][^hb620-effective].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> For covered providers, do not try to convert a non-compete into a patient non-solicit. Section 28-2-724 reaches both practice restrictions and restrictions on treating, advising, consulting with, establishing relationships with, or soliciting covered patients [^montana-healthcare-practice-ban].
+
+## What trade-secret and severance alternatives remain in Montana? {#trade-secrets-severance}
+
+**Short answer.** Montana employers should usually protect confidential information through the Montana Uniform Trade Secrets Act and narrow confidentiality covenants, while treating severance as a limited fallback rather than a reliable cure for overbroad non-competes [^mutsa-short-title][^mutsa-injunction][^montana-partial-void].
+
+MUTSA defines trade secrets as information or software that has independent economic value from not being generally known or readily ascertainable and is subject to reasonable secrecy efforts [^mutsa-trade-secret-definition]. It also authorizes injunctions for actual or threatened misappropriation, with limited royalty and affirmative-act remedies in appropriate cases [^mutsa-injunction].
+
+Section 28-2-604 gives Montana courts a partial-void rule when a contract has distinct lawful and unlawful objects. But restrictive covenants are strictly construed, and cases like *Curl* void overbroad restraints rather than rewriting them into better covenants. Treat severability as a cleanup rule for distinct promises, not a drafting strategy for an aggressive non-compete.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not assume Montana will rewrite an overbroad covenant into a narrower one. Draft separate confidentiality, trade-secret, customer, repayment, and competition provisions so lawful objects can stand on their own if a restraint fails [^montana-partial-void][^curl-void-covenant].
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-02. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not Montana. This article synthesizes Montana primary law and is not legal advice from a Montana-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^montana-restraint-baseline]: **Mont. Code Ann. § 28-2-703** — "28-2-703. Contracts in restraint of trade generally void. Any contract by which anyone is restrained from exercising a lawful profession, trade, or business of any kind, otherwise than is provided for by 28-2-704 or 28-2-705, is to that extent void." *Mont. Code Ann. § 28-2-703.* <https://mca.legmt.gov/bills/mca/title_0280/chapter_0020/part_0070/section_0030/0280-0020-0070-0030.html>
+
+[^dobbins-partial-restraint]: **Dobbins, DeGuire & Tucker, P.C. v. Rutherford, MacDonald & Olson** — "We hold that the written contract provisions do not constitute a restraint prohibited by Section 28-2-703, MCA." *Dobbins, DeGuire & Tucker, P.C. v. Rutherford, MacDonald & Olson, 218 Mont. 392, 708 P.2d 577 (1985).* <https://www.courtlistener.com/opinion/1183224/dobbins-deguire-tucker-pc-v-rutherford-macdonald-olson/#:~:text=We%20hold%20that%20the%20written,prohibited%20by%20Section%2028%2D2%2D703%2C%20MCA.>
+
+[^dobbins-three-part-test]: **Dobbins, DeGuire & Tucker, P.C. v. Rutherford, MacDonald & Olson** — "‘(1) the covenant should be limited in operation either as to time or place; (2) the covenant should be based on some good consideration; and (3) the covenant should afford a reasonable protection for and not impose an unreasonable burden upon the employer, the employee or the public.’" *Dobbins, DeGuire & Tucker, P.C. v. Rutherford, MacDonald & Olson, 218 Mont. 392, 708 P.2d 577 (1985).* <https://www.courtlistener.com/opinion/1183224/dobbins-deguire-tucker-pc-v-rutherford-macdonald-olson/#:~:text=%E2%80%9C(1)%20the%20covenant%20should%20be,the%20employee%20or%20the%20public.%E2%80%9D>
+
+[^alborn-dobbins-partial]: **Junkermier, Clark, Campanella, Stevens, P.C. v. Alborn, Uithoven, Riekenberg, P.C.** — "Because the Covenant is not an absolute prohibition, it cannot be declared invalid as a matter of law." *Junkermier, Clark, Campanella, Stevens, P.C. v. Alborn, Uithoven, Riekenberg, P.C., 2016 MT 218, 384 Mont. 464, 380 P.3d 747.* <https://www.courtlistener.com/opinion/4254366/junkermier-clark-campanella-stevens-pc-v-alborn-uithoven/#:~:text=Because%20the%20Covenant%20is%20not,as%20a%20matter%20of%20law.>
+
+[^access-continued-employment]: **Access Organics, Inc. v. Hernandez** — "In such circumstances, the simple fact of the employee’s continued employment may not serve as sufficient consideration." *Access Organics, Inc. v. Hernandez, 2008 MT 4, 341 Mont. 73, 175 P.3d 899.* <https://www.courtlistener.com/opinion/888657/access-organics-inc-v-hernandez/#:~:text=In%20such%20circumstances%2C%20the%20simple,not%20serve%20as%20sufficient%20consideration.>
+
+[^access-independent-consideration]: **Access Organics, Inc. v. Hernandez** — "Non-compete agreements entered into by existing employees may be supported by independent consideration." *Access Organics, Inc. v. Hernandez, 2008 MT 4, 341 Mont. 73, 175 P.3d 899.* <https://www.courtlistener.com/opinion/888657/access-organics-inc-v-hernandez/#:~:text=Non%2Dcompete%20agreements%20entered%20into%20by,be%20supported%20by%20independent%20consideration.>
+
+[^wrigg-employer-termination]: **Wrigg v. Junkermier, Clark, Campanella, Stevens, P.C.** — "This disfavor only heightens when an employer chooses to end the employment relationship and yet seeks to enforce the covenant not to compete." *Wrigg v. Junkermier, Clark, Campanella, Stevens, P.C., 2011 MT 290, 362 Mont. 496, 265 P.3d 646.* <https://www.courtlistener.com/opinion/889623/wrigg-v-junkermier-clark-campanella-stevens-pc/#:~:text=This%20disfavor%20only%20heightens%20when,the%20covenant%20not%20to%20compete.>
+
+[^wrigg-misconduct-exception]: **Wrigg v. Junkermier, Clark, Campanella, Stevens, P.C.** — "A court should analyze whether the former employee used trade secrets, customer relationships, or proprietary information that would provide an employee with an unfair advantage." *Wrigg v. Junkermier, Clark, Campanella, Stevens, P.C., 2011 MT 290, 362 Mont. 496, 265 P.3d 646.* <https://www.courtlistener.com/opinion/889623/wrigg-v-junkermier-clark-campanella-stevens-pc/#:~:text=A%20court%20should%20analyze%20whether,employee%20with%20an%20unfair%20advantage.>
+
+[^wrigg-trade-secret-analysis]: **Wrigg v. Junkermier, Clark, Campanella, Stevens, P.C.** — "JCCS never alleges that Wrigg acquired any JCCS trade secrets or intimate knowledge regarding any special accounting needs of JCCS’s clients." *Wrigg v. Junkermier, Clark, Campanella, Stevens, P.C., 2011 MT 290, 362 Mont. 496, 265 P.3d 646.* <https://www.courtlistener.com/opinion/889623/wrigg-v-junkermier-clark-campanella-stevens-pc/#:~:text=JCCS%20never%20alleges%20that%20Wrigg,accounting%20needs%20of%20JCCS%E2%80%99s%20clients.>
+
+[^alborn-partial-customer-fee]: **Junkermier, Clark, Campanella, Stevens, P.C. v. Alborn, Uithoven, Riekenberg, P.C.** — "Rather, the Covenant requires Former Shareholders to pay liquidated damages if they provide services to a Junkermier client within one year of their departure from the firm." *Junkermier, Clark, Campanella, Stevens, P.C. v. Alborn, Uithoven, Riekenberg, P.C., 2016 MT 218, 384 Mont. 464, 380 P.3d 747.* <https://www.courtlistener.com/opinion/4254366/junkermier-clark-campanella-stevens-pc-v-alborn-uithoven/#:~:text=Rather%2C%20the%20Covenant%20requires%20Former,their%20departure%20from%20the%20firm.>
+
+[^jccs-client-payment]: **Junkermier, Clark, Campanella, Stevens, P.C. v. Alborn** — "After conducting a bench trial, the District Court determined JCCS had proven the Covenant was reasonable based on the Dobbins factors." *Junkermier, Clark, Campanella, Stevens, P.C. v. Alborn, 2020 MT 179.* <https://www.courtlistener.com/opinion/4767942/jccs-v-alborn/#:~:text=After%20conducting%20a%20bench%20trial%2C,based%20on%20the%20Dobbins%20factors.>
+
+[^jccs-legitimate-client-base]: **Junkermier, Clark, Campanella, Stevens, P.C. v. Alborn** — "We conclude the District Court did not err by finding JCCS had a legitimate business interest in the Covenant of protecting its client base." *Junkermier, Clark, Campanella, Stevens, P.C. v. Alborn, 2020 MT 179.* <https://www.courtlistener.com/opinion/4767942/jccs-v-alborn/#:~:text=We%20conclude%20the%20District%20Court,of%20protecting%20its%20client%20base.>
+
+[^jccs-damages-amount]: **Junkermier, Clark, Campanella, Stevens, P.C. v. Alborn** — "Appellants owed JCCS $2,353,463.27." *Junkermier, Clark, Campanella, Stevens, P.C. v. Alborn, 2020 MT 179.* <https://www.courtlistener.com/opinion/4767942/jccs-v-alborn/#:~:text=Appellants%20owed%20JCCS%20%242%2C353%2C463.27.>
+
+[^q5-montana-restraint-baseline]: **Mont. Code Ann. § 28-2-703** — "28-2-703. Contracts in restraint of trade generally void. Any contract by which anyone is restrained from exercising a lawful profession, trade, or business of any kind, otherwise than is provided for by 28-2-704 or 28-2-705, is to that extent void." *Mont. Code Ann. § 28-2-703.* <https://mca.legmt.gov/bills/mca/title_0280/chapter_0020/part_0070/section_0030/0280-0020-0070-0030.html>
+
+[^curl-unreasonable-restraint]: **Montana Mountain Products v. Curl** — "Because the covenant prohibits Curl from engaging in her profession, we conclude that it is unreasonable and therefore an unlawful restraint on trade." *Mont. Mountain Prods. v. Curl, 2005 MT 102, 327 Mont. 7, 112 P.3d 979.* <https://www.courtlistener.com/opinion/887309/montana-mountain-products-v-curl/#:~:text=Because%20the%20covenant%20prohibits%20Curl,an%20unlawful%20restraint%20on%20trade.>
+
+[^mungas-absolute-prohibition]: **Mungas v. Great Falls Clinic, LLP** — "The Dobbins Court concluded that in those instances where a contract contains a restraint on a person’s ability to practice their profession, but such restraint is not an absolute prohibition, a factual determination must be made as to whether the covenant not to compete is reasonable." *Mungas v. Great Falls Clinic, LLP, 2009 MT 426, 354 Mont. 50, 221 P.3d 1230.* <https://www.courtlistener.com/opinion/888694/mungas-v-great-falls-clinic-llp/#:~:text=The%20Dobbins%20Court%20concluded%20that,not%20to%20compete%20is%20reasonable.>
+
+[^mungas-no-goodwill-sale]: **Mungas v. Great Falls Clinic, LLP** — "Section 28-2-704(1), MCA, the sale of goodwill exception to the prohibition on contracts in restraint of trade, does not apply to the partnership agreements at issue in this case." *Mungas v. Great Falls Clinic, LLP, 2009 MT 426, 354 Mont. 50, 221 P.3d 1230.* <https://www.courtlistener.com/opinion/888694/mungas-v-great-falls-clinic-llp/#:~:text=Section%2028%2D2%2D704(1)%2C%20MCA%2C%20the%20sale,at%20issue%20in%20this%20case.>
+
+[^montana-goodwill-sale]: **Mont. Code Ann. § 28-2-704** — "28-2-704. Exception -- sale of goodwill of business. (1) A person who sells the goodwill of a business may agree with the buyer to refrain from carrying on a similar business within the areas provided in subsection (2) so long as the buyer or any person deriving title to the goodwill from the buyer carries on a like business in the described areas." *Mont. Code Ann. § 28-2-704.* <https://mca.legmt.gov/bills/mca/title_0280/chapter_0020/part_0070/section_0040/0280-0020-0070-0040.html>
+
+[^montana-partnership-dissolution]: **Mont. Code Ann. § 28-2-705** — "28-2-705. Exception -- dissolution of partnership. Partners may, upon dissolution of the partnership, agree that one or more of them may not carry on a similar business within the areas provided in 28-2-704(2)." *Mont. Code Ann. § 28-2-705.* <https://mca.legmt.gov/bills/mca/title_0280/chapter_0020/part_0070/section_0050/0280-0020-0070-0050.html>
+
+[^montana-goodwill-areas]: **Mont. Code Ann. § 28-2-704** — "(2) The agreement authorized in subsection (1) may apply in: (a) the city where the principal office of the business is located; (b) the county where the principal office of the business is located; (c) a city in any county adjacent to the county in which the principal office of the business is located; (d) any county adjacent to the county in which the principal office of the business is located; or (e) any combination of the areas in subsections (2)(a) through (2)(d)." *Mont. Code Ann. § 28-2-704(2)(e).* <https://mca.legmt.gov/bills/mca/title_0280/chapter_0020/part_0070/section_0040/0280-0020-0070-0040.html>
+
+[^montana-healthcare-practice-ban]: **Mont. Code Ann. § 28-2-724** — "(1) A contract that creates or establishes the terms of employment, a partnership, or any other form of professional relationship with a health care provider described in subsection (2) may not restrict the right of the health care provider, after the termination of the employment, partnership, or other form of professional relationship, to: (a) practice or provide services for which the provider is licensed, in any geographic area and for any period; (b) treat, advise, consult with, or establish a provider-patient relationship with any current patient of the employer or with a patient affiliated with a partnership or other form of professional relationship; or (c) solicit or seek to establish a provider-patient relationship with any current patient of the employer or with a patient affiliated with a partnership or other form of professional relationship." *Mont. Code Ann. § 28-2-724(1).* <https://mca.legmt.gov/bills/mca/title_0280/chapter_0020/part_0070/section_0240/0280-0020-0070-0240.html>
+
+[^montana-healthcare-covered-providers]: **Mont. Code Ann. § 28-2-724** — "(2) The requirements of subsection (1) apply to contracts or agreements involving the following health care providers: (a) a physician licensed under Title 37, chapter 3; (b) a psychologist licensed under Title 37, chapter 17; (c) a naturopathic physician licensed under Title 37, chapter 26; (d) a social worker licensed under Title 37, chapter 39; (e) a professional counselor licensed under Title 37, chapter 39; (f) an addiction counselor licensed under Title 37, chapter 39; (g) a marriage and family therapist licensed under Title 37, chapter 39; (h) a behavioral health peer support specialist licensed under Title 37, chapter 39; (i) a registered professional nurse or an advanced practice registered nurse licensed under Title 37, chapter 8; or (j) a physician assistant licensed under Title 37, chapter 20." *Mont. Code Ann. § 28-2-724(2).* <https://mca.legmt.gov/bills/mca/title_0280/chapter_0020/part_0070/section_0240/0280-0020-0070-0240.html>
+
+[^montana-healthcare-exceptions]: **Mont. Code Ann. § 28-2-724** — "(3) This section does not apply to a contract in connection with the sale and purchase of a practice or to a provision for repayment of all or a portion of money paid or advanced to a physician licensed under Title 37, chapter 3, that is subject to a payback provision that decreases over time, including but not limited to a bona fide loan, relocation cost, signing bonus, education expense, and tuition repayment expense." *Mont. Code Ann. § 28-2-724(3).* <https://mca.legmt.gov/bills/mca/title_0280/chapter_0020/part_0070/section_0240/0280-0020-0070-0240.html>
+
+[^hb198-effective]: **House Bill 198 (Ch. 131, L. 2025)** — "Applicability. [This act] applies to contracts made or renewed on or after [the effective date of this act]." *2025 Mont. Laws ch. 131 (HB 198), §§ 2-3.* <https://archive.legmt.gov/content/Sessions/69th/Contractor_index/CH0131.pdf>
+
+[^hb620-effective]: **House Bill 620 (Ch. 698, L. 2025)** — "Applicability. [This act] applies to contracts made or renewed on or after January 1, 2026." *2025 Mont. Laws ch. 698 (HB 620), §§ 2-3.* <https://archive.legmt.gov/content/Sessions/69th/Contractor_index/CH0698.pdf>
+
+[^mutsa-short-title]: **Mont. Code Ann. § 30-14-401** — "30-14-401. Short title. This part may be cited as the ‘Uniform Trade Secrets Act’." *Mont. Code Ann. § 30-14-401.* <https://mca.legmt.gov/bills/mca/title_0300/chapter_0140/part_0040/section_0010/0300-0140-0040-0010.html>
+
+[^mutsa-injunction]: **Mont. Code Ann. § 30-14-403** — "30-14-403. Injunctive relief -- royalty. (1) Actual or threatened misappropriation may be enjoined." *Mont. Code Ann. § 30-14-403(1).* <https://mca.legmt.gov/bills/mca/title_0300/chapter_0140/part_0040/section_0030/0300-0140-0040-0030.html>
+
+[^montana-partial-void]: **Mont. Code Ann. § 28-2-604** — "28-2-604. When contract partially void. Where a contract has several distinct objects of which one at least is lawful and one at least is unlawful, in whole or in part, the contract is void as to the latter and valid as to the rest." *Mont. Code Ann. § 28-2-604.* <https://mca.legmt.gov/bills/mca/title_0280/chapter_0020/part_0060/section_0040/0280-0020-0060-0040.html>
+
+[^mutsa-trade-secret-definition]: **Mont. Code Ann. § 30-14-402** — "(4) ‘Trade secret’ means information or computer software, including a formula, pattern, compilation, program, device, method, technique, or process, that: (a) derives independent economic value, actual or potential, from not being generally known to and not being readily ascertainable by proper means by other persons who can obtain economic value from its disclosure or use; and (b) is the subject of efforts that are reasonable under the circumstances to maintain its secrecy." *Mont. Code Ann. § 30-14-402(4).* <https://mca.legmt.gov/bills/mca/title_0300/chapter_0140/part_0040/section_0020/0300-0140-0040-0020.html>
+
+[^curl-void-covenant]: **Montana Mountain Products v. Curl** — "However, because we conclude that the covenant is unreasonable, we nonetheless affirm the judgment of the District Court." *Mont. Mountain Prods. v. Curl, 2005 MT 102, 327 Mont. 7, 112 P.3d 979.* <https://www.courtlistener.com/opinion/887309/montana-mountain-products-v-curl/#:~:text=However%2C%20because%20we%20conclude%20that,judgment%20of%20the%20District%20Court.>

--- a/skills/non-compete-contract-explainer/content/nebraska.md
+++ b/skills/non-compete-contract-explainer/content/nebraska.md
@@ -1,0 +1,206 @@
+---
+jurisdiction: "Nebraska"
+slug: nebraska
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-02"
+canonicalUrl: https://openagreements.org/legal/non-compete/nebraska
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/nebraska · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in Nebraska[^about]
+
+Nebraska enforces only narrowly tailored, customer-specific covenants under a common-law reasonableness test, refuses to blue-pencil overbroad employment non-competes, and has no general statutory ban as of 2026.
+
+
+## At a glance
+
+| Question | Nebraska |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed if reasonable |
+| **Bottom line** | Nebraska enforces only narrowly tailored covenants limited to customers the employee personally served, refuses to rewrite overbroad ones, and has no general statutory ban as of 2026. |
+| **Main law or case** | common law (Securities Acceptance Corp. v. Brown, 106 N.W.2d 456 (Neb. 1960); Polly v. Ray D. Hilderman & Co., 407 N.W.2d 751 (Neb. 1987)) |
+| **Main exceptions** | Franchise non-competes reformable by statute (§ 87-404); sale-of-business more favorable; successor enforcement by merger |
+| **Can a court narrow it?** | No |
+| **Applies to contractors?** | Unclear |
+| **Restriction extended during a breach?** | Silent |
+| **Maximum length set by law** | No statutory limit |
+
+## Are employee non-compete agreements enforceable in Nebraska? {#employee-noncompetes}
+
+**Short answer.** Sometimes, but only if the covenant is narrow and reasonable. Nebraska has no general statutory ban as of June 2026, but Nebraska courts enforce employee restraints only when they protect a legitimate interest and do not go beyond what is reasonably necessary [^q1-brown-three-part-test].
+
+The practical rule is stricter than a generic reasonableness label suggests. Nebraska allows protection against unfair competition, such as siphoning customer goodwill, but not ordinary competition from a former employee. Broad bans on working in the same business, serving all company customers, or using general skills are high-risk.
+
+Nebraska also has statutory restraint-of-trade language in the background. The civil antitrust statute says contracts in restraint of trade or commerce are unlawful, and the older criminal statute declares covered restraints illegal [^q1-restraint-civil][^q1-restraint-criminal].
+
+## What is Nebraska's reasonableness test for non-competes? {#reasonableness-test}
+
+**Short answer.** Nebraska asks three questions: whether the restraint injures the public, whether it is no greater than reasonably necessary to protect a legitimate employer interest, and whether it is unduly harsh or oppressive to the employee [^q2-aon-reasonableness-test].
+
+That test is applied to the covenant as written. The employer's legitimate interest is usually customer goodwill, confidential information, or trade secrets. The employer is not entitled to stop ordinary competition just because the former worker became a stronger competitor through general experience.
+
+*Aon* shows the enforceable side of the line. The covenant there reached only customers with whom the employee had personal business dealings during the last two years, so the court treated it as focused on goodwill rather than ordinary competition [^q2-aon-focused-goodwill].
+
+## What customer restrictions work in Nebraska? {#customer-specific-rule}
+
+**Short answer.** The safest Nebraska customer covenant is limited to clients or accounts the employee actually served and had personal contact with. Limiting no-solicit or no-deal language to that customer set is a necessary condition under *Polly*, not a complete safe harbor — the covenant still must satisfy the general reasonableness test [^q3-polly-customer-rule].
+
+The key case is *Polly*. The employer had many accounts the employee never handled or even knew, so a covenant reaching those accounts was too broad. Nebraska's protectable interest is the goodwill the employee could unfairly take because of personal customer relationships, not every relationship the employer owns.
+
+*Sisk* applied the same rule in 2024. The court rejected a media-company non-solicit because it reached customers with whom the *company* had an actual or prospective relationship, instead of limiting the restraint to customers the employee actually did business with and personally contacted [^q3-sisk-prospective-clients].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not include prospective customers in an ordinary Nebraska employee customer restriction. Even if the employee had personal contact, a covenant that reaches beyond customers the employee actually did business with risks being void in full [^q3-sisk-prospective-clients].
+
+## Are geographic employee non-competes valid in Nebraska? {#geographic-noncompetes}
+
+**Short answer.** Usually high-risk for ordinary employees. Nebraska employment covenants are safest when customer-specific, because a geographic or business-activity ban often blocks ordinary competition rather than protecting a defined goodwill interest [^q4-gaver-ordinary-competition].
+
+*Gaver* shows the risk. Applying the reasonableness test, the Nebraska Supreme Court struck a covenant it found aimed at ordinary competition rather than at protecting a legitimate interest such as customer goodwill. The lesson for drafting is to tie any restraint to a recognized protectable interest and keep it no broader than necessary, rather than relying on a radius or territory.
+
+Older cases sometimes enforced geographic language, and sale-of-business covenants are different. For current employment drafting, the conservative Nebraska approach is to avoid a radius or territory ban unless the covenant is truly ancillary to a sale or is otherwise tied to a very specific customer pool.
+
+> [!NOTE]
+> **Practice note.**
+>
+> A short radius is not a Nebraska safe harbor. If the practical effect is to stop the employee from using general skill in the market, the restraint still risks failing as ordinary competition [^q4-gaver-ordinary-competition].
+
+## Will Nebraska courts rewrite an overbroad non-compete? {#court-narrowing}
+
+**Short answer.** No, not for ordinary employment covenants. Nebraska rejects blue-pencil rewriting and generally enforces the covenant as written or not at all [^q5-waadah-blue-pencil].
+
+This is one of Nebraska's most important drafting rules. If the covenant reaches too far, the court does not trim the term, delete the bad customer category, or rewrite the geography to something reasonable. *Waadah* also confirms that when integrated restraints are not severable, one invalid part can make the whole non-compete agreement unenforceable [^q5-waadah-entire-covenant].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Draft as if there is no rescue. Nebraska's franchise statute creates a separate exception, but that exception should not be carried into ordinary employment agreements [^q5-waadah-blue-pencil][^q5-waadah-entire-covenant].
+
+## How are sale-of-business non-competes treated in Nebraska? {#sale-of-business}
+
+**Short answer.** Sale-of-business covenants get more room than ordinary employee restraints, because the buyer is paying for goodwill and customer relationships. The covenant still must be reasonable in character, space, and time [^q6-chambers-goodwill-sale].
+
+*Chambers-Dobson* involved both a sale agreement and a later employment agreement. The sale covenant protected the purchased customer list and goodwill; the employment covenant was upheld separately because the employee acquired customer information and goodwill during employment and the restricted customer pools were limited. Either way, the restrained party could still compete broadly outside those specific customer pools.
+
+That distinction matters. A sale covenant can protect purchased goodwill; an employment covenant cannot be a disguised market ban merely because the employee knows the business.
+
+## Can a successor enforce a Nebraska non-compete after a merger? {#successor-merger}
+
+**Short answer.** Yes, when the merger statute governing the transaction transfers the covenant by operation of law. In *Aon*, applying a merger statute like Maryland's, the Nebraska Supreme Court held a successor could enforce a predecessor's covenant even without a separate assignment clause [^q7-aon-merger-successor].
+
+This rule is about merger law, not automatic enforcement of every assigned employee covenant. The surviving company still must prove the covenant is valid under Nebraska reasonableness rules. In *Aon*, that worked because the restriction was tied to customers the employee personally dealt with during the last two years [^q7-aon-valid-and-passed].
+
+## What is Nebraska's franchise non-compete exception? {#franchise-reformation}
+
+**Short answer.** Nebraska has a franchise-only statutory reformation rule. If a franchise non-compete is unreasonable, the court or arbitrator must reform it to a reasonable and enforceable scope [^q8-franchise-reformation].
+
+This is the lone statutory exception to the ordinary no-reformation rule covered in this note. It applies to franchise non-compete agreements and specified franchise-related parties, not to ordinary employer-employee covenants.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not cite the franchise statute as a general Nebraska blue-pencil rule. It says what happens in franchise non-compete agreements; employment covenants remain governed by Nebraska's common-law all-or-nothing approach [^q8-franchise-reformation][^q8-waadah-no-general-reform].
+
+## Can another state's law save a Nebraska non-compete? {#choice-of-law}
+
+**Short answer.** Not reliably. Nebraska courts may apply Nebraska law when the services and competition are centered in Nebraska, especially if enforcing broader foreign law would undercut Nebraska public policy [^q9-mertz-nebraska-law-controls].
+
+*Mertz* did not involve an express choice-of-law clause, but it is still important for multistate drafting. The Nebraska Supreme Court applied Nebraska law to an Iowa employer's covenant because the employee worked only in Nebraska and the competition affected Nebraska. The court also emphasized Nebraska's public policy against overbroad postemployment restraints [^q9-mertz-public-policy].
+
+For a Nebraska worker, a foreign-law clause is therefore a risk variable, not a cure. The covenant should be drafted to satisfy Nebraska law if Nebraska is the likely place of work, customers, and enforcement.
+
+## Do trade secrets make a Nebraska non-compete enforceable? {#trade-secrets}
+
+**Short answer.** No. Nebraska's Trade Secrets Act gives a separate statutory claim for misappropriation and a narrow definition of what counts as a trade secret, but it does not state a non-compete safe harbor. A covenant still must satisfy Nebraska's reasonableness limits [^q10-trade-secrets-act][^q10-trade-secret-definition][^q10-brown-reasonableness].
+
+Trade-secret and confidentiality tools are often better targeted than a broad non-compete. But Nebraska's statutory definition is demanding: the information must derive independent economic value from not being known or ascertainable by proper means, and the owner must make reasonable secrecy efforts.
+
+Use trade-secret provisions for information risk, and use customer covenants only for the customer relationships Nebraska recognizes as protectable.
+
+## Does a Nebraska non-compete period toll during breach or litigation? {#tolling-extension}
+
+**Short answer.** Nebraska appellate case law is silent. No staged Nebraska appellate decision squarely addresses whether a court may toll a non-compete period during breach or litigation, or whether a contractual extension-on-breach clause is enforceable [^q11-brown-reasonableness].
+
+The conservative read is to treat tolling as another restraint that must be reasonable when the covenant is enforced as written. Nebraska requires the restraint to be no greater than reasonably necessary, and Nebraska refuses to reform overbroad covenants simply to make them enforceable [^q11-brown-reasonableness][^q11-waadah-no-reform].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not describe Nebraska as having a tolling holding. An aggressive extension clause that lengthens the restraint during alleged breach or litigation could face the same all-or-nothing overbreadth problem as any other Nebraska covenant term [^q11-brown-reasonableness][^q11-waadah-no-reform].
+
+## What should a Nebraska non-compete drafting checklist include? {#drafting-checklist}
+
+**Short answer.** Start with the narrowest protectable interest: specific customers the employee personally served, a reasonable lookback, separate confidentiality and trade-secret terms, and no reliance on court rewriting [^q12-polly-customer-check][^q12-gaver-no-reform-check].
+
+For ordinary employees, avoid all-customer, prospective-customer, all-competitor, and broad geographic bans. Tie any no-solicit or no-deal restriction to customers the employee actually did business with and had personal contact with. Keep sale-of-business, franchise, merger, and trade-secret issues in separate drafting lanes.
+
+For modern media, technology, and sales roles, *Sisk* is the practical warning. Broad definitions of competitive work, including substantially similar products or services, can make even a short covenant too broad under Nebraska law [^q12-sisk-modern-warning].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> One overbroad term can be fatal. Nebraska drafting should be conservative at the front end because a court may not trim the covenant after the dispute starts [^q12-gaver-no-reform-check][^q12-sisk-modern-warning].
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-02. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not Nebraska. This article synthesizes Nebraska primary law and is not legal advice from a Nebraska-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^q1-brown-three-part-test]: **Securities Acceptance Corp. v. Brown** — "There are three general requirements relating to partial restraints of trade: First, is the restriction reasonable in the sense that it is not injurious to the public; second, is the restriction reasonable in the sense that it is no greater than is reasonably necessary to protect the employer in some legitimate interest; and, third, is the restriction reasonable in the sense that it is not unduly harsh and oppressive on the employee." *Securities Acceptance Corp. v. Brown, 171 Neb. 406, 417, 106 N.W.2d 456 (1960).* <https://www.courtlistener.com/opinion/1948918/securities-acceptance-corporation-v-brown/#:~:text=There%20are%20three%20general%20requirements,and%20oppressive%20on%20the%20employee.>
+
+[^q1-restraint-civil]: **Neb. Rev. Stat. § 59-1603** — "Any contract, combination, in the form of trust or otherwise, or conspiracy in restraint of trade or commerce shall be unlawful." *Neb. Rev. Stat. § 59-1603.* <https://nebraskalegislature.gov/laws/statutes.php?statute=59-1603>
+
+[^q1-restraint-criminal]: **Neb. Rev. Stat. § 59-801** — "Every contract, combination in the form of trust or otherwise, or conspiracy in restraint of trade or commerce, within this state, is hereby declared to be illegal." *Neb. Rev. Stat. § 59-801.* <https://nebraskalegislature.gov/laws/statutes.php?statute=59-801>
+
+[^q2-aon-reasonableness-test]: **Aon Consulting, Inc. v. Midlands Financial Benefits, Inc.** — "In determining whether a covenant not to compete is valid, a court considers whether the restriction is (1) reasonable in the sense that it is not injurious to the public, (2) not greater than is reasonably necessary to protect the employer in some legitimate interest, and (3) not unduly harsh and oppressive on the employee." *Aon Consulting, Inc. v. Midlands Fin. Benefits, Inc., 275 Neb. 642, 748 N.W.2d 626 (2008).* <https://www.courtlistener.com/opinion/2139960/aon-consulting-v-midlands-financial/#:~:text=In%20determining%20whether%20a%20covenant,and%20oppressive%20on%20the%20employee.>
+
+[^q2-aon-focused-goodwill]: **Aon Consulting, Inc. v. Midlands Financial Benefits, Inc.** — "The agreement was properly focused on the legitimate purpose of protecting Aon's goodwill with its customers." *Aon Consulting, Inc. v. Midlands Fin. Benefits, Inc., 275 Neb. 642, 748 N.W.2d 626 (2008).* <https://www.courtlistener.com/opinion/2139960/aon-consulting-v-midlands-financial/#:~:text=The%20agreement%20was%20properly%20focused,Aon's%20goodwill%20with%20its%20customers.>
+
+[^q3-polly-customer-rule]: **Polly v. Ray D. Hilderman & Co.** — "Such a covenant may be valid only if it restricts the former employee from working for or soliciting the former employer’s clients or accounts with whom the former employee actually did business and has personal contact." *Polly v. Ray D. Hilderman & Co., 225 Neb. 662, 668, 407 N.W.2d 751 (1987).* <https://www.courtlistener.com/opinion/1235956/polly-v-ray-d-hilderman-co/#:~:text=Such%20a%20covenant%20may%20be,business%20and%20has%20personal%20contact.>
+
+[^q3-sisk-prospective-clients]: **Sisk v. Scripps Media, Inc.** — "This provision greatly exceeds the permissible scope of customers an employee may be precluded from contacting by a restrictive covenant under Nebraska law." *Sisk v. Scripps Media, Inc., No. 8:24CV86, 2024 WL 1175140 (D. Neb. Mar. 18, 2024).* <https://www.govinfo.gov/app/details/USCOURTS-ned-8_24-cv-00086>
+
+[^q4-gaver-ordinary-competition]: **Gaver v. Schneider's O.K. Tire Co.** — "The noncompete agreement as written is an attempt to prevent ordinary competition, not improper or unjust competition, and we reject Schneider’s arguments to the contrary." *Gaver v. Schneider's O.K. Tire Co., 289 Neb. 491 (2014).* <https://www.courtlistener.com/opinion/2751413/gaver-v-schneiders-ok-tire-co/#:~:text=The%20noncompete%20agreement%20as%20written,Schneider%E2%80%99s%20arguments%20to%20the%20contrary.>
+
+[^q5-waadah-blue-pencil]: **Unlimited Opportunity, Inc. v. Waadah** — "We decline Jani-King’s invitation to reconsider our rejection of the blue pencil rule." *Unlimited Opportunity, Inc. v. Waadah, 290 Neb. 629, 637, 861 N.W.2d 437 (2015).* <https://www.courtlistener.com/opinion/2792825/unlimited-opportunity-v-waadah/#:~:text=We%20decline%20Jani%2DKing%E2%80%99s%20invitation%20to,of%20the%20blue%20pencil%20rule.>
+
+[^q5-waadah-entire-covenant]: **Unlimited Opportunity, Inc. v. Waadah** — "The district court was correct to consider the two covenants together and find the entire clause invalid if one portion is invalid." *Unlimited Opportunity, Inc. v. Waadah, 290 Neb. 629, 637, 861 N.W.2d 437 (2015).* <https://www.courtlistener.com/opinion/2792825/unlimited-opportunity-v-waadah/#:~:text=The%20district%20court%20was%20correct,if%20one%20portion%20is%20invalid.>
+
+[^q6-chambers-goodwill-sale]: **Chambers-Dobson, Inc. v. Squier** — "Thus, a covenant not to compete which is contained in a contract for sale of a business is a seller’s self-imposed restraint from trade and is frequently necessary to make goodwill in the seller’s business a transferable asset and ensure that the buyer receives the full value of acquired goodwill." *Chambers-Dobson, Inc. v. Squier, 238 Neb. 748, 756, 472 N.W.2d 391 (1991).* <https://www.courtlistener.com/opinion/2189174/chambers-dobson-inc-v-squier/#:~:text=Thus%2C%20a%20covenant%20not%20to,full%20value%20of%20acquired%20goodwill.>
+
+[^q7-aon-merger-successor]: **Aon Consulting, Inc. v. Midlands Financial Benefits, Inc.** — "We agree with those cases which hold, under statutes similar to Maryland's, that a covenant not to compete is an asset of a corporation which passes by operation of law to a successor corporation as the result of a merger, regardless of whether the agreement would otherwise be assignable." *Aon Consulting, Inc. v. Midlands Fin. Benefits, Inc., 275 Neb. 642, 748 N.W.2d 626 (2008).* <https://www.courtlistener.com/opinion/2139960/aon-consulting-v-midlands-financial/#:~:text=We%20agree%20with%20those%20cases,agreement%20would%20otherwise%20be%20assignable.>
+
+[^q7-aon-valid-and-passed]: **Aon Consulting, Inc. v. Midlands Financial Benefits, Inc.** — "For the reasons discussed, we conclude that the nonsolicitation agreement between Pearson and A & A was valid under Nebraska law and that the right to enforce the agreement passed to Aon by operation of law when it acquired A & A by merger." *Aon Consulting, Inc. v. Midlands Fin. Benefits, Inc., 275 Neb. 642, 748 N.W.2d 626 (2008).* <https://www.courtlistener.com/opinion/2139960/aon-consulting-v-midlands-financial/#:~:text=For%20the%20reasons%20discussed%2C%20we,A%20%26%20A%20by%20merger.>
+
+[^q8-franchise-reformation]: **Neb. Rev. Stat. § 87-404** — "If restrictions in a noncompete agreement are found by an arbitrator or a court to be unreasonable in restraining competition, the arbitrator or court shall reform the terms of the noncompete agreement to the extent necessary to cause the restrictions contained therein to be reasonable and enforceable." *Neb. Rev. Stat. § 87-404(2).* <https://nebraskalegislature.gov/laws/statutes.php?statute=87-404>
+
+[^q8-waadah-no-general-reform]: **Unlimited Opportunity, Inc. v. Waadah** — "It is not the function of the courts to reform a covenant not to compete in order to make it enforceable." *Unlimited Opportunity, Inc. v. Waadah, 290 Neb. 629, 630, 861 N.W.2d 437 (2015).* <https://www.courtlistener.com/opinion/2792825/unlimited-opportunity-v-waadah/#:~:text=It%20is%20not%20the%20function,order%20to%20make%20it%20enforceable.>
+
+[^q9-mertz-nebraska-law-controls]: **Mertz v. Pharmacists Mutual Insurance Co.** — "Accordingly, Nebraska law should be applied to determine the validity of the covenant." *Mertz v. Pharmacists Mut. Ins. Co., 261 Neb. 704, 710, 625 N.W.2d 197 (2001).* <https://www.courtlistener.com/opinion/1245316/mertz-v-pharmacists-mutual-insurance/#:~:text=Accordingly%2C%20Nebraska%20law%20should%20be,the%20validity%20of%20the%20covenant.>
+
+[^q9-mertz-public-policy]: **Mertz v. Pharmacists Mutual Insurance Co.** — "In Nebraska, this court has refused to enforce postemployment covenants not to compete which are broader than reasonably necessary to protect legitimate business interests on the ground that such covenants are against public policy and void." *Mertz v. Pharmacists Mut. Ins. Co., 261 Neb. 704, 710, 625 N.W.2d 197 (2001).* <https://www.courtlistener.com/opinion/1245316/mertz-v-pharmacists-mutual-insurance/#:~:text=In%20Nebraska%2C%20this%20court%20has,against%20public%20policy%20and%20void.>
+
+[^q10-trade-secrets-act]: **Neb. Rev. Stat. § 87-501** — "Sections 87-501 to 87-507 shall be known and may be cited as the Trade Secrets Act." *Neb. Rev. Stat. § 87-501.* <https://nebraskalegislature.gov/laws/statutes.php?statute=87-501>
+
+[^q10-trade-secret-definition]: **Neb. Rev. Stat. § 87-502** — "Trade secret shall mean information, including, but not limited to, a drawing, formula, pattern, compilation, program, device, method, technique, code, or process that: (a) Derives independent economic value, actual or potential, from not being known to, and not being ascertainable by proper means by, other persons who can obtain economic value from its disclosure or use; and (b) Is the subject of efforts that are reasonable under the circumstances to maintain its secrecy." *Neb. Rev. Stat. § 87-502(4).* <https://nebraskalegislature.gov/laws/statutes.php?statute=87-502>
+
+[^q10-brown-reasonableness]: **Securities Acceptance Corp. v. Brown** — "There are three general requirements relating to partial restraints of trade: First, is the restriction reasonable in the sense that it is not injurious to the public; second, is the restriction reasonable in the sense that it is no greater than is reasonably necessary to protect the employer in some legitimate interest; and, third, is the restriction reasonable in the sense that it is not unduly harsh and oppressive on the employee." *Securities Acceptance Corp. v. Brown, 171 Neb. 406, 417, 106 N.W.2d 456 (1960).* <https://www.courtlistener.com/opinion/1948918/securities-acceptance-corporation-v-brown/#:~:text=There%20are%20three%20general%20requirements,and%20oppressive%20on%20the%20employee.>
+
+[^q11-brown-reasonableness]: **Securities Acceptance Corp. v. Brown** — "A contract in restraint of trade, which is neither limited in time nor space, is against public policy and void." *Securities Acceptance Corp. v. Brown, 171 Neb. 406, 422, 106 N.W.2d 456 (1960).* <https://www.courtlistener.com/opinion/1948918/securities-acceptance-corporation-v-brown/#:~:text=A%20contract%20in%20restraint%20of,against%20public%20policy%20and%20void.>
+
+[^q11-waadah-no-reform]: **Unlimited Opportunity, Inc. v. Waadah** — "It is not the function of the courts to reform a covenant not to compete in order to make it enforceable." *Unlimited Opportunity, Inc. v. Waadah, 290 Neb. 629, 630, 861 N.W.2d 437 (2015).* <https://www.courtlistener.com/opinion/2792825/unlimited-opportunity-v-waadah/#:~:text=It%20is%20not%20the%20function,order%20to%20make%20it%20enforceable.>
+
+[^q12-polly-customer-check]: **Polly v. Ray D. Hilderman & Co.** — "Because the covenant not to compete in this case attempts to restrict Polly from soliciting or working for Hilderman’s clients with whom Polly did not work and did not even know, it is greater than is reasonably necessary to protect Hilderman’s legitimate interest in customer goodwill, and is thus unreasonable and unenforceable." *Polly v. Ray D. Hilderman & Co., 225 Neb. 662, 669, 407 N.W.2d 751 (1987).* <https://www.courtlistener.com/opinion/1235956/polly-v-ray-d-hilderman-co/#:~:text=Because%20the%20covenant%20not%20to,is%20thus%20unreasonable%20and%20unenforceable.>
+
+[^q12-gaver-no-reform-check]: **Gaver v. Schneider's O.K. Tire Co.** — "We have determined above that the noncompete agreement in this case is unreasonable, and we do not reform it to make it enforceable." *Gaver v. Schneider's O.K. Tire Co., 289 Neb. 491 (2014).* <https://www.courtlistener.com/opinion/2751413/gaver-v-schneiders-ok-tire-co/#:~:text=We%20have%20determined%20above%20that,it%20to%20make%20it%20enforceable.>
+
+[^q12-sisk-modern-warning]: **Sisk v. Scripps Media, Inc.** — "Because both covenants at issue are unreasonable and unenforceable under Nebraska law, Sisk has demonstrated a fair chance of prevailing on the merits of his underlying action." *Sisk v. Scripps Media, Inc., No. 8:24CV86, 2024 WL 1175140 (D. Neb. Mar. 18, 2024).* <https://www.govinfo.gov/app/details/USCOURTS-ned-8_24-cv-00086>

--- a/skills/non-compete-contract-explainer/content/nevada.md
+++ b/skills/non-compete-contract-explainer/content/nevada.md
@@ -1,0 +1,278 @@
+---
+jurisdiction: "Nevada"
+slug: nevada
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-02"
+canonicalUrl: https://openagreements.org/legal/non-compete/nevada
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/nevada · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in Nevada[^about]
+
+A question-by-question summary of Nevada non-compete law, including NRS 613.195, mandatory judicial revision, hourly-wage workers, volunteer customer limits, layoffs, assignment in transactions, healthcare covenants, and trade-secret alternatives.
+
+
+## At a glance
+
+| Question | Nevada |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed if reasonable |
+| **Bottom line** | Nevada enforces employee non-competes that meet a four-part statutory reasonableness test, but bans them for solely hourly-wage workers and requires courts to revise overbroad covenants. |
+| **Main law or case** | NRS 613.195 |
+| **Main exceptions** | Hourly-wage workers excluded; volunteer-customer safe harbor; layoff/RIF enforceable only while employer pays; sale-of-business antitrust carve-out (NRS 598A.040) |
+| **Can a court narrow it?** | Yes — rewrites to reasonable |
+| **Applies to contractors?** | Unclear |
+| **Restriction extended during a breach?** | Silent — no authority |
+| **Maximum length set by law** | No statutory limit |
+
+## Are employee non-compete agreements enforceable in Nevada? {#employee-noncompetes}
+
+**Short answer.** Yes, if they satisfy Nevada's statute. A non-compete is void unless it is supported by valuable consideration, protects no more than the employer needs, avoids undue hardship, and uses restrictions appropriate to the consideration given [^q1-nrs-613-195-enforceability].
+
+Nevada is a reasonableness state with a detailed statutory overlay. The core rule is NRS 613.195(1), which states the enforceability test directly.
+
+"A noncompetition covenant is void and unenforceable unless the noncompetition covenant: (a) Is supported by valuable consideration; (b) Does not impose any restraint that is greater than is required for the protection of the employer for whose benefit the restraint is imposed; (c) Does not impose any undue hardship on the employee; and (d) Imposes restrictions that are appropriate in relation to the valuable consideration supporting the noncompetition covenant."[^q1-nrs-613-195-enforceability]
+
+That makes Nevada more permissive than a ban state, but it is not a free drafting state. The statute also removes hourly-only workers, protects certain former customers, limits enforcement after a layoff or restructuring, and requires fee shifting in specified unlawful-enforcement cases.
+
+## What must a valid Nevada non-compete satisfy? {#valid-covenant-requirements}
+
+**Short answer.** Four statutory requirements. The covenant must have valuable consideration, avoid restraints greater than necessary, avoid undue hardship, and keep the restrictions appropriate to the consideration supporting the covenant [^q2-nrs-613-195-four-prong].
+
+The four requirements work together. Consideration alone does not make a restraint enforceable, and a reasonable time period does not cure an overbroad activity ban. A Nevada court still asks whether the covenant protects the employer without imposing an excessive restraint or employee hardship.
+
+The fourth requirement is especially important for mid-employment agreements. It asks whether the restriction is appropriate in relation to the consideration, so the value given for the covenant matters to the scope the employer asks a court to enforce [^q2-nrs-613-195-four-prong].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Draft the restriction around the actual interest being protected. Nevada's statutory text makes the employer justify both the business need and the fit between the restraint and the consideration [^q2-nrs-613-195-four-prong].
+
+## Must a Nevada court revise an overbroad non-compete instead of voiding it? {#court-revision}
+
+**Short answer.** Usually yes, when revision is possible. NRS 613.195(6) directs the court to revise and enforce an overbroad but consideration-supported covenant, and *Tough Turtle Turf* confirms that judicial revision is mandatory when the court can revise instead of rewrite the agreement [^q3-nrs-613-195-revision][^q3-tough-turtle-mandatory][^q3-tough-turtle-rewrite].
+
+The statute gives Nevada courts a mandatory reformation role for covenants that are supported by valuable consideration but are unreasonable in time, geography, activity scope, restraint level, or employee hardship.
+
+"If an employer brings an action to enforce a noncompetition covenant or an employee brings an action to challenge a noncompetition covenant and the court finds the covenant is supported by valuable consideration but contains limitations as to time, geographical area or scope of activity to be restrained that are not reasonable, imposes a greater restraint than is necessary for the protection of the employer for whose benefit the restraint is imposed or imposes undue hardship on the employee, the court shall revise the covenant to the extent necessary and enforce the covenant as revised."[^q3-nrs-613-195-revision]
+
+That was a statutory change from the prior *Golden Road* rule. In 2016, before NRS 613.195 took effect, the Nevada Supreme Court treated an unreasonable non-compete as wholly unenforceable [^q3-golden-road-old-rule].
+
+"Under Nevada law, such an unreasonable provision renders the noncompete agreement wholly unenforceable."[^q3-golden-road-old-rule]
+
+The Legislature then superseded that no-reformation rule. *Tough Turtle Turf* explains the history and the current limit: the court must revise when possible, but it need not supply missing essential terms or create a new contract.
+
+"This provision overruled Golden Road's holding that an unreasonable noncompete covenant can never be revised."[^q3-tough-turtle-overruled]
+
+"It nonetheless mandates judicial revision of a restrictive covenant if this can be done without subjecting employees to unreasonable terms."[^q3-tough-turtle-mandatory]
+
+For older agreements, *Duong* adds a separate path. Even before the statute applied, the Nevada Supreme Court allowed blue-penciling when the covenant itself had a savings or reformation clause [^q3-duong-savings-clause].
+
+"We hold that Golden Road does not prohibit a district court from blue-penciling an unreasonable noncompetition agreement if the agreement itself allows for it."[^q3-duong-savings-clause]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not rely on Nevada revision to fill missing deal terms. *Tough Turtle Turf* requires revision when possible, but the court still distinguishes revising an existing covenant from writing a new one for the parties [^q3-tough-turtle-mandatory][^q3-tough-turtle-rewrite].
+
+## Can a Nevada non-compete apply to an hourly-wage worker? {#hourly-wage-workers}
+
+**Short answer.** No, if the employee is paid solely on an hourly wage basis. NRS 613.195(3) says a non-compete may not apply to that employee, excluding tips and gratuities from the analysis [^q4-nrs-613-195-hourly].
+
+"A noncompetition covenant may not apply to an employee who is paid solely on an hourly wage basis, exclusive of any tips or gratuities."[^q4-nrs-613-195-hourly]
+
+The important unresolved edge case is the word *solely*. Nevada appellate courts have not squarely decided whether a worker paid hourly plus commission, a nondiscretionary bonus, or another non-tip form of compensation falls outside subsection 3. That issue should be treated as open until Nevada courts or the Legislature address it.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not assume a small add-on payment makes an hourly worker covenant enforceable. The statute creates mandatory fee risk for unlawful enforcement, and the hourly-plus-commission boundary remains unsettled [^q4-nrs-613-195-hourly][^q4-nrs-613-195-fees].
+
+## Can a Nevada employer stop a former employee from serving a customer who sought them out? {#volunteer-customers}
+
+**Short answer.** Usually no, if the statutory safe harbor is met. Nevada bars an employer from restricting service to a former customer when the employee did not solicit the customer, the customer voluntarily chose the employee, and the employee otherwise follows the covenant's valid time, geographic, and activity limits [^q5-nrs-613-195-customer].
+
+"A noncompetition covenant may not restrict, and an employer may not bring an action to restrict, a former employee of an employer from providing service to a former customer or client if: (a) The former employee did not solicit the former customer or client; (b) The customer or client voluntarily chose to leave and seek services from the former employee; and (c) The former employee is otherwise complying with the limitations in the covenant as to time, geographical area and scope of activity to be restrained, other than any limitation on providing services to a former customer or client who seeks the services of the former employee without any contact instigated by the former employee."[^q5-nrs-613-195-customer]
+
+This is a service safe harbor, not a general permission to solicit. The former employee still needs to comply with valid time, territory, and activity limits, and the customer must come without contact instigated by the employee.
+
+> [!NOTE]
+> **Practice note.**
+>
+> An absolute no-service clause for former customers is risky in Nevada. If the customer independently seeks out the former employee and the statutory conditions are met, enforcing that clause can trigger fee shifting [^q5-nrs-613-195-customer][^q5-nrs-613-195-fees].
+
+## What happens to a Nevada non-compete after a layoff or reduction in force? {#layoff-reduction-in-force}
+
+**Short answer.** It is enforceable only while the employer keeps paying. For an employer-driven reduction in force, reorganization, or similar restructuring, Nevada allows enforcement only during the period the employer pays salary, benefits, equivalent compensation, or severance [^q6-nrs-613-195-rif].
+
+"If the termination of the employment of an employee is the result of a reduction of force, reorganization or similar restructuring of the employer, a noncompetition covenant is only enforceable during the period in which the employer is paying the employee’s salary, benefits or equivalent compensation, including, without limitation, severance pay."[^q6-nrs-613-195-rif]
+
+This operates like conditional garden leave for layoffs and restructurings. It does not say every involuntary termination requires pay; the trigger is a reduction of force, reorganization, or similar restructuring. The current staged statute places this rule in subsection 5.
+
+## What are the penalties for enforcing an unlawful Nevada non-compete? {#fees-penalties}
+
+**Short answer.** Fee shifting can be mandatory. If the employer enforces against a solely hourly-wage employee, or restricts or attempts to restrict a protected volunteer-customer situation, the court must award the employee reasonable attorney's fees and costs [^q7-nrs-613-195-fees].
+
+"If an employer brings an action to enforce a noncompetition covenant or an employee brings an action to challenge a noncompetition covenant and the court finds that the noncompetition covenant applies to an employee described in subsection 3 or that the employer has restricted or attempted to restrict a former employee in the manner described in subsection 2, the court shall award the employee reasonable attorney’s fees and costs."[^q7-nrs-613-195-fees]
+
+The word *shall* matters. This is not merely a discretionary prevailing-party rule for every covenant dispute; it is a mandatory award tied to the hourly-worker ban and the volunteer-customer safe harbor.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Screen the worker's compensation structure and the customer facts before filing. Nevada makes the fee consequence mandatory when the covenant reaches subsection 3 employees or subsection 2 customer-service activity [^q7-nrs-613-195-fees].
+
+## What consideration supports a Nevada non-compete? {#consideration}
+
+**Short answer.** Historically, continued at-will employment was enough, but the modern statute adds a proportionality question. *Camco* held continued employment sufficient at common law, while NRS 613.195 now also requires restrictions appropriate to the valuable consideration supporting the covenant [^q8-camco-consideration][^q8-nrs-613-195-consideration].
+
+In *Camco*, the Nevada Supreme Court adopted the majority rule that continued employment can support a post-hire non-compete.
+
+"Today we adopt the majority rule which states that an at-will employee's continued employment is sufficient consideration for enforcing a non-competition agreement."[^q8-camco-consideration]
+
+The statute now speaks in two places. The covenant must be supported by valuable consideration, and the restrictions must be appropriate in relation to that consideration [^q8-nrs-613-195-consideration].
+
+"A noncompetition covenant is void and unenforceable unless the noncompetition covenant: (a) Is supported by valuable consideration; (b) Does not impose any restraint that is greater than is required for the protection of the employer for whose benefit the restraint is imposed; (c) Does not impose any undue hardship on the employee; and (d) Imposes restrictions that are appropriate in relation to the valuable consideration supporting the noncompetition covenant."[^q8-nrs-613-195-consideration]
+
+The open question is how much *Camco* survives the statutory proportionality requirement in a difficult case. Continued employment remains important Nevada authority, but no staged Nevada appellate source squarely decides whether continued employment alone satisfies NRS 613.195(1)(d) for a severe covenant.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> For a mid-employment rollout, fresh value is safer than relying only on continued employment. *Camco* supports continued employment as consideration, but the current statute separately tests whether the restriction is appropriate to the consideration [^q8-camco-consideration][^q8-nrs-613-195-consideration].
+
+## Does a Nevada non-compete toll or extend during breach or litigation? {#tolling-during-breach}
+
+**Short answer.** This is an open question. Nevada's staged statute and cases do not squarely address judicial tolling or contractual extension clauses, though NRS 613.195(6) lets a court revise and enforce reasonable terms when revision is possible [^q9-nrs-613-195-revision].
+
+Many covenants say the restricted period pauses during breach or litigation so the employer receives the full period of compliance. The staged Nevada authorities do not contain a Nevada holding approving or rejecting that kind of tolling clause.
+
+As a mandatory revision state, Nevada gives courts authority to revise time, geography, and activity restrictions and enforce the covenant as revised.
+
+"Such revisions must cause the limitations contained in the covenant as to time, geographical area and scope of activity to be restrained to be reasonable, to not impose undue hardship on the employee and to impose a restraint that is not greater than is necessary for the protection of the employer for whose benefit the restraint is imposed."[^q9-nrs-613-195-revision]
+
+That supports an inference that a reasonable, clearly drafted contractual extension-on-breach clause could be considered with the rest of the covenant. It is only an inference, not a Nevada tolling holding.
+
+> [!NOTE]
+> **Practice note.**
+>
+> No staged Nevada statute or case squarely decides whether a court may extend a non-compete period for breach or pending litigation. Treat tolling as unsettled, and draft any extension clause as a defined, reasonable term rather than an open-ended restraint [^q9-nrs-613-195-revision].
+
+## Can a Nevada non-compete be assigned in a sale of the business or a merger? {#assignment-sale-merger}
+
+**Short answer.** It depends on the transaction. In an asset sale, *Traffic Control Services* treats employee non-competes as personal and unassignable absent the employee's express consent, obtained through arm's-length negotiation and supported by separate consideration; in a statutory merger, *HD Supply* says the nonassignability rule does not apply [^q10-traffic-control-consent][^q10-hd-supply-merger].
+
+The asset-sale rule is strict. *Traffic Control Services* held that employee non-competes are personal in nature, so an asset buyer cannot enforce them without the employee's express consent, obtained through arm's-length negotiation and supported by separate consideration.
+
+"Covenants not to compete are personal in nature and therefore are not assignable absent the employee's express consent. Further, an employer must obtain such consent through arm's-length negotiation with the employee, supported by valuable consideration beyond that necessary to support the underlying covenant."[^q10-traffic-control-consent]
+
+The court later clarified in *HD Supply* that a statutory merger is different. The covenant passes by operation of law, so the *Traffic Control Services* assignment rule does not control merger succession.
+
+"Traffic Control's rule of nonassignability does not apply when a successor corporation acquires restrictive employment covenants as the result of a merger."[^q10-hd-supply-merger]
+
+Nevada also has a separate sale-of-business antitrust carve-out. Restrictive covenants that are part of a contract for the sale of a business are outside Chapter 598A when they bar the seller from competing within a reasonable market area for a reasonable period of time [^q10-nrs-598a-sale-business].
+
+"Restrictive covenants: (a) Which are part of a contract of sale for a business and which bar the seller of the business from competing with the purchaser of the business sold within a reasonable market area for a reasonable period of time; or (b) Which are part of a commercial shopping center lease and which bar the parties from permitting or engaging in the furnishing of certain services or the sale of certain commodities within the commercial shopping center where such leased premises are located."[^q10-nrs-598a-sale-business]
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not assume an employee covenant follows the assets automatically. Nevada draws a hard line between asset sales and statutory mergers, and an asset buyer should plan for employee consent, an express assignment clause, and separate consideration where *Traffic Control Services* applies [^q10-traffic-control-consent].
+
+## Are Nevada physician and healthcare non-competes enforceable? {#healthcare-physicians}
+
+**Short answer.** No healthcare-specific ban appears in Nevada's non-compete statute, so a physician or healthcare covenant is not automatically void — but it is not automatically enforceable either. It is judged case by case under the general NRS 613.195 requirements: valuable consideration, no excessive restraint, no undue hardship, and proportional restrictions [^q11-nrs-613-195-healthcare].
+
+The staged research reports note that the 2023 Nevada Legislature passed AB 11, a physician non-compete bill, but the Governor vetoed it. That legislative history signals scrutiny of healthcare covenants, not an enacted ban.
+
+Current enforceability therefore returns to the ordinary Nevada framework. A physician or healthcare covenant must fit the statute, and healthcare access or public-interest facts can matter when a court evaluates undue hardship and the reasonableness of the restraint.
+
+"A noncompetition covenant is void and unenforceable unless the noncompetition covenant: (a) Is supported by valuable consideration; (b) Does not impose any restraint that is greater than is required for the protection of the employer for whose benefit the restraint is imposed; (c) Does not impose any undue hardship on the employee; and (d) Imposes restrictions that are appropriate in relation to the valuable consideration supporting the noncompetition covenant."[^q11-nrs-613-195-healthcare]
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not treat the AB 11 veto as permission to use broad healthcare covenants. The current statute still requires narrow, consideration-linked restrictions that do not impose undue hardship [^q11-nrs-613-195-healthcare].
+
+## How do Nevada trade-secret protections and NDAs compare to non-competes? {#trade-secrets-ndas}
+
+**Short answer.** They remain available and often narrower. Nevada has adopted the Uniform Trade Secrets Act, and NRS 613.200 expressly allows reasonable, consideration-supported confidentiality agreements covering trade secrets and confidential business information [^q12-nrs-600a-010-utsa][^q12-nrs-613-200-nda].
+
+NRS Chapter 600A is Nevada's Uniform Trade Secrets Act.
+
+"This chapter may be cited as the Uniform Trade Secrets Act."[^q12-nrs-600a-010-utsa]
+
+The trade-secret definition focuses on economic value from secrecy and reasonable secrecy efforts.
+
+"‘Trade secret’: (a) Means information, including, without limitation, a formula, pattern, compilation, program, device, method, technique, product, system, process, design, prototype, procedure, computer programming instruction or code that: (1) Derives independent economic value, actual or potential, from not being generally known to, and not being readily ascertainable by proper means by the public or any other persons who can obtain commercial or economic value from its disclosure or use; and (2) Is the subject of efforts that are reasonable under the circumstances to maintain its secrecy."[^q12-nrs-600a-030-trade-secret]
+
+NRS 613.200 separately makes it unlawful to willfully prevent a discharged or departing person from getting other work, subject to the non-compete statute and other exceptions [^q12-nrs-613-200-mobility]. But it expressly preserves reasonable confidentiality agreements for trade secrets, business methods, customer lists, formulas, processes, and confidential information [^q12-nrs-613-200-nda].
+
+"The provisions of this section do not prohibit a person, association, company, corporation, agent or officer from negotiating, executing and enforcing an agreement with an employee of the person, association, company or corporation which, upon termination of the employment, prohibits the employee from disclosing any trade secrets, business methods, lists of customers, secret formulas or processes or confidential information learned or obtained during the course of his or her employment with the person, association, company or corporation if the agreement is supported by valuable consideration and is otherwise reasonable in its scope and duration."[^q12-nrs-613-200-nda]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Use confidentiality and trade-secret covenants for secrecy interests, not as a disguised non-compete. NRS 613.200 preserves reasonable NDAs, but it also prohibits willful interference with a former worker's ability to obtain other employment [^q12-nrs-613-200-nda][^q12-nrs-613-200-mobility].
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-02. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not Nevada. This article synthesizes Nevada primary law and is not legal advice from a Nevada-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^q1-nrs-613-195-enforceability]: **NRS 613.195** — "A noncompetition covenant is void and unenforceable unless the noncompetition covenant: (a) Is supported by valuable consideration; (b) Does not impose any restraint that is greater than is required for the protection of the employer for whose benefit the restraint is imposed; (c) Does not impose any undue hardship on the employee; and (d) Imposes restrictions that are appropriate in relation to the valuable consideration supporting the noncompetition covenant." *NRS 613.195(1).* <https://www.leg.state.nv.us/nrs/NRS-613.html>
+
+[^q2-nrs-613-195-four-prong]: **NRS 613.195** — "A noncompetition covenant is void and unenforceable unless the noncompetition covenant: (a) Is supported by valuable consideration; (b) Does not impose any restraint that is greater than is required for the protection of the employer for whose benefit the restraint is imposed; (c) Does not impose any undue hardship on the employee; and (d) Imposes restrictions that are appropriate in relation to the valuable consideration supporting the noncompetition covenant." *NRS 613.195(1)(a)-(d).* <https://www.leg.state.nv.us/nrs/NRS-613.html>
+
+[^q3-nrs-613-195-revision]: **NRS 613.195** — "If an employer brings an action to enforce a noncompetition covenant or an employee brings an action to challenge a noncompetition covenant and the court finds the covenant is supported by valuable consideration but contains limitations as to time, geographical area or scope of activity to be restrained that are not reasonable, imposes a greater restraint than is necessary for the protection of the employer for whose benefit the restraint is imposed or imposes undue hardship on the employee, the court shall revise the covenant to the extent necessary and enforce the covenant as revised." *NRS 613.195(6).* <https://www.leg.state.nv.us/nrs/NRS-613.html>
+
+[^q3-tough-turtle-mandatory]: **Tough Turtle Turf, LLC v. Scott** — "It nonetheless mandates judicial revision of a restrictive covenant if this can be done without subjecting employees to unreasonable terms." *Tough Turtle Turf, LLC v. Scott, 139 Nev. Adv. Op. 47, 537 P.3d 883 (2023).* <https://www.courtlistener.com/opinion/9456796/tough-turtle-turf-llc-v-scott/#:~:text=It%20nonetheless%20mandates%20judicial%20revision,subjecting%20employees%20to%20unreasonable%20terms.>
+
+[^q3-tough-turtle-rewrite]: **Tough Turtle Turf, LLC v. Scott** — "Reading subsection (1) harmoniously with subsection (6) indicates that there are instances when a noncompete covenant will be unenforceable, such as when no valuable consideration supports the noncompete covenant or when the court would need to rewrite rather than revise the noncompete covenant." *Tough Turtle Turf, LLC v. Scott, 139 Nev. Adv. Op. 47, 537 P.3d 883 (2023).* <https://www.courtlistener.com/opinion/9456796/tough-turtle-turf-llc-v-scott/#:~:text=Reading%20subsection%20(1)%20harmoniously%20with,than%20revise%20the%20noncompete%20covenant.>
+
+[^q3-golden-road-old-rule]: **Golden Road Motor Inn, Inc. v. Islam** — "Under Nevada law, such an unreasonable provision renders the noncompete agreement wholly unenforceable." *Golden Road Motor Inn, Inc. v. Islam, 132 Nev. 476, 376 P.3d 151 (2016).* <https://www.courtlistener.com/opinion/4240728/golden-rd-motor-inn-v-islam/#:~:text=Under%20Nevada%20law%2C%20such%20an,the%20noncompete%20agreement%20wholly%20unenforceable.>
+
+[^q3-tough-turtle-overruled]: **Tough Turtle Turf, LLC v. Scott** — "This provision overruled Golden Road's holding that an unreasonable noncompete covenant can never be revised." *Tough Turtle Turf, LLC v. Scott, 139 Nev. Adv. Op. 47, 537 P.3d 883 (2023).* <https://www.courtlistener.com/opinion/9456796/tough-turtle-turf-llc-v-scott/#:~:text=This%20provision%20overruled%20Golden%20Road's,covenant%20can%20never%20be%20revised.>
+
+[^q3-duong-savings-clause]: **Duong v. Fielden Hanson Isaacs Miyada Robison Yeh, Ltd.** — "We hold that Golden Road does not prohibit a district court from blue-penciling an unreasonable noncompetition agreement if the agreement itself allows for it." *Duong v. Fielden Hanson Isaacs Miyada Robison Yeh, Ltd., 136 Nev. Adv. Op. 87, 478 P.3d 380 (2020).* <https://www.courtlistener.com/opinion/5304741/duong-md-vs-fielden-hanson-isaacs-miyada-robison-yeh-ltd/#:~:text=We%20hold%20that%20Golden%20Road,agreement%20itself%20allows%20for%20it.>
+
+[^q4-nrs-613-195-hourly]: **NRS 613.195** — "A noncompetition covenant may not apply to an employee who is paid solely on an hourly wage basis, exclusive of any tips or gratuities." *NRS 613.195(3).* <https://www.leg.state.nv.us/nrs/NRS-613.html>
+
+[^q4-nrs-613-195-fees]: **NRS 613.195** — "If an employer brings an action to enforce a noncompetition covenant or an employee brings an action to challenge a noncompetition covenant and the court finds that the noncompetition covenant applies to an employee described in subsection 3 or that the employer has restricted or attempted to restrict a former employee in the manner described in subsection 2, the court shall award the employee reasonable attorney’s fees and costs." *NRS 613.195(7).* <https://www.leg.state.nv.us/nrs/NRS-613.html>
+
+[^q5-nrs-613-195-customer]: **NRS 613.195** — "A noncompetition covenant may not restrict, and an employer may not bring an action to restrict, a former employee of an employer from providing service to a former customer or client if: (a) The former employee did not solicit the former customer or client; (b) The customer or client voluntarily chose to leave and seek services from the former employee; and (c) The former employee is otherwise complying with the limitations in the covenant as to time, geographical area and scope of activity to be restrained, other than any limitation on providing services to a former customer or client who seeks the services of the former employee without any contact instigated by the former employee." *NRS 613.195(2).* <https://www.leg.state.nv.us/nrs/NRS-613.html>
+
+[^q5-nrs-613-195-fees]: **NRS 613.195** — "If an employer brings an action to enforce a noncompetition covenant or an employee brings an action to challenge a noncompetition covenant and the court finds that the noncompetition covenant applies to an employee described in subsection 3 or that the employer has restricted or attempted to restrict a former employee in the manner described in subsection 2, the court shall award the employee reasonable attorney’s fees and costs." *NRS 613.195(7).* <https://www.leg.state.nv.us/nrs/NRS-613.html>
+
+[^q6-nrs-613-195-rif]: **NRS 613.195** — "If the termination of the employment of an employee is the result of a reduction of force, reorganization or similar restructuring of the employer, a noncompetition covenant is only enforceable during the period in which the employer is paying the employee’s salary, benefits or equivalent compensation, including, without limitation, severance pay." *NRS 613.195(5).* <https://www.leg.state.nv.us/nrs/NRS-613.html>
+
+[^q7-nrs-613-195-fees]: **NRS 613.195** — "If an employer brings an action to enforce a noncompetition covenant or an employee brings an action to challenge a noncompetition covenant and the court finds that the noncompetition covenant applies to an employee described in subsection 3 or that the employer has restricted or attempted to restrict a former employee in the manner described in subsection 2, the court shall award the employee reasonable attorney’s fees and costs." *NRS 613.195(7).* <https://www.leg.state.nv.us/nrs/NRS-613.html>
+
+[^q8-camco-consideration]: **Camco, Inc. v. Baker** — "Today we adopt the majority rule which states that an at-will employee's continued employment is sufficient consideration for enforcing a non-competition agreement." *Camco, Inc. v. Baker, 113 Nev. 512, 936 P.2d 829 (1997).* <https://www.courtlistener.com/opinion/1224995/camco-inc-v-baker/#:~:text=Today%20we%20adopt%20the%20majority,for%20enforcing%20a%20non%2Dcompetition%20agreement.>
+
+[^q8-nrs-613-195-consideration]: **NRS 613.195** — "A noncompetition covenant is void and unenforceable unless the noncompetition covenant: (a) Is supported by valuable consideration; (b) Does not impose any restraint that is greater than is required for the protection of the employer for whose benefit the restraint is imposed; (c) Does not impose any undue hardship on the employee; and (d) Imposes restrictions that are appropriate in relation to the valuable consideration supporting the noncompetition covenant." *NRS 613.195(1)(a), (d).* <https://www.leg.state.nv.us/nrs/NRS-613.html>
+
+[^q9-nrs-613-195-revision]: **NRS 613.195** — "Such revisions must cause the limitations contained in the covenant as to time, geographical area and scope of activity to be restrained to be reasonable, to not impose undue hardship on the employee and to impose a restraint that is not greater than is necessary for the protection of the employer for whose benefit the restraint is imposed." *NRS 613.195(6).* <https://www.leg.state.nv.us/nrs/NRS-613.html>
+
+[^q10-traffic-control-consent]: **Traffic Control Servs., Inc. v. United Rentals Nw., Inc.** — "Covenants not to compete are personal in nature and therefore are not assignable absent the employee's express consent. Further, an employer must obtain such consent through arm's-length negotiation with the employee, supported by valuable consideration beyond that necessary to support the underlying covenant." *Traffic Control Servs., Inc. v. United Rentals Nw., Inc., 120 Nev. 168, 87 P.3d 1054 (2004).* <https://www.courtlistener.com/opinion/8085820/traffic-control-services-inc-v-united-rentals-northwest-inc/#:~:text=Covenants%20not%20to%20compete%20are,to%20support%20the%20underlying%20covenant.>
+
+[^q10-hd-supply-merger]: **HD Supply Facilities Maint., Ltd. v. Bymoen** — "Traffic Control's rule of nonassignability does not apply when a successor corporation acquires restrictive employment covenants as the result of a merger." *HD Supply Facilities Maint., Ltd. v. Bymoen, 125 Nev. 200, 210 P.3d 183 (2009).* <https://www.courtlistener.com/opinion/2575254/hd-supply-facilities-maintenance-ltd-v-bymoen/#:~:text=Traffic%20Control's%20rule%20of%20nonassignability,the%20result%20of%20a%20merger.>
+
+[^q10-nrs-598a-sale-business]: **NRS 598A.040** — "Restrictive covenants: (a) Which are part of a contract of sale for a business and which bar the seller of the business from competing with the purchaser of the business sold within a reasonable market area for a reasonable period of time; or (b) Which are part of a commercial shopping center lease and which bar the parties from permitting or engaging in the furnishing of certain services or the sale of certain commodities within the commercial shopping center where such leased premises are located." *NRS 598A.040(5).* <https://www.leg.state.nv.us/nrs/NRS-598A.html>
+
+[^q11-nrs-613-195-healthcare]: **NRS 613.195** — "A noncompetition covenant is void and unenforceable unless the noncompetition covenant: (a) Is supported by valuable consideration; (b) Does not impose any restraint that is greater than is required for the protection of the employer for whose benefit the restraint is imposed; (c) Does not impose any undue hardship on the employee; and (d) Imposes restrictions that are appropriate in relation to the valuable consideration supporting the noncompetition covenant." *NRS 613.195(1).* <https://www.leg.state.nv.us/nrs/NRS-613.html>
+
+[^q12-nrs-600a-010-utsa]: **NRS 600A.010** — "This chapter may be cited as the Uniform Trade Secrets Act." *NRS 600A.010.* <https://www.leg.state.nv.us/nrs/NRS-600A.html>
+
+[^q12-nrs-613-200-nda]: **NRS 613.200** — "The provisions of this section do not prohibit a person, association, company, corporation, agent or officer from negotiating, executing and enforcing an agreement with an employee of the person, association, company or corporation which, upon termination of the employment, prohibits the employee from disclosing any trade secrets, business methods, lists of customers, secret formulas or processes or confidential information learned or obtained during the course of his or her employment with the person, association, company or corporation if the agreement is supported by valuable consideration and is otherwise reasonable in its scope and duration." *NRS 613.200(4).* <https://www.leg.state.nv.us/nrs/NRS-613.html>
+
+[^q12-nrs-600a-030-trade-secret]: **NRS 600A.030** — "‘Trade secret’: (a) Means information, including, without limitation, a formula, pattern, compilation, program, device, method, technique, product, system, process, design, prototype, procedure, computer programming instruction or code that: (1) Derives independent economic value, actual or potential, from not being generally known to, and not being readily ascertainable by proper means by the public or any other persons who can obtain commercial or economic value from its disclosure or use; and (2) Is the subject of efforts that are reasonable under the circumstances to maintain its secrecy." *NRS 600A.030(5)(a).* <https://www.leg.state.nv.us/nrs/NRS-600A.html>
+
+[^q12-nrs-613-200-mobility]: **NRS 613.200** — "Except as otherwise provided in this section and NRS 613.195 , any person, association, company or corporation within this State, or any agent or officer on behalf of the person, association, company or corporation, who willfully does anything intended to prevent any person who for any cause left or was discharged from his, her or its employ from obtaining employment elsewhere in this State is guilty of a gross misdemeanor and shall be punished by a fine of not more than $5,000." *NRS 613.200(1).* <https://www.leg.state.nv.us/nrs/NRS-613.html>

--- a/skills/non-compete-contract-explainer/content/new-hampshire.md
+++ b/skills/non-compete-contract-explainer/content/new-hampshire.md
@@ -1,0 +1,233 @@
+---
+jurisdiction: "New Hampshire"
+slug: new-hampshire
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-02"
+canonicalUrl: https://openagreements.org/legal/non-compete/new-hampshire
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/new-hampshire · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in New Hampshire[^about]
+
+New Hampshire enforces reasonable non-competes under a common-law test, but RSA 275:70 creates a pre-acceptance notice rule, RSA 275:70-a voids low-wage employee noncompetes, healthcare statutes void certain geographic practice restrictions, and RSA chapter 350-B preserves trade-secret alternatives.
+
+
+## At a glance
+
+| Question | New Hampshire |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed above a pay level |
+| **Bottom line** | New Hampshire enforces reasonable non-competes under a three-part common-law test, but voids them for low-wage employees (at or below 200% of the federal minimum wage) and requires pre-acceptance notice to new hires. |
+| **Main law or case** | Smith, Batchelder & Rugg v. Foster, 119 N.H. 679 (1979); RSA 275:70 and RSA 275:70-a |
+| **Main exceptions** | Low-wage ban (≤200% federal min wage); pre-acceptance notice (RSA 275:70); geographic-practice bans for physicians/nurses/APRNs/podiatrists; sale-of-business |
+| **When the ban took effect** | APRN health-care ban eff. Aug 23, 2025 (low-wage ban date not stated) |
+| **Can a court narrow it?** | Yes — rewrites to reasonable |
+| **Applies to contractors?** | Unclear |
+| **Restriction extended during a breach?** | Unsettled — no controlling authority |
+| **Maximum length set by law** | No statutory limit |
+
+## Are employee non-compete agreements enforceable in New Hampshire? {#employee-noncompetes}
+
+**Short answer.** Yes, if the restraint is reasonable and no statute makes it unenforceable. New Hampshire uses a three-part reasonableness test: the restriction must protect a legitimate employer interest, avoid undue hardship on the employee, and avoid injury to the public interest [^foster-three-part-test][^hobert-reasonable-enforceable].
+
+The practical starting point is common law plus statutory gates. Even a reasonable covenant can fail if it was not disclosed before the employee accepted the offer, if the employee is covered by the low-wage ban, or if a profession-specific healthcare statute voids the restriction.
+
+New Hampshire also construes restraints narrowly. The court starts with the employer interest being protected, then asks whether the chosen time, geography, customer, and activity limits are broader than that interest requires [^foster-three-part-test].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not summarize New Hampshire as either a total-ban state or a free-enforcement state. It is a reasonableness-test state with statutory traps layered on top [^foster-three-part-test][^hobert-reasonable-enforceable].
+
+## Is continued employment enough consideration for a New Hampshire non-compete? {#consideration-after-hire}
+
+**Short answer.** Yes. New Hampshire recognizes continued employment after signing as consideration for a covenant not to compete [^foster-continued-employment].
+
+That consideration rule does not cure statutory notice problems. If the worker is a new employee covered by RSA 275:70, the employer still must provide the noncompete before the employee accepts the offer, regardless of common-law consideration [^rsa-275-70-notice-gate].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Separate consideration from timing. Continued employment may support the covenant, but late delivery can still make the noncompete unenforceable under RSA 275:70 [^foster-continued-employment][^rsa-275-70-notice-gate].
+
+## What is a legitimate protectable interest for a New Hampshire non-compete? {#legitimate-interests}
+
+**Short answer.** Protectable interests include trade secrets, confidential information, special customer influence, employment-developed contacts, goodwill, and a positive business image. Ordinary recruiting and hiring costs are not enough [^hobert-legitimate-interests][^olsten-recruiting-costs].
+
+Goodwill is often the practical center of the analysis. New Hampshire cases allow protection against a former employee appropriating customer or patient goodwill developed through the job, but they do not allow a covenant to block ordinary competition unrelated to that employer asset [^forbes-patient-goodwill].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Before enforcing, identify the employer asset at risk. A covenant based only on the cost of hiring or training workers is unlikely to satisfy the first prong of the New Hampshire test [^olsten-recruiting-costs].
+
+## How narrow must a New Hampshire non-compete's duration, geography, and customer scope be? {#scope-duration-geography}
+
+**Short answer.** Narrow enough to match the protected interest. Customer and geography limits generally should track the employee's actual sphere of customer influence, and duration should last no longer than needed to protect the employer's goodwill or confidential information [^near-customer-sphere][^forbes-duration-geography].
+
+New Hampshire courts are especially skeptical of all-customer restrictions. In *Near*, a covenant covering customers beyond the salesperson's contacts was too broad because the employee had no special claim on most of the employer's customer base [^near-customer-sphere].
+
+The same principle applies to geography. A territory is not reasonable merely because it is named. It should correspond to the market where the employee had customer or patient contact, or to another concrete employer interest.
+
+## Will a New Hampshire court reform an overbroad non-compete? {#court-reformation}
+
+**Short answer.** Yes, but only if the employer proves good faith in the execution of the agreement. New Hampshire courts have power to reform overbroad covenants, but bad-faith presentation can defeat that remedy [^near-good-faith-reformation][^syncom-bad-faith-reformation].
+
+The good-faith issue is practical, not cosmetic. Courts have treated lack of advance discussion, post-start presentation, first-day pressure, and lack of a meaningful opportunity to understand the restriction as facts relevant to denying reformation.
+
+Reformation is a narrowing remedy. It is not a license to draft an overbroad all-customer covenant and ask the court to rescue it later.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Draft for enforceability at signing. If the agreement is presented late, under pressure, or without a fair chance to understand it, New Hampshire courts may refuse to reform even if a narrower covenant might have been valid [^near-good-faith-reformation][^syncom-bad-faith-reformation].
+
+## What is New Hampshire's RSA 275:70 pre-acceptance notice requirement? {#pre-acceptance-notice}
+
+**Short answer.** RSA 275:70 is the marquee New Hampshire drafting trap. If an employer requires an employee who has not previously worked for the employer to sign a noncompete as a condition of employment, the employer must provide a copy before the employee accepts the offer, and an undisclosed noncompete is not enforceable against the employee [^rsa-275-70-preacceptance].
+
+The statute preserves other provisions in the same agreement. A notice failure defeats the noncompete, but confidentiality, nondisclosure, trade-secret, intellectual-property assignment, and other employment provisions can remain in force [^rsa-275-70-preacceptance].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Give the actual noncompete with the offer materials, not during onboarding. The statutory consequence is unenforceability of the noncompete itself, even though other agreement provisions may survive [^rsa-275-70-preacceptance].
+
+## What is New Hampshire's low-wage employee non-compete ban? {#low-wage-employees}
+
+**Short answer.** RSA 275:70-a prohibits employers from requiring low-wage employees to enter into noncompete agreements. A noncompete with a covered low-wage employee is void and unenforceable [^rsa-275-70-a-ban][^rsa-275-70-a-void].
+
+The statute defines a low-wage employee by hourly rate, not job title. The threshold is less than or equal to 200 percent of the federal minimum wage, currently $14.50 per hour while the federal minimum wage remains $7.25 per hour [^rsa-275-70-a-threshold].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Check wage coverage before drafting any New Hampshire noncompete for hourly or lower-paid roles. If RSA 275:70-a applies, narrower wording does not save a noncompete agreement with that low-wage employee [^rsa-275-70-a-ban][^rsa-275-70-a-void].
+
+## What special non-compete rules apply to New Hampshire healthcare practitioners? {#healthcare-practitioners}
+
+**Short answer.** New Hampshire statutes void certain post-termination geographic practice restrictions for physicians, nurses, advanced practice registered nurses, and podiatrists. The APRN statute is effective August 23, 2025 [^rsa-329-31-a-physicians][^rsa-326-b-45-a-nurses][^rsa-326-b-45-b-aprns][^rsa-315-18-podiatrists].
+
+These statutes target geographic practice restrictions in professional relationship contracts. They do not automatically answer every separate issue, such as confidentiality, patient records, trade secrets, or non-geographic solicitation wording.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not use a geographic practice ban for covered New Hampshire clinicians. Draft separate confidentiality and trade-secret provisions if the real concern is information protection rather than practice location [^rsa-329-31-a-physicians][^rsa-326-b-45-a-nurses][^rsa-326-b-45-b-aprns][^rsa-315-18-podiatrists].
+
+## Are sale-of-business non-competes enforceable in New Hampshire? {#sale-of-business}
+
+**Short answer.** Yes, when the restraint is reasonable and tied to the goodwill or business assets being sold. New Hampshire enforced a sale-of-business covenant that barred motel, restaurant, and resort competition for five years within a 15-mile radius [^gosselin-sale-covenant].
+
+Asset-purchase standing can also matter. In *Atronix*, the New Hampshire Supreme Court held that the buyer received the employee noncompete under the asset purchase agreement's transfer language, reversing dismissal for lack of standing [^atronix-assigned-covenant].
+
+That does not make sale covenants unlimited. The agreement still should tie the restraint to the goodwill or business assets being sold, and the written duration still matters.
+
+## Can New Hampshire independent contractors be bound by non-competes? {#independent-contractors}
+
+**Short answer.** New Hampshire appellate law in this source set does not supply a settled independent-contractor rule. Treat contractor noncompetes as high-risk restraints that still must satisfy the same concrete-interest and narrow-tailoring principles that govern employee covenants [^hobert-legitimate-interests-contractors][^hcc-persuasive-limits].
+
+The available non-binding material points in a cautious direction. A federal District of New Hampshire decision applying New Hampshire law is persuasive only, not controlling state appellate law, and it declined to enjoin the noncompete for lack of irreparable injury and a favorable balance of equities while still issuing the narrower nondisclosure injunction [^hcc-persuasive-limits][^hcc-nondisclosure-granted].
+
+Because the available appellate source set does not squarely address independent contractors, use the employee-covenant cases by analogy: the safer analysis is whether the contractor actually received trade secrets, confidential information, customer influence, or goodwill capable of appropriation.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not assume the contractor label expands enforceability. If the worker was engaged as an independent business and lacked concrete access to protectable goodwill or confidential information, the restraint may look like ordinary competition control rather than protection of an employer asset [^hobert-legitimate-interests-contractors].
+
+## What trade-secret alternatives remain when a New Hampshire non-compete fails? {#trade-secrets}
+
+**Short answer.** RSA chapter 350-B remains an important alternative. New Hampshire's trade-secret statute defines trade secrets by independent economic value and reasonable secrecy efforts, authorizes injunctions for actual or threatened misappropriation, and preserves contractual remedies [^rsa-350-b-1-definition][^rsa-350-b-2-injunction][^rsa-350-b-7-contracts].
+
+Trade-secret relief is not a substitute for an overbroad noncompete. It protects information that qualifies under the statute and can support narrower orders against misuse or disclosure, including affirmative acts in appropriate circumstances.
+
+> [!NOTE]
+> **Practice note.**
+>
+> If the business concern is information misuse, build the record for trade-secret protection: identify the information, document economic value from secrecy, and maintain reasonable secrecy measures. RSA chapter 350-B is strongest when the facts support secrecy, not merely competition [^rsa-350-b-1-definition][^rsa-350-b-2-injunction].
+
+## Does a New Hampshire non-compete period pause or extend during breach or litigation? {#tolling-during-breach}
+
+**Short answer.** This is unsettled for employment noncompetes. New Hampshire appellate law in this source set does not squarely decide whether a restricted period pauses during breach, extends while litigation is pending, or whether a contractual extension-during-breach clause is enforceable [^gosselin-no-extension].
+
+The remedial pattern points to caution. New Hampshire cases recognize reformation as a scope-narrowing remedy for overbroad covenants when the employer proves good faith, but those cases do not create a general rule extending the duration of a covenant after breach [^near-reformation-narrowing][^syncom-reformation-open].
+
+In the sale-of-business setting, *Gosselin* rejected a court-ordered extension of the written five-year covenant because there was no ambiguity or evidence of party intent to extend it. That holding does not answer every employment tolling clause question, but it is a strong reason not to assert a New Hampshire tolling rule [^gosselin-no-extension].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> A tolling or extension-during-breach clause is a drafting choice of uncertain enforceability in New Hampshire. If you include one, tie it to the protected interest and the covenant's overall duration, and do not assume a court will extend the period beyond the contract's fair and natural meaning [^gosselin-no-extension][^near-reformation-narrowing].
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-02. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not New Hampshire. This article synthesizes New Hampshire primary law and is not legal advice from a New Hampshire-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^foster-three-part-test]: **Smith, Batchelder & Rugg v. Foster** — "In scrutinizing restrictive covenants, this court employs the following three-pronged test: ‘[a] restraint on employment is reasonable only if it is no greater than necessary for the protection of the employer’s legitimate interest, does not impose undue hardship on the employee and is not injurious to the public interest.’" *Smith, Batchelder & Rugg v. Foster, 119 N.H. 679 (1979).* <https://www.courtlistener.com/opinion/2375592/smith-batchelder-rugg-v-foster/#:~:text=In%20scrutinizing%20restrictive%20covenants%2C%20this,injurious%20to%20the%20public%20interest.%E2%80%9D>
+
+[^hobert-reasonable-enforceable]: **ACAS Acquisitions (Precitech) Inc. v. Hobert** — "Accordingly, we conclude that the defendant’s non-competition covenant was reasonable and enforceable." *ACAS Acquisitions (Precitech) Inc. v. Hobert, 155 N.H. 381 (2007).* <https://www.courtlistener.com/opinion/2320967/acas-acquisitions-precitech-inc-v-hobert/#:~:text=Accordingly%2C%20we%20conclude%20that%20the%20defendant%E2%80%99s%20non%2Dcompetition%20covenant%20was%20reasonable%20and%20enforceable.>
+
+[^foster-continued-employment]: **Smith, Batchelder & Rugg v. Foster** — "Continued employment after signing an employment contract constitutes consideration for a covenant not to compete contained therein." *Smith, Batchelder & Rugg v. Foster, 119 N.H. 679 (1979).* <https://www.courtlistener.com/opinion/2375592/smith-batchelder-rugg-v-foster/#:~:text=Continued%20employment%20after%20signing%20an,not%20to%20compete%20contained%20therein.>
+
+[^rsa-275-70-notice-gate]: **RSA 275:70** — "A noncompete agreement that has not been disclosed to an employee as required by this section shall not be enforceable against the employee, but all other provisions of any employment, confidentiality, nondisclosure, trade secret, intellectual property assignment, or any other type of employment agreement or provision shall remain in full force and effect." *RSA 275:70.* <https://gc.nh.gov/rsa/html/XXIII/275/275-70.htm>
+
+[^hobert-legitimate-interests]: **ACAS Acquisitions (Precitech) Inc. v. Hobert** — "Legitimate interests of an employer that may be protected from competition include: the employer’s trade secrets that have been communicated to the employee during the course of employment; confidential information other than trade secrets communicated by the employer to the employee, such as information regarding a unique business method; an employee’s special influence over the employer’s customers, obtained during the course of employment; contacts developed during the employment; and the employer’s development of goodwill and a positive image." *ACAS Acquisitions (Precitech) Inc. v. Hobert, 155 N.H. 381 (2007).* <https://www.courtlistener.com/opinion/2320967/acas-acquisitions-precitech-inc-v-hobert/#:~:text=Legitimate%20interests%20of%20an%20employer,goodwill%20and%20a%20positive%20image.>
+
+[^olsten-recruiting-costs]: **National Employment Service Corp. v. Olsten Staffing Service, Inc.** — "Thus, we hold that although there may be valid reasons for restrictive covenants, the mere cost associated with recruiting and hiring employees is not a legitimate interest protectable by a restrictive covenant in an employment contract." *National Employment Service Corp. v. Olsten Staffing Service, Inc., 145 N.H. 158 (2000).* <https://www.courtlistener.com/opinion/8092147/national-employment-service-corp-v-olsten-staffing-service-inc/#:~:text=Thus%2C%20we%20hold%20that%20although,covenant%20in%20an%20employment%20contract.>
+
+[^forbes-patient-goodwill]: **Concord Orthopaedics Professional Ass'n v. Forbes** — "COPA has a legitimate interest in preventing Forbes from appropriating the goodwill of its business, developed in part by Forbes’ contact with patients in his capacity as a COPA physician." *Concord Orthopaedics Professional Ass'n v. Forbes, 142 N.H. 440 (1997).* <https://www.courtlistener.com/opinion/8091834/concord-orthopaedics-professional-assn-v-forbes/#:~:text=COPA%20has%20a%20legitimate%20interest,capacity%20as%20a%20COPA%20physician.>
+
+[^near-customer-sphere]: **Merrimack Valley Wood Products, Inc. v. Near** — "Thus, the restrictive covenant goes far beyond the defendant’s sphere of customer goodwill, and was more restrictive than necessary to protect the plaintiffs’ legitimate interests." *Merrimack Valley Wood Products, Inc. v. Near, 152 N.H. 192 (2005).* <https://www.courtlistener.com/opinion/8093022/merrimack-valley-wood-products-inc-v-near/#:~:text=Thus%2C%20the%20restrictive%20covenant%20goes,protect%20the%20plaintiffs%E2%80%99%20legitimate%20interests.>
+
+[^forbes-duration-geography]: **Concord Orthopaedics Professional Ass'n v. Forbes** — "A restraint on competition must be narrowly tailored in both geography and duration to protect COPA’s legitimate interest in its goodwill." *Concord Orthopaedics Professional Ass'n v. Forbes, 142 N.H. 440 (1997).* <https://www.courtlistener.com/opinion/8091834/concord-orthopaedics-professional-assn-v-forbes/#:~:text=A%20restraint%20on%20competition%20must,legitimate%20interest%20in%20its%20goodwill.>
+
+[^near-good-faith-reformation]: **Merrimack Valley Wood Products, Inc. v. Near** — "Courts have the power to reform overly broad restrictive covenants if the employer shows that it acted in good faith in the execution of the employment contract." *Merrimack Valley Wood Products, Inc. v. Near, 152 N.H. 192 (2005).* <https://www.courtlistener.com/opinion/8093022/merrimack-valley-wood-products-inc-v-near/#:~:text=Courts%20have%20the%20power%20to,execution%20of%20the%20employment%20contract.>
+
+[^syncom-bad-faith-reformation]: **Syncom Industries, Inc. v. Wood** — "If the trial court were to determine that the restrictive covenants could not be reformed due to Syncom’s bad faith, then there would be no need to further address their enforceability." *Syncom Industries, Inc. v. Wood, 155 N.H. 73 (2007).* <https://www.courtlistener.com/opinion/1896769/syncom-industries-inc-v-wood/#:~:text=If%20the%20trial%20court%20were,to%20further%20address%20their%20enforceability.>
+
+[^rsa-275-70-preacceptance]: **RSA 275:70** — "Any employer who requires an employee who has not previously been employed by the employer to execute a noncompete agreement as a condition of employment shall provide a copy of such agreement to the potential employee prior to the employee's acceptance of an offer of employment. A noncompete agreement that has not been disclosed to an employee as required by this section shall not be enforceable against the employee, but all other provisions of any employment, confidentiality, nondisclosure, trade secret, intellectual property assignment, or any other type of employment agreement or provision shall remain in full force and effect." *RSA 275:70.* <https://gc.nh.gov/rsa/html/XXIII/275/275-70.htm>
+
+[^rsa-275-70-a-ban]: **RSA 275:70-a** — "No employer shall require a low-wage employee to enter into a noncompete agreement." *RSA 275:70-a, II(a).* <https://gc.nh.gov/rsa/html/XXIII/275/275-70-a.htm>
+
+[^rsa-275-70-a-void]: **RSA 275:70-a** — "A noncompete agreement entered into between an employer and a low-wage employee shall be void and unenforceable." *RSA 275:70-a, II(b).* <https://gc.nh.gov/rsa/html/XXIII/275/275-70-a.htm>
+
+[^rsa-275-70-a-threshold]: **RSA 275:70-a** — "(b) ‘Low-wage employee’ means an employee who earns an hourly rate less than or equal to 200 percent of the federal minimum wage." *RSA 275:70-a, I(b).* <https://gc.nh.gov/rsa/html/XXIII/275/275-70-a.htm>
+
+[^rsa-329-31-a-physicians]: **RSA 329:31-a** — "Any contract or agreement which creates or established the terms of a partnership, employment, or any other form of professional relationship with a physician licensed by the board to practice in this state, which includes any restriction to the right of such physician to also practice medicine in any geographic area for any period of time after the termination of such partnership, employment, or professional relationship shall be void and unenforceable with respect to said restriction; provided however, that nothing herein shall render void or unenforceable the remaining provision of any such contract or agreement." *RSA 329:31-a.* <https://gc.nh.gov/rsa/html/XXX/329/329-31-a.htm>
+
+[^rsa-326-b-45-a-nurses]: **RSA 326-B:45-a** — "Any contract or agreement which creates or established the terms of a partnership, employment, or any other form of professional relationship with a nurse licensed by the board to practice in this state, which includes any restriction to the right of such nurse to also practice in any geographic area for any period of time after the termination of such partnership, employment, or professional relationship shall be void and unenforceable with respect to said restriction; provided however, that nothing herein shall render void or unenforceable the remaining provision of any such contract or agreement." *RSA 326-B:45-a.* <https://gc.nh.gov/rsa/html/XXX/326-B/326-B-45-a.htm>
+
+[^rsa-326-b-45-b-aprns]: **RSA 326-B:45-b** — "Any contract or agreement which creates or establishes the terms of a partnership, employment, or any other form of professional relationship with an advanced practice registered nurse licensed by the board to practice in this state, which includes any restriction to the right of such advanced practice registered nurse to also practice in any geographic area for any period of time after the termination of such partnership, employment, or professional relationship shall be void and unenforceable with respect to said restriction; provided however, that nothing herein shall render void or unenforceable the remaining provisions of any such contract or agreement." *RSA 326-B:45-b.* <https://gc.nh.gov/rsa/html/XXX/326-B/326-B-45-b.htm>
+
+[^rsa-315-18-podiatrists]: **RSA 315:18** — "Any contract or agreement which creates or established the terms of a partnership, employment, or any other form of professional relationship with a podiatrist licensed by the board to practice in this state, which includes any restriction to the right of such podiatrist to also practice podiatry in any geographic area for any period of time after the termination of such partnership, employment, or professional relationship shall be void and unenforceable with respect to said restriction; provided however, that nothing herein shall render void or unenforceable the remaining provision of any such contract or agreement." *RSA 315:18.* <https://gc.nh.gov/rsa/html/XXX/315/315-18.htm>
+
+[^gosselin-sale-covenant]: **Gosselin v. Archibald** — "The terms of the agreement, as set forth in the purchase and sale contract, are reasonable and enforceable." *Gosselin v. Archibald, 121 N.H. 1016 (1981).* <https://www.courtlistener.com/opinion/2059042/gosselin-v-archibald/#:~:text=The%20terms%20of%20the%20agreement%2C,contract%2C%20are%20reasonable%20and%20enforceable.>
+
+[^atronix-assigned-covenant]: **Atronix, Inc. v. Morris** — "Because we conclude that Morris’s non-compete agreement was conveyed to the plaintiff under the plain language of section 2.02(a)(xii), we need not address either the plaintiff’s additional arguments or the defendants’ argument" *Atronix, Inc. v. Morris, 197 A.3d 79 (N.H. 2018).* <https://www.courtlistener.com/opinion/4546183/atronix-inc-v-kenneth-morris-a/#:~:text=Because%20we%20conclude%20that%20Morris%E2%80%99s,arguments%20or%20the%20defendants%E2%80%99%20argument>
+
+[^hobert-legitimate-interests-contractors]: **ACAS Acquisitions (Precitech) Inc. v. Hobert** — "The first step in determining the reasonableness of a given restraint is to determine whether the restraint was narrowly tailored to protect the employer’s legitimate interests." *ACAS Acquisitions (Precitech) Inc. v. Hobert, 155 N.H. 381 (2007).* <https://www.courtlistener.com/opinion/2320967/acas-acquisitions-precitech-inc-v-hobert/#:~:text=The%20first%20step%20in%20determining,protect%20the%20employer%E2%80%99s%20legitimate%20interests.>
+
+[^hcc-persuasive-limits]: **HCC Specialty Underwriters, Inc. v. Woodbury** — "However, with respect to Woodbury's breach of the noncompete provisions, HCC has not demonstrated irreparable injury or a favorable balance of the equities." *HCC Specialty Underwriters, Inc. v. Woodbury, 289 F. Supp. 3d 303 (D.N.H. 2018).* <https://www.courtlistener.com/opinion/7328330/hcc-specialty-underwriters-inc-v-woodbury/#:~:text=However%2C%20with%20respect%20to%20Woodbury's,favorable%20balance%20of%20the%20equities.>
+
+[^hcc-nondisclosure-granted]: **HCC Specialty Underwriters, Inc. v. Woodbury** — "Therefore, the court issues a preliminary injunction requiring Woodbury to abide by the nondisclosure provisions of the 1996 Agreement." *HCC Specialty Underwriters, Inc. v. Woodbury, 289 F. Supp. 3d 303 (D.N.H. 2018).* <https://www.courtlistener.com/opinion/7328330/hcc-specialty-underwriters-inc-v-woodbury/#:~:text=Therefore%2C%20the%20court%20issues%20a,provisions%20of%20the%201996%20Agreement.>
+
+[^rsa-350-b-1-definition]: **RSA 350-B:1** — "IV. ‘Trade secret’ means information, including a formula, pattern, compilation, program, device, method, technique, or process, that: (a) Derives independent economic value, actual or potential, from not being generally known to, and not being readily ascertainable by proper means by, other persons who can obtain economic value from its disclosure or use; and (b) Is the subject of efforts that are reasonable under the circumstances to maintain its secrecy." *RSA 350-B:1.* <https://gc.nh.gov/rsa/html/XXXI/350-B/350-B-1.htm>
+
+[^rsa-350-b-2-injunction]: **RSA 350-B:2** — "Actual or threatened misappropriation may be enjoined." *RSA 350-B:2.* <https://gc.nh.gov/rsa/html/XXXI/350-B/350-B-2.htm>
+
+[^rsa-350-b-7-contracts]: **RSA 350-B:7** — "II. This chapter shall not affect: (a) Contractual remedies, whether or not based upon misappropriation of a trade secret; (b) Other civil remedies that are not based upon misappropriation of a trade secret; or (c) Criminal remedies, whether or not based upon misappropriation of a trade secret." *RSA 350-B:7, II.* <https://gc.nh.gov/rsa/html/XXXI/350-B/350-B-7.htm>
+
+[^gosselin-no-extension]: **Gosselin v. Archibald** — "We cannot agree with the master’s extension of the time limitation of the covenant not to compete." *Gosselin v. Archibald, 121 N.H. 1016 (1981).* <https://www.courtlistener.com/opinion/2059042/gosselin-v-archibald/#:~:text=We%20cannot%20agree%20with%20the%20master%E2%80%99s%20extension,the%20covenant%20not%20to%20compete.>
+
+[^near-reformation-narrowing]: **Merrimack Valley Wood Products, Inc. v. Near** — "Courts have the power to reform overly broad restrictive covenants if the employer shows that it acted in good faith in the execution of the employment contract." *Merrimack Valley Wood Products, Inc. v. Near, 152 N.H. 192 (2005).* <https://www.courtlistener.com/opinion/8093022/merrimack-valley-wood-products-inc-v-near/#:~:text=Courts%20have%20the%20power%20to,execution%20of%20the%20employment%20contract.>
+
+[^syncom-reformation-open]: **Syncom Industries, Inc. v. Wood** — "Finally, as the defendants have challenged both the geographic and temporal scope of the restrictive covenants, and have properly preserved those challenges, both aspects of the covenants are open to possible reformation." *Syncom Industries, Inc. v. Wood, 155 N.H. 73 (2007).* <https://www.courtlistener.com/opinion/1896769/syncom-industries-inc-v-wood/#:~:text=Finally%2C%20as%20the%20defendants%20have,are%20open%20to%20possible%20reformation.>

--- a/skills/non-compete-contract-explainer/content/new-jersey.md
+++ b/skills/non-compete-contract-explainer/content/new-jersey.md
@@ -1,0 +1,277 @@
+---
+jurisdiction: "New Jersey"
+slug: new-jersey
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-03"
+canonicalUrl: https://openagreements.org/legal/non-compete/new-jersey
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/new-jersey · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in New Jersey[^about]
+
+New Jersey enforces non-competes under the common-law Solari/Whitmyer reasonableness test, readily reforms overbroad covenants, and faces pending legislation that would ban most of them.
+
+
+## At a glance
+
+| Question | New Jersey |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed if reasonable |
+| **Bottom line** | New Jersey enforces employee non-competes under the common-law Solari/Whitmyer three-part reasonableness test and readily blue-pencils overbroad covenants, though a pending bill would ban most of them. |
+| **Main law or case** | Solari Industries, Inc. v. Malady, 55 N.J. 571 (1970); Whitmyer Bros., Inc. v. Doyle, 58 N.J. 25 (1971) |
+| **Main exceptions** | Sale-of-business more freely enforceable; physician public-interest scrutiny; psychologist rule (N.J.A.C. 13:42-10.16); attorney ban (RPC 5.6) |
+| **Can a court narrow it?** | Yes — rewrites to reasonable |
+| **Applies to contractors?** | Unclear |
+| **Restriction extended during a breach?** | Yes — court may toll the restricted period during an actual breach (ADP v. Kusins) |
+| **Maximum length set by law** | No statutory limit |
+
+## Are employee non-compete agreements enforceable in New Jersey? {#employee-noncompetes}
+
+**Short answer.** Yes, when reasonable. New Jersey has no general non-compete statute for the ordinary workforce, so enforceability turns on the common-law *Solari/Whitmyer* test: a covenant is enforced only where it protects the employer's legitimate interests, imposes no undue hardship on the employee, and is not injurious to the public [^solari-given-effect][^solari-three-prong].
+
+The standard comes from two early-1970s New Jersey Supreme Court decisions, *Solari Industries, Inc. v. Malady* and *Whitmyer Bros., Inc. v. Doyle*. A post-employment covenant is scrutinized more closely than a covenant tied to the sale of a business, because of the countervailing policy in favor of employee mobility, but it is still given effect when it is reasonable on the facts [^solari-given-effect].
+
+The three prongs — legitimate interest, undue hardship, and public interest — are weighed together, and the New Jersey Supreme Court restated them in the modern physician case *Community Hospital Group, Inc. v. More* [^more-three-prong].
+
+A covenant tied to the sale of a business is treated more leniently. *Whitmyer* explains that a seller's covenant protecting the goodwill sold to the buyer is freely enforceable, whereas an employee's post-employment covenant is scrutinized more closely because of the policy favoring employee mobility [^whitmyer-sale-of-business].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not treat New Jersey as either a free-for-all or a ban state. Test the restraint against all three *Solari/Whitmyer* prongs — legitimate interest, undue hardship, and public interest — before assuming a New Jersey covenant is enforceable [^solari-three-prong].
+
+## Is continued employment enough consideration for a New Jersey non-compete? {#consideration}
+
+**Short answer.** Often, yes. New Jersey is comparatively employer-friendly on consideration: *Hogan v. Bergen Brunswig Corp.* holds that adequate consideration for a post-employment restraint can be found in the original employment contract or in continued employment after the covenant is signed [^hogan-continued-employment].
+
+This distinguishes New Jersey from states that require independent, new consideration whenever an existing employee signs a covenant. Under *Hogan*, an employer need not promise a raise or bonus or even threaten discharge; the continuation of the employment relationship can itself supply the consideration [^hogan-three-years].
+
+That latitude is not unlimited. The covenant must still be reasonable under *Solari/Whitmyer*, and a court evaluating undue hardship may weigh how the consideration and the restraint actually balanced out for the particular employee.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not assume the New Jersey consideration rule excuses an unreasonable restraint. Continued employment can support the covenant, but the restraint itself must still pass the *Solari/Whitmyer* reasonableness test on duration, territory, and scope [^hogan-continued-employment].
+
+## What legitimate business interests can support a New Jersey non-compete? {#protectable-interests}
+
+**Short answer.** Trade secrets, confidential business information, and customer relationships are the recognized protectable interests, and the New Jersey Trade Secrets Act supplies the statutory trade-secret overlay [^whitmyer-legitimate-interest][^njtsa-trade-secret-definition].
+
+*Whitmyer* identifies the employer's legitimate interests as its trade secrets, confidential business information, and customer relationships [^whitmyer-legitimate-interest]. *Ingersoll-Rand Co. v. Ciavatta* repeats that employers may protect those same interests, while making clear that a covenant cannot exist merely to suppress ordinary competition or to keep an employee from using general skill and knowledge [^ingersoll-protectable-interests].
+
+The New Jersey Trade Secrets Act, codified at N.J.S.A. 56:15-1 and following, runs alongside contractual restraints. It defines a trade secret by independent economic value derived from secrecy and reasonable efforts to maintain that secrecy [^njtsa-trade-secret-definition].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not use a New Jersey non-compete to block competition disconnected from a protectable interest. Tie the restraint to specific trade secrets, confidential information, or customer relationships, and keep trade-secret remedies in a separate confidentiality and Trade Secrets Act strategy [^ingersoll-protectable-interests][^njtsa-trade-secret-definition].
+
+## What duration and geographic scope are reasonable for a New Jersey non-compete? {#duration-geography}
+
+**Short answer.** There is no statutory cap. New Jersey courts test duration and territory as part of the undue-hardship and public-interest analysis, and durations in the one-to-two-year range are commonly upheld when the geography is tailored to where the employee actually worked [^more-two-year][^more-geography-reduced].
+
+In *More*, the New Jersey Supreme Court found that, on its face, a two-year restriction was a reasonable period for the hospital to replace and train a successor [^more-two-year]. Geography is judged against the employer's real footprint and the public's access to the service: in the same case the Court held that limiting the covenant to a radius small enough to exclude a nearby hospital would remove the covenant's harmful impact on the public [^more-geography-reduced].
+
+Because the analysis is holistic, a restraint matched to the employee's actual territory and to the time needed to protect the relationship is far easier to defend than a long, open-ended, statewide ban.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not copy a fixed term or radius from another form. Match the duration and territory to the employee's role and the employer's real market, because a New Jersey court weighs the restraint as a whole and there is no safe-harbor number [^more-two-year][^more-geography-reduced].
+
+## Will a New Jersey court blue-pencil or reform an overbroad non-compete? {#court-narrowing}
+
+**Short answer.** Yes. *Solari* abandoned the old void-per-se rule in favor of total or partial enforcement to the extent reasonable, so New Jersey courts narrow overbroad covenants rather than striking them down outright [^solari-partial-enforcement][^rafferty-curtail-scope].
+
+*Solari* is the foundational statement: New Jersey rejected the rule that an overbroad covenant is wholly void and adopted partial enforcement to the extent reasonable under the circumstances [^solari-partial-enforcement]. Applying New Jersey law, the Third Circuit in *ADP, LLC v. Rafferty* described curtailing an overbroad covenant's scope as the approach prescribed by the New Jersey Supreme Court [^rafferty-curtail-scope].
+
+That reformation power is not a license to overreach. Reformation is an equitable remedy, and an employer that drafts an abusively broad covenant cannot assume a court will rewrite it into something enforceable.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not rely on New Jersey's reformation power as a safety net for an aggressive covenant. Draft tiered, severable, reasonable restraints, because a court narrows in equity and may decline to rescue a covenant it views as overreaching [^solari-partial-enforcement][^rafferty-curtail-scope].
+
+## How does New Jersey treat customer and employee non-solicitation covenants? {#non-solicitation}
+
+**Short answer.** Non-solicitation covenants are analyzed under the same *Solari/Whitmyer* reasonableness framework as non-competes, and overbroad ones are blue-penciled to a reasonable scope rather than discarded [^kusins-blue-pencil-definition][^rafferty-legitimate-interests].
+
+In *ADP, LLC v. Kusins*, the Appellate Division reviewed customer and employee non-solicitation provisions and applied blue-penciling — a court's modification or tailoring of a restrictive covenant — to narrow them to what reasonably protected the employer's interests [^kusins-blue-pencil-definition]. In related ADP litigation, the Third Circuit, applying New Jersey law, concluded that ADP's tiered restrictive covenants furthered legitimate business interests and complied with New Jersey public policy [^rafferty-legitimate-interests].
+
+A narrowly drawn non-solicitation clause — limited to customers the employee actually served or learned about — is generally easier to enforce than a broad covenant against all competition.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not draft a customer non-solicit that reaches every client regardless of the employee's contact with them. Limit it to customers the employee actually served or learned about, because New Jersey courts blue-pencil overbroad non-solicitation clauses and may narrow yours for you [^kusins-blue-pencil-definition].
+
+## Does a New Jersey non-compete toll or extend during breach or litigation? {#tolling-extension}
+
+**Short answer.** It can. In *ADP, LLC v. Kusins*, the Appellate Division enforced contractual tolling and remanded for the trial court to toll the restricted period during the time the former employees were violating their covenants [^kusins-tolling].
+
+*Kusins* shows that a well-drafted clause suspending the restricted period during an actual, court-determined violation can be given effect, so the employer realizes the benefit of its bargain rather than losing protection to delay [^kusins-tolling]. But the extension is tied to a real breach, not to the mere passage of time. *More* cautions that restrictive covenants are not favored and refused to extend a covenant beyond its stated period absent justification [^more-no-extension].
+
+The safer course is to draft any tolling clause so that it runs only for the duration of an actual breach, rather than as an automatic, open-ended extension that could itself be attacked as unreasonable.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Draft a tolling clause to run only while the former employee is actually violating the covenant, as determined by a court. New Jersey will enforce tolling tied to a real breach, but a covenant disfavors gratuitous extension, so an automatic, indefinite extension risks being found unreasonable [^kusins-tolling][^more-no-extension].
+
+## How does New Jersey treat physician and health-care non-competes? {#physician-covenants}
+
+**Short answer.** Physician covenants are enforceable when reasonable, but the public-interest prong gets close scrutiny. In *More*, the New Jersey Supreme Court applied the three-part test to a neurosurgeon's covenant and reduced its geographic reach to protect public access to care [^q8-more-three-prong][^q8-more-geography-reduced].
+
+New Jersey has long declined to treat physician covenants as per se void — the New Jersey Supreme Court established in *Karlin v. Weinberg* that a physician covenant is enforceable to the extent it is reasonable — but it weighs the community's access to medical care heavily. *More* reduced the radius of a hospital's covenant rather than voiding it, illustrating how the public-interest prong drives the remedy [^q8-more-geography-reduced]. Its companion decision, *Pierson v. Medical Health Centers, P.A.*, frames the same inquiry for the trial court: whether the covenant protects a legitimate interest, imposes no undue hardship, and is not adverse to the public interest [^pierson-physician-standard].
+
+For shortage specialties and on-call coverage, expect courts to scrutinize whether enforcement would deprive the community of needed care.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not assume a physician covenant fails or succeeds on duration and territory alone. In New Jersey the public-interest prong can shrink or defeat a health-care covenant where enforcement would limit patient access to needed care [^q8-more-geography-reduced][^pierson-physician-standard].
+
+## Which New Jersey professions have special non-compete limits? {#professional-carveouts}
+
+**Short answer.** Psychologists are the clearest example. A New Jersey regulation bars a licensed psychologist from entering a business agreement that restricts a client's ability to keep seeing the therapist of choice, and *Comprehensive Psychology System, P.C. v. Prince* treated that rule as controlling [^njac-therapist-choice][^prince-patient-rights].
+
+The Board of Psychological Examiners rule, N.J.A.C. 13:42-10.16, prohibits a licensee from entering any business agreement that interferes with or restricts a client's access to the therapist of choice [^njac-therapist-choice]. In *Prince*, the Appellate Division read that rule as a restriction on psychologist covenants and emphasized that the uniquely personal patient-psychologist relationship forbids restraints that interfere with ongoing treatment [^prince-treatment-interference]. The court explained the rule shifts the focus from the psychologist's rights to the patient's rights [^prince-patient-rights].
+
+Attorneys are the other clear example, and here the limit is stricter than ordinary reasonableness. RPC 5.6 prohibits a lawyer from making a partnership or employment agreement that restricts the right to practice law after the relationship ends, apart from retirement benefits [^rpc-attorney-restriction]. In *Jacob v. Norris, McLaughlin & Marcus*, the New Jersey Supreme Court held that this rule reaches not only outright bans but also indirect financial-disincentive provisions — clauses that strip compensation from a departing lawyer who keeps serving firm clients — because they violate the language and spirit of RPC 5.6 [^jacob-indirect-restriction]. Such a provision is unenforceable as against public policy [^jacob-public-policy].
+
+The analysis does not soften for in-house counsel. The Advisory Committee on Professional Ethics concluded in Opinion 708 that corporate and in-house counsel practicing in New Jersey must follow the Rules of Professional Conduct, including RPC 5.6, whether or not they are admitted in the State [^acpe-708-inhouse]. An employer therefore cannot bind its in-house lawyers with a covenant that RPC 5.6 would forbid for outside counsel.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not analyze a psychologist's covenant under ordinary reasonableness alone. N.J.A.C. 13:42-10.16 can bar enforcement where the covenant would interfere with a client's access to the therapist of choice, regardless of how reasonable the time and territory look [^njac-therapist-choice][^prince-treatment-interference].
+
+## Can confidentiality and non-disparagement clauses replace a New Jersey non-compete? {#confidentiality-lad}
+
+**Short answer.** Partly, but watch the discrimination-law trap. Trade-secret and confidentiality protection is available under the New Jersey Trade Secrets Act, yet a 2019 amendment to the Law Against Discrimination makes a clause unenforceable when it conceals the details of a discrimination, retaliation, or harassment claim [^njtsa-short-title][^lad-conceal-unenforceable].
+
+The New Jersey Trade Secrets Act gives employers a statutory remedy for misappropriation, which is often a better fit than a non-compete when the real concern is protecting confidential information [^njtsa-short-title]. But confidentiality and non-disparagement language has a New Jersey-specific limit: N.J.S.A. 10:5-12.8(a) makes any provision whose purpose or effect is to conceal the details of a discrimination, retaliation, or harassment claim unenforceable [^lad-conceal-unenforceable]. The New Jersey Supreme Court applied that rule in *Savage v. Township of Neptune*, holding a non-disparagement clause unenforceable and explaining that the label on the clause does not control [^savage-nondisparagement-void][^savage-labels-dont-control].
+
+Importantly, the same statute expressly preserves traditional non-competes and proprietary-information agreements, so the discrimination-concealment rule does not bar an ordinary non-compete [^lad-noncompete-carveout]. Trying to enforce a barred concealment provision also carries a fee-shifting penalty [^lad-fee-shifting].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not draft a confidentiality or non-disparagement clause that would conceal the details of a discrimination, retaliation, or harassment claim. New Jersey makes such a provision unenforceable and exposes the party trying to enforce it to the employee's attorney fees and costs [^lad-conceal-unenforceable][^lad-fee-shifting].
+
+## What pending New Jersey non-compete legislation should employers watch? {#pending-legislation}
+
+**Short answer.** None is law yet. Bills S1407 and A1829, introduced in the 2026 session, would prohibit non-compete clauses for most workers, void no-poach agreements, and leave only a narrow senior-executive carve-out that itself requires full pay during the restricted period [^s1407-ban][^s1407-no-poach].
+
+As introduced, S1407 would bar an employer from seeking, requiring, demanding, or accepting a non-compete clause from a worker who is not a senior executive [^s1407-ban]. Both bills define a *senior executive* as a worker in a policy-making position paid at least the statutory compensation threshold — the only category of worker for whom a prospective covenant could survive [^a1829-senior-executive]. Both bills also declare no-poach agreements contrary to public policy and void [^s1407-no-poach].
+
+Even for that narrow carve-out, a surviving senior-executive covenant would have to pay the worker an amount equal to 100 percent of pay during the restricted period — a garden-leave condition [^s1407-garden-leave]. The bills also leave the ordinary commercial exception intact: a non-compete entered as part of a bona-fide sale of a business would remain permissible [^s1407-sale-of-business].
+
+These bills follow earlier versions (A5708 and S4385) that advanced in the prior session without enactment. As of this review they remain pending, not enacted, so common-law *Solari/Whitmyer* analysis still governs.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Treat S1407 and A1829 as monitoring items, not present New Jersey law. Recheck the Legislature's bill status before changing forms or telling workers that New Jersey has banned non-competes, because the enacted baseline is still common-law reasonableness [^s1407-ban][^a1829-senior-executive].
+
+## Did the FTC's federal non-compete rule change New Jersey non-compete law? {#federal-ftc-overlay}
+
+**Short answer.** No. The FTC's 2024 nationwide Non-Compete Rule was set aside by a federal court before it took effect, so New Jersey non-competes remain governed by state common law [^ryan-ftc-rule-set-aside].
+
+*Ryan LLC v. FTC* held that the FTC lacked statutory authority to issue the rule and that the rule was arbitrary and capricious [^ryan-ftc-unlawful]. The court set the rule aside with nationwide effect so that it would not be enforced or take effect [^ryan-ftc-rule-set-aside].
+
+That outcome leaves New Jersey's *Solari/Whitmyer* reasonableness analysis in control, and it makes the state-level reform bills, rather than any federal rule, the live question for New Jersey employers.
+
+"The Non-Compete Rule, 16 C.F.R. § 910.1–.6, is hereby SET ASIDE and shall not be enforced or otherwise take effect on September 4, 2024, or thereafter."[^ryan-ftc-rule-set-aside]
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-03. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not New Jersey. This article synthesizes New Jersey primary law and is not legal advice from a New Jersey-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^solari-given-effect]: **Solari Industries, Inc. v. Malady** — "And while a covenant by an employee not to compete after the termination of his employment is not, because of the countervailing policy considerations, as freely enforceable, it will nonetheless be given effect if it is reasonable in view of all the circumstances of the particular case." *Solari Industries, Inc. v. Malady, 55 N.J. 571 (1970).* <https://www.courtlistener.com/opinion/7374715/solari-industries-inc-v-malady/#:~:text=And%20while%20a%20covenant%20by,circumstances%20of%20the%20particular%20case.>
+
+[^solari-three-prong]: **Solari Industries, Inc. v. Malady** — "It will generally be found to be reasonable where it simply protects the legitimate interests of the employer, imposes no undue hardship on the employee, and is not injurious to the public." *Solari Industries, Inc. v. Malady, 55 N.J. 571 (1970).* <https://www.courtlistener.com/opinion/7374715/solari-industries-inc-v-malady/#:~:text=It%20will%20generally%20be%20found,not%20injurious%20to%20the%20public.>
+
+[^more-three-prong]: **Community Hospital Group, Inc. v. More** — "That test requires us to determine whether (1) the restrictive covenant was necessary to protect the employer’s legitimate interests in enforcement, (2) whether it would cause undue hardship to the employee, and (3) whether it would be injurious to the public." *Community Hospital Group, Inc. v. More, 183 N.J. 36 (2005).* <https://www.courtlistener.com/opinion/1957320/community-hospital-group-inc-v-more/#:~:text=That%20test%20requires%20us%20to,be%20injurious%20to%20the%20public.>
+
+[^whitmyer-sale-of-business]: **Whitmyer Bros., Inc. v. Doyle** — "we pointed out that while a seller’s noncompetitive covenant designed to protect the good will of the business for the buyer is freely enforceable, an employee’s covenant not to compete after the termination of his employment is not as freely enforceable because of well recognized countervailing policy considerations." *Whitmyer Bros., Inc. v. Doyle, 58 N.J. 25 (1971).* <https://www.courtlistener.com/opinion/2061132/whitmyer-bros-inc-v-doyle/#:~:text=we%20pointed%20out%20that%20while,well%20recognized%20countervailing%20policy%20considerations.>
+
+[^hogan-continued-employment]: **Hogan v. Bergen Brunswig Corp.** — "The existence of sufficient consideration to support a post-employment restraint may be found in either the original contract of employment or in a post-employment contract, where the supporting consideration is at least, in part, the continuation of employment." *Hogan v. Bergen Brunswig Corp., 153 N.J. Super. 37 (App. Div. 1977).* <https://www.courtlistener.com/opinion/2358200/hogan-v-bergen-brunswig-corporation/#:~:text=The%20existence%20of%20sufficient%20consideration,part%2C%20the%20continuation%20of%20employment.>
+
+[^hogan-three-years]: **Hogan v. Bergen Brunswig Corp.** — "The continuation of plaintiff's employment for approximately three years after he signed the letter which acknowledges the covenant also provides consideration for the restrictive covenant." *Hogan v. Bergen Brunswig Corp., 153 N.J. Super. 37 (App. Div. 1977).* <https://www.courtlistener.com/opinion/2358200/hogan-v-bergen-brunswig-corporation/#:~:text=The%20continuation%20of%20plaintiff's%20employment,consideration%20for%20the%20restrictive%20covenant.>
+
+[^whitmyer-legitimate-interest]: **Whitmyer Bros., Inc. v. Doyle** — "But the employer has a patently legitimate interest in protecting his trade secrets as well as his confidential business information and he has an equally legitimate interest in protecting his customer relationships." *Whitmyer Bros., Inc. v. Doyle, 58 N.J. 25 (1971).* <https://www.courtlistener.com/opinion/2061132/whitmyer-bros-inc-v-doyle/#:~:text=But%20the%20employer%20has%20a,in%20protecting%20his%20customer%20relationships.>
+
+[^njtsa-trade-secret-definition]: **New Jersey Trade Secrets Act** — "Derives independent economic value, actual or potential, from not being generally known to, and not being readily ascertainable by proper means by, other persons who can obtain economic value from its disclosure or use;" *New Jersey Trade Secrets Act, N.J.S.A. 56:15-2.* <https://pub.njleg.gov/bills/2010/PL11/161_.PDF>
+
+[^ingersoll-protectable-interests]: **Ingersoll-Rand Co. v. Ciavatta** — "Employers, therefore, have the right to protect their trade secrets, confidential information, and customer relations." *Ingersoll-Rand Co. v. Ciavatta, 110 N.J. 609 (1988).* <https://www.courtlistener.com/opinion/1916343/ingersoll-rand-co-v-ciavatta/#:~:text=Employers%2C%20therefore%2C%20have%20the%20right,confidential%20information%2C%20and%20customer%20relations.>
+
+[^more-two-year]: **Community Hospital Group, Inc. v. More** — "On its face two years appears to be a reasonable period for JFK to replace and train a person to assume Dr. More’s prior role." *Community Hospital Group, Inc. v. More, 183 N.J. 36 (2005).* <https://www.courtlistener.com/opinion/1957320/community-hospital-group-inc-v-more/#:~:text=On%20its%20face%20two%20years,assume%20Dr.%20More%E2%80%99s%20prior%20role.>
+
+[^more-geography-reduced]: **Community Hospital Group, Inc. v. More** — "We are satisfied that if the covenant were limited to a distance less than thirteen miles so that Somerset was not within the restricted area, the covenant would not have the same adverse impact on the public that it presently has." *Community Hospital Group, Inc. v. More, 183 N.J. 36 (2005).* <https://www.courtlistener.com/opinion/1957320/community-hospital-group-inc-v-more/#:~:text=We%20are%20satisfied%20that%20if,public%20that%20it%20presently%20has.>
+
+[^solari-partial-enforcement]: **Solari Industries, Inc. v. Malady** — "We are entirely satisfied that the time is well due for the abandonment of New Jersey’s void per se rule in favor of the rule which permits the total or partial enforcement of noncompetitive agreements to the extent reasonable under the circumstances." *Solari Industries, Inc. v. Malady, 55 N.J. 571 (1970).* <https://www.courtlistener.com/opinion/7374715/solari-industries-inc-v-malady/#:~:text=We%20are%20entirely%20satisfied%20that,extent%20reasonable%20under%20the%20circumstances.>
+
+[^rafferty-curtail-scope]: **ADP, LLC v. Rafferty** — "Accordingly, we will remand for the District Court to consider whether and to what extent it is necessary to curtail the restrictive covenants’ scope, which is the approach prescribed by the New Jersey Supreme Court when confronted with overbroad restrictive covenants such as these." *ADP, LLC v. Rafferty, 923 F.3d 113 (3d Cir. 2019).* <https://www.courtlistener.com/opinion/4614026/adp-llc-v-nicole-rafferty-adp-llc/#:~:text=Accordingly%2C%20we%20will%20remand%20for,restrictive%20covenants%20such%20as%20these.>
+
+[^kusins-blue-pencil-definition]: **ADP, LLC v. Kusins** — "The term ‘blue pencil[ing]’ refers to a court's modification or tailoring of a restrictive covenant." *ADP, LLC v. Kusins, 460 N.J. Super. 368 (App. Div. 2019).* <https://www.courtlistener.com/opinion/4650682/adp-llc-vs-erik-kusins-adp-llc-vs-ryan-hopper-adp-llc-vs-anthony-m/#:~:text=The%20term%20%22blue%20pencil%5Bing%5D%22%20refers,tailoring%20of%20a%20restrictive%20covenant.>
+
+[^rafferty-legitimate-interests]: **ADP, LLC v. Rafferty** — "Applying New Jersey law, we conclude that both tiers of ADP’s restrictive covenants further legitimate business interests and otherwise comply with the state’s public policy." *ADP, LLC v. Rafferty, 923 F.3d 113 (3d Cir. 2019).* <https://www.courtlistener.com/opinion/4614026/adp-llc-v-nicole-rafferty-adp-llc/#:~:text=Applying%20New%20Jersey%20law%2C%20we,with%20the%20state%E2%80%99s%20public%20policy.>
+
+[^kusins-tolling]: **ADP, LLC v. Kusins** — "In all of the matters other than Kusins, we remand for a determination of the appropriate remedy for each defendant's breach of the RCA, including a tolling of the time limitations of the RCAs during the period of defendants' violations." *ADP, LLC v. Kusins, 460 N.J. Super. 368 (App. Div. 2019).* <https://www.courtlistener.com/opinion/4650682/adp-llc-vs-erik-kusins-adp-llc-vs-ryan-hopper-adp-llc-vs-anthony-m/#:~:text=In%20all%20of%20the%20matters,the%20period%20of%20defendants'%20violations.>
+
+[^more-no-extension]: **Community Hospital Group, Inc. v. More** — "Because restrictive covenants are not favored in the law, we find no justification to extend the agreement beyond that period." *Community Hospital Group, Inc. v. More, 183 N.J. 36 (2005).* <https://www.courtlistener.com/opinion/1957320/community-hospital-group-inc-v-more/#:~:text=Because%20restrictive%20covenants%20are%20not,the%20agreement%20beyond%20that%20period.>
+
+[^q8-more-three-prong]: **Community Hospital Group, Inc. v. More** — "That test requires us to determine whether (1) the restrictive covenant was necessary to protect the employer’s legitimate interests in enforcement, (2) whether it would cause undue hardship to the employee, and (3) whether it would be injurious to the public." *Community Hospital Group, Inc. v. More, 183 N.J. 36 (2005).* <https://www.courtlistener.com/opinion/1957320/community-hospital-group-inc-v-more/#:~:text=That%20test%20requires%20us%20to,be%20injurious%20to%20the%20public.>
+
+[^q8-more-geography-reduced]: **Community Hospital Group, Inc. v. More** — "We are satisfied that if the covenant were limited to a distance less than thirteen miles so that Somerset was not within the restricted area, the covenant would not have the same adverse impact on the public that it presently has." *Community Hospital Group, Inc. v. More, 183 N.J. 36 (2005).* <https://www.courtlistener.com/opinion/1957320/community-hospital-group-inc-v-more/#:~:text=We%20are%20satisfied%20that%20if,public%20that%20it%20presently%20has.>
+
+[^pierson-physician-standard]: **Pierson v. Medical Health Centers, P.A.** — "Rather, the trial court must determine whether the restrictive covenant protects the legitimate interests of the employer, imposes no undue hardship on the employee, and is not adverse to the public interest." *Pierson v. Medical Health Centers, P.A., 183 N.J. 65 (2005).* <https://www.courtlistener.com/opinion/1957686/pierson-v-medical-health-centers/#:~:text=Rather%2C%20the%20trial%20court%20must,adverse%20to%20the%20public%20interest.>
+
+[^njac-therapist-choice]: **N.J.A.C. 13:42-10.16** — "A licensee shall not enter into any business agreement that interferes with or restricts the ability of a client to see or continue to see his or her therapist of choice." *N.J.A.C. 13:42-10.16.* <https://dspace.njstatelib.org/bitstreams/13f70d2e-c854-4547-9f99-9997089d3164/download>
+
+[^prince-patient-rights]: **Comprehensive Psychology System, P.C. v. Prince** — "We are satisfied that the new regulation merely articulates the same restriction in language that shifts the focus of concern from the rights of the psychologist to the rights of the patient." *Comprehensive Psychology Sys., P.C. v. Prince, 375 N.J. Super. 273 (App. Div. 2005).* <https://www.courtlistener.com/opinion/1547623/comprehensive-psycho-sys-v-prince/#:~:text=We%20are%20satisfied%20that%20the%20new,the%20rights%20of%20the%20patient.>
+
+[^prince-treatment-interference]: **Comprehensive Psychology System, P.C. v. Prince** — "We also are persuaded that, apart from the existence of the regulations, the nature of the practice of psychology and the uniquely personal patient-psychologist relationship forbid any restrictions which might interfere with an ongoing course of treatment." *Comprehensive Psychology Sys., P.C. v. Prince, 375 N.J. Super. 273 (App. Div. 2005).* <https://www.courtlistener.com/opinion/1547623/comprehensive-psycho-sys-v-prince/#:~:text=We%20also%20are%20persuaded%20that%2C,an%20ongoing%20course%20of%20treatment.>
+
+[^rpc-attorney-restriction]: **N.J. Ct. R., RPC 5.6** — "A lawyer shall not participate in offering or making: (a) a partnership or employment agreement that restricts the rights of a lawyer to practice after termination of the relationship, except an agreement concerning benefits upon retirement; or (b) an agreement in which a restriction on the lawyer's right to practice is part of the settlement of a controversy between private parties." *N.J. Ct. R., RPC 5.6.* <https://www.njcourts.gov/sites/default/files/rpc.pdf>
+
+[^jacob-indirect-restriction]: **Jacob v. Norris, McLaughlin & Marcus** — "We believe that indirect restrictions on the practice of law, such as the financial disincentives at issue in this case, likewise violate both the language and the spirit of RPC 5.6." *Jacob v. Norris, McLaughlin & Marcus, 128 N.J. 10 (1992).* <https://www.courtlistener.com/opinion/1984610/jacob-v-norris-mclaughlin-marcus/#:~:text=We%20believe%20that%20indirect%20restrictions,the%20spirit%20of%20RPC%205.6.>
+
+[^jacob-public-policy]: **Jacob v. Norris, McLaughlin & Marcus** — "We conclude that the Agreement's competitive departure provision restricts the practice of law in contravention of RPC 5.6 and is therefore unenforceable as against public policy." *Jacob v. Norris, McLaughlin & Marcus, 128 N.J. 10 (1992).* <https://www.courtlistener.com/opinion/1984610/jacob-v-norris-mclaughlin-marcus/#:~:text=We%20conclude%20that%20the%20Agreement's,unenforceable%20as%20against%20public%20policy.>
+
+[^acpe-708-inhouse]: **ACPE Opinion 708** — "Therefore, it is our opinion that in-house or corporate counsel in New Jersey must abide by the Rules of Professional Conduct, regardless of whether they are members of the bar of our State." *N.J. Advisory Comm. on Prof'l Ethics, Op. 708 (2006).* <https://www.njcourts.gov/sites/default/files/notices/2006/07/ACPEOpinion708.pdf>
+
+[^njtsa-short-title]: **New Jersey Trade Secrets Act** — "This act shall be known and may be cited as the ‘New Jersey Trade Secrets Act.’" *New Jersey Trade Secrets Act, N.J.S.A. 56:15-1.* <https://pub.njleg.gov/bills/2010/PL11/161_.PDF>
+
+[^lad-conceal-unenforceable]: **N.J.S.A. 10:5-12.8 (P.L.2019, c.39)** — "A provision in any employment contract or settlement agreement which has the purpose or effect of concealing the details relating to a claim of discrimination, retaliation, or harassment (hereinafter referred to as a ‘non-disclosure provision’) shall be deemed against public policy and unenforceable against a current or former employee (hereinafter referred to as an ‘employee’) who is a party to the contract or settlement." *N.J.S.A. 10:5-12.8(a).* <https://pub.njleg.gov/bills/2018/PL19/39_.PDF>
+
+[^savage-nondisparagement-void]: **Savage v. Township of Neptune** — "The non-disparagement clause in the agreement is against public policy and cannot be enforced." *Savage v. Township of Neptune, 257 N.J. 204 (2024).* <https://www.courtlistener.com/opinion/9499942/christine-savage-v-township-of-neptune/#:~:text=The%20non%2Ddisparagement%20clause%20in%20the,policy%20and%20cannot%20be%20enforced.>
+
+[^savage-labels-dont-control]: **Savage v. Township of Neptune** — "As a result, labels like ‘non-disclosure,’ which is in the text, or ‘non-disparagement,’ which is not, do not control the meaning of section 12.8." *Savage v. Township of Neptune, 257 N.J. 204 (2024).* <https://www.courtlistener.com/opinion/9499942/christine-savage-v-township-of-neptune/#:~:text=As%20a%20result%2C%20labels%20like,the%20meaning%20of%20section%2012.8.>
+
+[^lad-noncompete-carveout]: **N.J.S.A. 10:5-12.8 (P.L.2019, c.39)** — "this section shall not be construed to prohibit an employer from requiring an employee to sign an agreement: (1) in which the employee agrees not to enter into competition with the employer during or after employment;" *N.J.S.A. 10:5-12.8(c).* <https://pub.njleg.gov/bills/2018/PL19/39_.PDF>
+
+[^lad-fee-shifting]: **N.J.S.A. 10:5-12.9 (P.L.2019, c.39)** — "A person who enforces or attempts to enforce a provision deemed against public policy and unenforceable pursuant to P.L.2019, c.39 (C.10:5-12.7 et seq.) shall be liable for the employee’s reasonable attorney fees and costs." *N.J.S.A. 10:5-12.9.* <https://pub.njleg.gov/bills/2018/PL19/39_.PDF>
+
+[^s1407-ban]: **New Jersey Senate Bill No. 1407 (2026)** — "With respect to a worker who is not a senior executive, an employer shall not: seek, require, demand, or accept a non-compete clause from the worker after the effective date of this act;" *S1407, 222nd Leg. (N.J. 2026).* <https://pub.njleg.state.nj.us/Bills/2026/S1500/1407_I1.PDF>
+
+[^s1407-no-poach]: **New Jersey Senate Bill No. 1407 (2026)** — "No-poach agreements are hereby declared to be contrary to public policy and any no-poach agreement shall be void." *S1407, 222nd Leg. (N.J. 2026).* <https://pub.njleg.state.nj.us/Bills/2026/S1500/1407_I1.PDF>
+
+[^a1829-senior-executive]: **New Jersey Assembly Bill No. 1829 (2026)** — "‘Senior executive’ means a worker who is in a policy-making position with an employer and is paid total compensation of not less than $151,164 during the year immediately preceding the end of employment, or not less than $151,164 when annualized if the worker was employed during only part of the preceding year." *A1829, 222nd Leg. (N.J. 2026).* <https://pub.njleg.state.nj.us/Bills/2026/A2000/1829_I1.PDF>
+
+[^s1407-garden-leave]: **New Jersey Senate Bill No. 1407 (2026)** — "The non-compete clause provides that during any period after the employment relationship ends in which the worker is prevented from engaging in work or taking employment because of restrictions imposed by the non-compete clause, the employer, unless the worker is terminated for misconduct or there is a breach by the worker, shall pay the worker an amount equal to 100 percent of the pay to which the worker would be entitled for the work during that period; and make any benefit contributions needed to maintain the fringe benefits to which the worker would be entitled during that period." *S1407, 222nd Leg. (N.J. 2026).* <https://pub.njleg.state.nj.us/Bills/2026/S1500/1407_I1.PDF>
+
+[^s1407-sale-of-business]: **New Jersey Senate Bill No. 1407 (2026)** — "To a non-compete clause that is entered into by an employer pursuant to a bona fide sale of a business entity, of the employer's ownership interest in a business entity, or of all or substantially all of a business entity's operating assets;" *S1407, 222nd Leg. (N.J. 2026).* <https://pub.njleg.state.nj.us/Bills/2026/S1500/1407_I1.PDF>
+
+[^ryan-ftc-rule-set-aside]: **Ryan LLC v. Federal Trade Commission** — "The Non-Compete Rule, 16 C.F.R. § 910.1–.6, is hereby SET ASIDE and shall not be enforced or otherwise take effect on September 4, 2024, or thereafter." *Ryan LLC v. Fed. Trade Comm'n, 746 F. Supp. 3d 369 (N.D. Tex. 2024).* <https://www.courtlistener.com/opinion/10205745/ryan-llc-v-federal-trade-commission/#:~:text=The%20Non%2DCompete%20Rule%2C%2016%20C.F.R.,September%204%2C%202024%2C%20or%20thereafter.>
+
+[^ryan-ftc-unlawful]: **Ryan LLC v. Federal Trade Commission** — "In sum, the Court concludes that the FTC lacks statutory authority to promulgate the Non- Compete Rule, and that the Rule is arbitrary and capricious." *Ryan LLC v. Fed. Trade Comm'n, 746 F. Supp. 3d 369 (N.D. Tex. 2024).* <https://www.courtlistener.com/opinion/10205745/ryan-llc-v-federal-trade-commission/#:~:text=In%20sum%2C%20the%20Court%20concludes%20that,Rule%20is%20arbitrary%20and%20capricious.>

--- a/skills/non-compete-contract-explainer/content/new-mexico.md
+++ b/skills/non-compete-contract-explainer/content/new-mexico.md
@@ -1,0 +1,244 @@
+---
+jurisdiction: "New Mexico"
+slug: new-mexico
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-03"
+canonicalUrl: https://openagreements.org/legal/non-compete/new-mexico
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/new-mexico · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in New Mexico[^about]
+
+New Mexico enforces ordinary employee non-competes only when they are reasonable and supported by valid consideration, with a statutory ban for covered health-care practitioners.
+
+
+## At a glance
+
+| Question | New Mexico |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed if reasonable |
+| **Bottom line** | New Mexico enforces ordinary employee non-competes only when reasonable and supported by valid consideration, but a statute makes covered health-care practitioner non-competes unenforceable. |
+| **Main law or case** | Lovelace Clinic v. Murphy, 76 N.M. 645 (1966); NMSA 1978, § 24A-4-2 |
+| **Main exceptions** | Health-care practitioner ban (§ 24A-4-2); sale-of-business more lenient |
+| **Can a court narrow it?** | Unsettled |
+| **Applies to contractors?** | — |
+| **Restriction extended during a breach?** | Open question — no authority |
+| **Maximum length set by law** | No statutory limit |
+
+## Are employee non-compete agreements enforceable in New Mexico? {#employee-noncompetes}
+
+**Short answer.** Yes, sometimes. New Mexico is a common-law reasonableness state for ordinary employee non-competes: the covenant must be reasonable in time, geography, and scope, and it must be tied to a legitimate business interest rather than a naked restraint on work [^lovelace-reasonableness-test][^mcgonigle-ordinary-enforceability].
+
+*Lovelace Clinic v. Murphy* is the foundational New Mexico case. It enforced a physician covenant because the restrictions were reasonable, while recognizing the public's competing interests in both free competition and contract enforcement [^lovelace-reasonableness-test]. Later cases restate the same basic frame: non-competes are ordinarily enforceable if the court deems the restraint reasonable [^mcgonigle-ordinary-enforceability].
+
+That does not mean every New Mexico covenant is enforceable. The employer still needs valid consideration, a protectable interest, and a restraint no broader than needed to protect that interest. Covered health-care practitioners also have a statutory ban addressed later in this note.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not treat New Mexico as either a general ban state or an automatic-enforcement state. Start with consideration and then test the covenant against reasonableness, legitimate interest, employee hardship, and public impact [^lovelace-public-interest][^lovelace-reasonableness-test].
+
+## Is continued at-will employment enough consideration for a New Mexico non-compete? {#consideration}
+
+**Short answer.** Probably not by itself for an existing at-will employee. *Piano v. Premier Distributing Co.* was an arbitration-agreement case, not a non-compete case, but it states New Mexico's general consideration rule: continued at-will employment is an illusory promise and cannot supply consideration [^piano-continued-employment-illusory][^piano-no-constraints].
+
+The new-hire and mid-stream situations differ. As a matter of general contract law, the initial offer of employment can itself serve as consideration for a covenant signed as a condition of being hired. The harder case is mid-stream: if an employer asks an existing at-will employee to sign a new non-compete after employment has already begun, *Piano* strongly supports requiring independent new consideration, such as a raise, bonus, promotion, equity grant, or other bargained-for benefit [^piano-no-constraints].
+
+The key point is not that *Piano* decided a non-compete dispute. It did not. The point is that New Mexico contract formation requires consideration, and a promise that leaves the employer free to terminate at will places no real constraint on the employer's future conduct [^piano-contract-elements].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not rely on a bare recital of continued at-will employment for a mid-stream New Mexico covenant. Document the new consideration in the agreement, because if consideration is missing, New Mexico treats the agreement as never formed [^piano-contract-never-formed][^piano-continued-employment-illusory].
+
+## What legitimate business interests can support a New Mexico non-compete? {#protectable-interests}
+
+**Short answer.** Specific proprietary interests can support a tailored restraint, especially confidential information and trade secrets. An employee's general skills and knowledge are not enough [^mcgonigle-general-skills][^utsa-trade-secret-definition].
+
+*Insure New Mexico v. McGonigle* is the leading caution on overclaiming ordinary employee knowledge. The employer had a confidentiality and trade-secret clause, but the court affirmed denial of a permanent injunction where customer information was not peculiar, current, or secret in the way the employer claimed [^mcgonigle-not-special].
+
+The New Mexico Uniform Trade Secrets Act supplies the statutory backstop. It defines trade secrets by economic value from secrecy and reasonable secrecy efforts, and it authorizes injunctions for actual or threatened misappropriation [^utsa-trade-secret-definition][^utsa-injunction]. That makes NDAs, trade-secret controls, return-of-property duties, and targeted non-solicits important alternatives when a full non-compete would be too broad.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not draft a New Mexico non-compete as a penalty for leaving or as protection against ordinary competition. Tie the restraint to a specific interest, and keep the trade-secret strategy separate enough to stand even if the non-compete is narrowed or denied [^mcgonigle-general-skills][^utsa-injunction].
+
+## What duration and geographic scope are reasonable for a New Mexico non-compete? {#duration-geography}
+
+**Short answer.** There is no general statutory cap. New Mexico courts evaluate time and territory under a facts-and-circumstances reasonableness test, looking at the business, the market, the parties, the protectable interest, and public impact [^bowen-facts-particular-case][^kidskare-facts-reformed-limits].
+
+The cases show outcomes, not safe harbors. *Lovelace* upheld a three-year, Bernalillo County physician restriction as reasonable in the circumstances [^lovelace-time-area]. *KidsKare* involved a dental covenant that a district court reduced from a one-hundred-mile restriction to thirty miles, with the court of appeals affirming the reformed covenant [^kidskare-facts-reformed-limits]. *Bowen* upheld a much longer sale-of-business covenant, but that posture is more employer-friendly because it protects purchased goodwill [^bowen-sale-more-deference].
+
+For employment covenants, the safer drafting pattern is to match the radius to the employee's actual territory and the duration to the time needed to protect goodwill or confidential relationships. For sale-of-business covenants, the purchase price, goodwill, payout period, and buyer's need for protection can support longer restraints than would be defensible for an ordinary employee [^bowen-sale-valid].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not copy a New Mexico duration or radius from another form. A term that worked in a physician-clinic, dental, or business-sale case may fail for a different employee if the employer cannot connect the time and territory to its actual protectable interest [^bowen-facts-particular-case][^kidskare-facts-reformed-limits].
+
+## Will a New Mexico court narrow or reform an overbroad non-compete? {#court-narrowing}
+
+**Short answer.** Sometimes, but do not assume an inherent blue-pencil power. *KidsKare* upheld modification because the parties' agreement expressly authorized amendment of an unenforceable provision and enforcement to the maximum reasonable extent [^kidskare-contract-reformation][^kidskare-bargained-reformation].
+
+New Mexico's reformation rule is narrow. In *KidsKare*, the court of appeals expressly avoided deciding the broader argument about New Mexico case law on reformation because the contract itself supplied the basis for modifying the covenant [^kidskare-no-general-ruling].
+
+The drafting takeaway is direct: include an express severability and reformation clause if the employer wants a court to enforce the covenant to the maximum reasonable extent. Even then, reformation is not a substitute for drafting a reasonable covenant in the first place.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not rely on a New Mexico court to rewrite a bare overbroad covenant. Include a clear reformation and severability clause, and draft the primary restriction narrowly enough that the court does not need to rescue it [^kidskare-contract-reformation][^kidskare-no-general-ruling].
+
+## Does a New Mexico non-compete toll or extend during breach or litigation? {#tolling-extension}
+
+**Short answer.** This is an open New Mexico question. The staged New Mexico non-compete cases and statutes do not squarely say that a court may automatically toll or extend a non-compete's restricted period while the former employee is allegedly breaching or while litigation is pending [^q6-lovelace-fixed-period][^q6-kidskare-fixed-period].
+
+The existing cases enforce or reform fixed restraints under a reasonableness framework. *Lovelace* enforced a physician covenant through the end of the contract's three-year period [^q6-lovelace-fixed-period]. *KidsKare* upheld a reformed one-year and thirty-mile restraint based on the contract's reformation language and the district court's reasonableness findings [^q6-kidskare-fixed-period]. Neither case announces a tolling rule.
+
+That silence matters. A contractual tolling clause should be drafted as its own restraint and tested for reasonableness, rather than assumed to revive or extend an expired covenant automatically.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Open question: New Mexico authority in this source set is silent on judicial tolling and contractual extension-on-breach clauses for non-competes. Draft any tolling clause narrowly, tie it to proven breach and legitimate interest, and do not assume a court will add time after the original period expires [^q6-lovelace-fixed-period][^q6-kidskare-fixed-period].
+
+## Which New Mexico workers have special non-compete limits? {#health-care-practitioners}
+
+**Short answer.** Covered health-care practitioners have the major New Mexico statutory limit. A non-compete that restricts a covered practitioner's right to provide clinical health-care services in New Mexico is unenforceable when the agreement, renewal, extension, or employment ends [^healthcare-ban][^healthcare-covered-practitioners].
+
+The covered practitioners include dentists, osteopathic physicians, physicians, podiatrists, certified registered nurse anesthetists, certified nurse practitioners, certified nurse-midwives, psychologists, physician assistants, and pharmacists [^healthcare-covered-practitioners]. The statute is not limited to one profession. Psychologists, physician assistants, and pharmacists are covered for agreements, renewals, or extensions executed on or after the effective date of the 2023 act [^healthcare-effective-dates].
+
+The statute leaves several tools available. It preserves repayment provisions for certain loans, relocation expenses, signing bonuses, recruiting, education, and training expenses when the practitioner worked for an initial period of less than three years [^healthcare-repayment]. It also preserves nondisclosure provisions for confidential information and trade secrets, patient and employee non-solicitation provisions lasting one year or less, other lawful provisions, and reasonable liquidated damages [^healthcare-nda-nonsolicit][^healthcare-liquidated-damages].
+
+Two additional limits matter. First, a covered clinical-services agreement cannot avoid New Mexico law through another state's law or an out-of-state litigation forum [^healthcare-choice-law-venue]. Second, the chapter does not apply to agreements between health-care practitioners who are shareholders, owners, partners, or directors of a health-care practice [^healthcare-owner-exemption].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not use ordinary common-law reasonableness to rescue a covered New Mexico health-care practitioner non-compete. If § 24A-4-2 applies, the non-compete provision is unenforceable, and drafting should shift to the statute's preserved tools: NDAs, capped non-solicits, repayment provisions, and reasonable liquidated damages [^healthcare-ban][^healthcare-nda-nonsolicit][^healthcare-liquidated-damages].
+
+## Will a choice-of-law or venue clause avoid New Mexico non-compete law? {#choice-of-law}
+
+**Short answer.** Not for covered clinical health-care services agreements. New Mexico voids provisions that make those agreements subject to another state's law or require litigation in another state [^q8-healthcare-choice-law-venue].
+
+That statutory rule is specific and strong. If a covered health-care practitioner is providing clinical services in New Mexico, the agreement cannot contract around the New Mexico statute through foreign law or out-of-state venue [^q8-healthcare-choice-law-venue].
+
+Outside the health-care statute, the provided New Mexico source set does not contain a non-compete-specific choice-of-law rule. The practical question is therefore whether the forum court will apply ordinary contract and conflicts principles while also respecting New Mexico's reasonableness and public-policy limits for restraints that operate in New Mexico [^q8-lovelace-public-policy].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not use a foreign choice-of-law or out-of-state venue clause to draft around New Mexico's health-care practitioner statute. For non-health-care covenants, do not assume the clause controls unless the forum and public-policy analysis also supports it [^q8-healthcare-choice-law-venue][^q8-lovelace-public-policy].
+
+## Did the FTC's federal non-compete rule change New Mexico non-compete law? {#federal-ftc-overlay}
+
+**Short answer.** No. A federal court set aside the FTC's 2024 nationwide Non-Compete Rule before it took effect, so New Mexico non-competes remain governed by New Mexico common law and the health-care practitioner statute [^q9-ftc-rule-set-aside][^q9-lovelace-state-law][^q9-healthcare-state-law].
+
+*Ryan LLC v. FTC* set the rule aside with nationwide effect so that it would not be enforced or take effect [^q9-ftc-rule-set-aside]. That federal overlay does not make any New Mexico covenant enforceable. It simply leaves the state-law analysis in place: ordinary employment covenants rise or fall under reasonableness, consideration, and protectable-interest rules, while covered health-care practitioner non-competes are governed by § 24A-4-2 [^q9-lovelace-state-law][^q9-healthcare-state-law].
+
+Employers should still monitor federal agency enforcement and the New Mexico Legislature. But unless a new operative federal rule or New Mexico statute applies, the sources in this note remain the working framework.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not update New Mexico forms as though a nationwide FTC ban currently displaces state law. Keep applying New Mexico's reasonableness, consideration, protectable-interest, and health-care statute rules until an operative source changes that analysis [^q9-lovelace-state-law][^q9-healthcare-state-law].
+
+## Are sale-of-business non-competes treated differently in New Mexico? {#sale-of-business}
+
+**Short answer.** Yes. New Mexico is more willing to enforce a reasonable covenant tied to the sale of a business than an ordinary employment covenant, because the buyer is paying for goodwill and protection from the seller's immediate competition [^q10-bowen-sale-valid][^q10-bowen-sale-deference].
+
+*Bowen v. Carlsbad Insurance & Real Estate* upheld a fifteen-year, fifteen-mile covenant connected to the sale of an insurance business. The court focused on the purchase price, the payout period, the nature of the insurance business, the seller's prominence, and the goodwill the buyer purchased [^q10-bowen-enforced-written].
+
+The sale context does not eliminate reasonableness. It changes the facts that support reasonableness: a buyer who paid for a going concern can often justify broader protection than an employer seeking to restrain a departing employee.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not use an employment covenant form for a New Mexico business sale. Draft the covenant around the purchased goodwill, the seller's role, the buyer's actual market, the purchase price, and the payout structure, because those facts drove the result in *Bowen* [^q10-bowen-sale-valid][^q10-bowen-enforced-written].
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-03. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not New Mexico. This article synthesizes New Mexico primary law and is not legal advice from a New Mexico-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^lovelace-reasonableness-test]: **Lovelace Clinic v. Murphy** — "All of the physician and surgeon cases either expressly hold or clearly indicate that the rights and duties created by the contract of employment or association are enforceable, if the restrictions thus imposed on the employee or the associate are reasonable." *Lovelace Clinic v. Murphy, 76 N.M. 645, 417 P.2d 450 (1966).* <https://www.courtlistener.com/opinion/1196089/lovelace-clinic-v-murphy/#:~:text=All%20of%20the%20physician%20and,or%20the%20associate%20are%20reasonable.>
+
+[^mcgonigle-ordinary-enforceability]: **Insure New Mexico, LLC v. McGonigle** — "Non-competition covenants are ordinarily enforceable as long as a court deems them reasonable." *Insure New Mexico, LLC v. McGonigle, 2000-NMCA-018, 995 P.2d 1053.* <https://www.courtlistener.com/opinion/1291299/insure-new-mexico-llc-v-mcgonigle/#:~:text=Non%2Dcompetition%20covenants%20are%20ordinarily%20enforceable,a%20court%20deems%20them%20reasonable.>
+
+[^lovelace-public-interest]: **Lovelace Clinic v. Murphy** — "The public has an interest in seeing that competition is not unreasonably limited or restricted, but it also has an interest in protecting the freedom of persons to contract, and in enforcing contractual rights and obligations." *Lovelace Clinic v. Murphy, 76 N.M. 645, 417 P.2d 450 (1966).* <https://www.courtlistener.com/opinion/1196089/lovelace-clinic-v-murphy/#:~:text=The%20public%20has%20an%20interest,enforcing%20contractual%20rights%20and%20obligations.>
+
+[^piano-continued-employment-illusory]: **Piano v. Premier Distributing Co.** — "Continued at-will employment is an illusory promise that cannot be consideration." *Piano v. Premier Distrib. Co., 2005-NMCA-018, 107 P.3d 11.* <https://www.courtlistener.com/opinion/2509475/piano-v-premier-distributing-co/#:~:text=Continued%20at%2Dwill%20employment%20is%20an,promise%20that%20cannot%20be%20consideration.>
+
+[^piano-no-constraints]: **Piano v. Premier Distributing Co.** — "The implied promise of continued at-will employment placed no constraints on Defendant’s future conduct; its decision to continue Plaintiffs at-will employment was entirely discretionary." *Piano v. Premier Distrib. Co., 2005-NMCA-018, 107 P.3d 11.* <https://www.courtlistener.com/opinion/2509475/piano-v-premier-distributing-co/#:~:text=The%20implied%20promise%20of%20continued,at%2Dwill%20employment%20was%20entirely%20discretionary.>
+
+[^piano-contract-elements]: **Piano v. Premier Distributing Co.** — "A legally enforceable contract requires evidence supporting the existence of ‘an offer, an acceptance, consideration, and mutual assent.’" *Piano v. Premier Distrib. Co., 2005-NMCA-018, 107 P.3d 11.* <https://www.courtlistener.com/opinion/2509475/piano-v-premier-distributing-co/#:~:text=A%20legally%20enforceable%20contract%20requires,acceptance%2C%20consideration%2C%20and%20mutual%20assent.%E2%80%9D>
+
+[^piano-contract-never-formed]: **Piano v. Premier Distributing Co.** — "Because we conclude that the agreement is not supported by consideration, a contract was never formed." *Piano v. Premier Distrib. Co., 2005-NMCA-018, 107 P.3d 11.* <https://www.courtlistener.com/opinion/2509475/piano-v-premier-distributing-co/#:~:text=Because%20we%20conclude%20that%20the,a%20contract%20was%20never%20formed.>
+
+[^mcgonigle-general-skills]: **Insure New Mexico, LLC v. McGonigle** — "General skills and knowledge do not rise to the level of trade secrets." *Insure New Mexico, LLC v. McGonigle, 2000-NMCA-018, 995 P.2d 1053.* <https://www.courtlistener.com/opinion/1291299/insure-new-mexico-llc-v-mcgonigle/#:~:text=General%20skills%20and%20knowledge%20do,the%20level%20of%20trade%20secrets.>
+
+[^utsa-trade-secret-definition]: **NMSA 1978, § 57-3A-2** — "‘trade secret’ means information, including a formula, pattern, compilation, program, device, method, technique or process, that: (1) derives independent economic value, actual or potential, from not being generally known to and not being readily ascertainable by proper means by other persons who can obtain economic value from its disclosure or use; and (2) is the subject of efforts that are reasonable under the circumstances to maintain its secrecy." *NMSA 1978, § 57-3A-2(D).* <https://nmonesource.com/nmos/nmsa/en/4423/1/document.do>
+
+[^mcgonigle-not-special]: **Insure New Mexico, LLC v. McGonigle** — "For this reason, there was substantial evidence supporting the trial court’s finding that the particular needs or characteristics of Plaintiffs customers were not peculiar and did not require special information." *Insure New Mexico, LLC v. McGonigle, 2000-NMCA-018, 995 P.2d 1053.* <https://www.courtlistener.com/opinion/1291299/insure-new-mexico-llc-v-mcgonigle/#:~:text=For%20this%20reason%2C%20there%20was,did%20not%20require%20special%20information.>
+
+[^utsa-injunction]: **NMSA 1978, § 57-3A-3** — "Actual or threatened misappropriation may be enjoined." *NMSA 1978, § 57-3A-3(A).* <https://nmonesource.com/nmos/nmsa/en/4423/1/document.do>
+
+[^bowen-facts-particular-case]: **Bowen v. Carlsbad Insurance & Real Estate, Inc.** — "Whether there is a reasonable restraint depends on the facts of a particular case, D. W. Trowbridge Ford, Inc. v. Galyen, 200 Neb. 103, 106 , 262 N.W.2d 442, 445 (1978), and is a matter of law for the courts to decide." *Bowen v. Carlsbad Ins. & Real Estate, Inc., 104 N.M. 514, 724 P.2d 223 (1986).* <https://www.courtlistener.com/opinion/1211410/bowen-v-carlsbad-insurance-real-estate-inc/#:~:text=Whether%20there%20is%20a%20reasonable,for%20the%20courts%20to%20decide.>
+
+[^kidskare-facts-reformed-limits]: **KidsKare, P.C. v. Mann** — "As its remedy, the district court reformed the 9 distance provision of clause one by reducing the radius to thirty miles, finding that 10 the covenant was thus enforceable." *KidsKare, P.C. v. Mann, 2015-NMCA-064, 350 P.3d 1228.* <https://www.courtlistener.com/opinion/2789328/kidskare-v-mann/#:~:text=As%20its%20remedy%2C%20the%20district,the%20covenant%20was%20thus%20enforceable.>
+
+[^lovelace-time-area]: **Lovelace Clinic v. Murphy** — "The limitations as to time and area in the covenant under consideration are clearly within the limitations upheld in the many 'cases above' cited and referred 'to in the A.L.R. annotations. • ■" *Lovelace Clinic v. Murphy, 76 N.M. 645, 417 P.2d 450 (1966).* <https://www.courtlistener.com/opinion/1196089/lovelace-clinic-v-murphy/#:~:text=The%20limitations%20as%20to%20time,the%20A.L.R.%20annotations.%20%E2%80%A2%20%E2%96%A0>
+
+[^bowen-sale-more-deference]: **Bowen v. Carlsbad Insurance & Real Estate, Inc.** — "Courts are more reluctant to disturb restrictive covenants in buy-sell agreements than those in employment contracts." *Bowen v. Carlsbad Ins. & Real Estate, Inc., 104 N.M. 514, 724 P.2d 223 (1986).* <https://www.courtlistener.com/opinion/1211410/bowen-v-carlsbad-insurance-real-estate-inc/#:~:text=Courts%20are%20more%20reluctant%20to,than%20those%20in%20employment%20contracts.>
+
+[^bowen-sale-valid]: **Bowen v. Carlsbad Insurance & Real Estate, Inc.** — "It is well-settled that a restrictive covenant is valid if it is within reasonable limits of time and space and ancillary to a sale of a business." *Bowen v. Carlsbad Ins. & Real Estate, Inc., 104 N.M. 514, 724 P.2d 223 (1986).* <https://www.courtlistener.com/opinion/1211410/bowen-v-carlsbad-insurance-real-estate-inc/#:~:text=It%20is%20well%2Dsettled%20that%20a,a%20sale%20of%20a%20business.>
+
+[^kidskare-contract-reformation]: **KidsKare, P.C. v. Mann** — "We hold that, contrary to the argument of Dr. Mann, the 11 covenant not to compete was amenable to modification by the district court because 12 the agreement explicitly provided for amendment of any unenforceable provision and 13 enforcement to the full extent deemed reasonable and enforceable by the reviewing 14 court." *KidsKare, P.C. v. Mann, 2015-NMCA-064, 350 P.3d 1228.* <https://www.courtlistener.com/opinion/2789328/kidskare-v-mann/#:~:text=We%20hold%20that%2C%20contrary%20to,by%20the%20reviewing%2014%20court.>
+
+[^kidskare-bargained-reformation]: **KidsKare, P.C. v. Mann** — "Reformation of 5 unreasonable clauses was an aspect of the bargain of the parties and consistent with 6 their mutual intent as expressed by the employment agreement." *KidsKare, P.C. v. Mann, 2015-NMCA-064, 350 P.3d 1228.* <https://www.courtlistener.com/opinion/2789328/kidskare-v-mann/#:~:text=Reformation%20of%205%20unreasonable%20clauses,expressed%20by%20the%20employment%20agreement.>
+
+[^kidskare-no-general-ruling]: **KidsKare, P.C. v. Mann** — "Because we conclude that an alternative basis to alter the covenant not to 6 compete allows for disposition of this case, we do not reach Defendant’s argument 7 regarding New Mexico case law." *KidsKare, P.C. v. Mann, 2015-NMCA-064, 350 P.3d 1228.* <https://www.courtlistener.com/opinion/2789328/kidskare-v-mann/#:~:text=Because%20we%20conclude%20that%20an,regarding%20New%20Mexico%20case%20law.>
+
+[^q6-lovelace-fixed-period]: **Lovelace Clinic v. Murphy** — "At the conclusion of the trial, judgínént was entered for the clinic restraining;.^nd enjoining Dr. Murphy from practicing viped-i-, icine, directly or indirectly, in Bernalillo, County from November 29, 1965, the .date, of the judgment, to and including January 31, 1967." *Lovelace Clinic v. Murphy, 76 N.M. 645, 417 P.2d 450 (1966).* <https://www.courtlistener.com/opinion/1196089/lovelace-clinic-v-murphy/#:~:text=At%20the%20conclusion%20of%20the,and%20including%20January%2031%2C%201967.>
+
+[^q6-kidskare-fixed-period]: **KidsKare, P.C. v. Mann** — "As reformed by the district 7 court, the covenant not to compete was reasonable and enforceable." *KidsKare, P.C. v. Mann, 2015-NMCA-064, 350 P.3d 1228.* <https://www.courtlistener.com/opinion/2789328/kidskare-v-mann/#:~:text=As%20reformed%20by%20the%20district,compete%20was%20reasonable%20and%20enforceable.>
+
+[^healthcare-ban]: **NMSA 1978, § 24A-4-2** — "A non-compete provision in an agreement, which provision restricts the right of a health care practitioner to provide clinical health care services in this state, shall be unenforceable upon the termination of: (1) the agreement; (2) a renewal or extension of the agreement; or (3) a health care practitioner's employment with a party seeking to enforce the agreement." *NMSA 1978, § 24A-4-2(A).* <https://nmonesource.com/nmos/nmsa/en/18973/1/document.do>
+
+[^healthcare-covered-practitioners]: **NMSA 1978, § 24A-4-1** — "‘health care practitioner’ means: (1) a dentist; (2) an osteopathic physician; (3) a physician; (4) a podiatrist; (5) a certified registered nurse anesthetist; (6) a certified nurse practitioner; (7) a certified nurse-midwife; (8) a psychologist; (9) a physician assistant; and (10) a pharmacist." *NMSA 1978, § 24A-4-1(B).* <https://nmonesource.com/nmos/nmsa/en/18973/1/document.do>
+
+[^healthcare-effective-dates]: **NMSA 1978, § 24A-4-5** — "For psychologists, physician assistants and pharmacists, the provisions of Chapter 24, Article 1I NMSA 1978 [Chapter 24A, Article 4 NMSA 1978] apply to agreements, or renewals or extensions of agreements, executed on or after the effective date of this 2023 act." *NMSA 1978, § 24A-4-5(D).* <https://nmonesource.com/nmos/nmsa/en/18973/1/document.do>
+
+[^healthcare-repayment]: **NMSA 1978, § 24A-4-3** — "Nothing in this act shall be construed to limit the enforceability of: A. a provision in an agreement requiring a health care practitioner who has worked for an employer for an initial period of less than three years to repay all or a portion of: (1) a loan; (2) relocation expenses; (3) a signing bonus or other remuneration to induce the health care practitioner to relocate or establish a health care practice in a specified geographic area; or (4) recruiting, education and training expenses;" *NMSA 1978, § 24A-4-3(A).* <https://nmonesource.com/nmos/nmsa/en/18973/1/document.do>
+
+[^healthcare-nda-nonsolicit]: **NMSA 1978, § 24A-4-3** — "Nothing in this act shall be construed to limit the enforceability of: A. a provision in an agreement requiring a health care practitioner who has worked for an employer for an initial period of less than three years to repay all or a portion of: (1) a loan; (2) relocation expenses; (3) a signing bonus or other remuneration to induce the health care practitioner to relocate or establish a health care practice in a specified geographic area; or (4) recruiting, education and training expenses; B. a nondisclosure provision relating to confidential information and trade secrets; C. a nonsolicitation provision with respect to patients and employees of the party seeking to enforce the agreement for a period of one year or less after the last date of employment; or D. any other provision of an agreement that is not in violation of law, including a provision for liquidated damages." *NMSA 1978, § 24A-4-3.* <https://nmonesource.com/nmos/nmsa/en/18973/1/document.do>
+
+[^healthcare-liquidated-damages]: **NMSA 1978, § 24A-4-4** — "An agreement may provide for liquidated damages in an amount that is reasonable at the time the agreement is executed and in light of anticipated harm and difficulty of proving the amount of loss resulting from breach of the agreement by any party." *NMSA 1978, § 24A-4-4(A).* <https://nmonesource.com/nmos/nmsa/en/18973/1/document.do>
+
+[^healthcare-choice-law-venue]: **NMSA 1978, § 24A-4-2** — "A provision in an agreement for clinical health care services to be rendered in this state is void, unenforceable and against public policy if the provision: (1) makes the agreement subject to the laws of another state; or (2) requires any litigation arising out of the agreement to be conducted in another state." *NMSA 1978, § 24A-4-2(B).* <https://nmonesource.com/nmos/nmsa/en/18973/1/document.do>
+
+[^healthcare-owner-exemption]: **NMSA 1978, § 24A-4-5** — "Chapter 24, Article 1I NMSA 1978 [Chapter 24A, Article 4 NMSA 1978] does not apply to agreements between health care practitioners who are shareholders, owners, partners or directors of a health care practice." *NMSA 1978, § 24A-4-5(A).* <https://nmonesource.com/nmos/nmsa/en/18973/1/document.do>
+
+[^q8-healthcare-choice-law-venue]: **NMSA 1978, § 24A-4-2** — "A provision in an agreement for clinical health care services to be rendered in this state is void, unenforceable and against public policy if the provision: (1) makes the agreement subject to the laws of another state; or (2) requires any litigation arising out of the agreement to be conducted in another state." *NMSA 1978, § 24A-4-2(B).* <https://nmonesource.com/nmos/nmsa/en/18973/1/document.do>
+
+[^q8-lovelace-public-policy]: **Lovelace Clinic v. Murphy** — "The public has an interest in seeing that competition is not unreasonably limited or restricted, but it also has an interest in protecting the freedom of persons to contract, and in enforcing contractual rights and obligations." *Lovelace Clinic v. Murphy, 76 N.M. 645, 417 P.2d 450 (1966).* <https://www.courtlistener.com/opinion/1196089/lovelace-clinic-v-murphy/#:~:text=The%20public%20has%20an%20interest,enforcing%20contractual%20rights%20and%20obligations.>
+
+[^q9-ftc-rule-set-aside]: **Ryan LLC v. Federal Trade Commission** — "The Non-Compete Rule, 16 C.F.R. § 910.1–.6, is hereby SET ASIDE and shall not be enforced or otherwise take effect on September 4, 2024, or thereafter." *Ryan LLC v. Fed. Trade Comm'n, 746 F. Supp. 3d 369 (N.D. Tex. 2024).* <https://www.courtlistener.com/opinion/10205745/ryan-llc-v-federal-trade-commission/#:~:text=The%20Non%2DCompete%20Rule%2C%2016%20C.F.R.,September%204%2C%202024%2C%20or%20thereafter.>
+
+[^q9-lovelace-state-law]: **Lovelace Clinic v. Murphy** — "All of the physician and surgeon cases either expressly hold or clearly indicate that the rights and duties created by the contract of employment or association are enforceable, if the restrictions thus imposed on the employee or the associate are reasonable." *Lovelace Clinic v. Murphy, 76 N.M. 645, 417 P.2d 450 (1966).* <https://www.courtlistener.com/opinion/1196089/lovelace-clinic-v-murphy/#:~:text=All%20of%20the%20physician%20and,or%20the%20associate%20are%20reasonable.>
+
+[^q9-healthcare-state-law]: **NMSA 1978, § 24A-4-2** — "A non-compete provision in an agreement, which provision restricts the right of a health care practitioner to provide clinical health care services in this state, shall be unenforceable upon the termination of: (1) the agreement; (2) a renewal or extension of the agreement; or (3) a health care practitioner's employment with a party seeking to enforce the agreement." *NMSA 1978, § 24A-4-2(A).* <https://nmonesource.com/nmos/nmsa/en/18973/1/document.do>
+
+[^q10-bowen-sale-valid]: **Bowen v. Carlsbad Insurance & Real Estate, Inc.** — "It is well-settled that a restrictive covenant is valid if it is within reasonable limits of time and space and ancillary to a sale of a business." *Bowen v. Carlsbad Ins. & Real Estate, Inc., 104 N.M. 514, 724 P.2d 223 (1986).* <https://www.courtlistener.com/opinion/1211410/bowen-v-carlsbad-insurance-real-estate-inc/#:~:text=It%20is%20well%2Dsettled%20that%20a,a%20sale%20of%20a%20business.>
+
+[^q10-bowen-sale-deference]: **Bowen v. Carlsbad Insurance & Real Estate, Inc.** — "Courts are more reluctant to disturb restrictive covenants in buy-sell agreements than those in employment contracts." *Bowen v. Carlsbad Ins. & Real Estate, Inc., 104 N.M. 514, 724 P.2d 223 (1986).* <https://www.courtlistener.com/opinion/1211410/bowen-v-carlsbad-insurance-real-estate-inc/#:~:text=Courts%20are%20more%20reluctant%20to,than%20those%20in%20employment%20contracts.>
+
+[^q10-bowen-enforced-written]: **Bowen v. Carlsbad Insurance & Real Estate, Inc.** — "The covenant should be enforced as written; it being entered into voluntarily and for consideration." *Bowen v. Carlsbad Ins. & Real Estate, Inc., 104 N.M. 514, 724 P.2d 223 (1986).* <https://www.courtlistener.com/opinion/1211410/bowen-v-carlsbad-insurance-real-estate-inc/#:~:text=The%20covenant%20should%20be%20enforced,into%20voluntarily%20and%20for%20consideration.>

--- a/skills/non-compete-contract-explainer/content/new-york.md
+++ b/skills/non-compete-contract-explainer/content/new-york.md
@@ -1,0 +1,226 @@
+---
+jurisdiction: "New York"
+slug: new-york
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-03"
+canonicalUrl: https://openagreements.org/legal/non-compete/new-york
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/new-york · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in New York[^about]
+
+New York has no general non-compete statute; employee non-competes are enforceable only to the extent they are reasonable under the common-law BDO Seidman test.
+
+
+## At a glance
+
+| Question | New York |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed if reasonable |
+| **Bottom line** | New York has no general non-compete statute; employee non-competes are enforceable only to the extent reasonable under the common-law BDO Seidman three-part test, with a statutory ban only for broadcast-industry employees. |
+| **Main law or case** | BDO Seidman v. Hirshberg, 93 N.Y.2d 382 (1999) |
+| **Main exceptions** | Broadcast-employee ban (N.Y. Labor Law § 202-k); sale-of-business/goodwill more favorable |
+| **Can a court narrow it?** | Yes — rewrites to reasonable |
+| **Applies to contractors?** | Unclear |
+| **Restriction extended during a breach?** | Open question — no controlling authority |
+| **Maximum length set by law** | No statutory limit |
+
+## Are employee non-compete agreements enforceable in New York? {#enforceability}
+
+**Short answer.** Yes, sometimes. New York has no general statute governing non-competes, so enforceability is decided under common law: an employee non-compete is enforceable only to the extent it is reasonable [^bdo-reasonableness-standard][^natural-organics-three-prong-test].
+
+The controlling standard comes from the Court of Appeals decision in *BDO Seidman v. Hirshberg*. A restraint is reasonable only if it: (1) is no greater than required to protect the employer's legitimate interest, (2) does not impose undue hardship on the employee, and (3) is not injurious to the public [^natural-organics-three-prong-test]. A violation of any prong invalidates the covenant, so a New York non-compete is enforced only when the employer can satisfy all three [^bdo-reasonableness-standard].
+
+The New York Attorney General's public guidance describes the same framework, adding that a covenant must also be reasonable in time period and geographic scope [^ag-faq-four-part-test]. Trial courts apply the test to non-competes and to closely related restraints such as customer and employee non-solicitation clauses [^otg-enforceability-standard].
+
+"‘A restraint is reasonable only if it: (1) is no greater than is required for the protection of the legitimate interest of the employer, (2) does not impose undue hardship on the employee, and (3) is not injurious to the public’"[^natural-organics-three-prong-test]
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not treat a New York non-compete as presumptively valid. The covenant must satisfy every prong of the reasonableness test, and one that flunks any prong is unenforceable [^bdo-reasonableness-standard][^otg-enforceability-standard].
+
+## What legitimate business interests can support a New York non-compete? {#protectable-interests}
+
+**Short answer.** The protectable interests are narrow: a New York covenant must guard against misappropriation of trade secrets or confidential customer information, or against competition by a former employee whose services were unique or extraordinary, or protect client goodwill the employer's resources helped the employee build [^gallagher-limited-interests][^bdo-goodwill-interest].
+
+These limits trace to *Reed, Roberts Associates v. Strauman*, which held that an employee's knowledge of an employer's ordinary, internal operations is not protectable absent a trade secret or a breach of trust [^reed-roberts-routine-knowledge]. A covenant aimed only at ordinary competition fails, because there is no protectable interest behind it [^natural-organics-no-interest].
+
+The *unique or extraordinary services* category is demanding. It is not enough that the employee excels or is valuable; the services must be special enough that the employee's loss would cause irreparable injury or be effectively irreplaceable [^weitz-unique-services-standard][^ticor-unique-services]. The inquiry turns on the employee's particular relationship to the business and is decided case by case [^ticor-case-by-case].
+
+"Where the knowledge does not qualify for protection as a trade secret and there has been no conspiracy or breach of trust resulting in commercial piracy we see no reason to inhibit the employee’s ability to realize his potential both professionally and financially by availing himself of opportunity."[^reed-roberts-routine-knowledge]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not draft a New York non-compete to block ordinary competition. Tie the restraint to a specific protectable interest — identified trade secrets, confidential customer information, employer-built client goodwill, or genuinely unique services — because a covenant unconnected to one of those interests is unenforceable regardless of how reasonable its time and geography look [^gallagher-limited-interests][^natural-organics-no-interest].
+
+## Will a New York court narrow (blue-pencil) an overbroad non-compete? {#court-narrowing}
+
+**Short answer.** Sometimes, but partial enforcement is discretionary, not automatic. New York rejects a per se rule voiding every overbroad covenant, yet a court will rewrite one to a reasonable scope only when the employer acted in good faith and did not overreach [^bdo-rejects-per-se][^bdo-partial-enforcement-standard].
+
+The decisive factor is the employer's conduct. If the employer shows an absence of overreaching, coercive use of bargaining power, or other anti-competitive misconduct, and sought in good faith to protect a legitimate interest, partial enforcement may be justified [^bdo-partial-enforcement-standard]. The Attorney General's guidance describes the same possibility — a court may enforce some parts of a covenant for a shorter time or smaller area while disregarding unreasonable portions [^ag-faq-partial-enforcement].
+
+But there is no severance to perform when the covenant protects no legitimate interest at all; in that case the agreement is simply unenforceable [^natural-organics-no-severance].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not rely on a New York court to save an overbroad covenant. Because partial enforcement is withheld where the employer overreached, draft duration, geography, and activity scope to the minimum the protectable interest actually requires — an aggressive covenant is more likely to be struck whole than trimmed [^bdo-partial-enforcement-standard][^natural-organics-no-severance].
+
+## Is continued employment enough consideration for a New York non-compete signed after hire? {#consideration}
+
+**Short answer.** It can be. New York treats at-will employment as a relationship that will support a restrictive covenant, and an employer's forbearance from discharging an at-will worker can supply consideration — but only if the employment then continues for a substantial period [^zellner-at-will-supports-covenant][^zellner-substantial-period].
+
+Like any contract term, a promise not to compete must be supported by adequate consideration [^zellner-consideration-required]. In the at-will setting, the employer's right to discharge without cause means that forbearing to exercise that right is a legal detriment that can stand as consideration [^zellner-forbearance]. The catch is duration: if the worker is fired shortly after signing, the forbearance is illusory and the consideration fails, whereas a relationship that continues for a substantial period validates it [^zellner-substantial-period].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not assume a mid-employment non-compete is supported merely because the worker kept their job. If New York at-will employment ends soon after the covenant is signed, a court may find the promised forbearance illusory and the consideration inadequate; fresh consideration (a raise, promotion, or bonus) reduces that risk [^zellner-substantial-period][^zellner-forbearance].
+
+## How does New York treat customer and employee non-solicitation covenants? {#nonsolicitation}
+
+**Short answer.** They are still measured for reasonableness, but employee non-recruitment clauses are treated as less restrictive than a full non-compete and may be enforceable when reasonable; a customer non-solicitation clause must be tied to the clients the employee actually served [^otg-nonrecruitment-less-restrictive][^brown-brown-overbroad-customers].
+
+In *OTG Management v. Konstantinidis*, the court denied a non-compete injunction but enforced a non-recruitment clause, finding it reasonable in scope and not a meaningful burden on the worker [^otg-nonrecruitment-enforced]. *OTG*, a New York trial court following lower-court and federal authority, treated no-recruit clauses as inherently more reasonable than non-competes because they restrict less [^otg-nonrecruitment-less-restrictive].
+
+Customer non-solicitation fares differently when it sweeps too broadly. In *Brown & Brown v. Johnson*, applying New York law, the Court of Appeals found the former employee's customer non-solicitation provision overbroad to the extent it reached customers she never serviced — even customers she had never met, did not know about, and did no work for. The Court applied New York reasonableness law and remitted, leaving partial enforcement to be decided below [^brown-brown-overbroad-customers].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not draft a customer non-solicit that reaches customers the employee never met, did not know about, and did no work for. Tie the restraint to customer relationships the employee actually developed or serviced through work for the employer, and preserve any request for partial enforcement under *BDO Seidman* [^brown-brown-overbroad-customers][^q5-bdo-partial-enforcement].
+
+## How are sale-of-business and goodwill non-competes treated in New York? {#sale-of-business}
+
+**Short answer.** More favorably than employee covenants. When someone sells a business and its goodwill, New York implies a covenant barring the seller from soliciting the former customers — a duty the Court of Appeals describes as permanent and narrower than an express non-compete [^bessemer-implied-covenant][^mohawk-permanent-duty].
+
+In *Bessemer Trust v. Branin*, the Court of Appeals confirmed that the implied covenant bars a seller of goodwill from improperly soliciting former clients [^bessemer-implied-covenant]. The seller may still accept business that comes without active solicitation, but remains under a permanent duty not to solicit [^mohawk-permanent-duty]. That implied duty is narrower than an express covenant because it restricts solicitation rather than competition generally [^mohawk-narrower-duty].
+
+If S4641A becomes law, it would expressly preserve sale-of-business non-competes for owners holding at least a 15% interest, leaving this category intact even under a statutory ban [^s4641a-sale-of-business].
+
+## Can an out-of-state choice-of-law clause avoid New York non-compete rules? {#choice-of-law}
+
+**Short answer.** Not when the chosen law is *truly obnoxious* to New York policy. In *Brown & Brown v. Johnson*, the Court of Appeals refused to apply a Florida choice-of-law clause to a non-solicitation dispute involving a New York employee, holding that doing so would violate New York public policy [^brown-brown-choice-of-law].
+
+New York generally honors a contractual choice of law, but reserves a public-policy exception for foreign laws that are truly obnoxious to the state's own policy — and it found Florida's employer-favorable restrictive-covenant law to meet that bar [^brown-brown-choice-of-law]. Looking ahead, S4641A would go further by voiding any choice-of-law or venue clause used to avoid the statute for workers who reside or work in New York [^s4641a-choice-of-law-antiavoidance].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not assume a non-New York choice-of-law clause will rescue an employer-favorable covenant against a New York-based worker. Under *Brown & Brown*, a court can disregard the chosen law and apply New York reasonableness limits where the foreign law is truly obnoxious to New York policy [^brown-brown-choice-of-law].
+
+## Does a New York non-compete's restricted period pause (toll) during a breach or litigation? {#tolling-extension}
+
+**Short answer.** Treat it as an open question. New York measures a covenant's duration as part of the reasonableness test, and no controlling New York decision establishes that the restricted period automatically tolls — pauses and extends — while a former employee is violating the covenant or while litigation is pending [^tolling-time-reasonableness].
+
+The uncertainty matters because duration is itself part of what a court must find reasonable. A contractual clause that extends the restricted period during a breach lengthens that very term, so an open-ended or automatic extension can push an otherwise reasonable covenant into unreasonable territory [^tolling-time-reasonableness]. An employer that wants the clock to pause during a breach should therefore say so expressly rather than assume a court will extend the period. Pending legislation points the same direction: S4641A would cap any permissible non-compete at a one-year term, which an extension-on-breach clause could exceed [^s4641a-one-year-cap].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not rely on an automatic tolling or extension-on-breach clause to lengthen a New York non-compete. Because no controlling New York rule blesses judicial tolling and duration drives reasonableness, draft any extension narrowly and time-limited; if S4641A becomes law, an extension that pushes the restriction past one year would conflict with the statutory cap [^tolling-time-reasonableness][^s4641a-one-year-cap].
+
+## What special non-compete rule applies to broadcast-industry employees in New York? {#broadcast-industry}
+
+**Short answer.** Broadcast employees have a statutory shield. New York Labor Law § 202-k bars a broadcasting-industry employer from requiring, as a condition of employment, that a broadcast employee refrain from working in a geographic area, for a period of time, or for a competitor after employment ends [^lab-202k-ban].
+
+This is the one place New York has a statutory non-compete prohibition rather than a common-law standard. The ban applies to post-employment restraints; it does not reach a covenant operating during the term of an employment contract [^lab-202k-in-term-carveout]. An employer who violates the section is civilly liable to the broadcast employee for damages, attorneys' fees, and costs [^lab-202k-ban].
+
+## What are the key recent developments in New York non-compete law? {#recent-developments}
+
+**Short answer.** New York has not banned non-competes, despite repeated attempts. A near-total statutory ban was vetoed at the end of 2023, a narrower successor bill is pending in 2026, and the federal FTC non-compete rule has been vacated — so common law still controls [^s3100a-vetoed-ban][^s4641a-pending-ban][^ftc-rule-vacated].
+
+- 
+- 
+- 
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not advise clients that New York has *banned* non-competes. As of this review, no statewide ban is in effect — S3100A was vetoed and S4641A has not passed the Assembly — so the common-law reasonableness test still governs. Re-check the status of S4641A before relying on the current rule [^s3100a-vetoed-ban][^s4641a-pending-ban].
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-03. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York. This article synthesizes New York primary law and is not legal advice. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^bdo-reasonableness-standard]: **BDO Seidman v. Hirshberg** — "The modern, prevailing common-law standard of reasonableness for employee agreements not to compete applies a three-pronged test." *BDO Seidman v. Hirshberg, 93 N.Y.2d 382, 388 (1999).* <https://www.courtlistener.com/opinion/2117265/bdo-seidman-v-hirshberg/#:~:text=The%20modern%2C%20prevailing%20common%2Dlaw%20standard,compete%20applies%20a%20three%2Dpronged%20test.>
+
+[^natural-organics-three-prong-test]: **Natural Organics, Inc. v. Kirkendall** — "‘A restraint is reasonable only if it: (1) is no greater than is required for the protection of the legitimate interest of the employer, (2) does not impose undue hardship on the employee, and (3) is not injurious to the public’" *Natural Organics, Inc. v. Kirkendall, 52 A.D.3d 488 (2d Dep't 2008).* <https://www.courtlistener.com/opinion/5897806/natural-organics-inc-v-kirkendall/#:~:text=%22A%20restraint%20is%20reasonable%20only,not%20injurious%20to%20the%20public%22>
+
+[^ag-faq-four-part-test]: **N.Y. Attorney General, Non-Compete Agreements in New York State: FAQ** — "A non-compete is only allowed and enforceable to the extent it (1) is necessary to protect the employer’s legitimate interests, (2) does not impose an undue hardship on the employee, (3) does not harm the public, and (4) is reasonable in time period and geographic scope." *N.Y. Att'y Gen., Non-Compete Agreements in New York State: Frequently Asked Questions (2022).* <https://ag.ny.gov/sites/default/files/non-competes.pdf>
+
+[^otg-enforceability-standard]: **OTG Management, LLC v. Konstantinidis** — "In order to be enforceable, an anticompetitive covenant ancillary to an employment agreement must be reasonable in time and area, necessary to protect the employer’s legitimate interests, not harmful to the public, and not unreasonably burdensome to the employee." *OTG Mgt., LLC v. Konstantinidis, 40 Misc. 3d 617 (Sup. Ct. N.Y. County 2013).* <https://www.courtlistener.com/opinion/6314442/otg-management-llc-v-konstantinidis/#:~:text=In%20order%20to%20be%20enforceable%2C,unreasonably%20burdensome%20to%20the%20employee.>
+
+[^gallagher-limited-interests]: **Arthur J. Gallagher & Co. v. Marchese** — "An employer’s interests justifying a restrictive covenant are limited ‘to the protection against misappropriation of the employer’s trade secrets or of confidential customer lists, or protection from competition by a former employee whose services are unique or extraordinary’" *Arthur J. Gallagher & Co. v. Marchese, 96 A.D.3d 791 (2d Dep't 2012).* <https://www.courtlistener.com/opinion/5999301/arthur-j-gallagher-co-v-marchese/#:~:text=An%20employer%E2%80%99s%20interests%20justifying%20a,services%20are%20unique%20or%20extraordinary%E2%80%9D>
+
+[^bdo-goodwill-interest]: **BDO Seidman v. Hirshberg** — "The employer has a legitimate interest in preventing former employees from exploiting or appropriating the goodwill of a client or customer, which had been created and maintained at the employer’s expense, to the employer’s competitive detriment" *BDO Seidman v. Hirshberg, 93 N.Y.2d 382, 392 (1999).* <https://www.courtlistener.com/opinion/2117265/bdo-seidman-v-hirshberg/#:~:text=The%20employer%20has%20a%20legitimate,to%20the%20employer%E2%80%99s%20competitive%20detriment>
+
+[^reed-roberts-routine-knowledge]: **Reed, Roberts Associates, Inc. v. Strauman** — "Where the knowledge does not qualify for protection as a trade secret and there has been no conspiracy or breach of trust resulting in commercial piracy we see no reason to inhibit the employee’s ability to realize his potential both professionally and financially by availing himself of opportunity." *Reed, Roberts Assocs., Inc. v. Strauman, 40 N.Y.2d 303 (1976).* <https://www.courtlistener.com/opinion/5682269/reed-roberts-associates-inc-v-strauman/#:~:text=Where%20the%20knowledge%20does%20not,by%20availing%20himself%20of%20opportunity.>
+
+[^natural-organics-no-interest]: **Natural Organics, Inc. v. Kirkendall** — "Since there is no legitimate employer interest to protect, the noncompete agreement is unenforceable and the issue of partial enforcement does not arise" *Natural Organics, Inc. v. Kirkendall, 52 A.D.3d 488 (2d Dep't 2008).* <https://www.courtlistener.com/opinion/5897806/natural-organics-inc-v-kirkendall/#:~:text=Since%20there%20is%20no%20legitimate,partial%20enforcement%20does%20not%20arise>
+
+[^weitz-unique-services-standard]: **Purchasing Associates, Inc. v. Weitz** — "More must, of course, be shown to establish such a quality than that the employee excels at his work or that his performance is of high value to his employer." *Purchasing Assocs., Inc. v. Weitz, 13 N.Y.2d 267 (1963).* <https://www.courtlistener.com/opinion/5673277/purchasing-associates-inc-v-weitz/#:~:text=More%20must%2C%20of%20course%2C%20be,high%20value%20to%20his%20employer.>
+
+[^ticor-unique-services]: **Ticor Title Insurance Co. v. Cohen** — "Services that are not simply of value to the employer, but that may also truly be said to be special, unique or extraordinary may entitle an employer to injunctive relief." *Ticor Title Ins. Co. v. Cohen, 173 F.3d 63 (2d Cir. 1999).* <https://www.courtlistener.com/opinion/763095/ticor-title-insurance-co-chicago-title-insurance-co-v-kenneth-c-cohen/#:~:text=Services%20that%20are%20not%20simply,an%20employer%20to%20injunctive%20relief.>
+
+[^ticor-case-by-case]: **Ticor Title Insurance Co. v. Cohen** — "Instead, now the inquiry is more focused on the employee’s relationship to the employer’s business to ascertain whether his or her services and value to that operation may be said to be unique, special or extraordinary; that inquiry, because individual circumstances differ so widely, must of necessity be on a case-by-case basis." *Ticor Title Ins. Co. v. Cohen, 173 F.3d 63 (2d Cir. 1999).* <https://www.courtlistener.com/opinion/763095/ticor-title-insurance-co-chicago-title-insurance-co-v-kenneth-c-cohen/#:~:text=Instead%2C%20now%20the%20inquiry%20is,be%20on%20a%20case%2Dby%2Dcase%20basis.>
+
+[^bdo-rejects-per-se]: **BDO Seidman v. Hirshberg** — "The prevailing, modern view rejects a per se rule that invalidates entirely any overbroad employee agreement not to compete." *BDO Seidman v. Hirshberg, 93 N.Y.2d 382, 394 (1999).* <https://www.courtlistener.com/opinion/2117265/bdo-seidman-v-hirshberg/#:~:text=The%20prevailing%2C%20modern%20view%20rejects,employee%20agreement%20not%20to%20compete.>
+
+[^bdo-partial-enforcement-standard]: **BDO Seidman v. Hirshberg** — "Under this approach, if the employer demonstrates an absence of overreaching, coercive use of dominant bargaining power, or other anti-competitive misconduct, but has in good faith sought to protect a legitimate business interest, consistent with reasonable standards of fair dealing, partial enforcement may be justified" *BDO Seidman v. Hirshberg, 93 N.Y.2d 382, 394 (1999).* <https://www.courtlistener.com/opinion/2117265/bdo-seidman-v-hirshberg/#:~:text=Under%20this%20approach%2C%20if%20the,partial%20enforcement%20may%20be%20justified>
+
+[^ag-faq-partial-enforcement]: **N.Y. Attorney General, Non-Compete Agreements in New York State: FAQ** — "A court may require an employee to comply with some parts of a non-compete agreement, even if other portions of the agreement are unreasonable, such as length of time or geographic scope." *N.Y. Att'y Gen., Non-Compete Agreements in New York State: Frequently Asked Questions (2022).* <https://ag.ny.gov/sites/default/files/non-competes.pdf>
+
+[^natural-organics-no-severance]: **Natural Organics, Inc. v. Kirkendall** — "Since there is no legitimate employer interest to protect, the noncompete agreement is unenforceable and the issue of partial enforcement does not arise" *Natural Organics, Inc. v. Kirkendall, 52 A.D.3d 488 (2d Dep't 2008).* <https://www.courtlistener.com/opinion/5897806/natural-organics-inc-v-kirkendall/#:~:text=Since%20there%20is%20no%20legitimate,partial%20enforcement%20does%20not%20arise>
+
+[^zellner-at-will-supports-covenant]: **Zellner v. Stephen D. Conrad, M.D., P.C.** — "We believe, however, that at-will employment qualifies as a relationship which will support a restrictive covenant." *Zellner v. Stephen D. Conrad, M.D., P.C., 183 A.D.2d 250 (2d Dep't 1992).* <https://www.courtlistener.com/opinion/6084767/zellner-v-stephen-d-conrad-md-p-c/#:~:text=We%20believe%2C%20however%2C%20that%20at%2Dwill,will%20support%20a%20restrictive%20covenant.>
+
+[^zellner-substantial-period]: **Zellner v. Stephen D. Conrad, M.D., P.C.** — "However, where, as here, a relationship continues for a substantial period after the covenant is given, the forbearance is real, not illusory, and the consideration given for the promise is validated." *Zellner v. Stephen D. Conrad, M.D., P.C., 183 A.D.2d 250 (2d Dep't 1992).* <https://www.courtlistener.com/opinion/6084767/zellner-v-stephen-d-conrad-md-p-c/#:~:text=However%2C%20where%2C%20as%20here%2C%20a,for%20the%20promise%20is%20validated.>
+
+[^zellner-consideration-required]: **Zellner v. Stephen D. Conrad, M.D., P.C.** — "As with any contract, the promise not to compete must be supported by adequate consideration on the part of the promisee." *Zellner v. Stephen D. Conrad, M.D., P.C., 183 A.D.2d 250 (2d Dep't 1992).* <https://www.courtlistener.com/opinion/6084767/zellner-v-stephen-d-conrad-md-p-c/#:~:text=As%20with%20any%20contract%2C%20the,the%20part%20of%20the%20promisee.>
+
+[^zellner-forbearance]: **Zellner v. Stephen D. Conrad, M.D., P.C.** — "Because in at-will employment the employer has the right to discharge the employee (or, as here, an independent contractor providing services under a similar arrangement), without cause, and without being subject to inquiry as to his or her motives (Sabetay v Sterling Drug, supra), forbearance of that right is a legal detriment which can stand as consideration for a restrictive covenant." *Zellner v. Stephen D. Conrad, M.D., P.C., 183 A.D.2d 250 (2d Dep't 1992).* <https://www.courtlistener.com/opinion/6084767/zellner-v-stephen-d-conrad-md-p-c/#:~:text=Because%20in%20at%2Dwill%20employment%20the,consideration%20for%20a%20restrictive%20covenant.>
+
+[^otg-nonrecruitment-less-restrictive]: **OTG Management, LLC v. Konstantinidis** — "While both Renaissance Nutrition and Lazer recognized that non-recruitment clauses are subject to reasonableness scrutiny because they are anti-competitive in nature, non-recruitment clauses are ‘inherently more reasonable and less restrictive’ than noncompete clauses." *OTG Mgt., LLC v. Konstantinidis, 40 Misc. 3d 617 (Sup. Ct. N.Y. County 2013).* <https://www.courtlistener.com/opinion/6314442/otg-management-llc-v-konstantinidis/#:~:text=While%20both%20Renaissance%20Nutrition%20and,less%20restrictive%E2%80%9D%20than%20noncompete%20clauses.>
+
+[^brown-brown-overbroad-customers]: **Brown & Brown, Inc. v. Johnson** — "even those Johnson had never met, did not know about and for whom she had done no work" *Brown & Brown, Inc. v. Johnson, 25 N.Y.3d 364 (2015).* <https://www.courtlistener.com/opinion/2807346/brown-brown-v-theresa-a-johnson/#:~:text=even%20those%20Johnson%20had%20never,she%20had%20done%20no%20work>
+
+[^otg-nonrecruitment-enforced]: **OTG Management, LLC v. Konstantinidis** — "Here, the court finds that the non-recruitment clause is enforceable because it is reasonable in scope and imposes no meaningful burden on Konstantinidis." *OTG Mgt., LLC v. Konstantinidis, 40 Misc. 3d 617 (Sup. Ct. N.Y. County 2013).* <https://www.courtlistener.com/opinion/6314442/otg-management-llc-v-konstantinidis/#:~:text=Here%2C%20the%20court%20finds%20that,no%20meaningful%20burden%20on%20Konstantinidis.>
+
+[^q5-bdo-partial-enforcement]: **BDO Seidman v. Hirshberg** — "Under this approach, if the employer demonstrates an absence of overreaching, coercive use of dominant bargaining power, or other anti-competitive misconduct, but has in good faith sought to protect a legitimate business interest, consistent with reasonable standards of fair dealing, partial enforcement may be justified" *BDO Seidman v. Hirshberg, 93 N.Y.2d 382, 394 (1999).* <https://www.courtlistener.com/opinion/2117265/bdo-seidman-v-hirshberg/#:~:text=Under%20this%20approach%2C%20if%20the,partial%20enforcement%20may%20be%20justified>
+
+[^bessemer-implied-covenant]: **Bessemer Trust Co., N.A. v. Branin** — "In answering the certified question, we continue to apply our precedents in Von Bremen and Mohawk and hold that the ‘implied covenant’ bars a seller of ‘good will’ from improperly soliciting his former clients." *Bessemer Trust Co., N.A. v. Branin, 16 N.Y.3d 549 (2011).* <https://www.courtlistener.com/opinion/2526164/bessemer-trust-co-na-v-branin/#:~:text=In%20answering%20the%20certified%20question%2C,improperly%20soliciting%20his%20former%20clients.>
+
+[^mohawk-permanent-duty]: **Mohawk Maintenance Co. v. Kessler** — "Although defendants may accept the patronage of those customers who were actively dealing with Mohawk on the date of the sale if such customers choose to leave Mohawk without prompting from defendants, the defendants remain under a positive and permanent duty to refrain from interfering with the rights acquired by plaintiff as a result of its acquisition of Mohawk’s ‘good will’." *Mohawk Maintenance Co. v. Kessler, 52 N.Y.2d 276 (1981).* <https://www.courtlistener.com/opinion/5684701/mohawk-maintenance-co-v-kessler/#:~:text=Although%20defendants%20may%20accept%20the,acquisition%20of%20Mohawk%E2%80%99s%20%E2%80%9Cgood%20will%E2%80%9D.>
+
+[^mohawk-narrower-duty]: **Mohawk Maintenance Co. v. Kessler** — "As such, the ‘implied covenant’ imposes a much narrower duty than do express covenants purporting to restrict the seller’s right to compete in a particular geographical area or field of endeavor." *Mohawk Maintenance Co. v. Kessler, 52 N.Y.2d 276 (1981).* <https://www.courtlistener.com/opinion/5684701/mohawk-maintenance-co-v-kessler/#:~:text=As%20such%2C%20the%20%E2%80%9Cimplied%20covenant%E2%80%9D,area%20or%20field%20of%20endeavor.>
+
+[^s4641a-sale-of-business]: **N.Y. Senate Bill 2025-S4641A (pending)** — "NOTHING IN THIS SECTION SHALL PROHIBIT THE INCLUSION AND ENFORCEMENT OF NON-COMPETE AGREEMENTS OR OTHER SIMILAR COVENANTS IN THE SALE OF THE GOODWILL OF A BUSINESS OR THE SALE OR DISPOSITION OF A MAJORITY OF AN OWNERSHIP INTEREST IN A BUSINESS BY A PARTNER OF A PARTNERSHIP, A MEMBER OF A LIMITED LIABILITY COMPANY, OR AN ENTITY" *N.Y. S.B. S4641A, § 191-d(6) (2025-2026 Reg. Sess.) (pending).* <https://www.nysenate.gov/legislation/bills/2025/S4641/amendment/A>
+
+[^brown-brown-choice-of-law]: **Brown & Brown, Inc. v. Johnson** — "On this appeal, we hold that applying Florida law on restrictive covenants related to the non-solicitation of customers by a former employee would violate the public policy of this state." *Brown & Brown, Inc. v. Johnson, 25 N.Y.3d 364 (2015).* <https://www.courtlistener.com/opinion/2807346/brown-brown-v-theresa-a-johnson/#:~:text=On%20this%20appeal%2C%20we%20hold,public%20policy%20of%20this%20state.>
+
+[^s4641a-choice-of-law-antiavoidance]: **N.Y. Senate Bill 2025-S4641A (pending)** — "NO CHOICE OF LAW PROVISION OR CHOICE OF VENUE PROVISION THAT WOULD HAVE THE EFFECT OF AVOIDING OR LIMITING THE REQUIREMENTS OF THIS SECTION SHALL BE ENFORCEABLE IF THE COVERED INDIVIDUAL IS AND HAS BEEN, FOR AT LEAST THIRTY DAYS IMMEDIATELY PRECEDING THE COVERED INDIVIDUAL'S CESSATION OF EMPLOYMENT, A RESIDENT OF NEW YORK OR EMPLOYED IN NEW YORK" *N.Y. S.B. S4641A, § 191-d(8) (2025-2026 Reg. Sess.) (pending).* <https://www.nysenate.gov/legislation/bills/2025/S4641/amendment/A>
+
+[^tolling-time-reasonableness]: **OTG Management, LLC v. Konstantinidis** — "In order to be enforceable, an anticompetitive covenant ancillary to an employment agreement must be reasonable in time and area, necessary to protect the employer’s legitimate interests, not harmful to the public, and not unreasonably burdensome to the employee." *OTG Mgt., LLC v. Konstantinidis, 40 Misc. 3d 617 (Sup. Ct. N.Y. County 2013).* <https://www.courtlistener.com/opinion/6314442/otg-management-llc-v-konstantinidis/#:~:text=In%20order%20to%20be%20enforceable%2C,unreasonably%20burdensome%20to%20the%20employee.>
+
+[^s4641a-one-year-cap]: **N.Y. Senate Bill 2025-S4641A (pending)** — "A NON-COMPETE AGREEMENT THAT IS REASONABLE IN TIME PURSUANT TO SUBPARAGRAPH (I) OF THIS PARAGRAPH SHALL NOT CONTAIN A TERM OF RESTRICTION GREATER THAN ONE YEAR" *N.Y. S.B. S4641A, § 191-d(7)(a) (2025-2026 Reg. Sess.) (pending).* <https://www.nysenate.gov/legislation/bills/2025/S4641/amendment/A>
+
+[^lab-202k-ban]: **N.Y. Labor Law § 202-k** — "A broadcasting industry employer shall not require as a condition of employment, whether in an employment contract or otherwise, that a broadcast employee or prospective broadcast employee refrain from obtaining employment: (a) in any specified geographic area; (b) for a specific period of time; or (c) with any particular employer or in any particular industry; after the conclusion of employment with such broadcasting industry employer." *N.Y. Lab. Law § 202-k(2).* <https://www.nysenate.gov/legislation/laws/LAB/202-K>
+
+[^lab-202k-in-term-carveout]: **N.Y. Labor Law § 202-k** — "This section shall not apply to preventing the enforcement of such a covenant during the term of an employment contract." *N.Y. Lab. Law § 202-k(2).* <https://www.nysenate.gov/legislation/laws/LAB/202-K>
+
+[^s3100a-vetoed-ban]: **N.Y. Senate Bill 2023-S3100A (vetoed)** — "NO EMPLOYER OR ITS AGENT, OR THE OFFICER OR AGENT OF ANY CORPORATION, PARTNERSHIP, LIMITED LIABILITY COMPANY, OR OTHER ENTITY, SHALL SEEK, REQUIRE, DEMAND OR ACCEPT A NON-COMPETE AGREEMENT FROM ANY COVERED INDIVIDUAL." *N.Y. S.B. S3100A, § 191-d(2) (2023-2024 Reg. Sess.) (vetoed Dec. 22, 2023).* <https://www.nysenate.gov/legislation/bills/2023/S3100/amendment/A>
+
+[^s4641a-pending-ban]: **N.Y. Senate Bill 2025-S4641A (pending)** — "ANY NON-COMPETE AGREEMENT SOUGHT, REQUIRED, DEMANDED OR ACCEPTED AFTER THE EFFECTIVE DATE OF THIS SECTION SHALL BE NULL, VOID, AND UNENFORCEABLE." *N.Y. S.B. S4641A, § 191-d(2) (2025-2026 Reg. Sess.) (pending).* <https://www.nysenate.gov/legislation/bills/2025/S4641/amendment/A>
+
+[^ftc-rule-vacated]: **FTC, Press Release: FTC Files to Accede to Vacatur of Non-Compete Clause Rule** — "Today the Federal Trade Commission took steps to dismiss its appeals in Ryan, LLC v. FTC, No. 24-10951 (5th Cir.), and Properties of the Villages v. FTC, No. 24-13102 (11th Cir.), and to accede to the vacatur of the Non-Compete Clause Rule." *FTC, Press Release, FTC Files to Accede to Vacatur of Non-Compete Clause Rule (Sept. 5, 2025).* <https://www.ftc.gov/news-events/news/press-releases/2025/09/federal-trade-commission-files-accede-vacatur-non-compete-clause-rule>

--- a/skills/non-compete-contract-explainer/content/north-carolina.md
+++ b/skills/non-compete-contract-explainer/content/north-carolina.md
@@ -1,0 +1,346 @@
+---
+jurisdiction: "North Carolina"
+slug: north-carolina
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-03"
+canonicalUrl: https://openagreements.org/legal/non-compete/north-carolina
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/north-carolina · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in North Carolina[^about]
+
+A question-by-question summary of North Carolina non-compete law, including the five-factor reasonableness test, the N.C. Gen. Stat. § 75-4 writing requirement, the new-consideration rule for mid-employment covenants, time-and-territory limits, the strict blue-pencil doctrine that bars judicial reformation, non-solicitation drafting, tolling and extension-on-breach clauses, physician public-policy limits, the § 22B-3 forum-clause bar, attorney-fee recovery, trade-secret alternatives, and the pending HB 269 and SB 673 bills.
+
+
+## At a glance
+
+| Question | North Carolina |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed if reasonable |
+| **Bottom line** | North Carolina enforces an employee non-compete only if it is in writing, supported by consideration, reasonable in time and territory, and protects a legitimate business interest. |
+| **Main law or case** | common law (Whittaker Gen. Med. Corp. v. Daniel, 324 N.C. 523 (1989)); writing requirement N.C. Gen. Stat. § 75-4 |
+| **Main exceptions** | Physician/health-care covenants face a public-policy bar (Zaldivar); pending HB 269 (<$75k) and SB 673 (hospital) not enacted |
+| **Can a court narrow it?** | Only strikes wording |
+| **Applies to contractors?** | Unclear |
+| **Restriction extended during a breach?** | Express tolling clauses enforced (federal courts); equitable tolling unsettled |
+| **Maximum length set by law** | No statutory limit |
+
+## Are employee non-compete agreements enforceable in North Carolina? {#enforceable}
+
+**Short answer.** Sometimes. North Carolina enforces an employee non-compete only when it satisfies a five-part common-law test: the covenant must be in writing, part of an employment contract, supported by valuable consideration, reasonable as to time and territory, and designed to protect a legitimate business interest [^q1-ridgway-five-factor]. Because a non-compete is a partial restraint of trade — a category North Carolina law disfavors — a covenant is upheld only when it is supported by consideration, reasonably necessary, and not against public policy [^q1-gs-75-1][^q1-kuykendall-partial-restraint].
+
+North Carolina has no general non-compete statute. Enforceability is governed by case law, with a single statutory overlay — N.C. Gen. Stat. § 75-4 — requiring that the agreement be in writing and signed. The Supreme Court has stated the governing test in consistent terms for decades.
+
+"Such covenants are enforceable in this state if they are (1) in writing, (2) made part of a contract of employment, (3) based on valuable consideration, (4) reasonable both as to time and territory, and (5) not against public policy."[^q1-daniel-five-factor]
+
+The writing requirement is statutory. Section 75-4 makes any agreement limiting a person's right to do business in the State unenforceable unless it is in writing and signed by the restrained party.
+
+"No contract or agreement hereafter made, limiting the rights of any person to do business anywhere in the State of North Carolina shall be enforceable unless such agreement is in writing duly signed by the party who agrees not to enter into any such business within such territory: Provided, nothing herein shall be construed to legalize any contract or agreement not to enter into business in the State of North Carolina, or at any point in the State of North Carolina, which contract is now illegal, or which contract is made illegal by any other section of this Chapter."[^q1-gs-75-4]
+
+> [!NOTE]
+> **Practice note.**
+>
+> Treat a North Carolina non-compete as enforceable only if every one of the five elements is met. Because the agreement must satisfy § 75-4's writing-and-signature rule and the covenant is read strictly against the drafter, a single defective element defeats enforcement [^q1-ridgway-five-factor][^q1-gs-75-4].
+
+## What consideration does a North Carolina non-compete require? {#consideration}
+
+**Short answer.** It depends on timing. A covenant signed at the start of employment is supported by the offer of employment itself [^q2-qsp-newemployment], but a covenant imposed on an existing employee must be supported by *new* consideration — continued at-will employment is not enough [^q2-empt-staffing-milner]. The new consideration can be modest; North Carolina courts do not weigh its adequacy, and payments as small as a few hundred dollars have been upheld [^q2-hejl-500][^q2-empt-staffing-amount].
+
+The dividing line is whether the employment relationship already exists when the covenant is signed. For a covenant added mid-employment, the employer must give something new.
+
+"‘[I]f an employment relationship already exists without a covenant not to compete, any such future covenant must be based upon new consideration.’"[^q2-empt-staffing-milner]
+
+The Supreme Court has described the kind of new consideration that suffices — a raise or a new job assignment, for example.
+
+"When the relationship of employer and employee is established before the covenant not to compete is signed there must be consideration for the covenant such as a raise in pay or a new job assignment."[^q2-daniel-consideration]
+
+Once some new consideration is present, courts do not second-guess its amount. A one-time payment of a few hundred dollars has been treated as adequate.
+
+"Therefore, because the parties dealt at arms length, and the Plaintiff received $500.00 as consideration for signing the Agreement, we find the Agreement is not void due to lack of consideration."[^q2-hejl-500]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not rely on continued at-will employment as consideration for a covenant signed by a current employee. Pair the covenant with a raise, bonus, promotion, or other new benefit and document it, because a mid-employment covenant must rest on new consideration to be enforceable [^q2-empt-staffing-milner][^q2-daniel-consideration].
+
+## How do North Carolina courts judge a non-compete's time and territory? {#time-territory}
+
+**Short answer.** Reasonableness is a question of law for the court, and the employer bears the burden of proving it [^q3-hartman-matter-of-law][^q3-hartman-burden]. A geographic restriction is reasonable only to the extent it protects the employer's interest in keeping its existing customers, so a territory broader than the area where the employee actually built customer relationships is vulnerable [^q3-hartman-territory].
+
+North Carolina assigns the reasonableness question to the judge, not the jury, and places the burden on the party seeking to enforce the covenant.
+
+"The reasonableness of a noncompetition covenant is a matter of law for the court to decide."[^q3-hartman-matter-of-law]
+
+"The party who seeks the enforcement of the covenant not to compete has the burden of proving that the covenant is reasonable."[^q3-hartman-burden]
+
+Territory is measured against the employer's legitimate interest in its customer base. A restriction reaching beyond the area the employee actually served is not reasonable.
+
+"A restriction as to territory is reasonable only to the extent it protects the legitimate interests of the employer in maintaining [its] customers."[^q3-hartman-territory]
+
+An overly broad restraint is not narrowed to a reasonable size; it is simply not enforced.
+
+"If a contract by an employee in restraint of competition is too broad to be a reasonable protection to the employer’s business it will not be enforced."[^q3-daniel-overbroad]
+
+> [!NOTE]
+> **Practice note.**
+>
+> Tie the geographic scope to the territory where the employee actually worked and built customer relationships, and keep the duration proportionate. Because the employer carries the burden of proving reasonableness as a matter of law, an unsupported nationwide or open-ended restraint invites a finding of unenforceability [^q3-hartman-territory][^q3-hartman-burden].
+
+## What counts as a legitimate business interest in North Carolina? {#legitimate-interest}
+
+**Short answer.** A covenant must protect something more than the employer's general wish to avoid competition. Before a restraint can be reasonably necessary to protect a legitimate interest, the employee must have acquired intimate knowledge of the business that is not generally available to the public [^q4-kuykendall-interest]. And the restriction must track the employee's actual duties — a covenant that bars work distinct from what the employee actually did is unenforceable [^q4-ridgway-duties].
+
+The leading Supreme Court statement ties the legitimate-interest requirement to the employee's access to confidential or specialized knowledge.
+
+"Before a covenant can be found reasonably necessary for the protection of a legitimate business interest, we hold that it is first necessary to find the employee, as a result of his employment, acquired intimate knowledge of the nature and character of the business which was not otherwise generally available to the public."[^q4-kuykendall-interest]
+
+The restriction must also be limited to the kind of work the employee performed.
+
+"However, we have held that restrictive covenants are unenforceable where they prohibit the employee from engaging in future work that is distinct from the duties actually performed by the employee."[^q4-ridgway-duties]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Define the restricted activities by reference to the employee's actual role, not every line of the company's business. A covenant that bars an employee from any capacity at a competitor, including work the employee never performed, reaches beyond a legitimate interest and risks non-enforcement [^q4-ridgway-duties].
+
+## Can a North Carolina court rewrite or blue-pencil an overbroad non-compete? {#blue-pencil}
+
+**Short answer.** No — and this is the trap that catches many employers. North Carolina follows the *strict* blue-pencil doctrine: a court may strike a distinctly separable, unreasonable part of a covenant, but it may not rewrite or revise the remaining terms to make them reasonable [^q5-beverage-strict][^q5-hartman-separable]. A reformation clause does not change this — parties cannot give a court a power the law withholds [^q5-beverage-contract].
+
+The North Carolina Supreme Court reaffirmed the strict rule in 2016, describing precisely what a court may and may not do.
+
+"North Carolina has adopted the ‘strict blue pencil doctrine’ under which a court cannot rewrite a faulty covenant not to compete but may enforce divisible and reasonable portions of the covenant while striking the unenforceable portions."[^q5-beverage-strict]
+
+The Court of Appeals draws the same line: a court may decline to enforce a distinctly separable part, but no more.
+
+"A court at most may choose not to enforce a distinctly separable part of a covenant in order to render the provision reasonable."[^q5-hartman-separable]
+
+Critically, a contractual clause purporting to authorize the court to revise the covenant does not work. The Supreme Court held that parties cannot confer a power the court does not possess.
+
+"However, parties cannot contract to give a court power that it does not have."[^q5-beverage-contract]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Draft each restriction to be reasonable on its own, and separate the time, territory, and scope terms into distinct, severable provisions so a court can strike an overbroad one without voiding the rest. Do not rely on a reformation or savings clause to rescue an overbroad covenant — North Carolina courts will not rewrite it, even when the contract asks them to [^q5-beverage-contract][^q5-daniel-rewrite].
+
+## How does North Carolina treat customer and employee non-solicitation covenants? {#non-solicitation}
+
+**Short answer.** Non-solicitation covenants are restrictive covenants, and their precise wording controls how far they reach. North Carolina courts read terms like *solicit*, *recruit*, and *induce* to require active persuasion, so a clause that bars only solicitation does not prohibit merely hiring or accepting a departing employee [^q6-crockett-solicit][^q6-crockett-definitions]. A customer non-solicit that reaches prospective customers or areas where the employee had no customer connections is overbroad [^q6-hejl-prospective].
+
+In *Crockett*, the court held that hiring former employees who were not actively solicited did not breach a non-solicitation covenant.
+
+"After a thorough review of the record, we hold that there is no genuine issue of material fact, as defendants did not ‘solicit, recruit or induce’ Brent West or Brian Fry to work for defendants in violation of the non-compete agreements and therefore, defendants were entitled to judgment as a matter of law."[^q6-crockett-solicit]
+
+The court grounded that result in the ordinary meaning of the operative verbs.
+
+"We note that all of the above-cited definitions of ‘solicit, recruit or induce’ are similar in that they involve active persuasion, request, or petition."[^q6-crockett-definitions]
+
+A customer non-solicit also has to stay within the employer's actual customer relationships. Reaching potential clients the employer never had is an impermissible restraint.
+
+"Defendant’s attempt to prevent Plaintiff from obtaining clients where Defendant had failed to do so, is an impermissible restraint on Plaintiff."[^q6-hejl-prospective]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Match the operative verb to the conduct you want to reach. If you intend to bar hiring as well as solicitation, say so expressly, because a covenant limited to *solicit, recruit, or induce* requires active persuasion and will not reach a passive hire; and confine customer non-solicits to actual, not prospective, customers [^q6-crockett-definitions][^q6-hejl-prospective].
+
+## Does a North Carolina non-compete period toll or extend during a breach or litigation? {#tolling}
+
+**Short answer.** Only if the contract says so. North Carolina has no appellate decision holding that a court will *equitably* extend a restricted period to make up for time the former employee spent violating the covenant, so equitable tolling is unsettled. But federal courts applying North Carolina law have enforced *express* extension-on-breach clauses, stating that such tolling provisions appear to be valid under North Carolina law [^q7-philips-valid][^q7-southtech-tolls].
+
+The clearest statement comes from the Middle District of North Carolina, enforcing a clause that paused the protected period while the employee was out of compliance.
+
+"Such tolling provisions appear to be valid under North Carolina law."[^q7-philips-valid]
+
+Applying that clause, the court treated the covenant as extended by the period of non-compliance rather than expired.
+
+"Thus, the expiration of the Non-Competition Agreement should be tolled for eleven months, until April 9, 2010."[^q7-philips-tolled]
+
+The Eastern District reached the same result, giving effect to a clause that tolled the time limit while the employee remained in violation.
+
+"On the other hand, as discussed above, paragraph ll(m) of the employment agreement tolls the time limitation of the non-compete as long as defendant is in violation of it, and so plaintiff will not be deprived of its bargained-for remedy if it later turns out that injunctive relief is warranted."[^q7-southtech-tolls]
+
+> [!NOTE]
+> **Practice note.**
+>
+> If you want the restricted period to extend for the time an employee spends breaching, include an express extension-on-breach (tolling) clause; do not assume a court will lengthen the period on its own. Federal courts applying North Carolina law have enforced express tolling clauses, but no North Carolina appellate decision recognizes equitable tolling without one [^q7-philips-valid][^q7-southtech-tolls].
+
+## Are physician and health-care non-competes enforceable in North Carolina? {#physicians}
+
+**Short answer.** Not categorically, and they face an extra public-policy hurdle. North Carolina courts will refuse to enforce a physician covenant when doing so would create a substantial question of potential harm to the public health, weighing factors such as the shortage of specialists in the restricted area, the risk of a local monopoly, emergency availability, and patient choice [^q8-zaldivar-balance][^q8-zaldivar-factors]. A pending bill, SB 673, would go further and ban non-competes for hospital-employed health-care professionals — defined as licensed physicians, physician assistants, advanced practice registered nurses, and registered nurses — outright [^q8-sb673][^q8-sb673-def].
+
+In *Zaldivar*, the Court of Appeals affirmed summary judgment for the physician, holding the covenants unenforceable on public-policy grounds.
+
+"After carefully reviewing the covenants, we find that they are unenforceable because they violate public policy and affirm the trial court’s grant of summary judgment for defendants."[^q8-zaldivar-publicpolicy]
+
+The governing test asks whether enforcement would threaten the public health.
+
+"If ordering the covenantor to honor his contractual obligation would create a substantial question of potential harm to the public health, then the public interests outweigh the contract interests of the covenantee, and the court will refuse to enforce the covenant."[^q8-zaldivar-balance]
+
+The court applies a set of public-health factors to that question.
+
+"This Court considers the following factors in determining the risk of substantial harm to the public: the shortage of specialists in the field in the restricted area, the impact of establishing a monopoly in the area, including the impact on fees in the future and the availability of a doctor at all times for emergencies, and the public interest in having a choice in the selection of a physician."[^q8-zaldivar-factors]
+
+> [!NOTE]
+> **Practice note.**
+>
+> For physician and other health-care covenants, evaluate the public-health impact before relying on the restraint, and watch SB 673. The covenant can fail on public-policy grounds even if its time and territory are otherwise reasonable, and a pending bill would bar hospital health-care non-competes entirely [^q8-zaldivar-balance][^q8-sb673].
+
+## Can an out-of-state employer force a North Carolina non-compete dispute into another state's courts? {#out-of-state-employers}
+
+**Short answer.** Not for a contract entered into in North Carolina. North Carolina voids any provision in a contract entered into in the State that requires a lawsuit or arbitration arising from the contract to be brought or heard in another state [^q9-gs-22b-3]. A national employer that drops its standard out-of-state forum or venue clause into an agreement entered into in North Carolina cannot count on that clause to move the dispute out of state. Section 22B-3 reaches forum and arbitration provisions; it does not by itself void an out-of-state choice-of-law clause.
+
+Section 22B-3 directly targets out-of-state forum-selection clauses.
+
+"Except as otherwise provided in this section, any provision in a contract entered into in North Carolina that requires the prosecution of any action or the arbitration of any dispute that arises from the contract to be instituted or heard in another state is against public policy and is void and unenforceable."[^q9-gs-22b-3]
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not rely on an out-of-state forum, venue, or arbitration clause for a covenant entered into in North Carolina. Section 22B-3 makes such a provision void as against public policy, so the action can proceed in a North Carolina forum [^q9-gs-22b-3].
+
+## Can a party recover attorney fees in a North Carolina non-compete dispute? {#attorney-fees}
+
+**Short answer.** Usually not in a plain contract action. North Carolina's reciprocal-fee statute for business contracts expressly excludes employment contracts, so a one-sided attorney-fee clause in an employment non-compete generally will not support a fee award [^q10-gs-6-21-6]. Fees are available on the margins — for example, to a prevailing party on an unfair-trade-practices claim under § 75-1.1, in the court's discretion and on findings of willfulness or a frivolous action [^q10-gs-75-16-1].
+
+The reciprocal-fee statute that applies to business contracts carves employment contracts out of its definition.
+
+"Business contract. - A contract entered into primarily for business or commercial purposes. The term does not include a consumer contract, an employment contract, or a contract to which a government or a governmental agency of this State is a party."[^q10-gs-6-21-6]
+
+A separate, narrower fee path exists for unfair-trade-practices claims, which sometimes accompany a covenant or trade-secret dispute.
+
+"In any suit instituted by a person who alleges that the defendant violated G.S. 75-1.1, the presiding judge may, in his discretion, allow a reasonable attorney fee to the duly licensed attorney representing the prevailing party, such attorney fee to be taxed as a part of the court costs and payable by the losing party, upon a finding by the presiding judge that: (1) The party charged with the violation has willfully engaged in the act or practice, and there was an unwarranted refusal by such party to fully resolve the matter which constitutes the basis of such suit; or (2) The party instituting the action knew, or should have known, the action was frivolous and malicious."[^q10-gs-75-16-1]
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not assume a fee-shifting clause in an employment non-compete will be enforced. Section 6-21.6 excludes employment contracts from the reciprocal business-contract fee statute, so fee recovery generally depends on a separate statutory hook such as a § 75-1.1 unfair-trade-practices claim [^q10-gs-6-21-6][^q10-gs-75-16-1].
+
+## How do North Carolina trade-secret protections compare to a non-compete? {#trade-secrets}
+
+**Short answer.** They remain available and are often the more durable tool. The North Carolina Trade Secrets Protection Act protects qualifying business and technical information without the reasonableness limits a non-compete faces, and misappropriation can be enjoined and remedied in damages, with punitive damages for willful and malicious conduct [^q11-gs-66-152][^q11-gs-66-154]. Because a trade-secret claim does not depend on a valid covenant, it survives even where a non-compete fails.
+
+The Act defines a trade secret by reference to its independent commercial value and reasonable secrecy efforts.
+
+"‘Trade secret’ means business or technical information, including but not limited to a formula, pattern, program, device, compilation of information, method, technique, or process that: a. Derives independent actual or potential commercial value from not being generally known or readily ascertainable through independent development or reverse engineering by persons who can obtain economic value from its disclosure or use; and b. Is the subject of efforts that are reasonable under the circumstances to maintain its secrecy."[^q11-gs-66-152]
+
+The remedies are robust, including injunctive relief and, for willful and malicious misappropriation, punitive damages.
+
+"If willful and malicious misappropriation exists, the trier of fact also may award punitive damages in its discretion."[^q11-gs-66-154]
+
+> [!NOTE]
+> **Practice note.**
+>
+> Protect confidential information with a trade-secret and confidentiality strategy, not just a covenant. The Trade Secrets Protection Act supplies injunctive and damages remedies that do not depend on a valid non-compete, so they remain available even if a covenant is unenforceable [^q11-gs-66-152][^q11-gs-66-154].
+
+## Is North Carolina non-compete law about to change? {#pending-legislation}
+
+**Short answer.** Possibly, but not yet. Two 2025 bills would restrict non-competes — HB 269 would bar them for covered employees earning less than $75,000 a year, and SB 673 would ban them for hospital-employed health-care professionals — but both were introduced in the 2025 session and remain pending, and neither has become law [^q12-hb269-threshold][^q12-sb673]. Until one is enacted, the common-law five-factor test continues to govern.
+
+HB 269, the Workforce Freedom and Protection Act, would declare a covenant restraining lawful work void for lower-paid workers.
+
+"Policy. – It is the public policy of this State that any contract by which anyone is restrained from exercising a lawful profession, trade, or business of any kind is to that extent void and unenforceable, except as provided in subsection (c) of this section."[^q12-hb269-policy]
+
+The bill sets the coverage line at an annual income below $75,000.
+
+"Employee. – An employee providing labor or services to another for pay of less than seventy–five thousand dollars ($75,000) per year."[^q12-hb269-threshold]
+
+SB 673 would impose a categorical ban for hospital-employed health-care professionals.
+
+"An employment contract for a health care professional employed by a hospital, as defined in G.S. 95-28.1B, shall not contain a non-compete clause."[^q12-sb673]
+
+> [!NOTE]
+> **Practice note.**
+>
+> Track HB 269 and SB 673 before relying on a covenant for a lower-paid worker or a hospital-employed clinician, but draft to current law. Both bills remain pending in committee and have not been enacted, so the existing common-law test still controls [^q12-hb269-policy][^q12-sb673].
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-03. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not North Carolina. This article synthesizes North Carolina primary law and is not legal advice from a North Carolina-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^q1-ridgway-five-factor]: **Medical Staffing Network, Inc. v. Ridgway** — "To be enforceable under North Carolina law, a non-competition agreement must be: (1) in writing; (2) part of an employment contract; (3) based on valuable consideration; (4) reasonable as to time and territory; and (5) designed to protect a legitimate business interest." *Med. Staffing Network, Inc. v. Ridgway, 194 N.C. App. 649 (2009).* <https://www.courtlistener.com/opinion/1156110/medical-staffing-network-inc-v-ridgway/#:~:text=To%20be%20enforceable%20under%20North,protect%20a%20legitimate%20business%20interest.>
+
+[^q1-gs-75-1]: **N.C. Gen. Stat. § 75-1** — "Every contract, combination in the form of trust or otherwise, or conspiracy in restraint of trade or commerce in the State of North Carolina is hereby declared to be illegal." *N.C. Gen. Stat. § 75-1.* <https://www.ncleg.gov/EnactedLegislation/Statutes/HTML/BySection/Chapter_75/GS_75-1.html>
+
+[^q1-kuykendall-partial-restraint]: **United Laboratories, Inc. v. Kuykendall** — "However, this position was modified and it became generally recognized that, while non-competition clauses were in partial restraint of trade, they would nevertheless be upheld if the covenants were supported by valuable consideration, reasonably necessary to protect the interests of the covenantee, and not against public policy." *United Labs., Inc. v. Kuykendall, 322 N.C. 643 (1988).* <https://www.courtlistener.com/opinion/1294109/united-laboratories-inc-v-kuykendall/#:~:text=However%2C%20this%20position%20was%20modified,and%20not%20against%20public%20policy.>
+
+[^q1-daniel-five-factor]: **Whittaker General Medical Corp. v. Daniel** — "Such covenants are enforceable in this state if they are (1) in writing, (2) made part of a contract of employment, (3) based on valuable consideration, (4) reasonable both as to time and territory, and (5) not against public policy." *Whittaker Gen. Med. Corp. v. Daniel, 324 N.C. 523 (1989).* <https://www.courtlistener.com/opinion/1205500/whittaker-general-medical-corp-v-daniel/#:~:text=Such%20covenants%20are%20enforceable%20in,(5)%20not%20against%20public%20policy.>
+
+[^q1-gs-75-4]: **N.C. Gen. Stat. § 75-4** — "No contract or agreement hereafter made, limiting the rights of any person to do business anywhere in the State of North Carolina shall be enforceable unless such agreement is in writing duly signed by the party who agrees not to enter into any such business within such territory: Provided, nothing herein shall be construed to legalize any contract or agreement not to enter into business in the State of North Carolina, or at any point in the State of North Carolina, which contract is now illegal, or which contract is made illegal by any other section of this Chapter." *N.C. Gen. Stat. § 75-4.* <https://www.ncleg.gov/EnactedLegislation/Statutes/HTML/BySection/Chapter_75/GS_75-4.html>
+
+[^q2-qsp-newemployment]: **QSP, Inc. v. Hair** — "This offer, made by QSP on 12 February 2000, was an offer of new employment and therefore constituted valuable consideration." *QSP, Inc. v. Hair, 152 N.C. App. 174 (2002).* <https://www.courtlistener.com/opinion/1422226/qsp-inc-v-hair/#:~:text=This%20offer%2C%20made%20by%20QSP,and%20therefore%20constituted%20valuable%20consideration.>
+
+[^q2-empt-staffing-milner]: **Employment Staffing Group, Inc. v. Little** — "‘[I]f an employment relationship already exists without a covenant not to compete, any such future covenant must be based upon new consideration.’" *Emp't Staffing Grp., Inc. v. Little, 243 N.C. App. 266 (2015).* <https://www.courtlistener.com/opinion/3007343/empt-staffing-grp-inc-v-little/#:~:text=%E2%80%9C%5BI%5Df%20an%20employment%20relationship%20already,be%20based%20upon%20new%20consideration.%E2%80%9D>
+
+[^q2-hejl-500]: **Hejl v. Hood, Hargett & Associates, Inc.** — "Therefore, because the parties dealt at arms length, and the Plaintiff received $500.00 as consideration for signing the Agreement, we find the Agreement is not void due to lack of consideration." *Hejl v. Hood, Hargett & Assocs., 196 N.C. App. 299 (2009).* <https://www.courtlistener.com/opinion/1283156/hejl-v-hood-hargett-associates-inc/#:~:text=Therefore%2C%20because%20the%20parties%20dealt,due%20to%20lack%20of%20consideration.>
+
+[^q2-empt-staffing-amount]: **Employment Staffing Group, Inc. v. Little** — "Accordingly, we hold that Defendant’s argument that this Court may invalidate the non-compete covenant based on the inadequacy of the $100 consideration is without merit." *Emp't Staffing Grp., Inc. v. Little, 243 N.C. App. 266 (2015).* <https://www.courtlistener.com/opinion/3007343/empt-staffing-grp-inc-v-little/#:~:text=Accordingly%2C%20we%20hold%20that%20Defendant%E2%80%99s,%24100%20consideration%20is%20without%20merit.>
+
+[^q2-daniel-consideration]: **Whittaker General Medical Corp. v. Daniel** — "When the relationship of employer and employee is established before the covenant not to compete is signed there must be consideration for the covenant such as a raise in pay or a new job assignment." *Whittaker Gen. Med. Corp. v. Daniel, 324 N.C. 523 (1989).* <https://www.courtlistener.com/opinion/1205500/whittaker-general-medical-corp-v-daniel/#:~:text=When%20the%20relationship%20of%20employer,or%20a%20new%20job%20assignment.>
+
+[^q3-hartman-matter-of-law]: **Hartman v. W.H. Odell & Associates, Inc.** — "The reasonableness of a noncompetition covenant is a matter of law for the court to decide." *Hartman v. W.H. Odell & Assocs., 117 N.C. App. 307 (1994).* <https://www.courtlistener.com/opinion/1305744/hartman-v-wh-odell-and-associates-inc/#:~:text=The%20reasonableness%20of%20a%20noncompetition,for%20the%20court%20to%20decide.>
+
+[^q3-hartman-burden]: **Hartman v. W.H. Odell & Associates, Inc.** — "The party who seeks the enforcement of the covenant not to compete has the burden of proving that the covenant is reasonable." *Hartman v. W.H. Odell & Assocs., 117 N.C. App. 307 (1994).* <https://www.courtlistener.com/opinion/1305744/hartman-v-wh-odell-and-associates-inc/#:~:text=The%20party%20who%20seeks%20the,that%20the%20covenant%20is%20reasonable.>
+
+[^q3-hartman-territory]: **Hartman v. W.H. Odell & Associates, Inc.** — "A restriction as to territory is reasonable only to the extent it protects the legitimate interests of the employer in maintaining [its] customers." *Hartman v. W.H. Odell & Assocs., 117 N.C. App. 307 (1994).* <https://www.courtlistener.com/opinion/1305744/hartman-v-wh-odell-and-associates-inc/#:~:text=A%20restriction%20as%20to%20territory,employer%20in%20maintaining%20%5Bits%5D%20customers.>
+
+[^q3-daniel-overbroad]: **Whittaker General Medical Corp. v. Daniel** — "If a contract by an employee in restraint of competition is too broad to be a reasonable protection to the employer’s business it will not be enforced." *Whittaker Gen. Med. Corp. v. Daniel, 324 N.C. 523 (1989).* <https://www.courtlistener.com/opinion/1205500/whittaker-general-medical-corp-v-daniel/#:~:text=If%20a%20contract%20by%20an,it%20will%20not%20be%20enforced.>
+
+[^q4-kuykendall-interest]: **United Laboratories, Inc. v. Kuykendall** — "Before a covenant can be found reasonably necessary for the protection of a legitimate business interest, we hold that it is first necessary to find the employee, as a result of his employment, acquired intimate knowledge of the nature and character of the business which was not otherwise generally available to the public." *United Labs., Inc. v. Kuykendall, 322 N.C. 643 (1988).* <https://www.courtlistener.com/opinion/1294109/united-laboratories-inc-v-kuykendall/#:~:text=Before%20a%20covenant%20can%20be,generally%20available%20to%20the%20public.>
+
+[^q4-ridgway-duties]: **Medical Staffing Network, Inc. v. Ridgway** — "However, we have held that restrictive covenants are unenforceable where they prohibit the employee from engaging in future work that is distinct from the duties actually performed by the employee." *Med. Staffing Network, Inc. v. Ridgway, 194 N.C. App. 649 (2009).* <https://www.courtlistener.com/opinion/1156110/medical-staffing-network-inc-v-ridgway/#:~:text=However%2C%20we%20have%20held%20that,actually%20performed%20by%20the%20employee.>
+
+[^q5-beverage-strict]: **Beverage Systems of the Carolinas, LLC v. Associated Beverage Repair, LLC** — "North Carolina has adopted the ‘strict blue pencil doctrine’ under which a court cannot rewrite a faulty covenant not to compete but may enforce divisible and reasonable portions of the covenant while striking the unenforceable portions." *Beverage Sys. of the Carolinas, LLC v. Associated Beverage Repair, LLC, 368 N.C. 693 (2016).* <https://www.courtlistener.com/opinion/3186954/beverage-systems-of-the-carolinas-llc-v-associated-beverage-repair-llc/#:~:text=North%20Carolina%20has%20adopted%20the,while%20striking%20the%20unenforceable%20portions.>
+
+[^q5-hartman-separable]: **Hartman v. W.H. Odell & Associates, Inc.** — "A court at most may choose not to enforce a distinctly separable part of a covenant in order to render the provision reasonable." *Hartman v. W.H. Odell & Assocs., 117 N.C. App. 307 (1994).* <https://www.courtlistener.com/opinion/1305744/hartman-v-wh-odell-and-associates-inc/#:~:text=A%20court%20at%20most%20may,to%20render%20the%20provision%20reasonable.>
+
+[^q5-beverage-contract]: **Beverage Systems of the Carolinas, LLC v. Associated Beverage Repair, LLC** — "However, parties cannot contract to give a court power that it does not have." *Beverage Sys. of the Carolinas, LLC v. Associated Beverage Repair, LLC, 368 N.C. 693 (2016).* <https://www.courtlistener.com/opinion/3186954/beverage-systems-of-the-carolinas-llc-v-associated-beverage-repair-llc/#:~:text=However%2C%20parties%20cannot%20contract%20to,that%20it%20does%20not%20have.>
+
+[^q5-daniel-rewrite]: **Whittaker General Medical Corp. v. Daniel** — "The courts will not rewrite a contract if it is too broad but will simply not enforce it." *Whittaker Gen. Med. Corp. v. Daniel, 324 N.C. 523 (1989).* <https://www.courtlistener.com/opinion/1205500/whittaker-general-medical-corp-v-daniel/#:~:text=The%20courts%20will%20not%20rewrite,will%20simply%20not%20enforce%20it.>
+
+[^q6-crockett-solicit]: **Inland American Winston Hotels, Inc. v. Crockett** — "After a thorough review of the record, we hold that there is no genuine issue of material fact, as defendants did not ‘solicit, recruit or induce’ Brent West or Brian Fry to work for defendants in violation of the non-compete agreements and therefore, defendants were entitled to judgment as a matter of law." *Inland Am. Winston Hotels, Inc. v. Crockett, 212 N.C. App. 349 (2011).* <https://www.courtlistener.com/opinion/2504879/inland-american-winston-hotels-inc-v-crockett/#:~:text=After%20a%20thorough%20review%20of,as%20a%20matter%20of%20law.>
+
+[^q6-crockett-definitions]: **Inland American Winston Hotels, Inc. v. Crockett** — "We note that all of the above-cited definitions of ‘solicit, recruit or induce’ are similar in that they involve active persuasion, request, or petition." *Inland Am. Winston Hotels, Inc. v. Crockett, 212 N.C. App. 349 (2011).* <https://www.courtlistener.com/opinion/2504879/inland-american-winston-hotels-inc-v-crockett/#:~:text=We%20note%20that%20all%20of,active%20persuasion%2C%20request%2C%20or%20petition.>
+
+[^q6-hejl-prospective]: **Hejl v. Hood, Hargett & Associates, Inc.** — "Defendant’s attempt to prevent Plaintiff from obtaining clients where Defendant had failed to do so, is an impermissible restraint on Plaintiff." *Hejl v. Hood, Hargett & Assocs., 196 N.C. App. 299 (2009).* <https://www.courtlistener.com/opinion/1283156/hejl-v-hood-hargett-associates-inc/#:~:text=Defendant%E2%80%99s%20attempt%20to%20prevent%20Plaintiff,an%20impermissible%20restraint%20on%20Plaintiff.>
+
+[^q7-philips-valid]: **Philips Electronics North America Corp. v. Hope** — "Such tolling provisions appear to be valid under North Carolina law." *Philips Elecs. N. Am. Corp. v. Hope, 631 F. Supp. 2d 705 (M.D.N.C. 2009).* <https://www.courtlistener.com/opinion/2579285/philips-electronics-north-america-corp-v-hope/#:~:text=Such%20tolling%20provisions%20appear%20to,valid%20under%20North%20Carolina%20law.>
+
+[^q7-southtech-tolls]: **Southtech Orthopedics, Inc. v. Dingus** — "On the other hand, as discussed above, paragraph ll(m) of the employment agreement tolls the time limitation of the non-compete as long as defendant is in violation of it, and so plaintiff will not be deprived of its bargained-for remedy if it later turns out that injunctive relief is warranted." *Southtech Orthopedics, Inc. v. Dingus, 428 F. Supp. 2d 410 (E.D.N.C. 2006).* <https://www.courtlistener.com/opinion/2524901/southtech-orthopedics-inc-v-dingus/#:~:text=On%20the%20other%20hand%2C%20as,that%20injunctive%20relief%20is%20warranted.>
+
+[^q7-philips-tolled]: **Philips Electronics North America Corp. v. Hope** — "Thus, the expiration of the Non-Competition Agreement should be tolled for eleven months, until April 9, 2010." *Philips Elecs. N. Am. Corp. v. Hope, 631 F. Supp. 2d 705 (M.D.N.C. 2009).* <https://www.courtlistener.com/opinion/2579285/philips-electronics-north-america-corp-v-hope/#:~:text=Thus%2C%20the%20expiration%20of%20the,months%2C%20until%20April%209%2C%202010.>
+
+[^q8-zaldivar-balance]: **Aesthetic Facial & Ocular Plastic Surgery Center, P.A. v. Zaldivar** — "If ordering the covenantor to honor his contractual obligation would create a substantial question of potential harm to the public health, then the public interests outweigh the contract interests of the covenantee, and the court will refuse to enforce the covenant." *Aesthetic Facial & Ocular Plastic Surgery Ctr., P.A. v. Zaldivar, 264 N.C. App. 260 (2019).* <https://www.courtlistener.com/opinion/4601038/aesthetic-facial-ocular-plastic-surgery-ctr-pa-v-zaldivar/#:~:text=If%20ordering%20the%20covenantor%20to,refuse%20to%20enforce%20the%20covenant.>
+
+[^q8-zaldivar-factors]: **Aesthetic Facial & Ocular Plastic Surgery Center, P.A. v. Zaldivar** — "This Court considers the following factors in determining the risk of substantial harm to the public: the shortage of specialists in the field in the restricted area, the impact of establishing a monopoly in the area, including the impact on fees in the future and the availability of a doctor at all times for emergencies, and the public interest in having a choice in the selection of a physician." *Aesthetic Facial & Ocular Plastic Surgery Ctr., P.A. v. Zaldivar, 264 N.C. App. 260 (2019).* <https://www.courtlistener.com/opinion/4601038/aesthetic-facial-ocular-plastic-surgery-ctr-pa-v-zaldivar/#:~:text=This%20Court%20considers%20the%20following,the%20selection%20of%20a%20physician.>
+
+[^q8-sb673]: **S.B. 673 (2025)** — "An employment contract for a health care professional employed by a hospital, as defined in G.S. 95-28.1B, shall not contain a non-compete clause." *S.B. 673, 2025 Gen. Assemb., Reg. Sess. (N.C. 2025).* <https://www.ncleg.gov/Sessions/2025/Bills/Senate/PDF/S673v1.pdf>
+
+[^q8-sb673-def]: **S.B. 673 (2025)** — "Health care professional. – An individual who is a licensed physician, physician assistant, advanced practice registered nurse as defined by the North Carolina Board of Nursing, or registered nurse." *S.B. 673, 2025 Gen. Assemb., Reg. Sess. (N.C. 2025).* <https://www.ncleg.gov/Sessions/2025/Bills/Senate/PDF/S673v1.pdf>
+
+[^q8-zaldivar-publicpolicy]: **Aesthetic Facial & Ocular Plastic Surgery Center, P.A. v. Zaldivar** — "After carefully reviewing the covenants, we find that they are unenforceable because they violate public policy and affirm the trial court’s grant of summary judgment for defendants." *Aesthetic Facial & Ocular Plastic Surgery Ctr., P.A. v. Zaldivar, 264 N.C. App. 260 (2019).* <https://www.courtlistener.com/opinion/4601038/aesthetic-facial-ocular-plastic-surgery-ctr-pa-v-zaldivar/#:~:text=After%20carefully%20reviewing%20the%20covenants%2C,of%20summary%20judgment%20for%20defendants.>
+
+[^q9-gs-22b-3]: **N.C. Gen. Stat. § 22B-3** — "Except as otherwise provided in this section, any provision in a contract entered into in North Carolina that requires the prosecution of any action or the arbitration of any dispute that arises from the contract to be instituted or heard in another state is against public policy and is void and unenforceable." *N.C. Gen. Stat. § 22B-3.* <https://www.ncleg.gov/EnactedLegislation/Statutes/HTML/BySection/Chapter_22B/GS_22B-3.html>
+
+[^q10-gs-6-21-6]: **N.C. Gen. Stat. § 6-21.6** — "Business contract. - A contract entered into primarily for business or commercial purposes. The term does not include a consumer contract, an employment contract, or a contract to which a government or a governmental agency of this State is a party." *N.C. Gen. Stat. § 6-21.6(1).* <https://www.ncleg.gov/EnactedLegislation/Statutes/HTML/BySection/Chapter_6/GS_6-21.6.html>
+
+[^q10-gs-75-16-1]: **N.C. Gen. Stat. § 75-16.1** — "In any suit instituted by a person who alleges that the defendant violated G.S. 75-1.1, the presiding judge may, in his discretion, allow a reasonable attorney fee to the duly licensed attorney representing the prevailing party, such attorney fee to be taxed as a part of the court costs and payable by the losing party, upon a finding by the presiding judge that: (1) The party charged with the violation has willfully engaged in the act or practice, and there was an unwarranted refusal by such party to fully resolve the matter which constitutes the basis of such suit; or (2) The party instituting the action knew, or should have known, the action was frivolous and malicious." *N.C. Gen. Stat. § 75-16.1.* <https://www.ncleg.gov/EnactedLegislation/Statutes/HTML/BySection/Chapter_75/GS_75-16.1.html>
+
+[^q11-gs-66-152]: **N.C. Gen. Stat. § 66-152** — "‘Trade secret’ means business or technical information, including but not limited to a formula, pattern, program, device, compilation of information, method, technique, or process that: a. Derives independent actual or potential commercial value from not being generally known or readily ascertainable through independent development or reverse engineering by persons who can obtain economic value from its disclosure or use; and b. Is the subject of efforts that are reasonable under the circumstances to maintain its secrecy." *N.C. Gen. Stat. § 66-152(3).* <https://www.ncleg.gov/EnactedLegislation/Statutes/HTML/BySection/Chapter_66/GS_66-152.html>
+
+[^q11-gs-66-154]: **N.C. Gen. Stat. § 66-154** — "If willful and malicious misappropriation exists, the trier of fact also may award punitive damages in its discretion." *N.C. Gen. Stat. § 66-154(c).* <https://www.ncleg.gov/EnactedLegislation/Statutes/HTML/BySection/Chapter_66/GS_66-154.html>
+
+[^q12-hb269-threshold]: **H.B. 269 (2025)** — "Employee. – An employee providing labor or services to another for pay of less than seventy–five thousand dollars ($75,000) per year." *H.B. 269, 2025 Gen. Assemb., Reg. Sess. (N.C. 2025).* <https://www.ncleg.gov/Sessions/2025/Bills/House/PDF/H269v1.pdf>
+
+[^q12-sb673]: **S.B. 673 (2025)** — "An employment contract for a health care professional employed by a hospital, as defined in G.S. 95-28.1B, shall not contain a non-compete clause." *S.B. 673, 2025 Gen. Assemb., Reg. Sess. (N.C. 2025).* <https://www.ncleg.gov/Sessions/2025/Bills/Senate/PDF/S673v1.pdf>
+
+[^q12-hb269-policy]: **H.B. 269 (2025)** — "Policy. – It is the public policy of this State that any contract by which anyone is restrained from exercising a lawful profession, trade, or business of any kind is to that extent void and unenforceable, except as provided in subsection (c) of this section." *H.B. 269, 2025 Gen. Assemb., Reg. Sess. (N.C. 2025).* <https://www.ncleg.gov/Sessions/2025/Bills/House/PDF/H269v1.pdf>

--- a/skills/non-compete-contract-explainer/content/north-dakota.md
+++ b/skills/non-compete-contract-explainer/content/north-dakota.md
@@ -1,0 +1,187 @@
+---
+jurisdiction: "North Dakota"
+slug: north-dakota
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-02"
+canonicalUrl: https://openagreements.org/legal/non-compete/north-dakota
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/north-dakota · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in North Dakota[^about]
+
+North Dakota voids employee non-competes under N.D. Cent. Code § 9-08-06, one of the strictest bans in the United States, with only sale-of-goodwill and dissociation exceptions.
+
+
+## At a glance
+
+| Question | North Dakota |
+| --- | --- |
+| **Are non-competes enforceable?** | Banned |
+| **Bottom line** | North Dakota voids employee non-competes by statute, with exceptions only for sale-of-goodwill and owner dissolution or dissociation covenants. |
+| **Main law or case** | N.D. Cent. Code § 9-08-06 |
+| **Main exceptions** | Sale of business goodwill; owner dissolution/dissociation; narrow employee anti-raiding non-solicits (Warner); customer non-solicits void |
+| **Can a court narrow it?** | No |
+| **Applies to contractors?** | Unclear |
+| **Restriction extended during a breach?** | Not addressed by statute |
+| **Maximum length set by law** | No statutory limit for the ban |
+
+## Are employee non-compete agreements enforceable in North Dakota? {#employee-noncompetes}
+
+**Short answer.** No. North Dakota law makes a contract that restrains a lawful profession, trade, or business to that extent void[^north-dakota-business-restraint-void].
+
+For employees, that is a prohibition, not a reasonableness test. The two statutory exceptions cover sale-of-goodwill and owner dissociation settings; ordinary employment non-competes do not fit either exception. North Dakota cases apply the rule strictly, including to insurance agents and emergency-room physicians [^werlinger-employee-noncompete-void][^spectrum-physician-employment-void].
+
+That does not make every workplace covenant invalid. A confidentiality clause, trade-secret remedy, or during-employment loyalty claim may stand on different law. But a post-employment covenant that keeps a worker from practicing the same lawful trade is usually void.
+
+## What statutory exceptions permit North Dakota non-competes? {#statutory-exceptions}
+
+**Short answer.** Only two categories are built into § 9-08-06: sale of business goodwill and certain owner dissociation or dissolution covenants [^north-dakota-goodwill-exception].
+
+The first exception lets a person who sells goodwill, together with that person's partners, members, or shareholders, agree with the buyer not to carry on a similar business within reasonable geographic and time limits. The second covers partners, LLC members, and shareholders in dissolution, dissociation, or ownership-sale settings.
+
+A covenant inside an exception is not automatically enforceable. The exception keeps the covenant from the near-total ban only if the transaction is genuinely tied to goodwill or owner separation, and the restraint still must fit the statutory geography and time limits. North Dakota goodwill law also treats goodwill as transferable property and a warranty against drawing off customers [^north-dakota-goodwill-transfer][^earthworks-goodwill-connection].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not treat a small equity repurchase or routine employment exit as a sale-of-goodwill non-compete. *Warner* held that a sale of 1/200th of the company could not transfer business goodwill as a matter of law [^warner-small-stock-goodwill].
+
+## Do North Dakota courts blue-pencil an overbroad non-compete? {#court-narrowing}
+
+**Short answer.** Usually no for employee non-competes. Section 9-08-06 makes the restraint to that extent void[^north-dakota-red-pencil-text], so courts strike the invalid restraint rather than save it through a general reasonableness rewrite.
+
+There is an important sale-of-business nuance. Older goodwill cases such as *Igoe*, *Hawkins*, and *Earthworks* allowed partial enforcement where the covenant fit the statutory exception but exceeded the permitted territory. That severability history is not a license to draft an employee non-compete and ask a court to make it reasonable later [^hawkins-sale-covenant-severability][^warner-replacement-clause-void].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> For employment covenants, draft as if an invalid restraint will be struck. North Dakota's main employment cases do not apply a general blue-pencil rescue to ordinary post-employment non-competes or customer restrictions [^warner-replacement-clause-void].
+
+## Can an out-of-state employer use a choice-of-law or forum-selection clause to enforce a North Dakota non-compete? {#choice-of-law-forum}
+
+**Short answer.** No, not when the practical result is enforcement of a non-compete against North Dakota work in violation of North Dakota public policy [^osborne-choice-forum-unenforceable].
+
+*Osborne* involved a South Dakota choice-of-law and forum clause in an employment agreement with a North Dakota sales representative. The North Dakota Supreme Court refused to enforce the forum clause because it would let the employer route around § 9-08-06.
+
+North Dakota's jurisdiction-by-agreement statute also gives a court room to refuse a foreign-forum clause when enforcement would be unfair or unreasonable [^north-dakota-foreign-forum-unreasonable].
+
+## Are customer non-solicitation covenants enforceable in North Dakota? {#customer-nonsolicits}
+
+**Short answer.** Usually no. North Dakota treats post-employment customer non-solicitation and customer-replacement clauses as restraints on trade when they restrict the worker's lawful business [^warner-customer-restriction-void].
+
+*Warner* is the key modern case. The employer argued that a narrower customer restriction should survive, but the North Dakota Supreme Court declined to create a judicial exception to the statute. The court separately recognized trade-secret and during-employment loyalty theories, but it did not save post-employment customer non-solicitation clauses as ordinary contract restraints.
+
+> [!NOTE]
+> **Practice note.**
+>
+> A North Dakota customer covenant should not be drafted as a substitute non-compete. If the real concern is confidential customer information, use trade-secret and confidentiality tools instead of a post-employment ban on doing business with customers [^warner-trade-secret-rationale].
+
+## Are employee or anti-raiding non-solicits enforceable in North Dakota? {#employee-nonsolicits}
+
+**Short answer.** A narrow anti-raiding covenant can be enforceable. *Warner* upheld the possibility of a clause barring a former agent from soliciting or influencing another employee to leave for the new agency [^warner-employee-nonsolicit-not-void].
+
+That answer is narrower than it sounds. The clause in *Warner* targeted solicitation or influence of employees, not competition for customers. *Pruco* read *Warner* the same way but denied preliminary relief on the facts, emphasizing the lack of clear solicitation evidence [^pruco-no-clear-solicitation].
+
+North Dakota also recognizes a separate duty during employment. An employee may prepare to leave, but cannot secretly solicit the employer's clients or business for the employee's own account while still employed [^biever-during-employment-solicitation].
+
+## Are forfeiture-for-competition clauses enforceable in North Dakota? {#forfeiture-for-competition}
+
+**Short answer.** No, if the forfeiture operates as an indirect restraint on lawful post-employment competition. *Werlinger* rejected the idea that a worker can be made to buy the freedom to compete [^werlinger-restraint-not-absolute].
+
+The rule matters for bonus, deferred compensation, termination pay, and liquidated-damages drafting. North Dakota looks at practical restraint, not only whether the clause expressly forbids the work. If the clause imposes a penalty for competing after employment, it is vulnerable under § 9-08-06 [^earthworks-penalty-restraint].
+
+## How are physician and healthcare non-competes treated in North Dakota? {#physician-healthcare-noncompetes}
+
+**Short answer.** Section 9-08-06 applies to physician and healthcare restraints. *Spectrum* voided restraints that blocked physicians from future hospital employment and contracting [^spectrum-physician-negotiation-protected].
+
+North Dakota does not need a separate physician non-compete ban to reach that result. The general statute protects a physician's ability to exercise a lawful profession. *Spectrum* also protected negotiation and contracting for future employment while the current agreement was still running, so long as the conduct did not cross into unfair competition or breach of loyalty.
+
+Section 43-17-42 supplies healthcare employment context: hospitals, nonprofits, and charitable trusts may employ physicians by written contract, but the contract must preserve independent medical judgment [^physician-independent-judgment].
+
+## How did the 2019 amendment change North Dakota non-compete law? {#amendment-effects}
+
+**Short answer.** The current statute frames both exceptions around a reasonable geographic area and a reasonable length of time, and expressly covers partners, members, and shareholders in goodwill sales and in owner dissolution or dissociation [^north-dakota-current-owner-exceptions].
+
+The core employee rule did not become a balancing test. The opening clause still voids contracts that restrain a lawful profession, trade, or business except for the listed categories. The current text now expressly refers to partners, members, and shareholders in the sale-of-goodwill exception, and to partnership, limited liability company, and corporation dissolution or dissociation settings in the owner-separation exception.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Reasonable geography and time now matter inside the statutory exceptions. They do not create a general safe harbor for employee non-competes outside those exceptions [^north-dakota-current-owner-exceptions].
+
+## What alternatives do North Dakota employers have? {#employer-alternatives}
+
+**Short answer.** Employers should use trade-secret, confidentiality, invention-assignment, return-of-property, and during-employment loyalty tools instead of post-employment competition bans [^north-dakota-trade-secret-injunction].
+
+North Dakota's Uniform Trade Secrets Act allows injunctions against actual or threatened misappropriation and damages for misappropriation. That is often the cleaner path when the real risk is misuse of customer lists, pricing, formulas, processes, or other protected information [^north-dakota-trade-secret-definition][^north-dakota-trade-secret-damages].
+
+Employers also can enforce ordinary loyalty duties while employment continues. Section 34-02-14 requires an employee transacting similar business on the employee's own account to prefer the employer's business [^north-dakota-loyalty-duty].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not repackage a non-compete as confidentiality. A valid alternative should target misuse of protected information or disloyal conduct, not ordinary work for a competitor after employment ends [^north-dakota-trade-secret-definition].
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-02. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not North Dakota. This article synthesizes North Dakota primary law and is not legal advice from a North Dakota-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^north-dakota-business-restraint-void]: **N.D. Cent. Code § 9-08-06** — "A contract by which anyone is restrained from exercising a lawful profession, trade, or business of any kind is to that extent void, except: 1. A person that sells the goodwill of a business and the person's partners, members, or shareholders may agree with the buyer to refrain from carrying on a similar business within a reasonable geographic area and for a reasonable length of time, if the buyer or any person deriving title to the goodwill from the buyer carries on a like business in that area." *N.D. Cent. Code § 9-08-06.* <https://ndlegis.gov/cencode/t09c08.pdf>
+
+[^werlinger-employee-noncompete-void]: **Werlinger v. Mutual Service Casualty Insurance Co.** — "The trial court ruled that Paragraph 12(D) was a restraint of trade, void and unenforceable under § 9-08-06, N.D.C.C." *Werlinger v. Mut. Serv. Cas. Ins. Co., 496 N.W.2d 26, 27 (N.D. 1993).* <https://www.courtlistener.com/opinion/1282430/werlinger-v-mutual-service-casualty-insurance-co/#:~:text=The%20trial%20court%20ruled%20that,unenforceable%20under%20%C2%A7%209%2D08%2D06%2C%20N.D.C.C.>
+
+[^spectrum-physician-employment-void]: **Spectrum Emergency Care, Inc. v. St. Joseph's Hospital & Health Center** — "There can be no doubt that section 9-08-06, N.D.C.C., makes void the provision which attempts to prohibit the physicians from being employed by the Hospital at the end of the contract period with Spectrum." *Spectrum Emergency Care, Inc. v. St. Joseph's Hosp. & Health Ctr., 479 N.W.2d 848, 851 (N.D. 1992).* <https://www.courtlistener.com/opinion/1229922/spectrum-emergency-care-inc-v-st-josephs-hospital-health-center/#:~:text=There%20can%20be%20no%20doubt,the%20contract%20period%20with%20Spectrum.>
+
+[^north-dakota-goodwill-exception]: **N.D. Cent. Code § 9-08-06** — "A contract by which anyone is restrained from exercising a lawful profession, trade, or business of any kind is to that extent void, except: 1. A person that sells the goodwill of a business and the person's partners, members, or shareholders may agree with the buyer to refrain from carrying on a similar business within a reasonable geographic area and for a reasonable length of time, if the buyer or any person deriving title to the goodwill from the buyer carries on a like business in that area. 2. Partners, members, or shareholders, upon or in anticipation of a dissolution of a partnership, limited liability company, or corporation; upon or in anticipation of a dissociation of a partner or member; or as part of an agreement addressing the dissociation or sale of a partner, member, or shareholder's ownership interest, may agree that all or any number of them will not carry on a similar business within a reasonable geographic area where the partnership, limited liability company, or corporation business has been transacted, or within a specified part of the area." *N.D. Cent. Code § 9-08-06.* <https://ndlegis.gov/cencode/t09c08.pdf>
+
+[^north-dakota-goodwill-transfer]: **N.D. Cent. Code §§ 47-07-10 to -12** — "The goodwill of a business is property transferable in the same manner as any other." *N.D. Cent. Code § 47-07-11.* <https://ndlegis.gov/cencode/t47c07.pdf>
+
+[^earthworks-goodwill-connection]: **Earthworks, Inc. v. Sehn** — "The exception relied on here by Earthworks makes valid a limited non-competition agreement only if it is connected with the sale of the goodwill of a business." *Earthworks, Inc. v. Sehn, 553 N.W.2d 490, 493 (N.D. 1996).* <https://www.courtlistener.com/opinion/895669/earthworks-inc-v-sehn/#:~:text=The%20exception%20relied%20on%20here,the%20goodwill%20of%20a%20business.>
+
+[^warner-small-stock-goodwill]: **Warner & Co. v. Solberg** — "We agree with the trial court that, as a matter of law, the sale of a l/200th interest cannot be said to transfer the goodwill of the business." *Warner & Co. v. Solberg, 2001 ND 156, ¶ 29, 634 N.W.2d 65.* <https://www.courtlistener.com/opinion/896854/warner-co-v-solberg/#:~:text=We%20agree%20with%20the%20trial,the%20goodwill%20of%20the%20business.>
+
+[^north-dakota-red-pencil-text]: **N.D. Cent. Code § 9-08-06** — "A contract by which anyone is restrained from exercising a lawful profession, trade, or business of any kind is to that extent void, except: 1. A person that sells the goodwill of a business and the person's partners, members, or shareholders may agree with the buyer to refrain from carrying on a similar business within a reasonable geographic area and for a reasonable length of time, if the buyer or any person deriving title to the goodwill from the buyer carries on a like business in that area." *N.D. Cent. Code § 9-08-06.* <https://ndlegis.gov/cencode/t09c08.pdf>
+
+[^hawkins-sale-covenant-severability]: **Hawkins Chemical, Inc. v. McNea** — "Because the property and business purchased from Saunders and McNea were located and conducted in Ward County, we hold the non-competition agreement to be enforceable in that county." *Hawkins Chem., Inc. v. McNea, 321 N.W.2d 918, 920 (N.D. 1982).* <https://www.courtlistener.com/opinion/1586088/hawkins-chemical-inc-v-mcnea/#:~:text=Because%20the%20property%20and%20business,be%20enforceable%20in%20that%20county.>
+
+[^warner-replacement-clause-void]: **Warner & Co. v. Solberg** — "These limitations constitute a restraint of trade and therefore the agreement is ‘to that extent void.’" *Warner & Co. v. Solberg, 2001 ND 156, ¶ 24, 634 N.W.2d 65.* <https://www.courtlistener.com/opinion/896854/warner-co-v-solberg/#:~:text=These%20limitations%20constitute%20a%20restraint,is%20%E2%80%9Cto%20that%20extent%20void.%E2%80%9D>
+
+[^osborne-choice-forum-unenforceable]: **Osborne v. Brown & Saenger, Inc.** — "Simply put, one may not contract for application of another state’s law or forum if the natural result is to allow enforcement of a non-compete agreement in violation of North Dakota’s longstanding and strong public policy against non-compete agreements." *Osborne v. Brown & Saenger, Inc., 2017 ND 288, ¶ 16, 904 N.W.2d 34.* <https://www.courtlistener.com/opinion/4449595/osborne-v-brown-saenger-inc/#:~:text=Simply%20put%2C%20one%20may%20not,public%20policy%20against%20non%2Dcompete%20agreements.>
+
+[^north-dakota-foreign-forum-unreasonable]: **N.D. Cent. Code § 28-04.1-03** — "If the parties have agreed in writing that an action on a controversy may be brought only in another state and it is brought in a court of this state, the court will dismiss or stay the action, as appropriate, unless: 1. The court is required by statute to entertain the action; 2. The plaintiff cannot secure effective relief in the other state, for reasons other than delay in bringing the action; 3. The other state would be a substantially less convenient place for the trial of the action than this state; 4. The agreement as to the place of the action was obtained by misrepresentation, duress, the abuse of economic power, or other unconscionable means; or 5. It would for some other reason be unfair or unreasonable to enforce the agreement." *N.D. Cent. Code § 28-04.1-03.* <https://ndlegis.gov/cencode/t28c04-1.pdf>
+
+[^warner-customer-restriction-void]: **Warner & Co. v. Solberg** — "The statute contains no exception for the contractual provisions in § 6(a) and (b) of the contract." *Warner & Co. v. Solberg, 2001 ND 156, ¶ 23, 634 N.W.2d 65.* <https://www.courtlistener.com/opinion/896854/warner-co-v-solberg/#:~:text=The%20statute%20contains%20no%20exception,and%20(b)%20of%20the%20contract.>
+
+[^warner-trade-secret-rationale]: **Warner & Co. v. Solberg** — "Because of the plain language of the statute, the history of legislation in North Dakota concerning this issue, and because North Dakota has enacted trade-secrets legislation, we decline to do so." *Warner & Co. v. Solberg, 2001 ND 156, ¶ 18, 634 N.W.2d 65.* <https://www.courtlistener.com/opinion/896854/warner-co-v-solberg/#:~:text=Because%20of%20the%20plain%20language,we%20decline%20to%20do%20so.>
+
+[^warner-employee-nonsolicit-not-void]: **Warner & Co. v. Solberg** — "This prohibition is narrowly drawn to penalize only Solberg’s actions of soliciting or influencing an employee to leave Warner and come to work for Vaaler and is not void as a restraint of trade." *Warner & Co. v. Solberg, 2001 ND 156, ¶ 25, 634 N.W.2d 65.* <https://www.courtlistener.com/opinion/896854/warner-co-v-solberg/#:~:text=This%20prohibition%20is%20narrowly%20drawn,as%20a%20restraint%20of%20trade.>
+
+[^pruco-no-clear-solicitation]: **Pruco Securities Corp. v. Montgomery** — "Simply stated, the record at this stage is devoid of any competent evidence that Montgomery improperly solicited Prudential agents to follow him to Minnesota Life." *Pruco Sec. Corp. v. Montgomery, 264 F. Supp. 2d 862, 868 (D.N.D. 2003).* <https://www.courtlistener.com/opinion/2507357/pruco-securities-corp-v-montgomery/#:~:text=Simply%20stated%2C%20the%20record%20at,follow%20him%20to%20Minnesota%20Life.>
+
+[^biever-during-employment-solicitation]: **Biever, Drees & Nordell v. Coutts** — "We believe the above provision clearly sets forth what the firm had a right to expect from Coutts, i. e., that he would not solicit clients of the firm for himself while he was employed by the firm." *Biever, Drees & Nordell v. Coutts, 305 N.W.2d 33, 36 (N.D. 1981).* <https://www.courtlistener.com/opinion/2226690/biever-drees-nordell-v-coutts/#:~:text=We%20believe%20the%20above%20provision,was%20employed%20by%20the%20firm.>
+
+[^werlinger-restraint-not-absolute]: **Werlinger v. Mutual Service Casualty Insurance Co.** — "Surely this was not freedom to practice his profession in Grand Forks, since he would have to purchase the freedom with $2,000, and there is no merit to this contention." *Werlinger v. Mut. Serv. Cas. Ins. Co., 496 N.W.2d 26, 29 (N.D. 1993).* <https://www.courtlistener.com/opinion/1282430/werlinger-v-mutual-service-casualty-insurance-co/#:~:text=Surely%20this%20was%20not%20freedom,no%20merit%20to%20this%20contention.>
+
+[^earthworks-penalty-restraint]: **Earthworks, Inc. v. Sehn** — "The statute represents one of the oldest and most continuous applications of public policy in contract law, and it invalidates provisions in employment contracts prohibiting an employee from working for a competitor after completion of his employment or imposing a penalty if he does so." *Earthworks, Inc. v. Sehn, 553 N.W.2d 490, 493 (N.D. 1996).* <https://www.courtlistener.com/opinion/895669/earthworks-inc-v-sehn/#:~:text=The%20statute%20represents%20one%20of,penalty%20if%20he%20does%20so.>
+
+[^spectrum-physician-negotiation-protected]: **Spectrum Emergency Care, Inc. v. St. Joseph's Hospital & Health Center** — "The ability to negotiate and contract for future employment is central to one's ability to exercise a lawful profession, trade, or business." *Spectrum Emergency Care, Inc. v. St. Joseph's Hosp. & Health Ctr., 479 N.W.2d 848, 851 (N.D. 1992).* <https://www.courtlistener.com/opinion/1229922/spectrum-emergency-care-inc-v-st-josephs-hospital-health-center/#:~:text=The%20ability%20to%20negotiate%20and,lawful%20profession%2C%20trade%2C%20or%20business.>
+
+[^physician-independent-judgment]: **N.D. Cent. Code § 43-17-42** — "The written contract must contain language to the effect the employment relationship with the physician may not affect the exercise of the physician's independent judgment in the practice of medicine, and the physician's independent judgment in the practice of medicine is in fact unaffected by the physician's employment relationship with the hospital, nonprofit entity, or charitable trust." *N.D. Cent. Code § 43-17-42.* <https://ndlegis.gov/cencode/t43c17.pdf>
+
+[^north-dakota-current-owner-exceptions]: **N.D. Cent. Code § 9-08-06** — "A contract by which anyone is restrained from exercising a lawful profession, trade, or business of any kind is to that extent void, except: 1. A person that sells the goodwill of a business and the person's partners, members, or shareholders may agree with the buyer to refrain from carrying on a similar business within a reasonable geographic area and for a reasonable length of time, if the buyer or any person deriving title to the goodwill from the buyer carries on a like business in that area. 2. Partners, members, or shareholders, upon or in anticipation of a dissolution of a partnership, limited liability company, or corporation; upon or in anticipation of a dissociation of a partner or member; or as part of an agreement addressing the dissociation or sale of a partner, member, or shareholder's ownership interest, may agree that all or any number of them will not carry on a similar business within a reasonable geographic area where the partnership, limited liability company, or corporation business has been transacted, or within a specified part of the area." *N.D. Cent. Code § 9-08-06.* <https://ndlegis.gov/cencode/t09c08.pdf>
+
+[^north-dakota-trade-secret-injunction]: **N.D. Cent. Code ch. 47-25.1** — "Actual or threatened misappropriation may be enjoined." *N.D. Cent. Code § 47-25.1-02(1).* <https://ndlegis.gov/cencode/t47c25-1.pdf>
+
+[^north-dakota-trade-secret-definition]: **N.D. Cent. Code ch. 47-25.1** — "4. ‘Trade secret’ means information, including a formula, pattern, compilation, program, device, method, technique, or process, that: a. Derives independent economic value, actual or potential, from not being generally known to, and not being readily ascertainable by proper means by, other persons who can obtain economic value from its disclosure or use; and b. Is the subject of efforts that are reasonable under the circumstances to maintain its secrecy." *N.D. Cent. Code § 47-25.1-01(4).* <https://ndlegis.gov/cencode/t47c25-1.pdf>
+
+[^north-dakota-trade-secret-damages]: **N.D. Cent. Code ch. 47-25.1** — "Damages can include both the actual loss caused by misappropriation and the unjust enrichment caused by misappropriation that is not taken into account in computing actual loss." *N.D. Cent. Code § 47-25.1-03(1).* <https://ndlegis.gov/cencode/t47c25-1.pdf>
+
+[^north-dakota-loyalty-duty]: **N.D. Cent. Code § 34-02-14** — "An employee who has any business to transact on the employee's own account similar to that entrusted to the employee by the employee's employer shall give the latter the preference always." *N.D. Cent. Code § 34-02-14.* <https://ndlegis.gov/cencode/t34c02.pdf>

--- a/skills/non-compete-contract-explainer/content/ohio.md
+++ b/skills/non-compete-contract-explainer/content/ohio.md
@@ -1,0 +1,207 @@
+---
+jurisdiction: "Ohio"
+slug: ohio
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-03"
+canonicalUrl: https://openagreements.org/legal/non-compete/ohio
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/ohio · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in Ohio[^about]
+
+Ohio enforces non-competes only when the restraint is reasonable under the Raimonde rule, and its courts may reform an overbroad covenant or decline to enforce it at all.
+
+
+## At a glance
+
+| Question | Ohio |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed if reasonable |
+| **Bottom line** | Ohio enforces an employee non-compete only to the extent it is reasonable under the Raimonde test — no broader than needed to protect the employer, not unduly harsh on the employee, and not injurious to the public. |
+| **Main law or case** | Raimonde v. Van Vlerah, 42 Ohio St. 2d 21 (1975) |
+| **Main exceptions** | Physician public-interest scrutiny; pending S.B. 301 (nonprofit-hospital cap) and S.B. 11 (broad ban) not enacted |
+| **Can a court narrow it?** | Yes — rewrites to reasonable |
+| **Applies to contractors?** | Unclear |
+| **Restriction extended during a breach?** | Yes — a covenant may not expire while enforceability is litigated (Homan) |
+| **Maximum length set by law** | No statutory cap |
+
+## Are employee non-compete agreements enforceable in Ohio? {#employee-noncompetes}
+
+**Short answer.** Yes, sometimes. Ohio is a reasonableness state, not a general ban state. A non-compete is enforceable only to the extent it is reasonable — meaning it is no greater than needed to protect the employer, does not impose undue hardship on the employee, and is not injurious to the public [^raimonde-reasonableness-test].
+
+The controlling standard comes from the Ohio Supreme Court's decision in *Raimonde v. Van Vlerah*, which set out a three-part rule of reasonableness for post-employment restraints [^raimonde-reasonableness-test]. There is no general Ohio non-compete statute for the ordinary workforce; enforceability is judge-made, applied covenant by covenant on its own facts.
+
+Because the test is holistic, no single term is decisive. A court weighs the employer's protectable interest, the burden on the employee, and the public effect together, rather than checking a covenant against fixed numbers.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not treat Ohio as either a free-for-all or a ban state. Test every covenant against the three *Raimonde* prongs — employer protection, hardship on the employee, and public injury — before assuming an Ohio restraint is enforceable [^raimonde-reasonableness-test].
+
+## Is continued at-will employment enough consideration for an Ohio non-compete? {#consideration}
+
+**Short answer.** Yes. Unlike some states, Ohio holds that an employer's agreement to continue an at-will employment relationship is itself sufficient consideration for a non-compete an existing employee signs [^lakeland-continued-employment].
+
+In *Lake Land Employment Group of Akron, LLC v. Columber*, the Ohio Supreme Court held that consideration exists when an employer continues an at-will relationship that it could legally have terminated without cause in exchange for the employee's assent to the covenant [^lakeland-continued-employment]. That makes Ohio more employer-favorable on consideration than states that require new, independent value for a mid-employment covenant.
+
+The rule is not a blank check. Continued employment supplies the consideration, but the covenant must still survive the *Raimonde* reasonableness analysis to be enforceable [^q2-raimonde-reasonableness].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not assume adequate consideration cures an overbroad covenant. Continued at-will employment satisfies *Lake Land*, but a restraint that fails *Raimonde* on time, territory, or scope is still unenforceable [^lakeland-continued-employment][^q2-raimonde-reasonableness].
+
+## What legitimate business interests can support an Ohio non-compete? {#protectable-interests}
+
+**Short answer.** Confidential information, trade secrets, and customer goodwill are the core interests that justify a tailored Ohio restraint. The Ohio Uniform Trade Secrets Act supplies the statutory trade-secret overlay that runs alongside the covenant [^outsa-trade-secret-definition].
+
+*Raimonde* itself lists the factors a court weighs, including whether the employee possessed confidential information or trade secrets and whether the covenant targets unfair competition rather than ordinary competition [^raimonde-confidential-factor]. A covenant that merely suppresses ordinary competition, untethered to a protectable interest, will not stand.
+
+The Ohio Uniform Trade Secrets Act, codified at R.C. 1333.61 through 1333.69, defines a trade secret by the twin tests of independent economic value from secrecy and reasonable efforts to maintain that secrecy [^outsa-trade-secret-definition]. The Act gives a separate remedy: actual or threatened misappropriation may be enjoined regardless of any contract [^outsa-injunction]. A non-solicitation or confidentiality strategy under the Act is often a stronger backstop than a broad non-compete.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not use an Ohio non-compete to block competition disconnected from a protectable interest. Tie the restraint to identified confidential information, trade secrets, or customer goodwill, and keep a separate confidentiality and trade-secret strategy under R.C. 1333.61 et seq. [^outsa-trade-secret-definition][^raimonde-confidential-factor].
+
+## What duration and geographic scope are reasonable for an Ohio non-compete? {#duration-geography}
+
+**Short answer.** There is no statutory cap. Ohio courts weigh duration and territory together against the employer's actual protectable interest under *Raimonde*, and they may cut back a restraint that reaches further than necessary [^q4-raimonde-factors][^metrohealth-modified].
+
+Because the standard is holistic, geography and duration are evaluated against the employer's real footprint rather than fixed numbers [^q4-raimonde-factors]. A restraint limited to the area and time genuinely needed to protect customer relationships or confidential information is far easier to defend than a long, open-ended, statewide ban.
+
+When a covenant overshoots, an Ohio court may trim it. In *MetroHealth System v. Khandelwal*, the court of appeals upheld a trial court's decision to narrow an overbroad physician covenant — modifying it rather than voiding it — because it was more restrictive than necessary to protect the employer's legitimate interests [^metrohealth-modified].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not copy a fixed term or radius from another form. Match duration and territory to the employee's role and the employer's actual market, because an Ohio court evaluates the restraint as a whole and there is no safe-harbor number [^q4-raimonde-factors][^metrohealth-modified].
+
+## Will an Ohio court reform or refuse to enforce an overbroad non-compete? {#court-narrowing}
+
+**Short answer.** It depends. *Raimonde* abandoned strict blue-penciling and lets Ohio courts enforce an overbroad covenant only to the extent reasonable, but reformation is discretionary — a court may instead refuse to rewrite an abusively broad covenant [^raimonde-reformation][^kross-discretionary].
+
+*Raimonde* holds that a covenant imposing unreasonable restrictions will be enforced to the extent necessary to protect the employer's legitimate interests, giving Ohio courts the power to modify rather than void [^raimonde-reformation]. But that power is not automatic. In *Kross Acquisition Co. v. Groundworks Ohio, LLC*, the First District confirmed that modifying a covenant is within the trial court's discretion, and it affirmed a refusal to rewrite a covenant so overbroad that reforming it would require the court to rebuild the agreement from scratch [^kross-discretionary].
+
+There is also a real cost to overreaching. In *Cintas Corp. v. Perry*, applying Ohio law, the employer's own prevailing-party fee clause boomeranged: after the covenant failed, the court held the former employee was entitled to recover his attorney's fees and litigation costs under that contract [^cintas-fee-shift].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not rely on reformation as a safety net for an aggressive Ohio covenant. Draft tiered, severable, reasonable restraints, because a court may refuse to rewrite an overbroad covenant — and a one-sided fee clause can shift fees to the departing employee when the covenant fails [^kross-discretionary][^cintas-fee-shift].
+
+## Can a successor company enforce a non-compete after a merger in Ohio? {#successor-enforcement}
+
+**Short answer.** Yes, after a statutory merger. In *Acordia of Ohio, L.L.C. v. Fishel*, the Ohio Supreme Court held that the surviving company may enforce non-competes the absorbed company's employees signed, as if it had stepped into the original employer's shoes — provided the covenant is reasonable [^acordia-successor].
+
+On reconsideration, the court in *Acordia* clarified that a merged entity can enforce acquired non-compete agreements without separate assignment language, because by operation of the merger statutes it succeeds to the predecessor's contracts [^acordia-successor]. The covenant still has to satisfy *Raimonde* in the successor's hands.
+
+That holding turns on a statutory merger. A deal structured as an asset purchase, or a covenant the parties intend to be personal to the original employer, can raise different assignability questions — so buyers should not assume every restrictive covenant transfers automatically.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not rely on *Acordia* for every transaction. It addresses covenants that pass by statutory merger; in an asset deal, include express assignment and successor-and-assigns language so the buyer can enforce the restraint [^acordia-successor].
+
+## Does an Ohio non-compete toll or extend during breach or litigation? {#tolling-extension}
+
+**Short answer.** It can. Ohio appellate courts have held that a non-compete may not expire while its enforceability is being litigated, so the restricted period can be effectively extended until the case is resolved [^homan-tolling].
+
+In *Homan, Inc. v. A1 AG Services, L.L.C.*, the Third District adopted the Sixth District's rule that a covenant not to compete may not expire while the enforceability of the contract is being litigated [^homan-tolling]. The court applied that rule to a covenant whose period it had already reformed for reasonableness, so the defendant remained bound for the remaining reasonable term after the litigation concluded.
+
+This judicial tolling is equitable rather than automatic, and it operates against the *Raimonde* reasonableness backdrop [^q7-raimonde-reasonableness]. A contractual extension-on-breach clause must itself be reasonable; an open-ended or indefinite extension risks being cut back like any other overbroad term.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not assume a fixed Ohio covenant simply lapses on its stated end date while a dispute is pending. Under *Homan*, the period can be tolled during litigation — but draft any extension-on-breach clause as a reasonable, bounded restraint tied to the breach, not an indefinite one [^homan-tolling][^q7-raimonde-reasonableness].
+
+## Which Ohio workers face special non-compete treatment? {#industry-specific-limits}
+
+**Short answer.** Physicians are the established category receiving special scrutiny. Ohio enforces their covenants but tests them closely under the public-injury prong, and a pending bill would add statutory limits for certain nonprofit-hospital clinicians [^metrohealth-physician-standard][^williams-public-injury][^sb301-healthcare-cap].
+
+Ohio courts apply a heightened public-interest analysis to physician covenants: a restraint is unreasonable where it imposes undue hardship on the physician and is injurious to the public because the physician's services are vital to the community and the demand for that expertise is critical [^metrohealth-physician-standard]. The principle is long-standing — in *Williams v. Hobbs*, the court affirmed findings that a physician's services were vital to the public and that the covenant was injurious to the public [^williams-public-injury].
+
+There is no enacted Ohio statute banning health care non-competes today. A pending bill, Senate Bill 301, would let a nonprofit hospital impose only a limited restriction on certain clinicians — no more than six months and within a fifteen-mile radius — and would void waivers of that protection [^sb301-healthcare-cap]. It has not become law.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not draft a physician or other health care non-compete in Ohio as if it were an ordinary commercial restraint. Expect heightened public-interest scrutiny under *MetroHealth* and *Williams*, and monitor Senate Bill 301, which would cap covered hospital clinician covenants if enacted [^metrohealth-physician-standard][^sb301-healthcare-cap].
+
+## Did the FTC's federal non-compete rule change Ohio non-compete law? {#federal-ftc-overlay}
+
+**Short answer.** No. The FTC's 2024 nationwide Non-Compete Rule was set aside by a federal court before it took effect, so Ohio non-competes remain governed by Ohio common law [^ryan-ftc-set-aside].
+
+In *Ryan LLC v. Federal Trade Commission*, the court held the FTC lacked statutory authority to issue the rule and that the rule was arbitrary and capricious [^ryan-ftc-authority]. It set the rule aside with nationwide effect so that it would not be enforced or take effect [^ryan-ftc-set-aside].
+
+That outcome does not make every Ohio covenant enforceable. It simply removes the FTC rule as a nationwide overlay and leaves Ohio's *Raimonde* reasonableness analysis in control.
+
+"The Non-Compete Rule, 16 C.F.R. § 910.1–.6, is hereby SET ASIDE and shall not be enforced or otherwise take effect on September 4, 2024, or thereafter."[^ryan-ftc-set-aside]
+
+## What Ohio non-compete reform efforts should employers watch? {#pending-reform}
+
+**Short answer.** None is law yet. The headline proposal, Senate Bill 11, would broadly prohibit employer non-competes, but it remains in committee and would apply only prospectively if enacted [^sb11-prohibition][^sb11-prospective].
+
+Senate Bill 11 would bar an employer from entering into, presenting, or enforcing an agreement that prevents a worker from taking other work or operating a business after the employment relationship ends [^sb11-prohibition]. Crucially, even if it passed, the bill voids only agreements entered into, modified, or extended on or after its effective date — it would not reach back to invalidate covenants already in place [^sb11-prospective].
+
+The enacted baseline therefore remains common-law reasonableness under *Raimonde*, plus the trade-secret overlay. These bills signal a possible direction of travel, not current law.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Treat Senate Bill 11 as a monitoring item, not present Ohio law. Recheck the Ohio General Assembly's bill status before changing forms or telling workers that Ohio has banned non-competes, and note that S.B. 11 as drafted would apply only to agreements made or modified after its effective date [^sb11-prohibition][^sb11-prospective].
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-03. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not Ohio. This article synthesizes Ohio primary law and is not legal advice from a Ohio-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^raimonde-reasonableness-test]: **Raimonde v. Van Vlerah** — "A covenant restraining an employee from competing with his former employer upon termination of employment is reasonable if it is no greater than is required for the protection of the employer, does not impose undue hardship on the employee, and is not injurious to the public." *Raimonde v. Van Vlerah, 42 Ohio St. 2d 21, 325 N.E.2d 544 (1975).* <https://www.courtlistener.com/opinion/6865409/raimonde-v-van-vlerah/#:~:text=A%20covenant%20restraining%20an%20employee,not%20injurious%20to%20the%20public.>
+
+[^lakeland-continued-employment]: **Lake Land Employment Group of Akron, LLC v. Columber** — "We therefore hold that consideration exists to support a noncompetition agreement when, in exchange for the assent of an at-will employee to a proffered noncompetition agreement, the employer continues an at-will employment relationship that could legally be terminated without cause." *Lake Land Emp. Group of Akron, LLC v. Columber, 101 Ohio St. 3d 242, 2004-Ohio-786.* <https://www.courtlistener.com/opinion/6892723/lake-land-employment-group-of-akron-llc-v-columber/#:~:text=We%20therefore%20hold%20that%20consideration,legally%20be%20terminated%20without%20cause.>
+
+[^q2-raimonde-reasonableness]: **Raimonde v. Van Vlerah** — "A covenant restraining an employee from competing with his former employer upon termination of employment is reasonable if it is no greater than is required for the protection of the employer, does not impose undue hardship on the employee, and is not injurious to the public." *Raimonde v. Van Vlerah, 42 Ohio St. 2d 21, 325 N.E.2d 544 (1975).* <https://www.courtlistener.com/opinion/6865409/raimonde-v-van-vlerah/#:~:text=A%20covenant%20restraining%20an%20employee,not%20injurious%20to%20the%20public.>
+
+[^outsa-trade-secret-definition]: **Ohio Rev. Code § 1333.61** — "(1) It derives independent economic value, actual or potential, from not being generally known to, and not being readily ascertainable by proper means by, other persons who can obtain economic value from its disclosure or use.(2) It is the subject of efforts that are reasonable under the circumstances to maintain its secrecy." *Ohio Rev. Code § 1333.61(D).* <https://codes.ohio.gov/ohio-revised-code/section-1333.61>
+
+[^raimonde-confidential-factor]: **Raimonde v. Van Vlerah** — "whether the employee is possessed with confidential information or trade secrets; whether the covenant seeks to eliminate competition which would be unfair to the employer or merely seeks to eliminate ordinary competition" *Raimonde v. Van Vlerah, 42 Ohio St. 2d 21, 325 N.E.2d 544 (1975).* <https://www.courtlistener.com/opinion/6865409/raimonde-v-van-vlerah/#:~:text=whether%20the%20employee%20is%20possessed,seeks%20to%20eliminate%20ordinary%20competition>
+
+[^outsa-injunction]: **Ohio Rev. Code § 1333.62** — "Actual or threatened misappropriation may be enjoined." *Ohio Rev. Code § 1333.62(A).* <https://codes.ohio.gov/ohio-revised-code/section-1333.62>
+
+[^q4-raimonde-factors]: **Raimonde v. Van Vlerah** — "A covenant restraining an employee from competing with his former employer upon termination of employment is reasonable if it is no greater than is required for the protection of the employer, does not impose undue hardship on the employee, and is not injurious to the public." *Raimonde v. Van Vlerah, 42 Ohio St. 2d 21, 325 N.E.2d 544 (1975).* <https://www.courtlistener.com/opinion/6865409/raimonde-v-van-vlerah/#:~:text=A%20covenant%20restraining%20an%20employee,not%20injurious%20to%20the%20public.>
+
+[^metrohealth-modified]: **MetroHealth System v. Khandelwal** — "In short, evidence presented at the hearing supported the trial court’s finding that the 2015 noncompete agreement was more restrictive than necessary but that it could be modified to protect MetroHealth’s legitimate business interests." *MetroHealth Sys. v. Khandelwal, 2022-Ohio-77, 183 N.E.3d 590 (8th Dist.).* <https://www.courtlistener.com/opinion/6205147/metrohealth-sys-v-khandelwal/#:~:text=In%20short%2C%20evidence%20presented%20at,protect%20MetroHealth%E2%80%99s%20legitimate%20business%20interests.>
+
+[^raimonde-reformation]: **Raimonde v. Van Vlerah** — "Courts are empowered to modify or amend employment agreements to achieve such results." *Raimonde v. Van Vlerah, 42 Ohio St. 2d 21, 325 N.E.2d 544 (1975).* <https://www.courtlistener.com/opinion/6865409/raimonde-v-van-vlerah/#:~:text=Courts%20are%20empowered%20to%20modify,agreements%20to%20achieve%20such%20results.>
+
+[^kross-discretionary]: **Kross Acquisition Co. v. Groundworks Ohio, LLC** — "We agree that it is within a trial court’s discretion to modify a noncompetition agreement, and so we review its decision not to modify such an agreement for an abuse of discretion." *Kross Acquisition Co. v. Groundworks Ohio, LLC, 2024-Ohio-592, 236 N.E.3d 453 (1st Dist.).* <https://www.courtlistener.com/opinion/9475789/kross-acquisition-co-llc-v-groundworks-ohio-llc/#:~:text=We%20agree%20that%20it%20is,for%20an%20abuse%20of%20discretion.>
+
+[^cintas-fee-shift]: **Cintas Corp. v. Perry** — "The district court correctly concluded Perry was entitled to attorney’s fees and litigation costs under the employment agreement." *Cintas Corp. v. Perry, 517 F.3d 459 (7th Cir. 2008).* <https://www.courtlistener.com/opinion/1462207/cintas-corporation-v-perry/#:~:text=The%20district%20court%20correctly%20concluded,costs%20under%20the%20employment%20agreement.>
+
+[^acordia-successor]: **Acordia of Ohio, L.L.C. v. Fishel** — "We hold that the L.L.C. may enforce the noncompete agreements as if it had stepped into the shoes of the original contracting companies, provided that the noncompete agreements are reasonable under the circumstances of this case." *Acordia of Ohio, L.L.C. v. Fishel, 133 Ohio St. 3d 356, 2012-Ohio-4648, 978 N.E.2d 823.* <https://www.courtlistener.com/opinion/2690659/acordia-of-ohio-llc-v-fishel/#:~:text=We%20hold%20that%20the%20L.L.C.,the%20circumstances%20of%20this%20case.>
+
+[^homan-tolling]: **Homan, Inc. v. A1 AG Services, L.L.C.** — "The Sixth Appellate District has held that a covenant not to compete may not expire while the enforceability of that contract is being litigated." *Homan, Inc. v. A1 AG Servs., L.L.C., 175 Ohio App. 3d 51, 2008-Ohio-277, 885 N.E.2d 253 (3d Dist.).* <https://www.courtlistener.com/opinion/3953241/homan-inc-v-a1-ag-services-llc/#:~:text=The%20Sixth%20Appellate%20District%20has,that%20contract%20is%20being%20litigated.>
+
+[^q7-raimonde-reasonableness]: **Raimonde v. Van Vlerah** — "A covenant restraining an employee from competing with his former employer upon termination of employment is reasonable if it is no greater than is required for the protection of the employer, does not impose undue hardship on the employee, and is not injurious to the public." *Raimonde v. Van Vlerah, 42 Ohio St. 2d 21, 325 N.E.2d 544 (1975).* <https://www.courtlistener.com/opinion/6865409/raimonde-v-van-vlerah/#:~:text=A%20covenant%20restraining%20an%20employee,not%20injurious%20to%20the%20public.>
+
+[^metrohealth-physician-standard]: **MetroHealth System v. Khandelwal** — "A covenant restraining a physician-employee from competing with his employer upon termination of employment is unreasonable where it imposes undue hardship on the physician and is injurious to the public, the physician’s services are vital to the health, care and treatment of the public, and the demand for his medical expertise is critical to the people in the community." *MetroHealth Sys. v. Khandelwal, 2022-Ohio-77, 183 N.E.3d 590 (8th Dist.).* <https://www.courtlistener.com/opinion/6205147/metrohealth-sys-v-khandelwal/#:~:text=A%20covenant%20restraining%20a%20physician%2Demployee,the%20people%20in%20the%20community.>
+
+[^williams-public-injury]: **Williams v. Hobbs** — "The covenant imposes an undue hardship on the plaintiff, and also, it is injurious to the public." *Williams v. Hobbs, 9 Ohio App. 3d 331, 460 N.E.2d 287 (10th Dist. 1983).* <https://www.courtlistener.com/opinion/4007467/williams-v-hobbs/#:~:text=The%20covenant%20imposes%20an%20undue,is%20injurious%20to%20the%20public.>
+
+[^sb301-healthcare-cap]: **Ohio S.B. 301 (136th General Assembly)** — "the employee will refrain, for a period not to exceed six months, from obtaining employment within a radius of fifteen miles of the physical location where the employee was employed with the hospital." *S.B. 301, 136th Gen. Assemb. (Ohio 2025).* <https://www.legislature.ohio.gov/legislation/136/sb301>
+
+[^ryan-ftc-set-aside]: **Ryan LLC v. Federal Trade Commission** — "The Non-Compete Rule, 16 C.F.R. § 910.1–.6, is hereby SET ASIDE and shall not be enforced or otherwise take effect on September 4, 2024, or thereafter." *Ryan LLC v. Fed. Trade Comm'n, 746 F. Supp. 3d 369 (N.D. Tex. 2024).* <https://www.courtlistener.com/opinion/10205745/ryan-llc-v-federal-trade-commission/#:~:text=The%20Non%2DCompete%20Rule%2C%2016%20C.F.R.,September%204%2C%202024%2C%20or%20thereafter.>
+
+[^ryan-ftc-authority]: **Ryan LLC v. Federal Trade Commission** — "In sum, the Court concludes that the FTC lacks statutory authority to promulgate the Non- Compete Rule, and that the Rule is arbitrary and capricious." *Ryan LLC v. Fed. Trade Comm'n, 746 F. Supp. 3d 369 (N.D. Tex. 2024).* <https://www.courtlistener.com/opinion/10205745/ryan-llc-v-federal-trade-commission/#:~:text=In%20sum%2C%20the%20Court%20concludes%20that,Rule%20is%20arbitrary%20and%20capricious.>
+
+[^sb11-prohibition]: **Ohio S.B. 11 (136th General Assembly)** — "Beginning on the effective date of this section, no employer shall enter into, attempt to enter into, present to a worker or prospective worker as a term of hire, or attempt to enforce an agreement, or part of an agreement, that prohibits the worker from, penalizes the worker for, or functions to prevent the worker from seeking or accepting work with a person, or operating a business, after the conclusion of the relationship between the employer and worker, including any of the following:" *S.B. 11, 136th Gen. Assemb. (Ohio 2025).* <https://www.legislature.ohio.gov/legislation/136/sb11>
+
+[^sb11-prospective]: **Ohio S.B. 11 (136th General Assembly)** — "An agreement, or part of an agreement, between an employer and worker entered into, modified, or extended on or after the effective date of this section that is prohibited under division (A) of this section is void." *S.B. 11, 136th Gen. Assemb. (Ohio 2025).* <https://www.legislature.ohio.gov/legislation/136/sb11>

--- a/skills/non-compete-contract-explainer/content/oklahoma.md
+++ b/skills/non-compete-contract-explainer/content/oklahoma.md
@@ -1,0 +1,196 @@
+---
+jurisdiction: "Oklahoma"
+slug: oklahoma
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-03"
+canonicalUrl: https://openagreements.org/legal/non-compete/oklahoma
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/oklahoma · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in Oklahoma[^about]
+
+Oklahoma voids employee non-compete agreements by statute and allows only narrow exceptions for customer non-solicitation, employee anti-raiding, and the sale of a business.
+
+
+## At a glance
+
+| Question | Oklahoma |
+| --- | --- |
+| **Are non-competes enforceable?** | Banned |
+| **Bottom line** | Oklahoma voids employee non-competes by statute, permitting only narrow carve-outs for direct customer non-solicitation, employee anti-raiding, and sale-of-business or partnership-dissolution covenants. |
+| **Main law or case** | Okla. Stat. tit. 15, § 217 |
+| **Main exceptions** | Sale of goodwill (§ 218); partnership dissolution (§ 219); direct customer non-solicit (§ 219A); employee anti-raiding (§ 219B); trade-secret clauses outside the ban |
+| **Can a court narrow it?** | No |
+| **Applies to contractors?** | Unclear |
+| **Restriction extended during a breach?** | Not addressed |
+| **Maximum length set by law** | No statutory limit on the ban; sale covenants limited to a county and contiguous counties |
+
+## Are employee non-compete agreements enforceable in Oklahoma? {#employee-noncompetes}
+
+**Short answer.** No. Oklahoma voids employee non-compete agreements by statute. A contract that restrains someone from exercising a lawful profession, trade, or business is void to that extent, except for the narrowly drawn covenants Oklahoma statutes specifically permit: sale-of-goodwill covenants (§ 218), partnership-dissolution covenants (§ 219), direct solicitation of established customers (§ 219A), and employee anti-raiding clauses (§ 219B) [^stat-217-general-void][^stat-219a-void-clause].
+
+This makes Oklahoma one of the most employee-protective jurisdictions in the country. Unlike a reasonableness state, Oklahoma does not ask whether a non-compete is reasonable in duration or geography — a covenant that bars a former employee from competing is simply outside the statute and therefore void. Oklahoma courts have applied that rule to strike conventional non-competes as exceeding what § 219A allows [^howard-noncompete-void].
+
+"The non-competition contracts go well beyond the bounds of what is allowable under § 219A and violate the legislatively expressed public policy."[^howard-noncompete-void]
+
+The U.S. Supreme Court later vacated that 2011 decision on arbitration-procedure grounds, so the void rule's firmest anchors are the statute itself and the Court of Civil Appeals' decision in *Autry v. Acosta, Inc.*, discussed below [^stat-217-general-void].
+
+What an Oklahoma employer *can* protect instead is a defined slice: direct solicitation of established customers, raiding of its workforce, the goodwill it buys when it acquires a business, and its trade secrets and confidential information. Each of those is addressed in its own question below.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not paper an Oklahoma employee with an out-of-state non-compete form and assume a court will narrow it to something enforceable. Oklahoma treats a conventional employee non-compete as void rather than reforming it, so the realistic question is which permitted covenant — customer non-solicitation, anti-raiding, or confidentiality — actually protects the interest at stake [^stat-217-general-void][^howard-noncompete-void].
+
+## What customer non-solicitation restrictions does Oklahoma allow? {#customer-nonsolicitation}
+
+**Short answer.** Only a narrow one. Under 15 O.S. § 219A a former employee may compete, but the agreement may bar the employee from *directly* soliciting the *established customers* of the former employer. A clause that reaches further — indirect solicitation, or prospective and former customers — is void [^stat-219a-rule][^autry-no-sever].
+
+The statute permits a tightly drawn customer non-solicitation covenant and nothing broader [^stat-219a-rule].
+
+"A person who makes an agreement with an employer, whether in writing or verbally, not to compete with the employer after the employment relationship has been terminated, shall be permitted to engage in the same business as that conducted by the former employer or in a similar business as that conducted by the former employer as long as the former employee does not directly solicit the sale of goods, services or a combination of goods and services from the established customers of the former employer."[^stat-219a-rule]
+
+Two drafting traps void these clauses. First, the word *indirectly*. In *Autry v. Acosta, Inc.*, the Oklahoma Court of Civil Appeals held that a covenant barring *direct or indirect* solicitation violated § 219A — and, critically, the court refused to save it by striking the offending word [^autry-no-sever][^autry-void].
+
+"We find that the remedy for this Non-Solicitation Agreement's shortcomings is not quite that simple and it cannot be made to comply with § 219A by merely deleting the word ‘indirectly.’"[^autry-no-sever]
+
+Second, even a covenant that tracks the statutory language must still be reasonable. In *Inergy Propane, LLC v. Lundy*, the court indicated that § 219A did not displace the common-law rule of reason for the duration and scope of a customer non-solicitation clause [^inergy-rule-of-reason]. Practitioners often use shorter durations — commonly two years or less — as a risk-control measure; no statutory safe harbor fixes that term.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Limit a customer non-solicitation clause to *direct* solicitation of *established* customers, and do not add *indirectly*, *prospective customers*, or *former customers*. Oklahoma courts will void the whole provision rather than blue-pencil the extra words out of it [^autry-no-sever][^autry-void].
+
+## Can an Oklahoma employer restrict soliciting its employees? {#employee-nonsolicitation}
+
+**Short answer.** Yes. 15 O.S. § 219B expressly allows an employee anti-raiding covenant that bars a former employee from soliciting the employer's employees or independent contractors — and, unlike the customer rule, it may reach *direct or indirect* solicitation [^stat-219b-antiraid].
+
+Section 219B was enacted to give employers broader protection for their workforce than § 219A gives them for their customers. It removes employee-anti-raiding clauses from the general restraint-of-trade prohibition altogether [^stat-219b-antiraid].
+
+"A contract or contractual provision which prohibits an employee or independent contractor of a person or business from soliciting, directly or indirectly, actively or inactively, the employees or independent contractors of that person or business to become employees or independent contractors of another person or business shall not be construed as a restraint from exercising a lawful profession, trade or business of any kind."[^stat-219b-antiraid]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Section 219B authorizes restrictions on *soliciting* employees, not a flat no-hire ban. A clause that purports to stop a former employee from hiring a colleague who applies on their own initiative — without any solicitation — is on far weaker ground, because it reaches beyond the solicitation the statute protects [^stat-219b-antiraid].
+
+## Are non-competes tied to the sale of a business enforceable in Oklahoma? {#sale-of-business}
+
+**Short answer.** Yes, within statutory limits. Under 15 O.S. § 218 the seller of a business's goodwill may agree not to compete within a specified county and contiguous counties, or a specified city or town. A parallel rule in § 219 allows the same on the dissolution of a partnership [^stat-218-goodwill][^stat-219-partners].
+
+This is the most important practical exception, and Oklahoma courts enforce it [^berry-218-goodwill].
+
+"We have consistently upheld non-compete agreements to protect business goodwill pursuant to § 218."[^berry-218-goodwill]
+
+The sale-of-business exception differs from the employment rules in a crucial way: it comes with a statutory blue-pencil. If a goodwill covenant reaches too far geographically, a court may scale it back to the primary county and contiguous counties rather than voiding it [^stat-218-goodwill][^eakle-218-reform].
+
+"The Oklahoma Supreme Court has held that non-compete agreements in connection with the sale of goodwill, which are otherwise valid, are subject to modification with respect to the territorial restrictions found in section 218."[^eakle-218-reform]
+
+The exception applies only to a genuine sale of goodwill. A token equity stake should not be assumed to convert an ordinary employment non-compete into a protected sale-of-business covenant; in *Bayly, Martin & Fay, Inc. v. Pickard* the Oklahoma Supreme Court indicated that only the sale of an appreciable ownership interest can carry a business's goodwill under § 218 [^bayly-appreciable-interest].
+
+> [!NOTE]
+> **Practice note.**
+>
+> The geographic ceiling in § 218 is a county-and-contiguous-counties (or a single city or town) footprint — far narrower than the multi-state radii common in sale agreements. Draft to that ceiling from the start; the statutory blue-pencil reduces overbroad geography to the primary county and its neighbors, not to whatever regional scope the parties wrote [^stat-218-goodwill][^eakle-218-reform].
+
+## Does continued employment count as consideration for an Oklahoma restrictive covenant? {#consideration}
+
+**Short answer.** It is unsettled. Oklahoma has not squarely decided whether continued at-will employment, by itself, is sufficient consideration for a restrictive covenant signed mid-employment. Whatever the consideration, the covenant must still fit § 219A or § 219B, or it is void regardless [^stat-219a-void-consideration].
+
+Practitioners often assume Oklahoma follows the majority rule that continued employment suffices, but no Oklahoma decision settles the point for a covenant introduced after hiring. The conservative course is to provide fresh, identifiable consideration — a bonus, a raise, a promotion, or access to confidential information — when an existing employee is asked to sign.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Treat mid-employment consideration as an open question, not a solved one. Pair any covenant presented to a current employee with new and identifiable consideration, and remember that adequate consideration does not rescue a covenant whose substance conflicts with § 219A [^stat-219a-void-consideration].
+
+## Are confidentiality and trade-secret protections still enforceable in Oklahoma? {#trade-secrets}
+
+**Short answer.** Yes. A confidentiality or trade-secret clause does not restrain a person from working — it restrains the misuse of protected information — so it sits outside the § 217 ban. The Oklahoma Uniform Trade Secrets Act backs that protection with injunctive relief and damages [^outsa-injunction].
+
+Because the Trade Secrets Act protects the information rather than the employment relationship, it is the most durable tool an Oklahoma employer has for guarding competitively sensitive material — and it operates whether or not any restrictive covenant survives [^outsa-injunction].
+
+"Actual or threatened misappropriation may be enjoined."[^outsa-injunction]
+
+## Can a choice-of-law or forum-selection clause escape Oklahoma's non-compete ban? {#choice-of-law}
+
+**Short answer.** Sometimes. An Oklahoma court will not apply a contractually chosen foreign law if doing so would violate Oklahoma public policy — so a Delaware or Texas choice-of-law clause will not, by itself, resurrect a void employee non-compete. But a mandatory forum-selection clause is a different lever: a federal court in Oklahoma has enforced one to transfer the dispute out of Oklahoma, after which the employer obtained injunctive relief under the chosen state's law [^eakle-public-policy][^griffin-order][^griffin-forum-selection].
+
+The choice-of-law limit is well settled [^eakle-public-policy].
+
+"As this general rule recognizes, however, the forum court will not apply the law chosen by the contracting parties should doing so violate the public policy of the forum state."[^eakle-public-policy]
+
+That public-policy backstop is why a foreign choice-of-law clause does not save an employee non-compete that § 217 voids. But it is not absolute: where the covenant fits an exception Oklahoma itself recognizes — for example a sale-of-goodwill covenant under § 218 — courts have applied the parties' chosen law and enforced the deal.
+
+The sharper risk for employees comes from forum selection. In the 2025 *Griffin v. Stryker* litigation, the U.S. District Court for the Northern District of Oklahoma enforced a mandatory Michigan forum-selection clause and transferred an Oklahoma employee's declaratory-judgment action out of Oklahoma — even though the court acknowledged it would *likely* find the covenants void if the case stayed [^griffin-order]. A firm summary of the litigation reports that the employer then obtained a preliminary injunction in Michigan [^griffin-forum-selection].
+
+"Plaintiff has therefore not met his burden of showing that exceptional circumstances exist that counsel against transfer to the contractually selected forum."[^griffin-order]
+
+> [!NOTE]
+> **Practice note.**
+>
+> An Oklahoma employee facing an out-of-state employer should treat a mandatory forum-selection clause as the real threat, not the governing-law clause. Oklahoma's public policy can defeat a foreign governing law, but it may not be enough to keep the case in Oklahoma if the contract requires litigation elsewhere [^griffin-order].
+
+## What recent legislative developments affect Oklahoma non-competes? {#recent-developments}
+
+**Short answer.** The framework held steady through the last attempt to loosen it. In 2024 the Legislature passed Senate Bill 1543, which would have broadened § 219A to let employers bar customer solicitation *directly or indirectly* and to reach *independent contractors* — but Governor Stitt vetoed it, and the veto was not overridden [^sb1543-enrolled][^mcafeetaft-sb1543-veto].
+
+The enrolled bill would have rewritten the operative clause so that a covenant could restrict solicitation *directly or indirectly, actively or inactively* — the very breadth *Autry* forbids today [^sb1543-enrolled].
+
+"A person who makes an agreement with an employer, whether in writing or verbally, not to compete with the employer after the employment relationship has been terminated, shall be permitted to engage in the same business as that conducted by the former employer or in a similar business as that conducted by the former employer as long as the former employee does not directly solicit, directly or indirectly, actively or inactively, the sale of goods, services or a combination of goods and services from the established customers or independent contractors of the former employer."[^sb1543-enrolled]
+
+The veto left the strict § 219A regime — and the *Autry* prohibition on reaching indirect solicitation — fully in place. Employers should keep watching for similar bills in future sessions, but for now the narrow direct-solicitation-of-established-customers rule is unchanged [^mcafeetaft-sb1543-veto].
+
+"UPDATE: Oklahoma Governor Kevin Stitt vetoed this bill April 30, 2024, and the Legislature did not override the veto in the 2024 legislative session."[^mcafeetaft-sb1543-veto]
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-03. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not Oklahoma. This article synthesizes Oklahoma primary law and is not legal advice from a Oklahoma-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^stat-217-general-void]: **15 O.S. § 217** — "Every contract by which any one is restrained from exercising a lawful profession, trade or business of any kind, otherwise than as provided by Sections 218 and 219 of this title, or otherwise than as provided by Section 2 of this act, is to that extent void." *Okla. Stat. tit. 15, § 217.* <https://oksenate.gov/sites/default/files/2022-05/os15.pdf>
+
+[^stat-219a-void-clause]: **15 O.S. § 219A** — "Any provision in a contract between an employer and an employee in conflict with the provisions of this section shall be void and unenforceable." *Okla. Stat. tit. 15, § 219A(B).* <https://oksenate.gov/sites/default/files/2022-05/os15.pdf>
+
+[^howard-noncompete-void]: **Howard v. Nitro-Lift Technologies, L.L.C.** — "The non-competition contracts go well beyond the bounds of what is allowable under § 219A and violate the legislatively expressed public policy." *Howard v. Nitro-Lift Techs., L.L.C., 2011 OK 98, 273 P.3d 20, vacated on other grounds sub nom. Nitro-Lift Techs., L.L.C. v. Howard, 568 U.S. 17 (2012).* <https://www.courtlistener.com/opinion/5327051/howard-v-nitro-lift-technologies-llc/#:~:text=The%20non%2Dcompetition%20contracts%20go%20well,the%20legislatively%20expressed%20public%20policy.>
+
+[^stat-219a-rule]: **15 O.S. § 219A** — "A person who makes an agreement with an employer, whether in writing or verbally, not to compete with the employer after the employment relationship has been terminated, shall be permitted to engage in the same business as that conducted by the former employer or in a similar business as that conducted by the former employer as long as the former employee does not directly solicit the sale of goods, services or a combination of goods and services from the established customers of the former employer." *Okla. Stat. tit. 15, § 219A(A).* <https://oksenate.gov/sites/default/files/2022-05/os15.pdf>
+
+[^autry-no-sever]: **Autry v. Acosta, Inc.** — "We find that the remedy for this Non-Solicitation Agreement's shortcomings is not quite that simple and it cannot be made to comply with § 219A by merely deleting the word ‘indirectly.’" *Autry v. Acosta, Inc., 2018 OK CIV APP 8, 410 P.3d 1017.* <https://www.courtlistener.com/opinion/4520541/autry-v-acosta-inc/#:~:text=We%20find%20that%20the%20remedy,merely%20deleting%20the%20word%20%E2%80%9Cindirectly.%E2%80%9D>
+
+[^autry-void]: **Autry v. Acosta, Inc.** — "Examined under the lens of § 219A, the Non-Solicitation Agreement is void and unenforceable as against Oklahoma's public policy expressed by the Legislature's enactment of that section." *Autry v. Acosta, Inc., 2018 OK CIV APP 8, 410 P.3d 1017.* <https://www.courtlistener.com/opinion/4520541/autry-v-acosta-inc/#:~:text=Examined%20under%20the%20lens%20of,Legislature's%20enactment%20of%20that%20section.>
+
+[^inergy-rule-of-reason]: **Inergy Propane, LLC v. Lundy** — "That does not, however, require abandonment of the rule of reason analysis required by previously established case law." *Inergy Propane, LLC v. Lundy, 2009 OK CIV APP 8, 219 P.3d 547.* <https://www.courtlistener.com/opinion/2629577/inergy-propane-llc-v-lundy/#:~:text=That%20does%20not%2C%20however%2C%20require,by%20previously%20established%20case%20law.>
+
+[^stat-219b-antiraid]: **15 O.S. § 219B** — "A contract or contractual provision which prohibits an employee or independent contractor of a person or business from soliciting, directly or indirectly, actively or inactively, the employees or independent contractors of that person or business to become employees or independent contractors of another person or business shall not be construed as a restraint from exercising a lawful profession, trade or business of any kind." *Okla. Stat. tit. 15, § 219B.* <https://oksenate.gov/sites/default/files/2022-05/os15.pdf>
+
+[^stat-218-goodwill]: **15 O.S. § 218** — "One who sells the goodwill of a business may agree with the buyer to refrain from carrying on a similar business within a specified county and any county or counties contiguous thereto, or a specified city or town or any part thereof, so long as the buyer, or any person deriving title to the goodwill from him carries on a like business therein. Provided, that any such agreement which is otherwise lawful but which exceeds the territorial limitations specified by this section may be deemed valid, but only within the county comprising the primary place of the conduct of the subject business and within any counties contiguous thereto." *Okla. Stat. tit. 15, § 218.* <https://oksenate.gov/sites/default/files/2022-05/os15.pdf>
+
+[^stat-219-partners]: **15 O.S. § 219** — "Partners may, upon or in anticipation of a dissolution of the partnership, agree that none of them will carry on a similar business within a specified county and any county or counties contiguous thereto, or a specified city or town or any part thereof. Provided, that any such agreement which is otherwise lawful but which exceeds the territorial limitations specified by this section may be deemed valid, but only within the county comprising the primary place of the conduct of the business of the subject partnership and within any counties contiguous thereto." *Okla. Stat. tit. 15, § 219.* <https://oksenate.gov/sites/default/files/2022-05/os15.pdf>
+
+[^berry-218-goodwill]: **Berry & Berry Acquisitions, LLC v. BFN Props. LLC** — "We have consistently upheld non-compete agreements to protect business goodwill pursuant to § 218." *Berry & Berry Acquisitions, LLC v. BFN Props. LLC, 2018 OK 27, 416 P.3d 1061.* <https://www.courtlistener.com/opinion/4483518/berry-berry-acquisitions-llc-v-bfn-props-llc/#:~:text=We%20have%20consistently%20upheld%20non%2Dcompete,goodwill%20pursuant%20to%20%C2%A7%20218.>
+
+[^eakle-218-reform]: **Eakle v. Grinnell Corp.** — "The Oklahoma Supreme Court has held that non-compete agreements in connection with the sale of goodwill, which are otherwise valid, are subject to modification with respect to the territorial restrictions found in section 218." *Eakle v. Grinnell Corp., 272 F. Supp. 2d 1304 (E.D. Okla. 2003).* <https://www.courtlistener.com/opinion/2296282/eakle-v-grinnell-corp/#:~:text=The%20Oklahoma%20Supreme%20Court%20has,restrictions%20found%20in%20section%20218.>
+
+[^bayly-appreciable-interest]: **Bayly, Martin & Fay, Inc. v. Pickard** — "Court held that the sale of an appreciable amount of stock, there 20%, could constitute a sale of good will within the meaning of § 218." *Bayly, Martin & Fay, Inc. v. Pickard, 1989 OK 122, 780 P.2d 1168.* <https://www.courtlistener.com/opinion/1190912/bayly-martin-fay-inc-v-pickard/#:~:text=Court%20held%20that%20the%20sale,the%20meaning%20of%20%C2%A7%20218.>
+
+[^stat-219a-void-consideration]: **15 O.S. § 219A** — "Any provision in a contract between an employer and an employee in conflict with the provisions of this section shall be void and unenforceable." *Okla. Stat. tit. 15, § 219A(B).* <https://oksenate.gov/sites/default/files/2022-05/os15.pdf>
+
+[^outsa-injunction]: **78 O.S. § 87** — "Actual or threatened misappropriation may be enjoined." *Okla. Stat. tit. 78, § 87(A).* <https://oksenate.gov/sites/default/files/2022-05/os78.pdf>
+
+[^eakle-public-policy]: **Eakle v. Grinnell Corp.** — "As this general rule recognizes, however, the forum court will not apply the law chosen by the contracting parties should doing so violate the public policy of the forum state." *Eakle v. Grinnell Corp., 272 F. Supp. 2d 1304 (E.D. Okla. 2003).* <https://www.courtlistener.com/opinion/2296282/eakle-v-grinnell-corp/#:~:text=As%20this%20general%20rule%20recognizes%2C,policy%20of%20the%20forum%20state.>
+
+[^griffin-order]: **Griffin v. Howmedica Osteonics Corp.** — "Plaintiff has therefore not met his burden of showing that exceptional circumstances exist that counsel against transfer to the contractually selected forum." *Griffin v. Howmedica Osteonics Corp., No. 25-CV-302-JFJ (N.D. Okla. Oct. 2, 2025).* <https://www.courtlistener.com/docket/70562720/21/griffin-v-howmedica-osteonics-corporation/#:~:text=Plaintiff%20has%20therefore%20not%20met,to%20the%20contractually%20selected%20forum.>
+
+[^griffin-forum-selection]: **GableGotwals — Restrictive Covenants for Oklahoma Employees: Lessons from Griffin v. Stryker** — "The court acknowledged Oklahoma’s strong policy against non-competes and said if the case stayed in Oklahoma, it would ‘likely’ find the non‑competition/non‑solicitation provisions void. Nevertheless, it concluded that Oklahoma’s policy interest did not constitute the type of ‘exceptional circumstance’ needed to override the parties’ mandatory Michigan forum selection, and it also referenced judicial interests against forum shopping and a race to the courthouse." *GableGotwals, Restrictive Covenants for Oklahoma Employees: Lessons from Griffin v. Stryker (Feb. 26, 2026).* <https://www.gablelaw.com/restrictive-covenants-for-oklahoma-employees-lessons-from-griffin-v-stryker/>
+
+[^sb1543-enrolled]: **Enrolled Senate Bill 1543 (2024)** — "A person who makes an agreement with an employer, whether in writing or verbally, not to compete with the employer after the employment relationship has been terminated, shall be permitted to engage in the same business as that conducted by the former employer or in a similar business as that conducted by the former employer as long as the former employee does not directly solicit, directly or indirectly, actively or inactively, the sale of goods, services or a combination of goods and services from the established customers or independent contractors of the former employer." *Enrolled S.B. 1543, 59th Leg., 2d Reg. Sess. (Okla. 2024) (vetoed).* <https://www.oklegislature.gov/cf_pdf/2023-24%20ENR/SB/SB1543%20ENR.PDF>
+
+[^mcafeetaft-sb1543-veto]: **McAfee & Taft — Oklahoma Legislature Passes Bill Broadening Scope of Permissible Non-Solicitation Agreements** — "UPDATE: Oklahoma Governor Kevin Stitt vetoed this bill April 30, 2024, and the Legislature did not override the veto in the 2024 legislative session." *McAfee & Taft, Oklahoma Legislature Passes Bill Broadening Scope of Permissible Non-Solicitation Agreements (Apr. 2024).* <https://www.mcafeetaft.com/oklahoma-legislature-passes-bill-broadening-scope-of-permissible-non-solicitation-agreements/>

--- a/skills/non-compete-contract-explainer/content/oregon.md
+++ b/skills/non-compete-contract-explainer/content/oregon.md
@@ -1,0 +1,359 @@
+---
+jurisdiction: "Oregon"
+slug: oregon
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-03"
+canonicalUrl: https://openagreements.org/legal/non-compete/oregon
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/oregon · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in Oregon[^about]
+
+A question-by-question summary of Oregon non-compete law, including ORS 653.295, the two-week notice rule, the exempt-employee salary threshold, the 12-month cap, garden-leave pay, void-not-voidable treatment, non-solicitation covenants, the 2025 medical-licensee ban, choice of law, and trade-secret alternatives.
+
+
+## At a glance
+
+| Question | Oregon |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed above a pay level |
+| **Bottom line** | An Oregon employee non-compete is void by default unless the employer meets a strict ORS 653.295 checklist — including pay above an inflation-indexed threshold ($119,541 for 2026) — or pays garden leave. |
+| **Main law or case** | ORS 653.295 |
+| **Main exceptions** | Medical-licensee (physician/nurse) ban (ORS 653.297, 2025, retroactive); non-solicit/bonus/sale-of-business outside the checklist; garden-leave path |
+| **When the ban took effect** | Salary threshold & 12-mo cap eff. Jan 1, 2022; medical-licensee ban eff. June 9, 2025 |
+| **Can a court narrow it?** | No |
+| **Applies to contractors?** | Unclear |
+| **Restriction extended during a breach?** | Silent — 12-month-from-termination cap cuts against tolling |
+| **Maximum length set by law** | 12 months from termination (excess void) |
+| **Must the employer pay to enforce?** | Yes — pay during the restriction |
+
+## Are employee non-compete agreements enforceable in Oregon? {#employee-noncompetes}
+
+**Short answer.** Sometimes, but only if the employer satisfies a strict statutory checklist. Under ORS 653.295, a non-compete is void and unenforceable unless the employer gave advance written notice or secured the covenant on a bona fide advancement, the employee is an exempt salaried worker who clears an annual income threshold, the employer has a protectable interest, and the employer delivers a signed copy within 30 days of termination — subject to the garden-leave and on-air-broadcasting paths discussed below [^q1-ors-653-295-void-unless].
+
+Oregon is not a ban state like California, but it is one of the most heavily regulated non-compete jurisdictions in the country. The governing statute is ORS 653.295, and it starts from a default of unenforceability that the employer must overcome by meeting every statutory condition.
+
+"A noncompetition agreement entered into between an employer and employee is void and unenforceable unless: (a)(A) The employer informs the employee in a written employment offer received by the employee at least two weeks before the first day of the employee's employment that a noncompetition agreement is required as a condition of employment; or (B) The noncompetition agreement is entered into upon a subsequent bona fide advancement of the employee by the employer"[^q1-ors-653-295-void-unless]
+
+Because the statute treats a non-conforming covenant as void rather than merely voidable, a single missed requirement — late notice, an income below the threshold, or no signed post-termination copy — defeats the entire non-compete. The sections below walk through each requirement and the practical drafting consequences.
+
+## What must a valid Oregon non-compete satisfy? {#valid-requirements}
+
+**Short answer.** Four more conditions beyond the notice rule. The employee must be a salaried exempt worker, the employer must have a statutory protectable interest, the employer must deliver a signed copy of the terms within 30 days after termination, and the employee's annual gross salary and commissions must exceed an inflation-indexed threshold [^q2-ors-653-295-conditions].
+
+The notice or bona-fide-advancement requirement in subsection (1)(a) is only the entry point. Subsections (1)(b) through (1)(e) add the substantive qualifications, all of which must be satisfied at the same time.
+
+"(1) A noncompetition agreement entered into between an employer and employee is void and unenforceable unless:...(b) The employee is a person described in ORS 653.020 (3); (c) The employer has a protectable interest as described in subsection (2) of this section; (d) Within 30 days after the date of the termination of the employee's employment, the employer provides a signed, written copy of the terms of the noncompetition agreement to the employee; and (e) The total amount of the employee's annual gross salary and commissions, calculated on an annual basis, at the time of the employee's termination exceeds $100,533, adjusted annually for inflation pursuant to the Consumer Price Index for All Urban Consumers, West Region (All Items), as published by the Bureau of Labor Statistics of the United States Department of Labor immediately preceding the calendar year of the employee's termination."[^q2-ors-653-295-conditions]
+
+The 30-day post-termination copy requirement in subsection (1)(d) is easy to overlook because it falls due after the employment relationship ends. The state labor agency lists it as a standalone condition of validity alongside the notice, salary, and exempt-status requirements [^q2-boli-conditions].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Calendar the 30-day post-termination copy obligation as part of every Oregon offboarding. The signed-copy delivery is an independent statutory condition, so missing it can void an otherwise compliant covenant [^q2-ors-653-295-conditions][^q2-boli-conditions].
+
+## Which Oregon employees earn enough to be bound by a non-compete? {#salary-threshold}
+
+**Short answer.** Only exempt salaried employees whose annual gross salary and commissions exceed an inflation-indexed dollar threshold. The baseline set when the 2021 amendments took effect was $100,533, adjusted each year for inflation; the labor agency publishes the figure annually, and for 2026 the amount the employee's pay must exceed is $119,541 [^q3-ors-653-295-threshold][^q3-boli-threshold].
+
+The statute fixes the mechanism and the labor agency fixes the number. ORS 653.295(1)(e) ties the threshold to the Consumer Price Index for the West Region and measures the employee's compensation at the time of termination.
+
+"The total amount of the employee's annual gross salary and commissions, calculated on an annual basis, at the time of the employee's termination exceeds $100,533, adjusted annually for inflation pursuant to the Consumer Price Index for All Urban Consumers, West Region (All Items), as published by the Bureau of Labor Statistics of the United States Department of Labor immediately preceding the calendar year of the employee's termination."[^q3-ors-653-295-threshold]
+
+Because the dollar figure resets every January, the relevant year is the year of termination, not the year the agreement was signed. The Bureau of Labor and Industries publishes the running table.
+
+"For the provisions of a noncompetition agreement to be valid, the statute generally requires that the total amount of the employee's annual gross salary and commissions at the time of the employee's termination must exceed a minimum amount."[^q3-boli-threshold]
+
+> [!NOTE]
+> **Practice note.**
+>
+> Test the income threshold against the year of termination, not the year of hire. An employee who cleared the threshold at signing but fell below it by the termination year may be outside the statute, voiding the covenant [^q3-ors-653-295-threshold][^q3-boli-threshold].
+
+## Can an Oregon employer enforce a non-compete against a worker below the salary threshold by paying during the restraint? {#garden-leave}
+
+**Short answer.** Yes, through a garden-leave option. ORS 653.295(7) lets an employer enforce a non-compete for up to 12 months even against an employee who does not meet the exempt-status or salary requirements, if the employer agrees in writing to pay, during the restricted period, the greater of half the employee's base salary and commissions or half the inflation-indexed threshold [^q4-ors-653-295-garden-leave].
+
+This pay-to-enforce path is the statute's safety valve. The employer trades compensation for enforceability and must commit to the payment in writing.
+
+"Notwithstanding subsection (1)(b) and (e) of this section, a noncompetition agreement is enforceable for the full term of the agreement, for up to 12 months, if the employer agrees in writing to provide the employee, for the time the employee is restricted from working, the greater of: (a) Compensation equal to at least 50 percent of the employee's annual gross base salary and commissions at the time of the employee's termination; or (b) Fifty percent of $100,533, adjusted annually for inflation pursuant to the Consumer Price Index for All Urban Consumers, West Region (All Items), as published by the Bureau of Labor Statistics of the United States Department of Labor immediately preceding the calendar year of the employee's termination."[^q4-ors-653-295-garden-leave]
+
+The labor agency describes the same option in plainer terms, framing it as enforcement available when the employer agrees to pay the greater of the two amounts for the term of the agreement [^q4-boli-garden-leave].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> If you plan to rely on the garden-leave option, put the payment promise in the agreement itself. The statute conditions this path on a written agreement to pay the greater of the two amounts for the restricted period [^q4-ors-653-295-garden-leave][^q4-boli-garden-leave].
+
+## How long can an Oregon non-compete last? {#duration}
+
+**Short answer.** No more than 12 months from termination. ORS 653.295(3) caps the term at 12 months after the employee's termination, and any portion of the term beyond 12 months is void and cannot be enforced [^q5-ors-653-295-duration].
+
+The 12-month cap is firm and self-executing. The 2021 amendments shortened the maximum term from 18 months to 12 months, and the statute voids only the excess rather than the whole covenant on this particular point.
+
+"The term of a noncompetition agreement may not exceed 12 months from the date of the employee's termination. The remainder of a term of a noncompetition agreement in excess of 12 months is void and may not be enforced by a court of this state."[^q5-ors-653-295-duration]
+
+The reference point matters: the clock runs from the date of termination, not from the date of breach or the date a lawsuit is filed. That fixed-from-termination measure is central to the tolling question discussed below.
+
+## When must an Oregon non-compete be signed to be valid? {#timing-advancement}
+
+**Short answer.** At the start of employment with two weeks' advance notice, or upon a later bona fide advancement. The Ninth Circuit applied that timing rule in *Nike, Inc. v. McCarthy*, holding that a non-compete signed in connection with a genuine promotion met the statutory requirements to be enforceable [^q6-ors-653-295-timing][^q6-nike-timing].
+
+Continued employment alone is not a valid trigger. The covenant must be tied either to the original hire (with the two-week notice) or to a subsequent bona fide advancement.
+
+"A noncompetition agreement entered into between an employer and employee is void and unenforceable unless: (a)(A) The employer informs the employee in a written employment offer received by the employee at least two weeks before the first day of the employee's employment that a noncompetition agreement is required as a condition of employment; or (B) The noncompetition agreement is entered into upon a subsequent bona fide advancement of the employee by the employer"[^q6-ors-653-295-timing]
+
+In *Nike v. McCarthy*, the court analyzed whether a non-compete an executive signed in connection with a promotion to regional footwear sales manager qualified under the bona-fide-advancement path, and concluded it did.
+
+"Construing the Oregon statute and reviewing the circumstances surrounding McCarthy's promotion and the execution of the noncompete agreement, we hold that the agreement meets the statutory requirements to be enforceable."[^q6-nike-timing]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not roll out a mid-employment non-compete on continued employment alone. Tie it to a real promotion or other bona fide advancement, because the statutory timing requirement is what *Nike v. McCarthy* tested before enforcing the covenant [^q6-ors-653-295-timing][^q6-nike-timing].
+
+## What counts as a protectable interest under Oregon's non-compete statute? {#protectable-interest}
+
+**Short answer.** Access to trade secrets or to competitively sensitive confidential information. ORS 653.295(2) defines the protectable interest as access to trade secrets or to confidential business or professional information that would not qualify as a trade secret, and the Ninth Circuit in *Nike, Inc. v. McCarthy* treated highly confidential strategic information as a legitimate interest supporting enforcement [^q7-ors-653-295-interest][^q7-nike-interest].
+
+The statute supplies three qualifying categories. The first two — access to trade secrets and access to competitively sensitive confidential information — are the ones most employers rely on, and the second is broader than trade-secret law.
+
+"For purposes of subsection (1)(c) of this section, an employer has a protectable interest when the employee: (a) Has access to trade secrets, as defined in ORS 646.461; (b) Has access to competitively sensitive confidential business or professional information that otherwise would not qualify as a trade secret, including product development plans, product launch plans, marketing strategy or sales plans"[^q7-ors-653-295-interest]
+
+A narrow third category covers certain on-air broadcasting talent, and it comes with its own promotional-spend and pay conditions rather than the ordinary salary threshold [^q7-ors-653-295-broadcast].
+
+"For purposes of subsection (1)(c) of this section, an employer has a protectable interest when the employee:...(c) Is employed as an on-air talent by an employer in the business of broadcasting and the employer: (A) In the year preceding the termination of the employee's employment, expended resources equal to or exceeding 10 percent of the employee's annual salary to develop, improve, train or publicly promote the employee, provided that the resources expended by the employer were expended on media that the employer does not own or control"[^q7-ors-653-295-broadcast]
+
+*Nike v. McCarthy* illustrates the second category. The court found a legitimate interest where a departing executive had acquired highly confidential information that a competitor could exploit, even without framing that information as a strict trade secret.
+
+"We also hold that Nike has a legitimate interest in enforcing the agreement, because there is a substantial risk that McCarthy — in shaping Reebok's product allocation, sales and pricing strategies — could enable Reebok to divert a significant amount of Nike's footwear sales given the highly confidential information McCarthy acquired at Nike."[^q7-nike-interest]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Document the specific confidential information the employee can access before asking a court to enforce. Oregon's protectable-interest test is concrete, and *Nike v. McCarthy* turned on the particular strategic information at risk, not a generic competitive concern [^q7-ors-653-295-interest][^q7-nike-interest].
+
+## Is a defective Oregon non-compete void or merely voidable, and can a court fix it? {#void-vs-voidable}
+
+**Short answer.** For agreements entered on or after January 1, 2022, a non-conforming employee non-compete is void, not merely voidable, so an employer should not assume a court can reform it into a lawful covenant. The statute expressly severs only the portion of a term beyond 12 months; the older voidable regime described in *Bernard v. S.B., Inc.* was superseded by the 2021 amendments [^q8-ors-653-295-void][^q8-bernard-voidable].
+
+The distinction is consequential. Under the prior law, a defective covenant was voidable, meaning it remained in effect until the employee took affirmative steps to void it. *Bernard v. S.B., Inc.* applied that older rule.
+
+"As explained below, we conclude that plaintiffs evidence established, at most, that the noncompetition agreement was voidable (not void) but remained valid and in effect at the time that defendant invoked it."[^q8-bernard-voidable]
+
+The 2021 amendments changed the default to void. A covenant that misses a statutory requirement is now unenforceable from the start, without any need for the employee to act. The statute does sever an over-long term, voiding only the portion beyond 12 months, but that targeted severance is not a general license for courts to rewrite an otherwise non-conforming covenant.
+
+"The remainder of a term of a noncompetition agreement in excess of 12 months is void and may not be enforced by a court of this state."[^q8-ors-653-295-void]
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not count on an Oregon court rescuing a non-conforming employee non-compete by narrowing it. Apart from the statutory severance of an over-long term, a non-conforming covenant is void, and the pre-2022 voidable rule from *Bernard v. S.B., Inc.* no longer applies [^q8-ors-653-295-void][^q8-bernard-voidable].
+
+## Are non-solicitation covenants treated differently in Oregon? {#nonsolicitation}
+
+**Short answer.** Yes. ORS 653.295(5) excludes covenants not to solicit the employer's employees or customers from the non-compete checklist, so they are governed by common-law reasonableness instead. In *Oregon Psychiatric Partners, LLP v. Henry*, the Court of Appeals narrowed *customers of the employer* to those with an active or ongoing relationship and held the covenant at least partly enforceable as a non-solicitation agreement [^q9-ors-653-295-carveout][^q9-henry-partial][^q9-henry-customers].
+
+The statute carves non-solicitation and bonus-restriction covenants out of the rules in subsections (1) and (3).
+
+"Subsections (1) and (3) of this section do not apply to: (a) Bonus restriction agreements, which are lawful agreements that may be enforced by the courts in this state; or (b) A covenant not to solicit employees of the employer or solicit or transact business with customers of the employer."[^q9-ors-653-295-carveout]
+
+*Henry* was decided in 2018 and refers to this carve-out by its former number, ORS 653.295(4)(b); the 2021 amendments renumbered the identical text to subsection (5)(b), so the court's construction of the customer exclusion remains good law. The same amendments also left the carve-out's wording unchanged.
+
+In *Henry*, the employer's covenant did not satisfy the non-compete checklist, but the court treated the customer-restriction component as a non-solicitation agreement within the carve-out and remanded for further proceedings.
+
+"For the reasons that follow, we agree with plaintiff's alternative argument that the agreement is at least in part enforceable under ORS 653.295(4)(b), and we leave to further proceedings in the trial court the resolution of any factual issues that may remain."[^q9-henry-partial]
+
+The court also narrowed the meaning of the customer carve-out, rejecting a broad reading that would let the exception swallow the rule.
+
+"Those definitions support defendant's contention that the phrase ‘customers of the employer’ refers to those people with an active or ongoing relationship with the employer and does not include former or merely incidental patrons."[^q9-henry-customers]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Draft customer non-solicitation clauses around active, ongoing customer relationships, not former or incidental patrons. *Oregon Psychiatric Partners v. Henry* read the customer carve-out narrowly, so an overbroad customer definition risks losing the protection the carve-out provides [^q9-ors-653-295-carveout][^q9-henry-customers].
+
+## Does ORS 653.295 apply to sale-of-business and owner covenants in Oregon? {#sale-of-business}
+
+**Short answer.** No. ORS 653.295(4) limits the statutory checklist and 12-month cap to non-competes made in the context of an employment relationship, so a covenant given as part of selling a business or by an owner outside of employment is not governed by the statute. Those covenants are instead evaluated under Oregon common-law reasonableness [^q9b-ors-653-295-employment-only].
+
+The statute draws an explicit line around the employment relationship.
+
+"Subsections (1) and (3) of this section apply only to noncompetition agreements made in the context of an employment relationship or contract and not otherwise."[^q9b-ors-653-295-employment-only]
+
+Because the checklist and the 12-month limit do not reach non-employment covenants, a sale-of-business or owner non-compete is analyzed under the common-law rule of reason — focused on a legitimate protectable interest and reasonable scope in time, geography, and activity — rather than the ORS 653.295 conditions. Sale-of-business restraints have historically been given more latitude than employee covenants.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Match the legal framework to the deal. An employee non-compete must clear the ORS 653.295 checklist, but a covenant tied to a business sale or an owner's interest falls outside the statute and is judged under common-law reasonableness, so do not assume the 12-month statutory cap applies to it [^q9b-ors-653-295-employment-only].
+
+## Does an Oregon non-compete toll or extend during breach or litigation? {#tolling-during-breach}
+
+**Short answer.** Oregon authority is silent, and the statute's fixed cap cuts against tolling. ORS 653.295(3) measures the maximum 12-month term from the date of termination and voids any term in excess of 12 months, so a clause that purports to pause and extend the restriction past 12 months from termination risks running into that hard cap. No Oregon statute or case squarely approves or rejects a tolling clause [^q10-ors-653-295-cap].
+
+Many covenants include a clause stating that the restricted period pauses while the employee is in breach or while litigation is pending, so the employer receives the full period of compliance. Oregon's staged statutes and cases do not contain a holding that approves or rejects that kind of judicial or contractual tolling.
+
+The complication is the way the statute measures the term. The 12-month maximum runs from termination, not from the last day of compliance, and the excess is void by statute.
+
+"The term of a noncompetition agreement may not exceed 12 months from the date of the employee's termination. The remainder of a term of a noncompetition agreement in excess of 12 months is void and may not be enforced by a court of this state."[^q10-ors-653-295-cap]
+
+A tolling clause that extends the effective restraint beyond 12 months after termination is therefore in tension with the statutory cap, even though no Oregon decision has tested such a clause directly. Treat the question as open and draft conservatively.
+
+> [!NOTE]
+> **Practice note.**
+>
+> No Oregon statute or case squarely decides whether a non-compete may be tolled or extended for breach or pending litigation, and the 12-month-from-termination cap voids any excess term. Treat tolling as unsettled and avoid a clause that would push the effective restraint past 12 months after termination [^q10-ors-653-295-cap].
+
+## Are physician and other medical non-competes enforceable in Oregon? {#healthcare-licensees}
+
+**Short answer.** Usually not. Under ORS 653.297, added by the 2025 legislation, a non-compete that restricts the practice of medicine or nursing is void and unenforceable between a medical licensee and a person, management services organization, or hospital, unless a narrow exception applies — most notably the licensee holding at least a 1.5 percent ownership interest. The companion provision reaches agreements entered before, on, or after the June 9, 2025 effective date [^q11-ors-653-297-ban][^q11-ors-653-297-equity][^q11-ors-653-298-retro].
+
+This is Oregon's newest and most aggressive restriction, enacted as part of the 2025 corporate-practice-of-medicine package. The default rule voids medical-licensee non-competes outright.
+
+"a noncompetition agreement that restricts the practice of medicine or the practice of nursing is void and unenforceable between a medical licensee and: (A) A person, as defined in ORS 442.015; (B) A management services organization; or (C) A hospital, as defined in ORS 442.015, or a hospital-affiliated clinic, as defined in ORS 442.612."[^q11-ors-653-297-ban]
+
+The statute then provides exceptions, including one tied to a meaningful ownership stake in the entity.
+
+"A noncompetition agreement between a medical licensee and another person that restricts the practice of medicine or the practice of nursing is valid and enforceable to the extent and under the terms provided in ORS 653.295 if: (A) The medical licensee is a shareholder or member of the other person or otherwise owns or controls an ownership or membership interest and the medical licensee's ownership or membership interest in the other person is equivalent to 1.5 percent or more of the entire ownership or membership interest that exists in the other person"[^q11-ors-653-297-equity]
+
+The equity stake is not the only exception. The statute also permits a covenant tied to a professional medical entity's documented recruitment investment, capped at three or five years depending on whether the licensee provides direct care in a designated shortage area, and it permits a covenant against a licensee who does not directly provide medical, health care, or clinical care [^q11-ors-653-297-nonclinical].
+
+"The medical licensee does not engage directly in providing medical services, health care services or clinical care."[^q11-ors-653-297-nonclinical]
+
+The reach is also retroactive. The 2025 law applies to qualifying medical-licensee agreements regardless of when they were signed.
+
+"Sections 7 [653.297] and 8 [653.298], chapter 295, Oregon Laws 2025, apply to noncompetition agreements, as defined in section 7, chapter 295, Oregon Laws 2025, that restrict the practice of medicine or the practice of nursing and into which a medical licensee, as defined in section 7, chapter 295, Oregon Laws 2025, enters before, on or after the effective date of chapter 295, Oregon Laws 2025 [June 9, 2025]."[^q11-ors-653-298-retro]
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not rely on a pre-2025 physician or nurse non-compete in Oregon. ORS 653.297 voids medical-licensee non-competes absent a narrow exception, and the 2025 law reaches agreements signed before its effective date [^q11-ors-653-297-ban][^q11-ors-653-298-retro].
+
+## What is a bonus restriction agreement, and why does it matter? {#bonus-restriction}
+
+**Short answer.** It is a separate, expressly lawful tool that penalizes competition only by forfeiting unpaid bonus compensation. ORS 653.295 excludes bonus restriction agreements from the non-compete checklist and defines them so that the only penalty for competing is forfeiture of profit sharing or other bonus compensation not yet paid [^q12-ors-653-295-bonus-carveout][^q12-ors-653-295-bonus-def].
+
+Because a bonus restriction agreement does not bar the employee from working, it sits outside the non-compete requirements. The statute confirms these agreements are lawful and enforceable.
+
+"Subsections (1) and (3) of this section do not apply to: (a) Bonus restriction agreements, which are lawful agreements that may be enforced by the courts in this state; or (b) A covenant not to solicit employees of the employer or solicit or transact business with customers of the employer."[^q12-ors-653-295-bonus-carveout]
+
+The defining feature is the limited penalty. The employee who competes loses only unpaid bonus money, not the ability to take a competing job.
+
+"The penalty imposed on the employee for competition against the employer is limited to forfeiture of profit sharing or other bonus compensation that has not yet been paid to the employee."[^q12-ors-653-295-bonus-def]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> If the only consequence you need is forfeiture of unpaid bonus money, use a bonus restriction agreement rather than a non-compete. The statute keeps that tool outside the non-compete checklist as long as the penalty is limited to unpaid bonus compensation [^q12-ors-653-295-bonus-carveout][^q12-ors-653-295-bonus-def].
+
+## Can an out-of-state employer use a choice-of-law clause to avoid ORS 653.295, and what is the fee exposure? {#choice-of-law-and-fees}
+
+**Short answer.** Generally no. ORS 15.320 provides that an employment contract for services rendered primarily in Oregon by an Oregon resident is governed by Oregon law, which limits the use of a foreign choice-of-law clause to escape ORS 653.295. And ORS 20.096 makes one-sided contractual attorney-fee clauses reciprocal, so a prevailing employee can recover fees even if the contract named only the employer [^q13-ors-15-320][^q13-ors-20-096].
+
+ORS 15.320 provides that, subject to the limitations in ORS 15.305, the law of Oregon applies to several listed categories of contracts. One of those categories is employment performed primarily in the state by an Oregon resident.
+
+"Notwithstanding any other provision of ORS 15.300 to 15.380, but subject to the limitations on applicability imposed by ORS 15.305, the law of Oregon applies to the following contracts:...(3) A contract of employment for services to be rendered primarily in Oregon by a resident of Oregon."[^q13-ors-15-320]
+
+The fee statute then changes the litigation calculus. A contractual fee clause that runs in only one direction is made mutual by statute.
+
+"the party that prevails on the claim shall be entitled to reasonable attorney fees in addition to costs and disbursements, without regard to whether the prevailing party is the party specified in the contract and without regard to whether the prevailing party is a party to the contract."[^q13-ors-20-096]
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not assume a Delaware or other out-of-state choice-of-law clause will save a non-compete against an Oregon-resident employee working in Oregon. ORS 15.320 points to Oregon law, and ORS 20.096 can shift fees to a prevailing employee even under an employer-drafted one-way fee clause [^q13-ors-15-320][^q13-ors-20-096].
+
+## How do Oregon trade-secret protections and NDAs compare to non-competes? {#trade-secrets-ndas}
+
+**Short answer.** They remain available and are often the better tool. Oregon has adopted the Uniform Trade Secrets Act, and ORS 653.295 preserves the right to protect trade secrets and proprietary information by other lawful means; but the Workplace Fairness Act limits using nondisclosure and nondisparagement provisions to suppress discrimination or harassment complaints [^q14-ors-646-461-trade-secret][^q14-ors-653-295-preserve][^q14-ors-659a-370-wfa].
+
+Even where a non-compete is unavailable, the employer keeps its trade-secret remedies. Oregon's Uniform Trade Secrets Act defines the protected information.
+
+"‘Trade secret’ means information, including a drawing, cost data, customer list, formula, pattern, compilation, program, device, method, technique or process that: (a) Derives independent economic value, actual or potential, from not being generally known to the public or to other persons who can obtain economic value from its disclosure or use; and (b) Is the subject of efforts that are reasonable under the circumstances to maintain its secrecy."[^q14-ors-646-461-trade-secret]
+
+The non-compete statute itself preserves these alternative protections.
+
+"Nothing in this section restricts the right of any person to protect trade secrets or other proprietary information by injunction or any other lawful means under other applicable laws."[^q14-ors-653-295-preserve]
+
+Confidentiality and non-disparagement clauses have their own statutory limit. The Workplace Fairness Act makes it unlawful to use them to prevent an employee from discussing discrimination or harassment.
+
+"it is an unlawful employment practice for an employer to enter into an agreement with a former, current or prospective employee, as a condition of employment, continued employment, promotion, compensation or the receipt of benefits, that contains a nondisclosure provision, a nondisparagement provision or any other provision that has the purpose or effect of preventing the employee from disclosing or discussing conduct: (a)(A) That constitutes discrimination prohibited by ORS 659A.030, including conduct that constitutes sexual assault; or (B) That constitutes discrimination prohibited by ORS 659A.082 or 659A.112; and (b)(A) That occurred between employees or between an employer and an employee in the workplace or at a work-related event that is off the employment premises and coordinated by or through the employer; or (B) That occurred between an employer and an employee off the employment premises."[^q14-ors-659a-370-wfa]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Use confidentiality and trade-secret tools for secrecy interests, and scope nondisclosure and nondisparagement clauses to avoid the Workplace Fairness Act. ORS 653.295 preserves trade-secret remedies, but ORS 659A.370 bars provisions that prevent an employee from discussing discrimination or harassment [^q14-ors-653-295-preserve][^q14-ors-659a-370-wfa].
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-03. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not Oregon. This article synthesizes Oregon primary law and is not legal advice from a Oregon-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^q1-ors-653-295-void-unless]: **ORS 653.295** — "A noncompetition agreement entered into between an employer and employee is void and unenforceable unless: (a)(A) The employer informs the employee in a written employment offer received by the employee at least two weeks before the first day of the employee's employment that a noncompetition agreement is required as a condition of employment; or (B) The noncompetition agreement is entered into upon a subsequent bona fide advancement of the employee by the employer" *ORS 653.295(1).* <https://www.oregonlegislature.gov/bills_laws/ors/ors653.html>
+
+[^q2-ors-653-295-conditions]: **ORS 653.295** — "(1) A noncompetition agreement entered into between an employer and employee is void and unenforceable unless:...(b) The employee is a person described in ORS 653.020 (3); (c) The employer has a protectable interest as described in subsection (2) of this section; (d) Within 30 days after the date of the termination of the employee's employment, the employer provides a signed, written copy of the terms of the noncompetition agreement to the employee; and (e) The total amount of the employee's annual gross salary and commissions, calculated on an annual basis, at the time of the employee's termination exceeds $100,533, adjusted annually for inflation pursuant to the Consumer Price Index for All Urban Consumers, West Region (All Items), as published by the Bureau of Labor Statistics of the United States Department of Labor immediately preceding the calendar year of the employee's termination." *ORS 653.295(1)(b)-(e).* <https://www.oregonlegislature.gov/bills_laws/ors/ors653.html>
+
+[^q2-boli-conditions]: **Oregon BOLI, Noncompetition Agreements** — "In addition, a noncompetition agreement is also void unless: The employee meets the criteria for a salaried exempt employee whose annual income at termination exceeds a minimum amount adjusted each year for inflation. (See below for details). The employer has an interest to protect, such as trade secrets; sensitive, confidential business or professional information; product development plans; launch plans; marketing strategy or sales plans; and finally, The employer must also provide a signed, written copy of the terms of the noncompetition agreement to the employee within 30 days after the employee's termination." *Oregon BOLI, Noncompetition Agreements.* <https://www.oregon.gov/boli/employers/pages/noncompetition-agreements.aspx>
+
+[^q3-ors-653-295-threshold]: **ORS 653.295** — "The total amount of the employee's annual gross salary and commissions, calculated on an annual basis, at the time of the employee's termination exceeds $100,533, adjusted annually for inflation pursuant to the Consumer Price Index for All Urban Consumers, West Region (All Items), as published by the Bureau of Labor Statistics of the United States Department of Labor immediately preceding the calendar year of the employee's termination." *ORS 653.295(1)(e).* <https://www.oregonlegislature.gov/bills_laws/ors/ors653.html>
+
+[^q3-boli-threshold]: **Oregon BOLI, Noncompetition Agreements** — "For the provisions of a noncompetition agreement to be valid, the statute generally requires that the total amount of the employee's annual gross salary and commissions at the time of the employee's termination must exceed a minimum amount." *Oregon BOLI, Noncompetition Agreements.* <https://www.oregon.gov/boli/employers/pages/noncompetition-agreements.aspx>
+
+[^q4-ors-653-295-garden-leave]: **ORS 653.295** — "Notwithstanding subsection (1)(b) and (e) of this section, a noncompetition agreement is enforceable for the full term of the agreement, for up to 12 months, if the employer agrees in writing to provide the employee, for the time the employee is restricted from working, the greater of: (a) Compensation equal to at least 50 percent of the employee's annual gross base salary and commissions at the time of the employee's termination; or (b) Fifty percent of $100,533, adjusted annually for inflation pursuant to the Consumer Price Index for All Urban Consumers, West Region (All Items), as published by the Bureau of Labor Statistics of the United States Department of Labor immediately preceding the calendar year of the employee's termination." *ORS 653.295(7).* <https://www.oregonlegislature.gov/bills_laws/ors/ors653.html>
+
+[^q4-boli-garden-leave]: **Oregon BOLI, Noncompetition Agreements** — "when the employer agrees in writing to pay either 50% of the employee's annual base salary plus commissions at termination or 50% of minimum salary listed above, whichever is greater, for the term of the agreement." *Oregon BOLI, Noncompetition Agreements.* <https://www.oregon.gov/boli/employers/pages/noncompetition-agreements.aspx>
+
+[^q5-ors-653-295-duration]: **ORS 653.295** — "The term of a noncompetition agreement may not exceed 12 months from the date of the employee's termination. The remainder of a term of a noncompetition agreement in excess of 12 months is void and may not be enforced by a court of this state." *ORS 653.295(3).* <https://www.oregonlegislature.gov/bills_laws/ors/ors653.html>
+
+[^q6-ors-653-295-timing]: **ORS 653.295** — "A noncompetition agreement entered into between an employer and employee is void and unenforceable unless: (a)(A) The employer informs the employee in a written employment offer received by the employee at least two weeks before the first day of the employee's employment that a noncompetition agreement is required as a condition of employment; or (B) The noncompetition agreement is entered into upon a subsequent bona fide advancement of the employee by the employer" *ORS 653.295(1)(a).* <https://www.oregonlegislature.gov/bills_laws/ors/ors653.html>
+
+[^q6-nike-timing]: **Nike, Inc. v. McCarthy** — "Construing the Oregon statute and reviewing the circumstances surrounding McCarthy's promotion and the execution of the noncompete agreement, we hold that the agreement meets the statutory requirements to be enforceable." *Nike, Inc. v. McCarthy, 379 F.3d 576 (9th Cir. 2004).* <https://www.courtlistener.com/opinion/787342/nike-inc-v-eugene-mccarthy/#:~:text=Construing%20the%20Oregon%20statute%20and,statutory%20requirements%20to%20be%20enforceable.>
+
+[^q7-ors-653-295-interest]: **ORS 653.295** — "For purposes of subsection (1)(c) of this section, an employer has a protectable interest when the employee: (a) Has access to trade secrets, as defined in ORS 646.461; (b) Has access to competitively sensitive confidential business or professional information that otherwise would not qualify as a trade secret, including product development plans, product launch plans, marketing strategy or sales plans" *ORS 653.295(2).* <https://www.oregonlegislature.gov/bills_laws/ors/ors653.html>
+
+[^q7-nike-interest]: **Nike, Inc. v. McCarthy** — "We also hold that Nike has a legitimate interest in enforcing the agreement, because there is a substantial risk that McCarthy — in shaping Reebok's product allocation, sales and pricing strategies — could enable Reebok to divert a significant amount of Nike's footwear sales given the highly confidential information McCarthy acquired at Nike." *Nike, Inc. v. McCarthy, 379 F.3d 576 (9th Cir. 2004).* <https://www.courtlistener.com/opinion/787342/nike-inc-v-eugene-mccarthy/#:~:text=We%20also%20hold%20that%20Nike,information%20McCarthy%20acquired%20at%20Nike.>
+
+[^q7-ors-653-295-broadcast]: **ORS 653.295** — "For purposes of subsection (1)(c) of this section, an employer has a protectable interest when the employee:...(c) Is employed as an on-air talent by an employer in the business of broadcasting and the employer: (A) In the year preceding the termination of the employee's employment, expended resources equal to or exceeding 10 percent of the employee's annual salary to develop, improve, train or publicly promote the employee, provided that the resources expended by the employer were expended on media that the employer does not own or control" *ORS 653.295(2)(c).* <https://www.oregonlegislature.gov/bills_laws/ors/ors653.html>
+
+[^q8-ors-653-295-void]: **ORS 653.295** — "The remainder of a term of a noncompetition agreement in excess of 12 months is void and may not be enforced by a court of this state." *ORS 653.295(3).* <https://www.oregonlegislature.gov/bills_laws/ors/ors653.html>
+
+[^q8-bernard-voidable]: **Bernard v. S.B., Inc.** — "As explained below, we conclude that plaintiffs evidence established, at most, that the noncompetition agreement was voidable (not void) but remained valid and in effect at the time that defendant invoked it." *Bernard v. S.B., Inc., 270 Or. App. 710 (2015).* <https://www.courtlistener.com/opinion/8166117/bernard-v-sb-inc/#:~:text=As%20explained%20below%2C%20we%20conclude,time%20that%20defendant%20invoked%20it.>
+
+[^q9-ors-653-295-carveout]: **ORS 653.295** — "Subsections (1) and (3) of this section do not apply to: (a) Bonus restriction agreements, which are lawful agreements that may be enforced by the courts in this state; or (b) A covenant not to solicit employees of the employer or solicit or transact business with customers of the employer." *ORS 653.295(5).* <https://www.oregonlegislature.gov/bills_laws/ors/ors653.html>
+
+[^q9-henry-partial]: **Oregon Psychiatric Partners, LLP v. Henry** — "For the reasons that follow, we agree with plaintiff's alternative argument that the agreement is at least in part enforceable under ORS 653.295(4)(b), and we leave to further proceedings in the trial court the resolution of any factual issues that may remain." *Oregon Psychiatric Partners, LLP v. Henry, 293 Or. App. 471, 429 P.3d 399 (2018).* <https://www.courtlistener.com/opinion/6657507/or-psychiatric-partners-llp-v-henry/#:~:text=For%20the%20reasons%20that%20follow%2C,factual%20issues%20that%20may%20remain.>
+
+[^q9-henry-customers]: **Oregon Psychiatric Partners, LLP v. Henry** — "Those definitions support defendant's contention that the phrase ‘customers of the employer’ refers to those people with an active or ongoing relationship with the employer and does not include former or merely incidental patrons." *Oregon Psychiatric Partners, LLP v. Henry, 293 Or. App. 471, 429 P.3d 399 (2018).* <https://www.courtlistener.com/opinion/6657507/or-psychiatric-partners-llp-v-henry/#:~:text=Those%20definitions%20support%20defendant's%20contention,former%20or%20merely%20incidental%20patrons.>
+
+[^q9b-ors-653-295-employment-only]: **ORS 653.295** — "Subsections (1) and (3) of this section apply only to noncompetition agreements made in the context of an employment relationship or contract and not otherwise." *ORS 653.295(4).* <https://www.oregonlegislature.gov/bills_laws/ors/ors653.html>
+
+[^q10-ors-653-295-cap]: **ORS 653.295** — "The term of a noncompetition agreement may not exceed 12 months from the date of the employee's termination. The remainder of a term of a noncompetition agreement in excess of 12 months is void and may not be enforced by a court of this state." *ORS 653.295(3).* <https://www.oregonlegislature.gov/bills_laws/ors/ors653.html>
+
+[^q11-ors-653-297-ban]: **ORS 653.297** — "a noncompetition agreement that restricts the practice of medicine or the practice of nursing is void and unenforceable between a medical licensee and: (A) A person, as defined in ORS 442.015; (B) A management services organization; or (C) A hospital, as defined in ORS 442.015, or a hospital-affiliated clinic, as defined in ORS 442.612." *ORS 653.297(2)(a).* <https://www.oregonlegislature.gov/bills_laws/ors/ors653.html>
+
+[^q11-ors-653-297-equity]: **ORS 653.297** — "A noncompetition agreement between a medical licensee and another person that restricts the practice of medicine or the practice of nursing is valid and enforceable to the extent and under the terms provided in ORS 653.295 if: (A) The medical licensee is a shareholder or member of the other person or otherwise owns or controls an ownership or membership interest and the medical licensee's ownership or membership interest in the other person is equivalent to 1.5 percent or more of the entire ownership or membership interest that exists in the other person" *ORS 653.297(2)(b)(A).* <https://www.oregonlegislature.gov/bills_laws/ors/ors653.html>
+
+[^q11-ors-653-298-retro]: **ORS 653.298** — "Sections 7 [653.297] and 8 [653.298], chapter 295, Oregon Laws 2025, apply to noncompetition agreements, as defined in section 7, chapter 295, Oregon Laws 2025, that restrict the practice of medicine or the practice of nursing and into which a medical licensee, as defined in section 7, chapter 295, Oregon Laws 2025, enters before, on or after the effective date of chapter 295, Oregon Laws 2025 [June 9, 2025]." *ORS 653.298 (2025 c.295 §9 note).* <https://www.oregonlegislature.gov/bills_laws/ors/ors653.html>
+
+[^q11-ors-653-297-nonclinical]: **ORS 653.297** — "The medical licensee does not engage directly in providing medical services, health care services or clinical care." *ORS 653.297(2)(b)(C).* <https://www.oregonlegislature.gov/bills_laws/ors/ors653.html>
+
+[^q12-ors-653-295-bonus-carveout]: **ORS 653.295** — "Subsections (1) and (3) of this section do not apply to: (a) Bonus restriction agreements, which are lawful agreements that may be enforced by the courts in this state; or (b) A covenant not to solicit employees of the employer or solicit or transact business with customers of the employer." *ORS 653.295(5)(a).* <https://www.oregonlegislature.gov/bills_laws/ors/ors653.html>
+
+[^q12-ors-653-295-bonus-def]: **ORS 653.295** — "The penalty imposed on the employee for competition against the employer is limited to forfeiture of profit sharing or other bonus compensation that has not yet been paid to the employee." *ORS 653.295(8)(a)(C).* <https://www.oregonlegislature.gov/bills_laws/ors/ors653.html>
+
+[^q13-ors-15-320]: **ORS 15.320** — "Notwithstanding any other provision of ORS 15.300 to 15.380, but subject to the limitations on applicability imposed by ORS 15.305, the law of Oregon applies to the following contracts:...(3) A contract of employment for services to be rendered primarily in Oregon by a resident of Oregon." *ORS 15.320(3).* <https://www.oregonlegislature.gov/bills_laws/ors/ors015.html>
+
+[^q13-ors-20-096]: **ORS 20.096** — "the party that prevails on the claim shall be entitled to reasonable attorney fees in addition to costs and disbursements, without regard to whether the prevailing party is the party specified in the contract and without regard to whether the prevailing party is a party to the contract." *ORS 20.096(1).* <https://www.oregonlegislature.gov/bills_laws/ors/ors020.html>
+
+[^q14-ors-646-461-trade-secret]: **ORS 646.461** — "‘Trade secret’ means information, including a drawing, cost data, customer list, formula, pattern, compilation, program, device, method, technique or process that: (a) Derives independent economic value, actual or potential, from not being generally known to the public or to other persons who can obtain economic value from its disclosure or use; and (b) Is the subject of efforts that are reasonable under the circumstances to maintain its secrecy." *ORS 646.461(4).* <https://www.oregonlegislature.gov/bills_laws/ors/ors646.html>
+
+[^q14-ors-653-295-preserve]: **ORS 653.295** — "Nothing in this section restricts the right of any person to protect trade secrets or other proprietary information by injunction or any other lawful means under other applicable laws." *ORS 653.295(6).* <https://www.oregonlegislature.gov/bills_laws/ors/ors653.html>
+
+[^q14-ors-659a-370-wfa]: **ORS 659A.370** — "it is an unlawful employment practice for an employer to enter into an agreement with a former, current or prospective employee, as a condition of employment, continued employment, promotion, compensation or the receipt of benefits, that contains a nondisclosure provision, a nondisparagement provision or any other provision that has the purpose or effect of preventing the employee from disclosing or discussing conduct: (a)(A) That constitutes discrimination prohibited by ORS 659A.030, including conduct that constitutes sexual assault; or (B) That constitutes discrimination prohibited by ORS 659A.082 or 659A.112; and (b)(A) That occurred between employees or between an employer and an employee in the workplace or at a work-related event that is off the employment premises and coordinated by or through the employer; or (B) That occurred between an employer and an employee off the employment premises." *ORS 659A.370(1).* <https://www.oregonlegislature.gov/bills_laws/ors/ors659A.html>

--- a/skills/non-compete-contract-explainer/content/pennsylvania.md
+++ b/skills/non-compete-contract-explainer/content/pennsylvania.md
@@ -1,0 +1,254 @@
+---
+jurisdiction: "Pennsylvania"
+slug: pennsylvania
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-03"
+canonicalUrl: https://openagreements.org/legal/non-compete/pennsylvania
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/pennsylvania · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in Pennsylvania[^about]
+
+Pennsylvania enforces non-competes only when they are ancillary to employment, supported by adequate consideration, and reasonably limited, and a 2024 statute sharply restricts health care non-competes.
+
+
+## At a glance
+
+| Question | Pennsylvania |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed if reasonable |
+| **Bottom line** | Pennsylvania enforces an employee non-compete only if it is ancillary to employment, supported by adequate consideration, reasonably limited in time and territory, and tied to a legitimate business interest, with a 2024 statute sharply restricting health care covenants. |
+| **Main law or case** | Socko v. Mid-Atlantic Systems of CPA, Inc., 126 A.3d 1266 (Pa. 2015) |
+| **Main exceptions** | Health-care practitioner restrictions (Act 74 of 2024, eff. Jan 1, 2025 — voids covenants over one year and any where employer dismissed practitioner); B2B no-hire clauses unenforceable (Beemac) |
+| **Can a court narrow it?** | Yes — rewrites to reasonable |
+| **Applies to contractors?** | Unclear |
+| **Restriction extended during a breach?** | Unsettled |
+| **Maximum length set by law** | No statutory limit (except Act 74 one-year cap for health care) |
+
+## Are employee non-compete agreements enforceable in Pennsylvania? {#employee-noncompetes}
+
+**Short answer.** Yes, sometimes. Pennsylvania is a reasonableness state, not a general ban state, but its courts are historically hostile to restraints on trade. A non-compete is enforceable only if it is ancillary to an employment relationship, supported by adequate consideration, reasonably limited in time and territory, and designed to protect a legitimate business interest of the employer [^socko-four-part-test].
+
+The modern statement of the test comes from *Socko v. Mid-Atlantic Systems of CPA, Inc.*, where the Pennsylvania Supreme Court restated the four requirements every covenant must meet [^socko-four-part-test]. The framework traces back to *Morgan's Home Equipment Corp. v. Martucci*, which held that a post-employment covenant is only *prima facie* enforceable when it is reasonably limited as to duration and geographic extent [^morgans-prima-facie].
+
+Pennsylvania has not enacted a general non-compete statute for the ordinary workforce. The core analysis is judge-made, with one significant statutory exception for health care practitioners covered later in this note.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not treat Pennsylvania as either a free-for-all or a ban state. Confirm the covenant is ancillary and supported by consideration, then test it for reasonableness in time, territory, and protectable interest, because Pennsylvania courts scrutinize restraints closely [^socko-four-part-test].
+
+## Is continued at-will employment enough consideration for a Pennsylvania non-compete? {#consideration}
+
+**Short answer.** No, not by itself, for an existing employee. When a covenant is added after employment has begun, it is enforceable only if the employee receives new and valuable consideration beyond merely keeping the job [^socko-mid-employment][^maintenance-continued-employment].
+
+In *Socko*, the Pennsylvania Supreme Court confirmed that a mid-employment restraint requires new and valuable consideration — a corresponding benefit or a beneficial change in employment status — not just continued at-will employment [^socko-mid-employment]. The rule predates *Socko*: in *Maintenance Specialties, Inc. v. Gottus*, the court held that continued employment is not sufficient consideration for a covenant signed after employment began [^maintenance-continued-employment].
+
+"In the context of requiring an employee to agree to a restrictive covenant mid-employment, however, such a restraint on trade will be enforceable only if new and valuable consideration, beyond mere continued employment, is provided and is sufficient to support the restrictive clause."[^socko-mid-employment]
+
+*Socko* also closed a drafting loophole. Employers had relied on the Uniform Written Obligations Act, which lets a signed writing reciting an intent to be legally bound stand without consideration. The court held that this statutory recital does not cure a missing consideration in the restrictive-covenant context [^socko-uwoa].
+
+A separate timing rule governs covenants signed shortly after the first day of work. In *Rullex Co. v. Tel-Stream, Inc.*, the court held that a covenant executed after the first day is enforceable without new consideration only if the parties agreed to its essential provisions at the start of the relationship [^rullex-essential-provisions]. Otherwise, as *George W. Kistler, Inc. v. O'Brien* put it, a later-added covenant must be supported by new consideration [^kistler-new-consideration].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not rely on continued at-will employment, or on an *intend to be legally bound* recital, when an existing Pennsylvania employee signs a new covenant. Tie the signature to identifiable new consideration such as a raise, bonus, or promotion, and document it, because the recital did not save the agreement in *Socko* [^socko-mid-employment][^socko-uwoa].
+
+## What legitimate business interests can support a Pennsylvania non-compete? {#protectable-interests}
+
+**Short answer.** Genuinely specialized training and trade secrets are the clearest examples, alongside confidential information and customer goodwill. A covenant that exists only to suppress ordinary competition is not protecting anything Pennsylvania law recognizes [^morgans-specialized-training].
+
+*Morgan's Home Equipment* identified the kinds of interests an employer may guard, including the specialized training, skills, and carefully guarded methods that amount to trade secrets of a particular enterprise [^morgans-specialized-training]. Those covenants are enforced only so far as reasonably necessary to protect the employer [^q3-morgans-reasonably-necessary].
+
+The emphasis on *specialized* training matters. Courts distinguish a real, proprietary investment by the employer from ordinary on-the-job experience or general sales technique, which an employee remains free to use elsewhere. The same tailoring requirement applies to covenants built on customer goodwill or confidential information: the restraint must track the specific relationships or information the employer actually needs to protect, not competition in general.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not use a Pennsylvania non-compete to block competition that is disconnected from a protectable interest. Tie the restraint to specific trade secrets, confidential information, customer goodwill, or genuinely specialized training, because a covenant aimed at ordinary competition is not reasonably necessary to protect the employer [^q3-morgans-reasonably-necessary].
+
+## What duration and geographic scope are reasonable for a Pennsylvania non-compete? {#duration-geography}
+
+**Short answer.** Outside Act 74's health care rules, there is no statutory cap. Pennsylvania courts permit enforcement only where the covenant is incident to employment, reasonably necessary to protect the employer, and reasonably limited in both duration and geographic extent [^sidco-general-rule][^beemac-geo-duration].
+
+*Sidco Paper Co. v. Aaron* states the standard: post-employment restraints are enforced only when they are incident to the employment relationship, reasonably necessary to protect the employer, and reasonably limited in duration and geographic extent [^sidco-general-rule]. The Supreme Court reaffirmed in *Pittsburgh Logistics Systems, Inc. v. Beemac Trucking, LLC* that a court weighs the reasonableness of the restraint's geographic scope together with its duration [^beemac-geo-duration].
+
+Because the analysis is holistic, time and territory are measured against the employer's actual market and the interest being protected. A restraint matched to where the employer competes and to the time needed to protect a relationship is far easier to defend than a long, open-ended, statewide ban.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not copy a fixed term or radius from another form. Match the duration and territory to the employee's role and the employer's real market, because a Pennsylvania court evaluates the restraint as a whole and there is no safe-harbor number [^sidco-general-rule][^beemac-geo-duration].
+
+## Will a Pennsylvania court blue-pencil or reform an overbroad non-compete? {#court-narrowing}
+
+**Short answer.** Sometimes, but do not count on it. A Pennsylvania court of equity may enforce only the reasonable portions of an overbroad covenant, yet it will scrutinize the restraint closely and may decline to rewrite a covenant drafted far broader than necessary [^sidco-partial-enforcement][^reading-aviation-overreach].
+
+*Sidco Paper* confirms the power: where a covenant imposes restrictions broader than necessary, a court of equity may grant enforcement limited to the portions that are reasonably necessary to protect the employer [^sidco-partial-enforcement]. But the power is bounded. In *Reading Aviation Service, Inc. v. Bertolet*, the Supreme Court explained that freely rewriting overbroad covenants would encourage employers with superior bargaining power to insist on excessive restrictions, secure in the knowledge that a court will simply pare them back [^reading-aviation-overreach]. Pennsylvania courts therefore subject these covenants to close scrutiny [^reading-aviation-close-scrutiny].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not rely on a Pennsylvania court to rescue an aggressive covenant. Draft tiered, severable, reasonable restraints, because reformation is discretionary and a court may refuse to narrow a covenant it sees as gratuitously overbroad [^sidco-partial-enforcement][^reading-aviation-overreach].
+
+## Does it matter whether the employer or the employee ended the employment? {#termination-effect}
+
+**Short answer.** Yes. How the employment ended is an important factor. A Pennsylvania court is markedly less willing to enforce a covenant against an employee the employer fired for failing to do the job than against one who voluntarily left [^brobston-distinction][^brobston-fired].
+
+In *Insulation Corp. of America v. Brobston*, the Superior Court drew a sharp line between an employee who voluntarily leaves and one who is terminated for failing to do his job [^brobston-distinction]. Where an employer fires an employee for failing to promote the employer's legitimate business interests, the court reasoned, the employer has effectively decided that its interests are better served without that employee — which undercuts the claim that it still needs a covenant to protect those same interests [^brobston-fired].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not assume a Pennsylvania covenant is enforceable after the employer terminates the employee. Where the discharge is for poor performance, the circumstances of termination weigh heavily against enforcement, so weigh that risk before suing a fired employee on a non-compete [^brobston-fired].
+
+## How does Pennsylvania treat customer non-solicitation and no-accept clauses? {#customer-nonsolicit}
+
+**Short answer.** Sometimes. Narrow customer non-solicitation clauses can be enforceable, but a recent non-precedential Superior Court decision read *solicit* to require an affirmative act and treated a clause as overbroad where it lacked a geographic limit and barred an employee from merely accepting business [^english-affirmative-act][^english-no-geo].
+
+A 2026 Superior Court memorandum, *First National Trust Co. v. English*, illustrates the limits. The court held that the verbs *solicit*, *divert*, and *entice* each require an affirmative act, so an employee who merely accepts business from clients who seek him out has not breached [^english-affirmative-act]. It found the non-solicitation clause unenforceable as written because it had no geographic scope [^english-no-geo]. The court also declined to extend the restriction to customers whose relationships predated their advisor's employment [^english-predated-customers].
+
+*English* is a non-precedential memorandum, so it does not bind future panels, but it reflects how Pennsylvania courts apply settled reasonableness principles to non-solicitation and no-accept language.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not draft a Pennsylvania non-solicitation clause that bars merely *accepting* business or that omits a geographic limit. Restrict the clause to affirmative solicitation of customers the employee actually served, because a no-accept or geographically unbounded clause invites a finding that it is unenforceable as written [^english-affirmative-act][^english-no-geo].
+
+## Does a Pennsylvania non-compete toll or extend during breach or litigation? {#tolling-extension}
+
+**Short answer.** This is an unsettled Pennsylvania question. No Pennsylvania statute or appellate decision discussed in this note squarely endorses automatically tolling or extending the restricted period while the former employee is in breach or while litigation is pending [^q8-sidco-reasonably-necessary][^q8-morgans-prima-facie].
+
+Pennsylvania law gives signals rather than a rule. Any clause that extends the restricted period must still be reasonably necessary to protect the employer and reasonably limited in duration, so an open-ended extension risks being found unreasonable [^q8-sidco-reasonably-necessary]. And because a covenant is only *prima facie* enforceable when it is reasonably limited as to time, a clause that effectively lengthens the restraint each time the employer alleges a breach sits in tension with that requirement [^q8-morgans-prima-facie].
+
+A contractual extension-on-breach clause is therefore fact-dependent in Pennsylvania. It is most defensible when tied to the duration of an actual breach and a legitimate interest, rather than written as an automatic, indefinite extension.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Open question: Pennsylvania law is unsettled on whether an extension-on-breach or tolling clause is enforceable after the original restricted period expires. Draft any such clause as a separate, reasonable restraint tied to the breach, and do not assume a Pennsylvania court will automatically extend an expired covenant [^q8-sidco-reasonably-necessary][^q8-morgans-prima-facie].
+
+## Are non-competes for health care practitioners restricted in Pennsylvania? {#healthcare-act74}
+
+**Short answer.** Yes. The Fair Contracting for Health Care Practitioners Act (Act 74 of 2024), effective January 1, 2025, voids non-compete covenants longer than one year for covered practitioners and voids a covenant of any length when the employer dismisses the practitioner [^act74-applicability][^act74-exception].
+
+Under the Act, a noncompete covenant entered into after its effective date is contrary to public policy and void and unenforceable by an employer [^act74-applicability]. The one exception is narrow: an employer may enforce a covenant only if it runs no more than one year and the practitioner was not dismissed by the employer [^act74-exception].
+
+"(b) Exception.--An employer may enforce a noncompete covenant if the length of the noncompete covenant is no more than one year, provided that the health care practitioner was not dismissed by the employer."[^act74-exception]
+
+The Act covers a defined set of practitioners — medical doctors, doctors of osteopathy, certified registered nurse anesthetists, certified registered nurse practitioners, and physician assistants [^act74-practitioner]. Separately, when a covered practitioner leaves, the employer must notify patients the practitioner saw within the past year — where there was an ongoing outpatient relationship of at least two years — within 90 days of the departure [^act74-notice]. The Act also does not bar a contract provision letting an employer recover reasonable, practitioner-specific expenses such as relocation, training, and patient-base establishment costs accrued within the three years before separation, amortized over up to five years, although that recovery is unavailable when the employer dismisses the practitioner.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not apply ordinary reasonableness analysis to a covered health care non-compete. For a covered practitioner, Act 74 voids any covenant longer than one year and any covenant at all where the employer did the dismissing, regardless of how reasonable the terms look [^act74-applicability][^act74-exception].
+
+## Are business-to-business no-hire clauses enforceable in Pennsylvania? {#b2b-no-hire}
+
+**Short answer.** Generally no. In *Pittsburgh Logistics Systems, Inc. v. Beemac Trucking, LLC*, the Pennsylvania Supreme Court held that a no-hire clause between two businesses was unreasonably in restraint of trade and unenforceable [^beemac-unenforceable].
+
+The clause in *Beemac* barred one company from hiring the other's employees during their contract and for two years after. Balancing the company's interest against the clause's overbreadth and the likelihood of harm to the public, the court found it an unreasonable restraint of trade [^beemac-unenforceable]. The court emphasized that such a clause is broader than needed to protect the company's interest and creates a probability of harm to the public, in part because it restricts employees who are not parties to the contract and received no consideration [^beemac-overbroad].
+
+"Balancing PLS’s interest against the overbreadth of the no-hire provision and the likelihood of harm to the public, we conclude that the no-hire provision is unreasonably in restraint of trade and therefore unenforceable."[^beemac-unenforceable]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not rely on a no-hire or no-poach clause buried in a Pennsylvania commercial services contract. After *Beemac*, such clauses are vulnerable as unreasonable restraints of trade, so protect legitimate interests through narrowly drawn confidentiality and direct restrictive covenants supported by consideration instead [^beemac-overbroad].
+
+## Can a buyer enforce a non-compete assigned in an asset sale? {#assignment}
+
+**Short answer.** Not automatically. A Pennsylvania restrictive covenant is personal to the original employer and is not assignable to a buyer in an asset sale unless the employment agreement contains a specific assignability provision [^hess-not-assignable].
+
+In *Hess v. Gebhard & Co.*, the Pennsylvania Supreme Court held that a non-compete in an employment agreement is not assignable to the purchasing entity in a sale of assets absent a specific assignability provision [^hess-not-assignable]. The covenant is tied to the employer with whom the employee made the agreement, reflecting its personal nature [^hess-personal].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not assume a Pennsylvania non-compete travels with the business in an asset sale. If a buyer needs to enforce existing covenants, confirm each agreement contains an express assignability provision, because *Hess* bars automatic assignment without one [^hess-not-assignable].
+
+## What Pennsylvania non-compete reform efforts should employers watch? {#pending-reform}
+
+**Short answer.** No general statewide ban is law in Pennsylvania. The only enacted statutory restriction is Act 74's health care carve-out; broader change exists only as pending bills that have not become law [^q12-act74-applicability].
+
+As of this review, Pennsylvania has not enacted a general non-compete ban. Two narrower bills in the 2025-2026 session are worth tracking: Senate Bill 142, which would prohibit enforcement of non-compete covenants in broadcast employment agreements and which the Senate Labor and Industry Committee reported out to first consideration on June 2, 2026, and Senate Bill 680, which would extend Act 74's health care protections to therapists and remains in the Senate Health and Human Services Committee. Neither has passed either chamber or been enacted.
+
+Because the enacted baseline remains common-law reasonableness plus the Act 74 health care carve-out, these bills matter as a signal of direction, not as current law.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Treat Senate Bill 142 and Senate Bill 680 as monitoring items, not present Pennsylvania law, and do not assume any general statewide non-compete ban has passed. Recheck the General Assembly's bill status before changing forms, because only Act 74's health care restriction is currently enacted [^q12-act74-applicability].
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-03. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not Pennsylvania. This article synthesizes Pennsylvania primary law and is not legal advice from a Pennsylvania-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^socko-four-part-test]: **Socko v. Mid-Atlantic Systems of CPA, Inc.** — "Consistent with this legal background, currently in Pennsylvania, restrictive covenants are enforceable only if they are: (1) ancillary to an employment relationship between an employee and an employer; (2) supported by adequate consideration; (3) the restrictions are reasonably limited in duration and geographic extent; and (4) the restrictions are designed to protect the legitimate interests of the employer." *Socko v. Mid-Atlantic Systems of CPA, Inc., 126 A.3d 1266 (Pa. 2015).* <https://www.courtlistener.com/opinion/3155889/socko-d-v-mid-atantic-systems-of-cpa-inc-aplt/#:~:text=Consistent%20with%20this%20legal%20background%2C,legitimate%20interests%20of%20the%20employer.>
+
+[^morgans-prima-facie]: **Morgan's Home Equipment Corp. v. Martucci** — "We have held that employment contracts containing general covenants by an employe not to compete after the termination of his employment are prima facie enforcible if they are reasonably limited as to duration of time and geographical extent." *Morgan's Home Equipment Corp. v. Martucci, 136 A.2d 838 (Pa. 1957).* <https://www.courtlistener.com/opinion/2330966/morgans-home-equipment-corp-v-martucci/#:~:text=We%20have%20held%20that%20employment,of%20time%20and%20geographical%20extent.>
+
+[^socko-mid-employment]: **Socko v. Mid-Atlantic Systems of CPA, Inc.** — "In the context of requiring an employee to agree to a restrictive covenant mid-employment, however, such a restraint on trade will be enforceable only if new and valuable consideration, beyond mere continued employment, is provided and is sufficient to support the restrictive clause." *Socko v. Mid-Atlantic Systems of CPA, Inc., 126 A.3d 1266 (Pa. 2015).* <https://www.courtlistener.com/opinion/3155889/socko-d-v-mid-atantic-systems-of-cpa-inc-aplt/#:~:text=In%20the%20context%20of%20requiring,to%20support%20the%20restrictive%20clause.>
+
+[^maintenance-continued-employment]: **Maintenance Specialties, Inc. v. Gottus** — "An employee's continued employment is not sufficient consideration for a covenant not to compete which the employee signed after the inception of his employment, where the employer makes no promise of continued employment for a definite term." *Maintenance Specialties, Inc. v. Gottus, 314 A.2d 279 (Pa. 1974).* <https://www.courtlistener.com/opinion/1925441/maintenance-specialties-inc-v-gottus/#:~:text=An%20employee's%20continued%20employment%20is,employment%20for%20a%20definite%20term.>
+
+[^socko-uwoa]: **Socko v. Mid-Atlantic Systems of CPA, Inc.** — "we conclude that a construction of the UWOA which would vitiate the need for new and valuable consideration when entering into an agreement containing a restrictive covenant after the initiation of employment would be unreasonable." *Socko v. Mid-Atlantic Systems of CPA, Inc., 126 A.3d 1266 (Pa. 2015).* <https://www.courtlistener.com/opinion/3155889/socko-d-v-mid-atantic-systems-of-cpa-inc-aplt/#:~:text=we%20conclude%20that%20a%20construction,of%20employment%20would%20be%20unreasonable.>
+
+[^rullex-essential-provisions]: **Rullex Co. v. Tel-Stream, Inc.** — "From the foregoing it should be evident that, for a restrictive covenant executed after the first day of employment to be enforceable absent new consideration, the parties must have agreed to its essential provisions as of the beginning of the employment relationship." *Rullex Co. v. Tel-Stream, Inc., 232 A.3d 620 (Pa. 2020).* <https://www.courtlistener.com/opinion/4761300/rullex-co-llc-aplt-v-tel-stream-inc/#:~:text=From%20the%20foregoing%20it%20should,beginning%20of%20the%20employment%20relationship.>
+
+[^kistler-new-consideration]: **George W. Kistler, Inc. v. O'Brien** — "While a restrictive covenant, in order to be valid need not appear in the initial contract, if it is agreed upon at some later time it must be supported by new consideration." *George W. Kistler, Inc. v. O'Brien, 347 A.2d 311 (Pa. 1975).* <https://www.courtlistener.com/opinion/1482686/george-w-kistler-inc-v-obrien/#:~:text=While%20a%20restrictive%20covenant%2C%20in,be%20supported%20by%20new%20consideration.>
+
+[^morgans-specialized-training]: **Morgan's Home Equipment Corp. v. Martucci** — "An employe may receive specialized training and skills, and learn the carefully guarded methods of doing business which are the trade secrets of a particular enterprise." *Morgan's Home Equipment Corp. v. Martucci, 136 A.2d 838 (Pa. 1957).* <https://www.courtlistener.com/opinion/2330966/morgans-home-equipment-corp-v-martucci/#:~:text=An%20employe%20may%20receive%20specialized,secrets%20of%20a%20particular%20enterprise.>
+
+[^q3-morgans-reasonably-necessary]: **Morgan's Home Equipment Corp. v. Martucci** — "They are enforced by the courts as reasonably necessary for the protection of the employer." *Morgan's Home Equipment Corp. v. Martucci, 136 A.2d 838 (Pa. 1957).* <https://www.courtlistener.com/opinion/2330966/morgans-home-equipment-corp-v-martucci/#:~:text=They%20are%20enforced%20by%20the,the%20protection%20of%20the%20employer.>
+
+[^sidco-general-rule]: **Sidco Paper Co. v. Aaron** — "Our courts will permit the equitable enforcement of post-employment restraints only where they are incident to an employment relation between the parties to the covenant, the restrictions are reasonably necessary for the protection of the employer, and the restrictions are reasonably limited in duration and geographic extent." *Sidco Paper Co. v. Aaron, 351 A.2d 250 (Pa. 1976).* <https://www.courtlistener.com/opinion/1437137/sidco-paper-company-v-aaron/#:~:text=Our%20courts%20will%20permit%20the,in%20duration%20and%20geographic%20extent.>
+
+[^beemac-geo-duration]: **Pittsburgh Logistics Systems, Inc. v. Beemac Trucking, LLC** — "As part of this balancing test, courts also consider the reasonableness of the restraint’s geographical scope as well as its duration of time." *Pittsburgh Logistics Systems, Inc. v. Beemac Trucking, LLC, 249 A.3d 918 (Pa. 2021).* <https://www.courtlistener.com/opinion/4878381/pgh-logistics-aplt-v-beemac-trucking/#:~:text=As%20part%20of%20this%20balancing,as%20its%20duration%20of%20time.>
+
+[^sidco-partial-enforcement]: **Sidco Paper Co. v. Aaron** — "However, where the covenant imposes restrictions broader than necessary to protect the employer, we have repeatedly held that a court of equity may grant enforcement limited to those portions of the restrictions which are reasonably necessary for the protection of the employer." *Sidco Paper Co. v. Aaron, 351 A.2d 250 (Pa. 1976).* <https://www.courtlistener.com/opinion/1437137/sidco-paper-company-v-aaron/#:~:text=However%2C%20where%20the%20covenant%20imposes,the%20protection%20of%20the%20employer.>
+
+[^reading-aviation-overreach]: **Reading Aviation Service, Inc. v. Bertolet** — "The objection to such a practice is that it tends to encourage employers and purchasers possessing superior bargaining power over that of their employees and vendors to insist upon unreasonable and excessive restrictions, secure in the knowledge that the promise may be upheld in part, if not in full." *Reading Aviation Service, Inc. v. Bertolet, 311 A.2d 628 (Pa. 1973).* <https://www.courtlistener.com/opinion/6390927/reading-aviation-service-inc-v-bertolet/#:~:text=The%20objection%20to%20such%20a,part%2C%20if%20not%20in%20full.>
+
+[^reading-aviation-close-scrutiny]: **Reading Aviation Service, Inc. v. Bertolet** — "Because of the inherently unequal bargaining positions of the parties, we have consistently subjected covenants of non-competition between employees and their employers to close scrutiny." *Reading Aviation Service, Inc. v. Bertolet, 311 A.2d 628 (Pa. 1973).* <https://www.courtlistener.com/opinion/6390927/reading-aviation-service-inc-v-bertolet/#:~:text=Because%20of%20the%20inherently%20unequal,their%20employers%20to%20close%20scrutiny.>
+
+[^brobston-distinction]: **Insulation Corp. of America v. Brobston** — "It bears noting that there is a significant factual distinction between the hardship imposed by the enforcement of a restrictive covenant on an employee who voluntarily leaves his employer and that imposed upon an employee who is terminated for failing to do his job." *Insulation Corp. of America v. Brobston, 667 A.2d 729 (Pa. Super. 1995).* <https://www.courtlistener.com/opinion/2383660/insulation-corp-of-america-v-brobston/#:~:text=It%20bears%20noting%20that%20there,failing%20to%20do%20his%20job.>
+
+[^brobston-fired]: **Insulation Corp. of America v. Brobston** — "Where an employee is terminated by his employer on the grounds that he has failed to promote the employer's legitimate business interests, it clearly suggests an implicit decision on the part of the employer that its business interests are best promoted without the employee in its service." *Insulation Corp. of America v. Brobston, 667 A.2d 729 (Pa. Super. 1995).* <https://www.courtlistener.com/opinion/2383660/insulation-corp-of-america-v-brobston/#:~:text=Where%20an%20employee%20is%20terminated,the%20employee%20in%20its%20service.>
+
+[^english-affirmative-act]: **First National Trust Co. v. English** — "Significantly, the terms ‘solicit’, ‘divert,’ and ‘entice’ are verbs, with each requiring an affirmative act." *First National Trust Co. v. English, No. 1109 WDA 2025 (Pa. Super. Feb. 18, 2026) (non-precedential).* <https://www.pacourts.us/assets/opinions/Superior/out/J-A02018-26m%20-%20106684106347494370.pdf>
+
+[^english-no-geo]: **First National Trust Co. v. English** — "Thus, the non-solicitation clause is unenforceable as written." *First National Trust Co. v. English, No. 1109 WDA 2025 (Pa. Super. Feb. 18, 2026) (non-precedential).* <https://www.pacourts.us/assets/opinions/Superior/out/J-A02018-26m%20-%20106684106347494370.pdf>
+
+[^english-predated-customers]: **First National Trust Co. v. English** — "Keeping in mind that Pennsylvania law disfavors restrictive covenants, see Socko, we conclude that it would be unreasonable to include the customers of Advisors, whose relationships predated each advisor’s employment with Appellant." *First National Trust Co. v. English, No. 1109 WDA 2025 (Pa. Super. Feb. 18, 2026) (non-precedential).* <https://www.pacourts.us/assets/opinions/Superior/out/J-A02018-26m%20-%20106684106347494370.pdf>
+
+[^q8-sidco-reasonably-necessary]: **Sidco Paper Co. v. Aaron** — "Our courts will permit the equitable enforcement of post-employment restraints only where they are incident to an employment relation between the parties to the covenant, the restrictions are reasonably necessary for the protection of the employer, and the restrictions are reasonably limited in duration and geographic extent." *Sidco Paper Co. v. Aaron, 351 A.2d 250 (Pa. 1976).* <https://www.courtlistener.com/opinion/1437137/sidco-paper-company-v-aaron/#:~:text=Our%20courts%20will%20permit%20the,in%20duration%20and%20geographic%20extent.>
+
+[^q8-morgans-prima-facie]: **Morgan's Home Equipment Corp. v. Martucci** — "We have held that employment contracts containing general covenants by an employe not to compete after the termination of his employment are prima facie enforcible if they are reasonably limited as to duration of time and geographical extent." *Morgan's Home Equipment Corp. v. Martucci, 136 A.2d 838 (Pa. 1957).* <https://www.courtlistener.com/opinion/2330966/morgans-home-equipment-corp-v-martucci/#:~:text=We%20have%20held%20that%20employment,of%20time%20and%20geographical%20extent.>
+
+[^act74-applicability]: **Fair Contracting for Health Care Practitioners Act § 4(a)** — "(a) Applicability.--Except as provided under subsection (b), a noncompete covenant entered into after the effective date of this subsection is deemed contrary to the public policy and is void and unenforceable by an employer." *Fair Contracting for Health Care Practitioners Act, Act of July 17, 2024, P.L. 846, No. 74, § 4(a) (Pa.).* <https://www.legis.state.pa.us/WU01/LI/LI/US/HTM/2024/0/0074..HTM>
+
+[^act74-exception]: **Fair Contracting for Health Care Practitioners Act § 4(b)** — "(b) Exception.--An employer may enforce a noncompete covenant if the length of the noncompete covenant is no more than one year, provided that the health care practitioner was not dismissed by the employer." *Fair Contracting for Health Care Practitioners Act, Act of July 17, 2024, P.L. 846, No. 74, § 4(b) (Pa.).* <https://www.legis.state.pa.us/WU01/LI/LI/US/HTM/2024/0/0074..HTM>
+
+[^act74-practitioner]: **Fair Contracting for Health Care Practitioners Act § 3** — "‘Health care practitioner.’ The following: (1) A medical doctor as defined in section 2 of the act of December 20, 1985 (P.L.457, No.112), known as the Medical Practice Act of 1985. (2) A doctor of osteopathy under the act of October 5, 1978 (P.L.1109, No.261), known as the Osteopathic Medical Practice Act. (3) A certified registered nurse anesthetist as defined in section 2(16) of the act of May 22, 1951 (P.L.317, No.69), known as The Professional Nursing Law. (4) A certified registered nurse practitioner as defined in section 2(12) of The Professional Nursing Law. (5) A physician assistant as defined in section 2 of the Osteopathic Medical Practice Act or section 2 of the Medical Practice Act of 1985." *Fair Contracting for Health Care Practitioners Act, Act of July 17, 2024, P.L. 846, No. 74, § 3 (Pa.).* <https://www.legis.state.pa.us/WU01/LI/LI/US/HTM/2024/0/0074..HTM>
+
+[^act74-notice]: **Fair Contracting for Health Care Practitioners Act § 5(b)** — "(b) Time period.--The employer shall provide the notice within 90 days of the health care practitioner's departure." *Fair Contracting for Health Care Practitioners Act, Act of July 17, 2024, P.L. 846, No. 74, § 5(b) (Pa.).* <https://www.legis.state.pa.us/WU01/LI/LI/US/HTM/2024/0/0074..HTM>
+
+[^beemac-unenforceable]: **Pittsburgh Logistics Systems, Inc. v. Beemac Trucking, LLC** — "Balancing PLS’s interest against the overbreadth of the no-hire provision and the likelihood of harm to the public, we conclude that the no-hire provision is unreasonably in restraint of trade and therefore unenforceable." *Pittsburgh Logistics Systems, Inc. v. Beemac Trucking, LLC, 249 A.3d 918 (Pa. 2021).* <https://www.courtlistener.com/opinion/4878381/pgh-logistics-aplt-v-beemac-trucking/#:~:text=Balancing%20PLS%E2%80%99s%20interest%20against%20the,of%20trade%20and%20therefore%20unenforceable.>
+
+[^beemac-overbroad]: **Pittsburgh Logistics Systems, Inc. v. Beemac Trucking, LLC** — "However, the no-hire provision is both greater than needed to protect PLS’s interest and creates a probability of harm to the public." *Pittsburgh Logistics Systems, Inc. v. Beemac Trucking, LLC, 249 A.3d 918 (Pa. 2021).* <https://www.courtlistener.com/opinion/4878381/pgh-logistics-aplt-v-beemac-trucking/#:~:text=However%2C%20the%20no%2Dhire%20provision%20is,of%20harm%20to%20the%20public.>
+
+[^hess-not-assignable]: **Hess v. Gebhard & Co.** — "Therefore, we hold that a restrictive covenant not to compete, contained in an employment agreement, is not assignable to the purchasing business entity, in the absence of a specific assignability provision, where the covenant is included in a sale of assets." *Hess v. Gebhard & Co. Inc., 808 A.2d 912 (Pa. 2002).* <https://www.courtlistener.com/opinion/1931597/hess-v-gebhard-co-inc/#:~:text=Therefore%2C%20we%20hold%20that%20a,in%20a%20sale%20of%20assets.>
+
+[^hess-personal]: **Hess v. Gebhard & Co.** — "Like the contract for hire, upon which the covenant was given, the employee’s restrictive covenant is confined to the employer with whom the agreement was made, absent specific provisions for assignability." *Hess v. Gebhard & Co. Inc., 808 A.2d 912 (Pa. 2002).* <https://www.courtlistener.com/opinion/1931597/hess-v-gebhard-co-inc/#:~:text=Like%20the%20contract%20for%20hire%2C,absent%20specific%20provisions%20for%20assignability.>
+
+[^q12-act74-applicability]: **Fair Contracting for Health Care Practitioners Act § 4(a)** — "(a) Applicability.--Except as provided under subsection (b), a noncompete covenant entered into after the effective date of this subsection is deemed contrary to the public policy and is void and unenforceable by an employer." *Fair Contracting for Health Care Practitioners Act, Act of July 17, 2024, P.L. 846, No. 74, § 4(a) (Pa.).* <https://www.legis.state.pa.us/WU01/LI/LI/US/HTM/2024/0/0074..HTM>

--- a/skills/non-compete-contract-explainer/content/philippines.md
+++ b/skills/non-compete-contract-explainer/content/philippines.md
@@ -1,0 +1,211 @@
+---
+jurisdiction: "Philippines"
+slug: philippines
+countryCode: PH
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-03"
+canonicalUrl: https://openagreements.org/legal/non-compete/philippines
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/philippines · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in the Philippines[^about]
+
+The Philippines has no non-compete statute; a post-employment restraint is enforceable only if it is reasonable — limited as to time, trade, and place, tied to a legitimate business interest, and not contrary to public policy — and a suit to enforce one is a civil case for the regular courts, not the labor tribunals.
+
+
+## At a glance
+
+| Question | Philippines |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed if reasonable |
+| **Bottom line** | The Philippines has no non-compete statute. A post-employment restraint is enforceable only if it is reasonable — limited as to time, trade, and place, tied to a legitimate business interest, and not contrary to public policy — and suing on one is a civil case for the regular courts, not the labor tribunals. |
+| **Main law or case** | Rivera v. Solidbank Corp., G.R. No. 163269 (2006); Tiu v. Platinum Plans Phil., Inc., G.R. No. 163512 (2007) |
+| **Main exceptions** | No statutory industry carve-outs. Independent-contractor restraints are treated as ordinary civil/commercial contracts rather than labor matters (Consulta v. CA, G.R. No. 145443). A forfeiture clause can bite for competition during employment (Century Properties v. Babiano, G.R. No. 220978). |
+| **Can a court narrow it?** | Unsettled |
+| **Applies to contractors?** | Yes |
+| **Restriction extended during a breach?** | Not addressed |
+| **Maximum length set by law** | No statutory limit; one- and two-year restraints have been upheld when otherwise reasonable |
+
+## Are non-competes enforceable in the Philippines? {#employee-noncompetes}
+
+**Short answer.** Yes, if they are reasonable. The Philippines has no statute that governs non-competes, and it is not a per se ban jurisdiction. A post-employment non-compete or *non-involvement* clause is enforced under the Civil Code's freedom-to-contract principle — provided the stipulation is not contrary to law, morals, good customs, public order, or public policy [^civilcode-1306]. Within that limit a restraint is valid as long as it carries reasonable limitations as to time, trade, and place [^tiu-time-trade-place].
+
+This puts the Philippines in the middle of the global map. It is not California or North Dakota, where an employee non-compete is void no matter how narrowly drawn, and it is not India, where post-employment restraints are categorically unenforceable. It is a reasonableness jurisdiction whose rules are largely judge-made, built on top of the Civil Code's presumption that a freely negotiated contract has the force of law between the parties.
+
+"Not being contrary to public policy, the non-involvement clause, which petitioner and respondent freely agreed upon, has the force of law between them, and thus, should be complied with in good faith."[^tiu-force-of-law]
+
+The Supreme Court's 2007 decision in *Tiu v. Platinum Plans Phil., Inc.* is the leading modern authority. It confirms that a non-involvement clause is not automatically void as a restraint of trade, and that once a reasonable clause survives scrutiny the courts will enforce it according to its terms.
+
+## What makes a non-compete reasonable in the Philippines? {#reasonableness-test}
+
+**Short answer.** Reasonableness is decided clause by clause against a five-factor test. In *Rivera v. Solidbank Corp.*, the Supreme Court directed trial courts to weigh whether the covenant protects a legitimate business interest, whether it unduly burdens the employee, whether it harms the public welfare, whether its time and territorial limits are reasonable, and whether it is reasonable as a matter of public policy [^rivera-five-factors]. A restraint that flunks any of these — most classically one that is *not limited as to trade* — is void as against public policy [^ferrazzini-not-trade].
+
+The five factors are not a checklist with numeric thresholds; they are a structured way of asking the older question the Court has posed since 1916 — whether the restraint goes further than the employer's legitimate interest requires. The foundational case, *Ferrazzini v. Gsell*, struck down a clause barring a discharged foreman from *any* employment anywhere in the Philippine Islands for five years, holding it an unreasonable restraint precisely because it was bounded in time and space but left the employee no trade to practise.
+
+"The contract under consideration, tested by the law, rules and principles above set forth, is clearly one in undue or unreasonable restraint of trade and therefore against public policy. It is limited as to time and space but not as to trade."[^ferrazzini-not-trade]
+
+Because reasonableness turns on the facts, it is generally not a question a court can resolve on the pleadings. In *Rivera* itself the Supreme Court set aside a summary judgment, holding that the trial court had foreclosed the evidence needed to decide whether the covenant was reasonable [^rivera-summary-judgment].
+
+## How long and how wide can a Philippine non-compete be? {#duration-geography}
+
+**Short answer.** There is no statutory limit, but the durations the Supreme Court has actually upheld are short. In *Tiu*, a two-year non-involvement clause confined to the employer's pre-need industry was held reasonable [^tiu-two-year]. Geography matters too: the Court has said a territorial limitation is necessary so the employee knows what counts as a violation and so the restraint tracks where the employer actually does business [^rivera-territorial].
+
+A covenant does not need to limit *both* time and place to survive; a reasonable limitation on either dimension can be enough, as the Court held in 1924 in *Del Castillo v. Richmond* when it upheld a restriction on a pharmacist opening a competing drugstore in the same locality [^delcastillo-time-or-place]. But the absence of any geographic boundary is a serious weakness. In *Rivera*, a one-year ban on joining any competitor bank — with no territorial limit at all — was treated as suspect on its face and could not be enforced without evidence justifying so broad a sweep.
+
+"A provision on territorial limitation is necessary to guide an employee of what constitutes as violation of a restrictive covenant and whether the geographic scope is co-extensive with that in which the employer is doing business."[^rivera-territorial]
+
+The practical takeaway is that a defensible Philippine covenant looks narrow: a year or two, confined to the employer's actual line of business, and tied to a market where the employer competes — not an open-ended bar on working anywhere for anyone.
+
+## What interest must a Philippine non-compete protect? {#legitimate-interest}
+
+**Short answer.** A legitimate business interest — typically confidential strategies, trade secrets, or goodwill the employee was trusted with. The first *Rivera* factor asks exactly that: whether the covenant protects a legitimate business interest of the employer [^q4-rivera-interest]. *Tiu* shows what qualifies: the clause there was upheld because the employee was a senior executive who would otherwise carry the employer's sensitive, industry-specific knowledge straight to a direct competitor [^q4-tiu-trade].
+
+The line the courts police is between protecting an asset and merely suppressing a competitor. A restraint built around genuinely confidential information, key client relationships, or specialised training the employer paid for stands on firm ground. A bare desire to keep a former employee out of the market does not. That is also why a confidentiality or non-disclosure obligation — which restricts only the misuse of information, not the right to work — is the most durable protection an employer has, while a blanket bar on competing is the most exposed.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Anchor the covenant to a specific protectable interest — the confidential strategy, trade secret, or client goodwill the employee actually handled — rather than barring competition in the abstract. A clause framed around a real interest and confined to the employer's line of business is what carried the day in *Tiu*; an untethered ban on working for a competitor is the weakest position [^q4-tiu-trade].
+
+## Can a Philippine court narrow an overbroad non-compete? {#court-narrowing}
+
+**Short answer.** There is no established practice of doing so. When the Supreme Court has found a restraint unreasonable, it has treated the covenant as void against public policy — as it did with the five-year, all-trades ban in *Ferrazzini* [^q5-ferrazzini-void] — rather than rewriting it to a reasonable scope. No decision squarely holds whether a Philippine court may instead narrow an overbroad covenant, and the courts have not adopted the judicial-reformation or read-down approach used in some United States states. The safe assumption is therefore that an overbroad clause fails entirely rather than being trimmed.
+
+The drafting consequence is the same one that follows from the reasonableness test: each restriction has to be defensible on its own terms, because there is no settled doctrine for a court to salvage an aggressive clause by narrowing it. What a court *can* adjust is the money side. Under the Civil Code a court may equitably reduce a stipulated penalty when it is iniquitous or unconscionable, but in *Tiu* the Court refused to reduce the agreed liquidated damages because the employee had shown no good-faith intention to comply [^q5-tiu-goodfaith].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not draft a deliberately broad non-compete in the hope a court will pare it back. A restraint the Supreme Court has found unreasonable was struck down as contrary to public policy, and no decision establishes that a court will instead narrow an overbroad covenant [^q5-ferrazzini-void], so calibrate the time, trade, and territory to what you can defend as reasonable from the outset.
+
+## Which court hears a Philippine non-compete dispute? {#which-court}
+
+**Short answer.** The regular civil courts, not the labor tribunals — when the breach is post-employment. A suit to recover damages for breaching a post-employment non-compete is a civil-law action over which the regular courts, not the Labor Arbiter or the NLRC, have jurisdiction [^daichi-civil]. The Supreme Court has reaffirmed this repeatedly: the covenant takes effect only after the employment relationship ends, so the claim sounds in contract, not labor law [^portillo-civil].
+
+This is a recurring trap for employers who assume that anything in an employment contract belongs before the NLRC. It does not. In *Dai-Chi Electronics v. Villarama* and again in *Yusen Air and Sea Service v. Villamor*, the Court routed post-employment non-compete damage claims to the regular courts because they concern the parties' post-employment relations [^yusen-civil].
+
+A related consequence is that the employer cannot help itself to the employee's pay. In *Portillo v. Rudolf Lietz, Inc.*, the Court held there was no causal connection between an employee's claim for unpaid wages and the employer's claim for liquidated damages under a goodwill clause, so the two could not be set off against each other [^portillo-no-setoff]. The employer must release the final pay and pursue the non-compete claim as a separate civil action.
+
+"Such cause of action is within the realm of Civil Law, and jurisdiction over the controversy belongs to the regular courts. More so when we consider that the stipulation refers to the post-employment relations of the parties."[^daichi-civil]
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not withhold a departing employee's final pay to offset a suspected non-compete breach. Unpaid wages and a liquidated-damages claim arise in different fora with no causal connection between them, so they cannot be set off [^portillo-no-setoff]; release the pay and file the non-compete claim separately in the regular courts.
+
+## What if the employee competed while still employed? {#during-employment}
+
+**Short answer.** That changes the analysis. A restraint that operates *during* employment is backed by the employee's duty of loyalty, and the labor tribunals can enforce it as part of a compensation dispute. In *Century Properties v. Babiano*, the Supreme Court upheld the forfeiture of a sales executive's unpaid commissions because he accepted a position with a direct competitor while still employed — a breach of the contract's confidentiality and non-compete clause [^century-violation].
+
+The distinction is timing, not labels. *Portillo* keeps post-employment non-compete claims in the regular courts; *Century Properties* shows that when the disloyal competition happens before the employee resigns, an express forfeiture clause can be applied against the unpaid commissions and incentives it covers, within the labor proceeding itself. The clause there spelled out the consequence in plain terms [^century-forfeiture].
+
+"Irrefragably, this is a glaring violation of the ‘Confidentiality of Documents and Non-Compete Clause’ in his employment contract with CPI, thus, justifying the forfeiture of his unpaid commissions."[^century-violation]
+
+## Do non-competes apply to independent contractors in the Philippines? {#contractors}
+
+**Short answer.** Yes. When the restrained party is an independent contractor rather than an employee, the dispute is handled as an ordinary civil action under the freedom-to-contract principle rather than as a labor case. In *Consulta v. Court of Appeals*, once the Supreme Court found that the managing associate was an independent agent and not an employee, it upheld her one-year exclusivity restriction as a reasonable restriction designed to protect the company's business interest [^consulta-reasonable].
+
+The threshold question is status. In *Consulta* the Court held that the managing associate was an independent agent, not an employee [^consulta-status], so the dispute fell to the regular courts as an ordinary civil matter rather than to the labor tribunals. The restriction was also narrow — it barred only competing activity, leaving the associate free to take on non-competing business — and that tailoring is what made it reasonable. *Consulta* is best read for that status point rather than as announcing a separate, more lenient standard for contractor covenants: the later *Tiu* decision cites it under the same time-trade-place reasonableness test applied to employees.
+
+## How is a Philippine non-compete enforced? {#remedies}
+
+**Short answer.** By injunction and by damages, including liquidated damages. A continuing breach of a valid negative covenant can be restrained by injunction, because the ongoing harm cannot be adequately repaired through an ordinary damages suit [^ollendorff-injunction]. To avoid having to prove actual loss, employers typically attach a penal clause; under the Civil Code such a penalty substitutes for damages on breach [^civilcode-1226].
+
+Injunctive relief has a built-in expiry, though. Once the restraint period itself lapses, a suit for an injunction becomes moot — although a claim for damages already incurred survives [^yusen-moot]. That is one reason liquidated-damages clauses are common: they remain enforceable after the covenant period ends and spare the employer the difficult task of quantifying lost business. As covered above, the courts will enforce a reasonable stipulated penalty, equitably reducing it only in the limited cases the Civil Code allows.
+
+"With respect to the contention that an injunction may only be granted to prevent irreparable injury, the answer is that any continuing breach of a valid negative covenant is irreparable by the ordinary process of courts of law."[^ollendorff-injunction]
+
+## Is garden leave allowed in the Philippines? {#garden-leave}
+
+**Short answer.** Yes. The Supreme Court has said there is no prohibition under Philippine labor law against a garden-leave clause in an employment contract [^mejila-garden-leave]. Because garden leave keeps the employee on the payroll and bound by the duty of loyalty during the notice period, it is a useful — and lower-risk — alternative to a post-employment restraint, which must instead run the full reasonableness gauntlet.
+
+Garden leave operates while the employment relationship still exists, so it does not depend on the restraint-of-trade analysis that governs post-termination covenants. For an employer worried about a departing employee's access to live information, paying the employee through a notice period can protect the business without the enforceability risk that attaches to a non-compete that bites after the job ends.
+
+"There is no prohibition under our labor laws against a garden leave clause in an employment contract."[^mejila-garden-leave]
+
+## Does a Philippine non-compete pause or extend if the employee breaches? {#tolling}
+
+**Short answer.** The Supreme Court has not addressed it. No Philippine decision holds that the restraint period tolls — pauses and then resumes — while a former employee is in breach or while litigation runs, so a clause that purports to extend the covenant by the length of any breach is untested. An employer should treat the stated period as the maximum and not assume the clock stops while the employee competes.
+
+This open question sits in tension with a principle the Court *has* stated. *Rivera* requires a covenant to be drawn so the employee can tell with certainty what counts as a violation and how far the restraint reaches [^q11-rivera-certainty]. An automatic extension-on-breach provision cuts the other way: it leaves the end date contingent on contested conduct, which is exactly the kind of uncertainty the Court has warned against. Until there is direct authority, the safer course is a fixed, defensible period rather than a self-extending one.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not rely on a clause that extends the non-compete by the length of any breach. No Philippine authority validates tolling of the restraint period, and an open-ended end date is in tension with the requirement that the employee be able to tell with certainty what the covenant forbids [^q11-rivera-certainty]. Treat the stated duration as the ceiling.
+
+## Is a non-compete statute coming in the Philippines? {#statutory-outlook}
+
+**Short answer.** Not as of June 2026. There is no Philippine statute that bans or specifically regulates employee non-competes; enforceability still turns entirely on the Civil Code and the Supreme Court's reasonableness jurisprudence. The constitutional backdrop reinforces that scrutiny — the 1987 Constitution declares that no combinations in restraint of trade or unfair competition shall be allowed [^consti-art12] — but it is applied as a public-policy lens on contracts, not as a self-executing ban on covenants.
+
+Reform of employee non-competes has been a topic of legislative and practitioner discussion, mirroring debates abroad, but no bill specifically regulating them has been enacted or has materially advanced as of June 2026. Until that changes, the framework set out in this note governs, and the Constitution's anti-restraint-of-trade policy functions mainly to sharpen the courts' review of overbroad covenants rather than to supply a fixed rule.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not draft to an anticipated Philippine non-compete statute. None is in force as of June 2026, so enforceability still rests entirely on the Civil Code and the courts' reasonableness test, read against the Constitution's policy that no combinations in restraint of trade shall be allowed [^consti-art12].
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-03. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not Philippines. This article synthesizes Philippines primary law and is not legal advice from a Philippines-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^civilcode-1306]: **Civil Code of the Philippines (RA 386), Art. 1306** — "Article 1306. The contracting parties may establish such stipulations, clauses, terms and conditions as they may deem convenient, provided they are not contrary to law, morals, good customs, public order, or public policy." *Civil Code of the Philippines, Republic Act No. 386, Art. 1306.* <https://lawphil.net/statutes/repacts/ra1949/ra_386_1949.html>
+
+[^tiu-time-trade-place]: **Tiu v. Platinum Plans Phil., Inc.** — "Conformably then with the aforementioned pronouncements, a non-involvement clause is not necessarily void for being in restraint of trade as long as there are reasonable limitations as to time, trade, and place." *Tiu v. Platinum Plans Phil., Inc., G.R. No. 163512, Feb. 28, 2007.* <https://lawphil.net/judjuris/juri2007/feb2007/gr_163512_2007.html>
+
+[^tiu-force-of-law]: **Tiu v. Platinum Plans Phil., Inc.** — "Not being contrary to public policy, the non-involvement clause, which petitioner and respondent freely agreed upon, has the force of law between them, and thus, should be complied with in good faith." *Tiu v. Platinum Plans Phil., Inc., G.R. No. 163512, Feb. 28, 2007.* <https://lawphil.net/judjuris/juri2007/feb2007/gr_163512_2007.html>
+
+[^rivera-five-factors]: **Rivera v. Solidbank Corp.** — "Thus, in determining whether the contract is reasonable or not, the trial court should consider the following factors: (a) whether the covenant protects a legitimate business interest of the employer; (b) whether the covenant creates an undue burden on the employee; (c) whether the covenant is injurious to the public welfare; (d) whether the time and territorial limitations contained in the covenant are reasonable; and (e) whether the restraint is reasonable from the standpoint of public policy." *Rivera v. Solidbank Corp., G.R. No. 163269, Apr. 19, 2006.* <https://lawphil.net/judjuris/juri2006/apr2006/gr_163269_2006.html>
+
+[^ferrazzini-not-trade]: **Ferrazzini v. Gsell** — "The contract under consideration, tested by the law, rules and principles above set forth, is clearly one in undue or unreasonable restraint of trade and therefore against public policy. It is limited as to time and space but not as to trade." *Ferrazzini v. Gsell, G.R. No. L-10712, Aug. 10, 1916.* <https://lawphil.net/judjuris/juri1916/aug1916/gr_l-10712_1916.html>
+
+[^rivera-summary-judgment]: **Rivera v. Solidbank Corp.** — "There is no factual basis for the trial court's ruling, for the simple reason that it rendered summary judgment and thereby foreclosed the presentation of evidence by the parties to prove whether the restrictive covenant is reasonable or not." *Rivera v. Solidbank Corp., G.R. No. 163269, Apr. 19, 2006.* <https://lawphil.net/judjuris/juri2006/apr2006/gr_163269_2006.html>
+
+[^tiu-two-year]: **Tiu v. Platinum Plans Phil., Inc.** — "In this case, the non-involvement clause has a time limit: two years from the time petitioner's employment with respondent ends." *Tiu v. Platinum Plans Phil., Inc., G.R. No. 163512, Feb. 28, 2007.* <https://lawphil.net/judjuris/juri2007/feb2007/gr_163512_2007.html>
+
+[^rivera-territorial]: **Rivera v. Solidbank Corp.** — "A provision on territorial limitation is necessary to guide an employee of what constitutes as violation of a restrictive covenant and whether the geographic scope is co-extensive with that in which the employer is doing business." *Rivera v. Solidbank Corp., G.R. No. 163269, Apr. 19, 2006.* <https://lawphil.net/judjuris/juri2006/apr2006/gr_163269_2006.html>
+
+[^delcastillo-time-or-place]: **Del Castillo v. Richmond** — "Later cases, and we think the rule is now well established, have held that a contract in restraint of trade is valid providing there is a limitation upon either time or place." *Del Castillo v. Richmond, G.R. No. L-21127, Feb. 9, 1924.* <https://lawphil.net/judjuris/juri1924/feb1924/gr_21127_1924.html>
+
+[^q4-rivera-interest]: **Rivera v. Solidbank Corp.** — "Thus, in determining whether the contract is reasonable or not, the trial court should consider the following factors: (a) whether the covenant protects a legitimate business interest of the employer; (b) whether the covenant creates an undue burden on the employee; (c) whether the covenant is injurious to the public welfare; (d) whether the time and territorial limitations contained in the covenant are reasonable; and (e) whether the restraint is reasonable from the standpoint of public policy." *Rivera v. Solidbank Corp., G.R. No. 163269, Apr. 19, 2006.* <https://lawphil.net/judjuris/juri2006/apr2006/gr_163269_2006.html>
+
+[^q4-tiu-trade]: **Tiu v. Platinum Plans Phil., Inc.** — "It is also limited as to trade, since it only prohibits petitioner from engaging in any pre-need business akin to respondent's." *Tiu v. Platinum Plans Phil., Inc., G.R. No. 163512, Feb. 28, 2007.* <https://lawphil.net/judjuris/juri2007/feb2007/gr_163512_2007.html>
+
+[^q5-ferrazzini-void]: **Ferrazzini v. Gsell** — "The contract under consideration, tested by the law, rules and principles above set forth, is clearly one in undue or unreasonable restraint of trade and therefore against public policy. It is limited as to time and space but not as to trade." *Ferrazzini v. Gsell, G.R. No. L-10712, Aug. 10, 1916.* <https://lawphil.net/judjuris/juri1916/aug1916/gr_l-10712_1916.html>
+
+[^q5-tiu-goodfaith]: **Tiu v. Platinum Plans Phil., Inc.** — "Not being contrary to public policy, the non-involvement clause, which petitioner and respondent freely agreed upon, has the force of law between them, and thus, should be complied with in good faith." *Tiu v. Platinum Plans Phil., Inc., G.R. No. 163512, Feb. 28, 2007.* <https://lawphil.net/judjuris/juri2007/feb2007/gr_163512_2007.html>
+
+[^daichi-civil]: **Dai-Chi Electronics Mfg. Corp. v. Villarama** — "Such cause of action is within the realm of Civil Law, and jurisdiction over the controversy belongs to the regular courts. More so when we consider that the stipulation refers to the post-employment relations of the parties." *Dai-Chi Electronics Mfg. Corp. v. Villarama, G.R. No. 112940, Nov. 21, 1994.* <https://lawphil.net/judjuris/juri1994/nov1994/gr_112940_1994.html>
+
+[^portillo-civil]: **Portillo v. Rudolf Lietz, Inc.** — "In accordance with jurisprudence, breach of the undertaking is a civil law dispute, not a labor law case." *Portillo v. Rudolf Lietz, Inc., G.R. No. 196539, Oct. 10, 2012.* <https://lawphil.net/judjuris/juri2012/oct2012/gr_196539_2012.html>
+
+[^yusen-civil]: **Yusen Air & Sea Service Phils., Inc. v. Villamor** — "It merely seeks to recover damages based on the parties' contract of employment as redress for respondent's breach thereof. Such cause of action is within the realm of Civil Law, and jurisdiction over the controversy belongs to the regular courts." *Yusen Air & Sea Service Phils., Inc. v. Villamor, G.R. No. 154060, Aug. 16, 2005.* <https://lawphil.net/judjuris/juri2005/aug2005/gr_154060_2005.html>
+
+[^portillo-no-setoff]: **Portillo v. Rudolf Lietz, Inc.** — "There is no causal connection between the petitioner employees' claim for unpaid wages and the respondent employers' claim for damages for the alleged ‘Goodwill Clause’ violation." *Portillo v. Rudolf Lietz, Inc., G.R. No. 196539, Oct. 10, 2012.* <https://lawphil.net/judjuris/juri2012/oct2012/gr_196539_2012.html>
+
+[^century-violation]: **Century Properties, Inc. v. Babiano** — "Irrefragably, this is a glaring violation of the ‘Confidentiality of Documents and Non-Compete Clause’ in his employment contract with CPI, thus, justifying the forfeiture of his unpaid commissions." *Century Properties, Inc. v. Babiano, G.R. No. 220978, July 5, 2016.* <https://lawphil.net/judjuris/juri2016/jul2016/gr_220978_2016.html>
+
+[^century-forfeiture]: **Century Properties, Inc. v. Babiano** — "Finally, if undersigned breaches any terms of this contract, forms of compensation including commissions and incentives will be forfeited." *Century Properties, Inc. v. Babiano, G.R. No. 220978, July 5, 2016.* <https://lawphil.net/judjuris/juri2016/jul2016/gr_220978_2016.html>
+
+[^consulta-reasonable]: **Consulta v. Court of Appeals** — "The exclusivity provision was a reasonable restriction designed to prevent similar acts prejudicial to Pamana's business interest." *Consulta v. Court of Appeals, G.R. No. 145443, Mar. 18, 2005.* <https://lawphil.net/judjuris/juri2005/mar2005/gr_145443_2005.html>
+
+[^consulta-status]: **Consulta v. Court of Appeals** — "Consulta was an independent agent and not an employee of Pamana." *Consulta v. Court of Appeals, G.R. No. 145443, Mar. 18, 2005.* <https://lawphil.net/judjuris/juri2005/mar2005/gr_145443_2005.html>
+
+[^ollendorff-injunction]: **Ollendorff v. Abrahamson** — "With respect to the contention that an injunction may only be granted to prevent irreparable injury, the answer is that any continuing breach of a valid negative covenant is irreparable by the ordinary process of courts of law." *Ollendorff v. Abrahamson, G.R. No. 13228, Sept. 13, 1918.* <https://lawphil.net/judjuris/juri1918/sep1918/gr_13228_1918.html>
+
+[^civilcode-1226]: **Civil Code of the Philippines (RA 386), Art. 1226** — "Article 1226. In obligations with a penal clause, the penalty shall substitute the indemnity for damages and the payment of interests in case of noncompliance, if there is no stipulation to the contrary." *Civil Code of the Philippines, Republic Act No. 386, Art. 1226.* <https://lawphil.net/statutes/repacts/ra1949/ra_386_1949.html>
+
+[^yusen-moot]: **Yusen Air & Sea Service Phils., Inc. v. Villamor** — "Necessarily, upon the expiration of said period, a suit seeking the issuance of a writ of injunction becomes functus oficio and therefore moot." *Yusen Air & Sea Service Phils., Inc. v. Villamor, G.R. No. 154060, Aug. 16, 2005.* <https://lawphil.net/judjuris/juri2005/aug2005/gr_154060_2005.html>
+
+[^mejila-garden-leave]: **Mejila v. Wrigley Philippines, Inc.** — "There is no prohibition under our labor laws against a garden leave clause in an employment contract." *Mejila v. Wrigley Philippines, Inc., G.R. Nos. 199469 & 199505, Sept. 11, 2019.* <https://lawphil.net/judjuris/juri2019/sep2019/gr_199469_2019.html>
+
+[^q11-rivera-certainty]: **Rivera v. Solidbank Corp.** — "A provision on territorial limitation is necessary to guide an employee of what constitutes as violation of a restrictive covenant and whether the geographic scope is co-extensive with that in which the employer is doing business." *Rivera v. Solidbank Corp., G.R. No. 163269, Apr. 19, 2006.* <https://lawphil.net/judjuris/juri2006/apr2006/gr_163269_2006.html>
+
+[^consti-art12]: **1987 Constitution, Article XII, Section 19** — "No combinations in restraint of trade or unfair competition shall be allowed." *1987 Constitution, Art. XII, Sec. 19.* <https://lawphil.net/consti/cons1987.html>

--- a/skills/non-compete-contract-explainer/content/puerto-rico.md
+++ b/skills/non-compete-contract-explainer/content/puerto-rico.md
@@ -1,0 +1,163 @@
+---
+jurisdiction: "Puerto Rico"
+slug: puerto-rico
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-02"
+canonicalUrl: https://openagreements.org/legal/non-compete/puerto-rico
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/puerto-rico · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in Puerto Rico[^about]
+
+Puerto Rico has no non-compete statute; post-employment covenants are enforceable only if they satisfy the strict three-part reasonableness test of Arthur Young & Co. v. Vega III, and courts void rather than rewrite any covenant that falls short.
+
+
+## At a glance
+
+| Question | Puerto Rico |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed if reasonable |
+| **Bottom line** | Puerto Rico has no non-compete statute; a covenant is enforceable only if it satisfies the strict three-part Arthur Young reasonableness test — capped at twelve months, supported by real consideration, and in writing — and courts void rather than rewrite any covenant that falls short. |
+| **Main law or case** | Arthur Young & Co. v. Vega III, 136 D.P.R. 157 (1994) |
+| **Main exceptions** | Covenants ancillary to a sale of business / ownership exit (e.g. stock-redemption) judged more flexibly than the strict Arthur Young employer-employee test (Reyes Ramis) |
+| **Can a court narrow it?** | No |
+| **Applies to contractors?** | Unclear |
+| **Restriction extended during a breach?** | Silent — risky if it pushes enforcement past the 12-month ceiling |
+| **Maximum length set by law** | 12 months (additional time excessive and unnecessary) |
+
+## Are employee non-compete agreements enforceable in Puerto Rico? {#employee-noncompetes}
+
+**Short answer.** Sometimes. Puerto Rico has no statute that governs non-competes. As a civil-law jurisdiction, it enforces post-employment covenants only when they satisfy the strict three-part reasonableness test the Puerto Rico Supreme Court announced in *Arthur Young & Co. v. Vega III* [^ay-test].
+
+Puerto Rico is not a per se ban jurisdiction like California or North Dakota, and it is not a statutory-reasonableness jurisdiction either. Enforceability rests on freedom of contract under the Puerto Rico Civil Code, as constrained by case law. *Arthur Young* is the controlling decision, and it frames every non-compete question that follows.
+
+The threshold framing matters for in-house counsel. Because the limits are judge-made rather than statutory, a covenant that would survive in a blue-pencil state can be void here, and the analysis turns on a single line of Supreme Court and federal authority rather than on a code section.
+
+"Para ser razonable, un acuerdo de no competir debe reunir los siguientes requisitos: (1) debe ser necesario para proteger un interés legítimo del patrono, (2) no debe imponer al empleado una carga demasiado onerosa, (3) y no debe afectar demasiado al público."[^ay-test]
+
+In plain English, the covenant must protect a legitimate employer interest, must not impose too onerous a burden on the employee, and must not unduly harm the public. The sections below break those principles into the operating requirements Puerto Rico courts actually apply.
+
+## What requirements must a Puerto Rico non-compete satisfy? {#reasonableness-requirements}
+
+**Short answer.** A federal court applying Puerto Rico law restated *Arthur Young* as a five-element checklist: a legitimate employer interest, a scope that fits that interest and does not exceed twelve months, consideration beyond mere job tenure, a valid underlying contract, and a writing [^sc-elements].
+
+The duration ceiling is unusually concrete. *Arthur Young* holds that a non-competition term must not exceed twelve months, and that any additional time is excessive and unnecessary to protect the employer [^ay-duration]. That is a bright-line public-policy ceiling, not a starting point for negotiation, so a two-year covenant is exposed even if the rest of the terms are modest.
+
+Two formal requirements round out the test. The covenant must protect a real employer interest and be limited to activities similar to the employee's work, and it must be in writing [^ay-writing]. An oral understanding or a covenant aimed at ordinary competition rather than a protectable interest does not qualify.
+
+## Will Puerto Rico courts narrow an overbroad non-compete? {#court-narrowing}
+
+**Short answer.** No. *Arthur Young* directs courts to declare an overbroad covenant null rather than modify the parties' agreement to make it reasonable [^ay-nullity].
+
+Puerto Rico rejects the blue-pencil and partial-enforcement approaches that many states allow. The Supreme Court reaffirmed in *PACIV, Inc. v. Pérez Rivera* that once any one of the requirements is breached, the agreement is null in its entirety [^paciv-nullity]. There is no judicial salvage of a covenant that reaches too far.
+
+Federal courts apply the same rule. In *TLS Management & Marketing Services, LLC v. Rodríguez-Toledo*, the First Circuit refused to narrow overbroad agreements to a reasonable scope under Puerto Rico law [^tls-decline], echoing the instruction in *Smarte Carte* that courts may not apply a common-law reasonableness rule to modify the provision [^sc-noreform].
+
+"We decline to rewrite the nondisclosure agreements by narrowing their scope to be reasonable."[^tls-decline]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not rely on a court to rescue an aggressive covenant. In Puerto Rico, a single overbroad term voids the entire non-compete, so drafting to the twelve-month ceiling and to a genuine protectable interest is the only protection [^ay-nullity][^paciv-nullity].
+
+## What consideration supports a Puerto Rico non-compete? {#consideration}
+
+**Short answer.** Real consideration is required, and continued employment alone does not count. *Arthur Young* holds that mere continued employment will not be accepted as the consideration for a non-compete [^ay-consideration].
+
+Timing is the practical trap. In *Cherena v. Coors Brewing Co.*, the federal court held that consideration must be given when the agreement is signed, not at the moment of discharge [^cherena-timing]. A covenant imposed on an existing employee therefore likely needs new and distinct consideration, for example a promotion or a bonus, beyond simply keeping the job, although Puerto Rico courts have not spelled out what qualifies.
+
+"Such a consideration in this jurisdiction must be forthcoming at the moment the agreement was entered into and not at the moment of discharge from employment."[^cherena-timing]
+
+The consideration rule is specific to non-competes. In *Soto v. State Industrial Products, Inc.*, the First Circuit declined to extend *Arthur Young*'s special consideration requirement to an arbitration agreement [^soto-scope], a reminder that the *Arthur Young* line is a targeted restrictive-covenant doctrine rather than a general contract rule.
+
+## How does Puerto Rico treat NDAs, non-solicits, and confidentiality clauses? {#other-covenants}
+
+**Short answer.** A confidentiality or non-solicitation clause that operates like a disguised non-compete is judged by the same *Arthur Young* standard. In *TLS Management*, an overbroad nondisclosure agreement was unenforceable because it functioned as a *de facto* non-compete [^tls-decline-2].
+
+The drafting lesson is precision. A confidentiality clause that effectively bars the employee from working in the field will be treated as a non-compete and subjected to the twelve-month ceiling and the reasonableness requirements, rather than escaping review because it is labeled an NDA.
+
+A genuinely separate covenant can survive, however, even when the non-compete fails. In *Cherena*, the court voided the non-compete but enforced the distinct non-disclosure provisions in the same agreement [^cherena-severable]. A severability clause does not save the non-compete itself, but it can preserve an independent and reasonable NDA.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Draft confidentiality and non-solicitation covenants as standalone, narrowly tailored restraints. If an NDA sweeps so broadly that it stops the employee from competing, a Puerto Rico court will analyze it as a non-compete and may void it [^tls-decline-2].
+
+## How specific must the geographic and customer scope be? {#scope-territory-clients}
+
+**Short answer.** A covenant does not need both a geographic limit and a customer limit; one of them suffices. In *Reyes Ramis CPA Group, P.S.C. v. Serra Torres*, the Supreme Court held that it is not correct to require every non-compete to contain both a territorial and a client restriction [^rr-disjunctive].
+
+This is a meaningful clarification of *Arthur Young*. The Court explained that it never made a combined geographic-and-client limitation a constitutive requirement of a valid covenant [^rr-scope]. A covenant that is tightly limited to the customers an employee actually served can be reasonable even without a geographic radius, and vice versa.
+
+*Reyes Ramis* also confirms that the strict *Arthur Young* requirements are an employment-law doctrine. The Court held that a non-compete tied to a stock-redemption arrangement among owners did not have to conform fully to the strict conditions established in *Arthur Young* [^rr-stock]. Covenants ancillary to the sale of a business or an ownership exit are analyzed more flexibly than employer-employee restraints.
+
+## Does the restricted period toll or extend if the employee breaches? {#tolling}
+
+**Short answer.** Puerto Rico primary law is silent. No Puerto Rico Supreme Court, Court of Appeals, federal district, or First Circuit decision squarely approves or rejects either a contractual extension-on-breach clause or a court-ordered equitable extension of a Puerto Rico non-compete. The safest assumption is that a court will hold the employer to the twelve-month ceiling [^ay-duration-2].
+
+Because there is no Puerto Rico authority on point, the question is genuinely open, and an employer should not assume a court will pause the clock while litigation runs. The nearest guidance comes from outside Puerto Rico. In *EMC Corp. v. Arturi*, the First Circuit, applying Massachusetts law, refused to equitably extend a covenant after its term had expired and observed that the employer could have contracted for tolling instead [^emc-contract].
+
+"Being forewarned, EMC could have contracted, as the district judge noted, for tolling the term of the restriction during litigation, or for a period of restriction to commence upon preliminary finding of breach."[^emc-contract]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> A tolling clause carries a Puerto Rico-specific risk. *EMC v. Arturi* is Massachusetts law, not Puerto Rico law, and a contractual extension that pushes actual enforcement past *Arthur Young*'s twelve-month ceiling could itself render the covenant void under Puerto Rico's bright-line rule [^emc-contract][^ay-duration-2]. Treat tolling as an unsettled question and weigh a shorter base term against an extension mechanism.
+
+## What recent developments should employers monitor? {#recent-developments}
+
+**Short answer.** As of June 2, 2026, the governing framework remains the *Arthur Young* line of cases. The Supreme Court last restated and refined that test in *Reyes Ramis* in 2016, and no Puerto Rico statute has displaced it [^rr-current].
+
+Two background developments matter for monitoring but do not change the Puerto Rico rule. Puerto Rico's labor reform legislation did not codify a non-compete standard, so the judge-made *Arthur Young* test still controls. And the federal FTC Non-Compete Rule was challenged and, as of this review, has been treated as unenforceable, so it is not an operative Puerto Rico rule either.
+
+The practical takeaway is stability with a narrow margin. Because the framework is judicial, the most reliable signal of change would be a new Supreme Court decision rather than a bill, and *Reyes Ramis* remains the most recent word: the strict requirements apply to employer-employee covenants, with a single territorial or customer limit sufficing [^rr-current].
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-02. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not Puerto Rico. This article synthesizes Puerto Rico primary law and is not legal advice from a Puerto Rico-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^ay-test]: **Arthur Young & Co. v. Vega III** — "Para ser razonable, un acuerdo de no competir debe reunir los siguientes requisitos: (1) debe ser necesario para proteger un interés legítimo del patrono, (2) no debe imponer al empleado una carga demasiado onerosa, (3) y no debe afectar demasiado al público." *Arthur Young & Co. v. Vega III, 136 D.P.R. 157 (1994).* <https://aldia.microjuris.com/wp-content/uploads/2022/09/136DPR157.pdf>
+
+[^sc-elements]: **Smarte Carte, Inc. v. Colón** — "The elements of a valid non-competition agreement in Puerto Rico as set forth in Arthur Young are: (1.) The employer must have a legitimate interest in the agreement; (2.)the scope of the prohibition must fit the employer's interest but not exceed twelve months; (3.) The employer shall offer a consideration in exchange for the employee signing the non-competition covenant other than mere job tenure; (4.) Non-competition agreements must be valid contracts; (5.) Non-competition covenants must be in writing." *Smarte Carte, Inc. v. Colón, 47 F. Supp. 2d 183 (D.P.R. 1999).* <https://www.courtlistener.com/opinion/2527549/smarte-carte-inc-v-colon/#:~:text=The%20elements%20of%20a%20valid,covenants%20must%20be%20in%20writing.>
+
+[^ay-duration]: **Arthur Young & Co. v. Vega III** — "El término de no competencia no debe exceder de doce meses, entendiéndose que cualquier tiempo adicional es excesivo e innecesario para proteger adecuadamente al patrono." *Arthur Young & Co. v. Vega III, 136 D.P.R. 157 (1994).* <https://aldia.microjuris.com/wp-content/uploads/2022/09/136DPR157.pdf>
+
+[^ay-writing]: **Arthur Young & Co. v. Vega III** — "Finalmente, es indispensable que los pactos de no competencia consten por escrito." *Arthur Young & Co. v. Vega III, 136 D.P.R. 157 (1994).* <https://aldia.microjuris.com/wp-content/uploads/2022/09/136DPR157.pdf>
+
+[^ay-nullity]: **Arthur Young & Co. v. Vega III** — "Por tal razón, en vez de modificar la voluntad de las partes para ajustarla a normas razonables, se declarará nulo todo pacto de no competir que no cumpla con las anteriores condiciones." *Arthur Young & Co. v. Vega III, 136 D.P.R. 157 (1994).* <https://aldia.microjuris.com/wp-content/uploads/2022/09/136DPR157.pdf>
+
+[^paciv-nullity]: **PACIV, Inc. v. Pérez Rivera** — "Una vez se incumple con alguno de los requisitos establecidos en nuestra jurisprudencia, el acuerdo es nulo en su totalidad." *PACIV, Inc. v. Pérez Rivera, 159 D.P.R. 523 (2003).* <https://www.lexjuris.com/LEXJURIS/tspr2003/lexj2003084.htm>
+
+[^tls-decline]: **TLS Management & Marketing Services, LLC v. Rodríguez-Toledo** — "We decline to rewrite the nondisclosure agreements by narrowing their scope to be reasonable." *TLS Mgmt. & Mktg. Servs., LLC v. Rodríguez-Toledo, 966 F.3d 46 (1st Cir. 2020).* <https://www.courtlistener.com/opinion/4769672/tls-mgmt-and-mktg-ser-llc-v-rodriguez-toledo/#:~:text=We%20decline%20to%20rewrite%20the,their%20scope%20to%20be%20reasonable.>
+
+[^sc-noreform]: **Smarte Carte, Inc. v. Colón** — "This invalidation is strictly enforced, and courts are instructed not to apply the common law rule of reasonableness in order to modify the provision." *Smarte Carte, Inc. v. Colón, 47 F. Supp. 2d 183 (D.P.R. 1999).* <https://www.courtlistener.com/opinion/2527549/smarte-carte-inc-v-colon/#:~:text=This%20invalidation%20is%20strictly%20enforced%2C,order%20to%20modify%20the%20provision.>
+
+[^ay-consideration]: **Arthur Young & Co. v. Vega III** — "Sin embargo, no se admitirá como causa del acuerdo de no competencia la mera permanencia en el empleo." *Arthur Young & Co. v. Vega III, 136 D.P.R. 157 (1994).* <https://aldia.microjuris.com/wp-content/uploads/2022/09/136DPR157.pdf>
+
+[^cherena-timing]: **Cherena v. Coors Brewing Co.** — "Such a consideration in this jurisdiction must be forthcoming at the moment the agreement was entered into and not at the moment of discharge from employment." *Cherena v. Coors Brewing Co., 20 F. Supp. 2d 282 (D.P.R. 1998).* <https://www.courtlistener.com/opinion/2423610/cherena-v-coors-brewing-co/#:~:text=Such%20a%20consideration%20in%20this,moment%20of%20discharge%20from%20employment.>
+
+[^soto-scope]: **Soto v. State Industrial Products, Inc.** — "For these reasons, we reject Soto's invitation to expand the scope of Arthur Young to hold that continued employment cannot constitute valid consideration for an arbitration agreement." *Soto v. State Indus. Prods., Inc., 642 F.3d 67 (1st Cir. 2011).* <https://www.courtlistener.com/opinion/214787/soto-v-state-industrial-products-inc/#:~:text=For%20these%20reasons%2C%20we%20reject,consideration%20for%20an%20arbitration%20agreement.>
+
+[^tls-decline-2]: **TLS Management & Marketing Services, LLC v. Rodríguez-Toledo** — "We decline to rewrite the nondisclosure agreements by narrowing their scope to be reasonable." *TLS Mgmt. & Mktg. Servs., LLC v. Rodríguez-Toledo, 966 F.3d 46 (1st Cir. 2020).* <https://www.courtlistener.com/opinion/4769672/tls-mgmt-and-mktg-ser-llc-v-rodriguez-toledo/#:~:text=We%20decline%20to%20rewrite%20the,their%20scope%20to%20be%20reasonable.>
+
+[^cherena-severable]: **Cherena v. Coors Brewing Co.** — "Thus, although the non-competition clause is null and void, the rest of the provisions contained in the Agreement, including the non-disclosure provisions, are valid and enforceable." *Cherena v. Coors Brewing Co., 20 F. Supp. 2d 282 (D.P.R. 1998).* <https://www.courtlistener.com/opinion/2423610/cherena-v-coors-brewing-co/#:~:text=Thus%2C%20although%20the%20non%2Dcompetition%20clause,provisions%2C%20are%20valid%20and%20enforceable.>
+
+[^rr-disjunctive]: **Reyes Ramis CPA Group, P.S.C. v. Serra Torres** — "Por lo tanto, no es correcto afirmar que todo contrato de no competencia debe contener una restricción territorial y de clientela, basta con una de ellas." *Reyes Ramis CPA Group, P.S.C. v. Serra Torres, 194 D.P.R. ___ (2016).* <http://www.lexjuris.com/lexjuris/tspr2016/lexj2016126.htm>
+
+[^rr-scope]: **Reyes Ramis CPA Group, P.S.C. v. Serra Torres** — "No obstante, es importante destacar que esta Curia no estableció como requisito constitutivo de un acuerdo de no competencia el que se limite geográficamente las restricciones impuestas y los clientes que estarán comprendidos." *Reyes Ramis CPA Group, P.S.C. v. Serra Torres, 194 D.P.R. ___ (2016).* <http://www.lexjuris.com/lexjuris/tspr2016/lexj2016126.htm>
+
+[^rr-stock]: **Reyes Ramis CPA Group, P.S.C. v. Serra Torres** — "Por lo tanto, contrario a la conclusión a la que llegaron los foros inferiores, la cláusula de no competencia bajo análisis no tenía que ajustarse íntegramente a las estrictas condiciones establecidas en Arthur Young & Co. v. Vega III , supra." *Reyes Ramis CPA Group, P.S.C. v. Serra Torres, 194 D.P.R. ___ (2016).* <http://www.lexjuris.com/lexjuris/tspr2016/lexj2016126.htm>
+
+[^ay-duration-2]: **Arthur Young & Co. v. Vega III** — "El término de no competencia no debe exceder de doce meses, entendiéndose que cualquier tiempo adicional es excesivo e innecesario para proteger adecuadamente al patrono." *Arthur Young & Co. v. Vega III, 136 D.P.R. 157 (1994).* <https://aldia.microjuris.com/wp-content/uploads/2022/09/136DPR157.pdf>
+
+[^emc-contract]: **EMC Corp. v. Arturi** — "Being forewarned, EMC could have contracted, as the district judge noted, for tolling the term of the restriction during litigation, or for a period of restriction to commence upon preliminary finding of breach." *EMC Corp. v. Arturi, 655 F.3d 75 (1st Cir. 2011).* <https://www.courtlistener.com/opinion/612666/emc-corp-v-arturi/#:~:text=Being%20forewarned%2C%20EMC%20could%20have,upon%20preliminary%20finding%20of%20breach.>
+
+[^rr-current]: **Reyes Ramis CPA Group, P.S.C. v. Serra Torres** — "Por lo tanto, no es correcto afirmar que todo contrato de no competencia debe contener una restricción territorial y de clientela, basta con una de ellas." *Reyes Ramis CPA Group, P.S.C. v. Serra Torres, 194 D.P.R. ___ (2016).* <http://www.lexjuris.com/lexjuris/tspr2016/lexj2016126.htm>

--- a/skills/non-compete-contract-explainer/content/rhode-island.md
+++ b/skills/non-compete-contract-explainer/content/rhode-island.md
@@ -1,0 +1,171 @@
+---
+jurisdiction: "Rhode Island"
+slug: rhode-island
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-02"
+canonicalUrl: https://openagreements.org/legal/non-compete/rhode-island
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/rhode-island · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in Rhode Island[^about]
+
+Rhode Island bans non-competes for several worker categories and regulated professions, while other restrictive covenants remain governed by strict common-law reasonableness limits and trade-secret law.
+
+
+## At a glance
+
+| Question | Rhode Island |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed above a pay level |
+| **Bottom line** | Rhode Island applies common-law reasonableness to most workers but bans non-competes for low-wage and several other worker categories (FLSA-nonexempt, student interns, age 18 or younger) and for physicians and APRNs. |
+| **Main law or case** | R.I. Gen. Laws § 28-59-3 (Rhode Island Noncompetition Agreement Act) |
+| **Main exceptions** | Worker-category bans (low-wage, FLSA-nonexempt, interns, ≤18); physician (§ 5-37-33) and APRN (§ 5-34-50) bans with a 5-year sale-of-practice exception; non-solicits/NDAs/sale excluded from definition |
+| **When the ban took effect** | Physician/APRN bans eff. June 17, 2024 (worker-category ban date not stated in note) |
+| **Can a court narrow it?** | Yes — rewrites to reasonable |
+| **Applies to contractors?** | No |
+| **Restriction extended during a breach?** | Not addressed |
+| **Maximum length set by law** | No general statutory length limit; physician/APRN sale-of-practice exception capped at 5 years |
+
+## Are employee non-compete agreements enforceable in Rhode Island? {#employee-noncompetes}
+
+**Short answer.** Often no for covered workers. The Rhode Island Noncompetition Agreement Act makes a non-compete unenforceable against FLSA-nonexempt employees, student interns, workers age 18 or younger, and low-wage employees [^rinaa-covered-workers].
+
+The statutory ban is targeted rather than universal. It applies to covered employees within Chapter 28-59, and the statute defines an employee to exclude independent contractors [^rinaa-employee-definition]. For workers outside the banned categories, Rhode Island common law still requires a valid relationship, consideration, a legitimate interest, and a reasonable restraint.
+
+The low-wage category is indexed to the federal poverty level. The statute defines it as an employee whose average annual earnings are not more than 250 percent of the federal poverty level for individuals [^rinaa-low-wage-definition].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not treat Rhode Island as a total-ban state. Chapter 28-59 bars non-competes only for the worker categories listed in the statute, while other workers and other restrictive covenants still require separate analysis [^rinaa-covered-workers][^durapin-reasonableness-baseline].
+
+## What Rhode Island restrictions are excluded from the statutory non-compete definition? {#excluded-covenants}
+
+**Short answer.** Rhode Island excludes several common restraints from the Chapter 28-59 definition of a noncompetition agreement, including employee non-solicits, customer non-solicits, confidentiality agreements, and sale-of-business covenants [^rinaa-noncompete-definition].
+
+That does not make those covenants automatically enforceable. It means the RINAA ban does not decide the issue. Customer non-solicits, employee non-solicits, NDAs, confidentiality clauses, sale covenants, and qualifying separation agreements fall back to common law, trade-secret law, or the separate statute that governs the profession or industry.
+
+"‘Noncompetition agreement’ means an agreement between an employer and an employee, or otherwise arising out of an existing or anticipated employment relationship, under which the employee or expected employee agrees that he or she will not engage in certain specified activities competitive with his or her employer after the employment relationship has ended."[^rinaa-noncompete-definition]
+
+For drafting, the most important consequence is precision. A customer non-solicit should be written as a customer restraint, a confidentiality clause as a confidentiality clause, and a sale covenant as a sale covenant, because calling every restraint a non-compete can blur the statutory analysis.
+
+## What common-law test applies to Rhode Island restrictive covenants not banned by statute? {#common-law-reasonableness}
+
+**Short answer.** Rhode Island applies strict reasonableness review. The party seeking enforcement must show a valid underlying relationship, adequate consideration, a legitimate interest, and a restraint no broader than reasonably necessary [^durapin-enforcement-elements][^cranston-strict-scrutiny].
+
+*Durapin* supplies the core framework. Rhode Island recognizes that non-competes can serve legitimate purposes, but treats them as disfavored restraints. The key practical point is that ordinary competition is not enough. The promisee needs a legitimate interest such as confidential customer relationships, goodwill, trade secrets, or another protectable interest.
+
+*Cranston Print Works* reinforces the same standard and calls for strict judicial scrutiny. It also warns that covenants lacking both time and geographic limits may still be enforceable in some settings, but only to the extent necessary to protect legitimate interests [^cranston-necessity-limit].
+
+## Does continued employment support a Rhode Island restrictive covenant? {#continued-employment-termination}
+
+**Short answer.** It can. In *Walls*, the Rhode Island Supreme Court treated continued at-will employment, plus training and licensure support, as part of a lawful exchange supporting a 24-month customer restriction [^walls-continued-employment].
+
+*Walls* matters because the agreement was signed during employment, not only at initial hire. The court also rejected the argument that involuntary termination prevented enforcement; the covenant applied on termination from employment without limiting language tied to the reason for departure [^walls-involuntary-termination].
+
+The restraint in *Walls* was customer-focused. It barred solicitation and pest-control work for current and former company customers for 24 months, and the court emphasized that it did not use a geographic territory [^walls-customer-scope]. That makes the case useful for customer non-solicits and customer-service restrictions, not for broad bans on working in the same industry.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Read *Walls* for what it is. The Rhode Island Supreme Court affirmed a *preliminary* injunction under deferential abuse-of-discretion review, not a final judgment on the covenant's validity [^walls-pi-posture]. It is a strong signal on consideration and customer-scope drafting, but a defendant can still develop a fuller record on reasonableness and legitimate interest at trial.
+
+## Will Rhode Island courts narrow an overbroad non-compete? {#court-narrowing}
+
+**Short answer.** Usually yes if equitable. *Durapin* adopted partial enforcement rather than an all-or-nothing or mechanical blue-pencil rule, absent bad faith or deliberate overreaching [^durapin-partial-enforcement].
+
+Partial enforcement is not a drafting strategy. Even under *Durapin*, the court should go no further than reasonably necessary to protect the promisee's legitimate interests [^durapin-no-further-than-necessary]. Overbreadth still creates litigation risk and may leave the employer without meaningful relief if the employee did not jeopardize a protectable interest.
+
+RINAA also has a severability rule for contracts containing a non-compete that is unenforceable under § 28-59-3. That rule preserves the remainder of the contract and allows a court to impose a non-compete restriction as a remedy for breach of another agreement or duty [^rinaa-severability-remedy].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not confuse statutory severability with automatic enforcement. Rhode Island may preserve the rest of the contract, but common-law reformation still depends on reasonableness, legitimate interests, and equitable limits [^durapin-partial-enforcement][^rinaa-severability-remedy].
+
+## Which Rhode Island professions have special non-compete bans? {#profession-specific-bans}
+
+**Short answer.** Rhode Island has separate statutory bans for physicians and advanced practice registered nurses, each with a sale-of-practice exception for covenants lasting no more than five years [^physician-restrictive-covenants][^aprn-restrictive-covenants].
+
+The physician statute voids restrictions on the right to practice medicine, including geographic practice limits and limits on treating, consulting with, or soliciting current patients. The APRN statute uses parallel language for APRNs licensed under Rhode Island nursing law.
+
+Both statutes share the same shape: a categorical ban on practice restrictions, paired with a sale-of-practice exception capped at five years. Outside these regulated professions, Rhode Island has no other occupation-specific non-compete ban, so most workers fall under Chapter 28-59 and common law.
+
+## How do Rhode Island trade-secret rules affect non-compete drafting? {#trade-secrets}
+
+**Short answer.** Rhode Island trade-secret law is the main confidentiality alternative to a non-compete. RIUTSA protects qualifying information and authorizes injunctions for actual or threatened misappropriation [^riutsa-trade-secret-definition][^riutsa-injunctive-relief].
+
+RINAA itself preserves agreements not to share trade-secret information after employment [^rinaa-trade-secret-preserved]. That makes trade-secret and confidentiality drafting especially important when a worker falls within a non-compete ban or when a broad activity restraint would be difficult to justify.
+
+"Nothing in this section shall preclude an employer from entering into an agreement with an employee not to share any information, including after the employee is no longer employed by the employer, regarding the employer or the employment that is a trade secret."[^rinaa-trade-secret-preserved]
+
+RIUTSA also preserves contractual remedies, so a well-drafted NDA can operate alongside statutory trade-secret claims. The safer approach is to define confidential information carefully, reserve trade-secret protection for information that meets the statutory definition, and avoid writing an NDA so broadly that it functions like a hidden non-compete.
+
+## What recent Rhode Island and federal developments should employers monitor? {#recent-developments}
+
+**Short answer.** As of June 2, 2026, Rhode Island's enacted baseline remains Chapter 28-59 plus profession-specific statutes and common law. Recent proposals and federal activity matter for monitoring, but they should not be treated as the current Rhode Island rule unless enacted or effective [^rinaa-current-baseline][^aprn-current-baseline].
+
+The 2024 Rhode Island broad-ban bill, H8059/S2436, passed both houses but was vetoed by Governor McKee in June 2024. The 2025 S0302 proposal would have added a $125,000 earnings threshold, but monitor the official General Assembly record before relying on any pending or prior-session bill as law.
+
+The federal FTC Non-Compete Rule is also background rather than an operative Rhode Island rule. The rule was challenged, blocked, and later treated by the FTC as not enforceable, so Rhode Island analysis still starts with state statutes, profession-specific statutes, common law, and trade-secret law.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Rhode Island non-compete law may change through future legislation, but un-enacted bills do not replace the enacted worker-category statute. Check Chapter 28-59 and any active bill text before reusing a Rhode Island form [^rinaa-current-baseline].
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-02. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not Rhode Island. This article synthesizes Rhode Island primary law and is not legal advice from a Rhode Island-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^rinaa-covered-workers]: **R.I. Gen. Laws § 28-59-3** — "A noncompetition agreement shall not be enforceable against the following types of workers:" *R.I. Gen. Laws § 28-59-3(a).* <https://webserver.rilegislature.gov/Statutes/TITLE28/28-59/28-59-3.htm>
+
+[^rinaa-employee-definition]: **R.I. Gen. Laws § 28-59-2** — "‘Employee’ means an individual who works for hire, including an individual employed in a supervisory, managerial, or confidential position, but shall not include an independent contractor." *R.I. Gen. Laws § 28-59-2(3).* <https://webserver.rilegislature.gov/Statutes/TITLE28/28-59/28-59-2.htm>
+
+[^rinaa-low-wage-definition]: **R.I. Gen. Laws § 28-59-2** — "‘Low-wage employee’ means an employee whose average annual earnings, as defined in subsection (2), are not more than two hundred fifty percent (250%) of the federal poverty level for individuals as established by the United States Department of Health and Human Services federal poverty guidelines." *R.I. Gen. Laws § 28-59-2(7).* <https://webserver.rilegislature.gov/Statutes/TITLE28/28-59/28-59-2.htm>
+
+[^durapin-reasonableness-baseline]: **Durapin, Inc. v. American Products, Inc.** — "However, since such provisions are not favored, they are subject to judicial scrutiny and will be enforced as written only if the contract is reasonable and does not extend beyond what is apparently necessary for the protection of those in whose favor it runs." *Durapin, Inc. v. Am. Prods., Inc., 559 A.2d 1051, 1053 (R.I. 1989).* <https://www.courtlistener.com/opinion/2334248/durapin-inc-v-american-products-inc/#:~:text=However%2C%20since%20such%20provisions%20are,in%20whose%20favor%20it%20runs.>
+
+[^rinaa-noncompete-definition]: **R.I. Gen. Laws § 28-59-2** — "‘Noncompetition agreement’ means an agreement between an employer and an employee, or otherwise arising out of an existing or anticipated employment relationship, under which the employee or expected employee agrees that he or she will not engage in certain specified activities competitive with his or her employer after the employment relationship has ended." *R.I. Gen. Laws § 28-59-2(8).* <https://webserver.rilegislature.gov/Statutes/TITLE28/28-59/28-59-2.htm>
+
+[^durapin-enforcement-elements]: **Durapin, Inc. v. American Products, Inc.** — "Before a court reaches this question, however, the party seeking to enforce a noncompetition provision must show that (1) the provision is ancillary to an otherwise valid transaction or relationship, such as an employment contract or a contract for the purchase and sale of a business, Restatement (Second)" *Durapin, Inc. v. Am. Prods., Inc., 559 A.2d 1051, 1053 (R.I. 1989).* <https://www.courtlistener.com/opinion/2334248/durapin-inc-v-american-products-inc/#:~:text=Before%20a%20court%20reaches%20this,of%20a%20business%2C%20Restatement%20(Second)>
+
+[^cranston-strict-scrutiny]: **Cranston Print Works Co. v. Pothier** — "It is well settled that covenants not to compete are disfavored and subject to strict judicial scrutiny." *Cranston Print Works Co. v. Pothier, 848 A.2d 213, 219 (R.I. 2004).* <https://www.courtlistener.com/opinion/2195476/cranston-print-works-co-v-pothier/#:~:text=It%20is%20well%20settled%20that,subject%20to%20strict%20judicial%20scrutiny.>
+
+[^cranston-necessity-limit]: **Cranston Print Works Co. v. Pothier** — "courts should uphold them only to the extent they are necessary to protect the promisee’s legitimate interests." *Cranston Print Works Co. v. Pothier, 848 A.2d 213, 220 (R.I. 2004).* <https://www.courtlistener.com/opinion/2195476/cranston-print-works-co-v-pothier/#:~:text=courts%20should%20uphold%20them%20only,protect%20the%20promisee%E2%80%99s%20legitimate%20interests.>
+
+[^walls-continued-employment]: **Griggs & Browne Pest Control Co. v. Walls** — "employment relationship with plaintiff: In consideration for continued employment" *Griggs & Browne Pest Control Co. v. Walls, 313 A.3d 616, 625 (R.I. 2024).* <https://www.courtlistener.com/opinion/9457984/griggs-browne-pest-control-co-inc-v-brian-walls/#:~:text=employment%20relationship%20with%20plaintiff%3A%20In%20consideration%20for%20continued%20employment>
+
+[^walls-involuntary-termination]: **Griggs & Browne Pest Control Co. v. Walls** — "Walls’s argument that an involuntary termination would preclude enforcement of" *Griggs & Browne Pest Control Co. v. Walls, 313 A.3d 616, 627 (R.I. 2024).* <https://www.courtlistener.com/opinion/9457984/griggs-browne-pest-control-co-inc-v-brian-walls/#:~:text=Walls%E2%80%99s%20argument%20that%20an%20involuntary,termination%20would%20preclude%20enforcement%20of>
+
+[^walls-customer-scope]: **Griggs & Browne Pest Control Co. v. Walls** — "month period, and extends only to plaintiff’s current and previous clients, rather than" *Griggs & Browne Pest Control Co. v. Walls, 313 A.3d 616, 626 (R.I. 2024).* <https://www.courtlistener.com/opinion/9457984/griggs-browne-pest-control-co-inc-v-brian-walls/#:~:text=month%20period%2C%20and%20extends%20only,and%20previous%20clients%2C%20rather%20than>
+
+[^walls-pi-posture]: **Griggs & Browne Pest Control Co. v. Walls** — "This Court reviews a trial justice’s decision to grant a preliminary injunction for an abuse of discretion." *Griggs & Browne Pest Control Co. v. Walls, 313 A.3d 616, 623 (R.I. 2024).* <https://www.courtlistener.com/opinion/9457984/griggs-browne-pest-control-co-inc-v-brian-walls/#:~:text=This%20Court%20reviews%20a%20trial,for%20an%20abuse%20of%20discretion.>
+
+[^durapin-partial-enforcement]: **Durapin, Inc. v. American Products, Inc.** — "We believe this is the appropriate time to choose the route that permits unreasonable restraints to be modified and enforced, whether or not their terms are divisible, unless the circumstances indicate bad faith or deliberate overreaching on the part of the promisee." *Durapin, Inc. v. Am. Prods., Inc., 559 A.2d 1051, 1058-59 (R.I. 1989).* <https://www.courtlistener.com/opinion/2334248/durapin-inc-v-american-products-inc/#:~:text=We%20believe%20this%20is%20the,the%20part%20of%20the%20promisee.>
+
+[^durapin-no-further-than-necessary]: **Durapin, Inc. v. American Products, Inc.** — "Even under this approach a court will go no further in granting relief than is reasonably necessary to protect a promisee’s legitimate interests." *Durapin, Inc. v. Am. Prods., Inc., 559 A.2d 1051, 1059 (R.I. 1989).* <https://www.courtlistener.com/opinion/2334248/durapin-inc-v-american-products-inc/#:~:text=Even%20under%20this%20approach%20a,protect%20a%20promisee%E2%80%99s%20legitimate%20interests.>
+
+[^rinaa-severability-remedy]: **R.I. Gen. Laws § 28-59-3** — "This section does not render void or unenforceable the remainder of a contract or agreement containing the unenforceable noncompetition agreement, nor does it preclude the imposition of a noncompetition restriction by a court, whether through preliminary or permanent injunctive relief or otherwise, as a remedy for a breach of another agreement or of a statutory or common law duty." *R.I. Gen. Laws § 28-59-3(b).* <https://webserver.rilegislature.gov/Statutes/TITLE28/28-59/28-59-3.htm>
+
+[^physician-restrictive-covenants]: **R.I. Gen. Laws § 5-37-33** — "Any contract or agreement that creates or establishes the terms of a partnership, employment, or any other form of professional relationship with a physician licensed to practice medicine pursuant to this chapter that includes any restriction of the right of such physician to practice medicine shall be void and unenforceable with respect to said restriction; provided, however, that nothing herein shall render void or unenforceable the remaining provisions of any such contract or agreement." *R.I. Gen. Laws § 5-37-33(a).* <https://webserver.rilegislature.gov/Statutes/TITLE5/5-37/5-37-33.htm>
+
+[^aprn-restrictive-covenants]: **R.I. Gen. Laws § 5-34-50** — "Any contract or agreement that creates or establishes the terms of a partnership, employment, or any other form of professional relationship with an advanced practice registered nurse (‘APRN’) licensed to practice pursuant to § 5-34-45 that includes any restriction of the right of the APRN to practice shall be void and unenforceable with respect to said restriction; provided, however, that nothing herein shall render void or unenforceable the remaining provisions of any such contract or agreement." *R.I. Gen. Laws § 5-34-50(a).* <https://webserver.rilegislature.gov/Statutes/TITLE5/5-34/5-34-50.htm>
+
+[^riutsa-trade-secret-definition]: **R.I. Gen. Laws § 6-41-1** — "‘Trade secret’ means information, including a formula, pattern, compilation, program, device, method, technique, or process, that:" *R.I. Gen. Laws § 6-41-1(4).* <https://webserver.rilegislature.gov/Statutes/TITLE6/6-41/6-41-1.htm>
+
+[^riutsa-injunctive-relief]: **R.I. Gen. Laws § 6-41-2** — "Actual or threatened misappropriation may be enjoined." *R.I. Gen. Laws § 6-41-2(a).* <https://webserver.rilegislature.gov/Statutes/TITLE6/6-41/6-41-2.htm>
+
+[^rinaa-trade-secret-preserved]: **R.I. Gen. Laws § 28-59-3** — "Nothing in this section shall preclude an employer from entering into an agreement with an employee not to share any information, including after the employee is no longer employed by the employer, regarding the employer or the employment that is a trade secret." *R.I. Gen. Laws § 28-59-3(c).* <https://webserver.rilegislature.gov/Statutes/TITLE28/28-59/28-59-3.htm>
+
+[^rinaa-current-baseline]: **R.I. Gen. Laws §§ 28-59-1 to 28-59-3** — "This chapter shall be known and may be cited as the ‘Rhode Island Noncompetition Agreement Act.’" *R.I. Gen. Laws § 28-59-1.* <https://webserver.rilegislature.gov/Statutes/TITLE28/28-59/28-59-1.htm>
+
+[^aprn-current-baseline]: **R.I. Gen. Laws § 5-34-50** — "P.L. 2024, ch. 118, § 1, effective June 17, 2024; P.L. 2024, ch. 128, § 1, effective June 17, 2024." *R.I. Gen. Laws § 5-34-50, history.* <https://webserver.rilegislature.gov/Statutes/TITLE5/5-34/5-34-50.htm>

--- a/skills/non-compete-contract-explainer/content/singapore.md
+++ b/skills/non-compete-contract-explainer/content/singapore.md
@@ -1,0 +1,229 @@
+---
+jurisdiction: "Singapore"
+slug: singapore
+countryCode: SG
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-03"
+canonicalUrl: https://openagreements.org/legal/non-compete/singapore
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/singapore · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in Singapore[^about]
+
+Singapore has no non-compete statute; a post-employment restraint is presumptively void as a restraint of trade and binds a former employee only if the employer proves a legitimate proprietary interest and that the clause is reasonable between the parties and in the public interest, and a court may strike out but never rewrite an overbroad clause.
+
+
+## At a glance
+
+| Question | Singapore |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed if reasonable |
+| **Bottom line** | Singapore has no non-compete statute; a post-employment restraint is presumptively void and binds a former employee only if the employer proves a legitimate proprietary interest and shows the clause is reasonable between the parties and in the public interest. |
+| **Main law or case** | Man Financial (S) Pte Ltd v Wong Bark Chuan David [2007] SGCA 53 |
+| **Main exceptions** | No statutory industry carve-outs; sale-of-business covenants are judged more leniently (CLAAS Medical Centre [2010] SGCA 3). The confidentiality over-and-above trap (Stratech [2005] SGCA 17) often defeats employment non-competes. |
+| **Can a court narrow it?** | Only strikes wording |
+| **Applies to contractors?** | Unclear |
+| **Restriction extended during a breach?** | Not addressed |
+| **Maximum length set by law** | No statutory limit |
+
+## Are employee non-competes enforceable in Singapore? {#employee-noncompetes}
+
+**Short answer.** Only if the employer can justify them. Singapore has no statute that governs non-competes. A post-employment restraint is treated as a restraint of trade, which the courts presume is *void* and contrary to public policy [^mf-prima-facie-void]. To displace that presumption the employer must show the restraint protects a legitimate proprietary interest — not a mere wish to avoid competition [^mf-interest-required] — and that the clause is reasonable both between the parties and in the interests of the public [^mf-parties-public].
+
+Singapore is not a per se ban jurisdiction like California or North Dakota, where the covenant is void no matter how narrow. Nor is it a statutory-reasonableness jurisdiction with fixed numeric limits. It is a pure common-law restraint-of-trade jurisdiction: the starting point is that every post-employment covenant — non-compete, customer non-solicitation, employee non-solicitation, or non-dealing — is presumptively unenforceable, and the employer must earn enforcement clause by clause.
+
+"All interference with individual liberty of action in trading, and all restraints of trade of themselves, if there is nothing more, are contrary to public policy, and therefore void."[^mf-prima-facie-void]
+
+The Court of Appeal's decision in *Man Financial (S) Pte Ltd v Wong Bark Chuan David* is the controlling modern authority and supplies the analytical framework used throughout this note. It requires an employer to clear three cumulative hurdles, examined in the sections that follow: a legitimate proprietary interest, reasonableness between the parties, and reasonableness in the public interest.
+
+## What must an employer prove to enforce a non-compete? {#legitimate-interest}
+
+**Short answer.** A legitimate proprietary interest worth protecting. A desire to avoid competition is never enough — a court will not enforce a covenant taken merely to shield the employer from a former employee's competition [^stratech-no-competition]. The employer must point to a recognised interest such as trade secrets and confidential information, the employer's trade connection with its customers, or the maintenance of a stable, trained workforce — the last usually protected through an employee non-solicitation clause rather than a blanket bar on the employee joining a competitor [^mf-trade-connection].
+
+The distinction is between protecting an asset and suppressing a rival. An employer has no protectable interest in stopping a departing employee from working for a competitor simply because the new employer competes [^mf-no-competition]. What the law protects instead is the employer's investment: secret information the employee was trusted with, the customer relationships the employee was placed to influence, and the integrity of the workforce the employee might poach. The employee's own general skill, experience, and know-how are not the employer's property and cannot be locked up.
+
+"But an employer has no legitimate interest in preventing an employee, after leaving his service, from entering the service of a competitor merely on the ground that the new employer is a competitor."[^mf-no-competition]
+
+How real this requirement is was shown in 2025. In *FirstCom Academy Pte Ltd v Oom Academy Pte Ltd*, the High Court dismissed an employer's suit on its restraint and non-solicitation clauses because the employer never established any legitimate proprietary interest in the first place — so the court did not even reach the question of whether the clause's scope was reasonable [^firstcom-no-lpi].
+
+"The Restraint of Trade Clauses in Mr Chew's and Ms Leong's LOAs are unenforceable on account of FCA failing to prove that it has a legitimate proprietary interest which ought to be protected by way of a restraint of trade clause."[^firstcom-no-lpi]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> A clause that simply bars a former employee from joining or starting a competing business, without tying the restraint to a specific protectable interest, is the weakest possible position. Identify the actual interest — the confidential information, the customer connection, or the workforce — and draft the restraint around it, because an employer who cannot prove a legitimate proprietary interest loses before reasonableness is even considered [^firstcom-no-lpi].
+
+## Can a non-compete protect information an NDA already covers? {#confidentiality-overlap}
+
+**Short answer.** Usually not, without more. If the confidential information is already protected by a separate confidentiality clause, the employer must show the non-compete protects a legitimate interest *over and above* that information — otherwise the court treats the non-compete as a bare attempt to stifle competition and strikes it down [^shopee-over-and-above].
+
+This is the single most important trap in Singapore non-compete drafting. The reasoning, which traces back to *Stratech Systems Ltd v Nyam Chiu Shin* and was reaffirmed in *Man Financial*, is that if a confidentiality clause already does the protective work, a non-compete adds nothing legitimate unless the employer can identify a distinct interest *over and above* that confidentiality protection — otherwise its real purpose must be to prevent competition, which is not a protectable interest.
+
+"Where the protection of confidential information or trade secrets is already covered by another contractual clause, the covenantee will have to demonstrate that the restraint of trade clause in question covers a legitimate proprietary interest over and above the protection of confidential information or trade secrets."[^shopee-over-and-above]
+
+Two High Court decisions in 2024 applied this directly against employers. In *Shopee Singapore Pte Ltd v Lim Teck Yong*, the court found serious doubt that the employer could rely on the protection of confidential information to validate a non-compete when an employment confidentiality agreement already covered that very interest [^shopee-serious-doubts]. In *MoneySmart Singapore Pte Ltd v Artem Musienko*, the court made the same observation — any confidentiality concern was already addressed and protected by the contract's separate confidentiality clause [^ms-confidentiality]. The lesson reinforces a related point from *Stratech*: an employer must *particularise* the confidential information it claims to protect, not gesture at it in the abstract [^stratech-particularise].
+
+## How long and how wide can a Singapore non-compete be? {#reasonableness}
+
+**Short answer.** There is no fixed limit. Reasonableness is decided case by case on the activity restrained, the geographic area, the duration, and the employee's seniority and actual influence. A restraint of *indefinite* duration is void [^smile-indefinite], but a bounded restraint tied to a real interest can be upheld even across multiple countries [^tky-reasonable].
+
+Because the limits are judge-made rather than set by a code section, there is no statutory ceiling on duration or geography to anchor a covenant. The analysis is fact-specific in both directions. In *Tan Kok Yong Steve v Itochu Singapore Pte Ltd*, the High Court enforced a roughly two-year non-compete covering markets including Vietnam, Bangladesh, and the Philippines against a specialist trader who had genuine knowledge of and influence over the employer's customers in those markets, finding the activity, geographic, and temporal scope all reasonable [^tky-reasonable].
+
+"In summary, I find that the activity scope, geographical scope and temporal scope of the Non-Competition Undertaking to be reasonable as between the parties and is not against the public interest."[^tky-reasonable]
+
+At the other extreme, breadth is fatal. A restraint with no end date is void absent the most exceptional circumstances [^smile-indefinite], and a restraint whose scope has only a tenuous connection to what the employee actually did will fail as overbroad. In *MoneySmart Singapore Pte Ltd v Artem Musienko*, the court refused to enforce a non-compete that barred the employee from any rival business regardless of role similarity, and criticised the clause's cascading, step-down structure as giving the employer multiple bites of the cherry on duration [^ms-cascading].
+
+"It appears that the claimant will have multiple bites of the cherry in relation to determining the duration of the Non-Compete Clause."[^ms-cascading]
+
+## Can a Singapore court narrow an overbroad non-compete? {#court-narrowing}
+
+**Short answer.** Only by deletion, never by rewriting. A Singapore court may apply the *blue pencil* — striking out offending words if what remains still makes grammatical sense and the bargain is unchanged — but it will not redraft a clause or read it down to a reasonable scope. The court will not rewrite the contract for the parties [^mf-blue-pencil].
+
+This is a sharp difference from jurisdictions that allow judicial reformation or notional severance. Singapore has not adopted the practice of reading an overly wide restraint down to whatever the court thinks reasonable; the most an employer can hope for is that genuinely severable, offending words can be excised while a coherent, narrower clause survives on its own terms.
+
+"In other words, the court will not rewrite the contract for the parties."[^mf-blue-pencil]
+
+The practical consequence is that an employer cannot draft an aggressive clause and rely on a court to trim it to size. If the only way to save the covenant is to add words, substitute words, or reinterpret it more narrowly, the court will strike it down entirely. A cascading clause that offers the court a menu of progressively shorter durations does not solve this; as *MoneySmart* shows, that structure is itself treated as a red flag rather than a safe harbour [^ms-cascading-narrow].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not rely on a Singapore court to narrow an overbroad non-compete. Draft each restriction at a scope you can defend as reasonable on its own, because the court can delete severable words but will not rewrite the clause or read it down, and an unreasonably wide covenant simply fails [^mf-blue-pencil].
+
+## Are non-competes from a business sale treated differently? {#sale-of-business}
+
+**Short answer.** Yes — more leniently. When a covenant is given by the seller of a business to protect the goodwill the buyer paid for, Singapore courts take a more liberal approach than in the employment context, because the parties bargain on more equal terms [^claas-liberal]. A multi-year restraint can be reasonable in that setting [^claas-three-year].
+
+The leniency is comparative, not unlimited. Even a sale-of-business restraint must go no further than necessary to protect the interest involved [^claas-no-further]. But the rationale that makes employment covenants suspect — unequal bargaining power and the risk of locking up a person's livelihood — is far weaker when a vendor sells a business for value and promises not to immediately compete away the goodwill just sold.
+
+"These being the general principles applicable in this area of the law, we would, however, hasten to add that the courts take a more liberal approach when considering restrictive covenants in the context of a sale of business as compared to the situation where such a clause is contained in a contract of employment."[^claas-liberal]
+
+In *CLAAS Medical Centre Pte Ltd v Ng Boon Ching*, the Court of Appeal upheld a three-year restraint given by the seller of an aesthetics-medicine practice [^claas-three-year]. The same decision confirms that a liquidated-damages clause attached to such a covenant is enforceable if it is a genuine pre-estimate of loss rather than a penalty [^claas-liquidated].
+
+## What if the employer wrongfully dismissed the employee? {#employer-breach}
+
+**Short answer.** The restraint may fall away. Under the principle in *General Billposting*, an employer who repudiates the contract — for example by dismissing the employee without the required notice — cannot then enforce the post-employment restraint, and the wrongfully dismissed employee is no longer bound by it [^hengxin-repudiation].
+
+The High Court applied this in *Hengxin Technology Ltd v Jiang Wei*, where an employer that had wrongfully terminated the employee without the required notice — a repudiatory breach — was held not entitled to enforce the restrictive covenant against him. The doctrine ties enforcement of the covenant to the employer's own performance: a party that has torn up the contract cannot selectively hold the other side to one of its clauses.
+
+"the House of Lords had held that a manager who was wrongfully dismissed without notice was entitled to treat the dismissal as a repudiation of the contract, sue for damages for breach and he was no longer bound by the covenant on restriction of trade."[^hengxin-repudiation]
+
+> [!NOTE]
+> **Practice note.**
+>
+> An employer that terminates abruptly — without giving contractual notice or paying in lieu — risks losing the very non-compete it is relying on. Before suing to enforce a restraint, confirm the termination was itself lawful, because a repudiatory breach by the employer can release the employee from the covenant [^hengxin-repudiation].
+
+## Is garden leave treated the same as a non-compete? {#garden-leave}
+
+**Short answer.** No. Garden leave is a restriction *during* employment, backed by the employee's continuing duty of fidelity, and a court assesses it more flexibly than a post-termination restraint. A non-compete that bites *after* employment ends is not assessed with the same flexibility as a garden-leave provision [^mano-garden-leave].
+
+In *Mano Vikrant Singh v Cargill TSF Asia Pte Ltd*, the Court of Appeal kept the two doctrines distinct. During the notice period the employee remains employed, still paid, and still bound by fidelity duties, so a negative covenant operating then rests on a different footing. Once employment ends, the restraint-of-trade doctrine applies in full force and the employer must satisfy the legitimate-interest and reasonableness requirements covered above.
+
+"Post termination employment restraints are thus not assessed with the same level of flexibility as garden leave provisions."[^mano-garden-leave]
+
+## Does a Singapore non-compete pause or extend if the employee breaches? {#tolling}
+
+**Short answer.** Singapore law has not addressed it. No Singapore decision holds that the restraint period tolls — pauses and then resumes — while a former employee is in breach or while litigation runs, so an automatic extension-on-breach clause is untested. What Singapore does offer instead is the *springboard* injunction, a separate equitable remedy that neutralises an unfair head-start rather than extending the covenant [^springboard-goh].
+
+This is an open question, and the practical answer is that an employer should not assume the clock stops while the employee competes. The covenant runs from the agreed start point. If the concern is that a departing employee has already used confidential information to gain an unfair advantage, the targeted remedy is not a longer non-compete but a *springboard* injunction.
+
+The *springboard* injunction, set out in *Goh Seng Heng v RSP Investments Pte Ltd*, restrains a competitor only for as long as needed to erase an advantage it unfairly obtained through misuse of confidential information [^springboard-goh]. It is temporal and remedial, aimed at the head-start, and it is not a device for tolling or lengthening the contractual restraint period.
+
+"The facts showed that the AM group had more than made out a prima facie case that confidential information had been misused by Dr Goh and Michelle to give an unfair advantage to Quikglow."[^springboard-goh]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not rely on a clause that purports to extend the non-compete by the length of any breach. No Singapore authority validates tolling of the restraint period, so treat the stated duration as the maximum, and pursue a springboard injunction if the real problem is an unfair head-start from misused confidential information [^springboard-goh].
+
+## How is a Singapore non-compete enforced? {#enforcement-remedies}
+
+**Short answer.** Mainly by injunction — but only to enforce a covenant that is itself valid. The applicant must first show a serious question that the restraint is valid and enforceable, and that it has been or will be breached [^shopee-validity]; a signed non-compete does not get automatic interim enforcement merely because breach is alleged. Once validity is in view, a prohibitory injunction to restrain breach of a negative covenant is granted comparatively readily [^rga-injunction]. Money damages are also available in principle, but in practice they are hard to win because the employer must prove the loss its breach caused [^tky-damages].
+
+The primary remedy is an interim or final prohibitory injunction stopping the former employee from competing in breach of a valid covenant. For a negative covenant, an injunction is granted comparatively readily [^rga-injunction]. Where the real harm is an unfair head-start from misused confidential information, the employer can seek the *springboard* injunction discussed above, which lasts only as long as the unfair advantage persists [^q10-springboard].
+
+"When a defendant is about to breach, or has already breached, a negative covenant in a contract, an interim prohibitory injunction will readily be granted to restrain a prospective breach or a further breach, as the case may be."[^rga-injunction]
+
+Damages are the weaker tool. Even where an injunction issues, a claim for damages can fail for want of proof: in *Tan Kok Yong*, the employer recovered no damages because it could not show the link between the employee's breach and any loss it suffered [^tky-damages].
+
+## Are new MOM guidelines on non-competes coming? {#upcoming-guidance}
+
+**Short answer.** They are being discussed, but none is in force yet. In its March 2026 Committee of Supply statement, the Ministry of Manpower confirmed it was still discussing with its tripartite partners how and when restraint-of-trade clauses should be used, and that any guidelines will be based on principles the courts have already articulated [^mom-cos]. The Ministry first signalled this in January 2025 [^mom-pq], and as of June 2026 no guideline has been published. Until one is issued, the common-law framework set out above governs.
+
+The Ministry of Manpower, the National Trades Union Congress, and the Singapore National Employers Federation have signalled that tripartite guidelines are coming — likely addressing the use of restraints for lower-wage workers and in retrenchment scenarios — but the guidance has not been published and would, in any event, restate principles the courts already apply rather than override them.
+
+"The Ministry of Manpower is discussing with its tripartite partners – the National Trades Union Congress and the Singapore National Employers Federation – on how and when restrictive clauses in employment contracts can and should be used, based on established principles that the Courts have articulated."[^mom-pq]
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not draft to an anticipated tripartite guideline that does not yet exist. No MOM restraint-of-trade guideline is in force as of June 2026, so the enforceability of a Singapore non-compete still turns entirely on the common-law restraint-of-trade test, and any future guideline is expected to build on those same court-articulated principles [^mom-pq].
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-03. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not Singapore. This article synthesizes Singapore primary law and is not legal advice from a Singapore-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^mf-prima-facie-void]: **Man Financial (S) Pte Ltd v Wong Bark Chuan David** — "All interference with individual liberty of action in trading, and all restraints of trade of themselves, if there is nothing more, are contrary to public policy, and therefore void." *Man Financial (S) Pte Ltd v Wong Bark Chuan David [2007] SGCA 53; [2008] 1 SLR(R) 663.* <https://www.elitigation.sg/gdviewer/s/2007_SGCA_53>
+
+[^mf-interest-required]: **Man Financial (S) Pte Ltd v Wong Bark Chuan David** — "There must always – and this is a fundamental legal proposition in this particular area of the law – be a legitimate proprietary interest which the court will then seek to protect by way of the doctrine of restraint of trade" *Man Financial (S) Pte Ltd v Wong Bark Chuan David [2007] SGCA 53; [2008] 1 SLR(R) 663.* <https://www.elitigation.sg/gdviewer/s/2007_SGCA_53>
+
+[^mf-parties-public]: **Man Financial (S) Pte Ltd v Wong Bark Chuan David** — "To recapitulate, Clause C.1 must be reasonable not only as between the parties, but also in the interests of the public as well before it will be upheld by the court." *Man Financial (S) Pte Ltd v Wong Bark Chuan David [2007] SGCA 53; [2008] 1 SLR(R) 663.* <https://www.elitigation.sg/gdviewer/s/2007_SGCA_53>
+
+[^stratech-no-competition]: **Stratech Systems Ltd v Nyam Chiu Shin** — "The court will never uphold a covenant taken by an employer merely to protect himself from competition by a former employee." *Stratech Systems Ltd v Nyam Chiu Shin (alias Yan Qiuxin) [2005] SGCA 17; [2005] 2 SLR(R) 579.* <https://www.elitigation.sg/gd/s/2005_SGCA_17>
+
+[^mf-trade-connection]: **Man Financial (S) Pte Ltd v Wong Bark Chuan David** — "The second proprietary interest that is traditionally recognised as well as protected by the courts in the employment context is that of trade connection." *Man Financial (S) Pte Ltd v Wong Bark Chuan David [2007] SGCA 53; [2008] 1 SLR(R) 663.* <https://www.elitigation.sg/gdviewer/s/2007_SGCA_53>
+
+[^mf-no-competition]: **Man Financial (S) Pte Ltd v Wong Bark Chuan David** — "But an employer has no legitimate interest in preventing an employee, after leaving his service, from entering the service of a competitor merely on the ground that the new employer is a competitor." *Man Financial (S) Pte Ltd v Wong Bark Chuan David [2007] SGCA 53; [2008] 1 SLR(R) 663.* <https://www.elitigation.sg/gdviewer/s/2007_SGCA_53>
+
+[^firstcom-no-lpi]: **FirstCom Academy Pte Ltd v Oom Academy Pte Ltd** — "The Restraint of Trade Clauses in Mr Chew's and Ms Leong's LOAs are unenforceable on account of FCA failing to prove that it has a legitimate proprietary interest which ought to be protected by way of a restraint of trade clause." *FirstCom Academy Pte Ltd v Oom Academy Pte Ltd [2025] SGHC 266.* <https://www.elitigation.sg/gd/s/2025_SGHC_266>
+
+[^shopee-over-and-above]: **Shopee Singapore Pte Ltd v Lim Teck Yong** — "Where the protection of confidential information or trade secrets is already covered by another contractual clause, the covenantee will have to demonstrate that the restraint of trade clause in question covers a legitimate proprietary interest over and above the protection of confidential information or trade secrets." *Shopee Singapore Pte Ltd v Lim Teck Yong [2024] SGHC 29.* <https://www.elitigation.sg/gd/s/2024_SGHC_29>
+
+[^shopee-serious-doubts]: **Shopee Singapore Pte Ltd v Lim Teck Yong** — "As set out above, given that such an interest in the protection of confidential information is already protected elsewhere by the ECA, there are serious doubts that Shopee would be able to rely on such an interest in asserting the validity of the Non-Competition Restriction." *Shopee Singapore Pte Ltd v Lim Teck Yong [2024] SGHC 29.* <https://www.elitigation.sg/gd/s/2024_SGHC_29>
+
+[^ms-confidentiality]: **MoneySmart Singapore Pte Ltd v Artem Musienko** — "Further, any issue of confidentiality is already addressed and protected by the Confidentiality Clause." *MoneySmart Singapore Pte Ltd v Artem Musienko [2024] SGHC 94.* <https://www.elitigation.sg/gd/s/2024_SGHC_94>
+
+[^stratech-particularise]: **Stratech Systems Ltd v Nyam Chiu Shin** — "It follows from the foregoing that an employer must particularize the confidential information which he seeks to protect." *Stratech Systems Ltd v Nyam Chiu Shin (alias Yan Qiuxin) [2005] SGCA 17; [2005] 2 SLR(R) 579.* <https://www.elitigation.sg/gd/s/2005_SGCA_17>
+
+[^smile-indefinite]: **Smile Inc Dental Surgeons Pte Ltd v Lui Andrew Stewart** — "A restraint of trade that operates for an indefinite period of time is (absent the most exceptional circumstances, which are not present in this case) necessarily void and unenforceable." *Smile Inc Dental Surgeons Pte Ltd v Lui Andrew Stewart [2012] SGCA 39; [2012] 4 SLR 308.* <https://www.elitigation.sg/gd/s/2012_SGCA_39>
+
+[^tky-reasonable]: **Tan Kok Yong Steve v Itochu Singapore Pte Ltd** — "In summary, I find that the activity scope, geographical scope and temporal scope of the Non-Competition Undertaking to be reasonable as between the parties and is not against the public interest." *Tan Kok Yong Steve v Itochu Singapore Pte Ltd [2018] SGHC 85.* <https://www.elitigation.sg/gd/s/2018_SGHC_85>
+
+[^ms-cascading]: **MoneySmart Singapore Pte Ltd v Artem Musienko** — "It appears that the claimant will have multiple bites of the cherry in relation to determining the duration of the Non-Compete Clause." *MoneySmart Singapore Pte Ltd v Artem Musienko [2024] SGHC 94.* <https://www.elitigation.sg/gd/s/2024_SGHC_94>
+
+[^mf-blue-pencil]: **Man Financial (S) Pte Ltd v Wong Bark Chuan David** — "In other words, the court will not rewrite the contract for the parties." *Man Financial (S) Pte Ltd v Wong Bark Chuan David [2007] SGCA 53; [2008] 1 SLR(R) 663.* <https://www.elitigation.sg/gdviewer/s/2007_SGCA_53>
+
+[^ms-cascading-narrow]: **MoneySmart Singapore Pte Ltd v Artem Musienko** — "It appears that the claimant will have multiple bites of the cherry in relation to determining the duration of the Non-Compete Clause." *MoneySmart Singapore Pte Ltd v Artem Musienko [2024] SGHC 94.* <https://www.elitigation.sg/gd/s/2024_SGHC_94>
+
+[^claas-liberal]: **CLAAS Medical Centre Pte Ltd v Ng Boon Ching** — "These being the general principles applicable in this area of the law, we would, however, hasten to add that the courts take a more liberal approach when considering restrictive covenants in the context of a sale of business as compared to the situation where such a clause is contained in a contract of employment." *CLAAS Medical Centre Pte Ltd v Ng Boon Ching [2010] SGCA 3; [2010] 2 SLR 386.* <https://www.elitigation.sg/gd/s/2010_SGCA_3>
+
+[^claas-three-year]: **CLAAS Medical Centre Pte Ltd v Ng Boon Ching** — "These aforesaid considerations must be borne in mind when considering the reasonableness of the three-year period of restraint, which we find, with respect to the Judge, was not unreasonable." *CLAAS Medical Centre Pte Ltd v Ng Boon Ching [2010] SGCA 3; [2010] 2 SLR 386.* <https://www.elitigation.sg/gd/s/2010_SGCA_3>
+
+[^claas-no-further]: **CLAAS Medical Centre Pte Ltd v Ng Boon Ching** — "Moreover, even where a legitimate proprietary interest is shown, the court will ensure that the covenant in restraint of trade goes no further than what is necessary to protect the interest concerned." *CLAAS Medical Centre Pte Ltd v Ng Boon Ching [2010] SGCA 3; [2010] 2 SLR 386.* <https://www.elitigation.sg/gd/s/2010_SGCA_3>
+
+[^claas-liquidated]: **CLAAS Medical Centre Pte Ltd v Ng Boon Ching** — "Where parties stipulate in a contract the sum to be paid in the event of a breach, the contract sum is enforceable if it is a genuine pre-estimate of loss but not if it constitutes a penalty." *CLAAS Medical Centre Pte Ltd v Ng Boon Ching [2010] SGCA 3; [2010] 2 SLR 386.* <https://www.elitigation.sg/gd/s/2010_SGCA_3>
+
+[^hengxin-repudiation]: **Hengxin Technology Ltd v Jiang Wei** — "the House of Lords had held that a manager who was wrongfully dismissed without notice was entitled to treat the dismissal as a repudiation of the contract, sue for damages for breach and he was no longer bound by the covenant on restriction of trade." *Hengxin Technology Ltd v Jiang Wei [2009] SGHC 259.* <https://www.elitigation.sg/gd/s/2009_SGHC_259>
+
+[^mano-garden-leave]: **Mano Vikrant Singh v Cargill TSF Asia Pte Ltd** — "Post termination employment restraints are thus not assessed with the same level of flexibility as garden leave provisions." *Mano Vikrant Singh v Cargill TSF Asia Pte Ltd [2012] SGCA 42.* <https://www.elitigation.sg/gd/s/2012_SGCA_42>
+
+[^springboard-goh]: **Goh Seng Heng v RSP Investments Pte Ltd** — "The facts showed that the AM group had more than made out a prima facie case that confidential information had been misused by Dr Goh and Michelle to give an unfair advantage to Quikglow." *Goh Seng Heng v RSP Investments Pte Ltd [2016] SGHC 275; [2017] 3 SLR 657.* <https://www.elitigation.sg/gd/s/2016_SGHC_275>
+
+[^shopee-validity]: **Shopee Singapore Pte Ltd v Lim Teck Yong** — "In the context of a restraint of trade clause, the applicant must first show that the restraint of trade clause is valid and enforceable, in that it protects a legitimate interest of the applicant and in addition is reasonable in the interests of the parties and the public." *Shopee Singapore Pte Ltd v Lim Teck Yong [2024] SGHC 29.* <https://www.elitigation.sg/gd/s/2024_SGHC_29>
+
+[^rga-injunction]: **RGA Holdings International Inc v Loh Choon Phing Robin** — "When a defendant is about to breach, or has already breached, a negative covenant in a contract, an interim prohibitory injunction will readily be granted to restrain a prospective breach or a further breach, as the case may be." *RGA Holdings International Inc v Loh Choon Phing Robin [2017] SGCA 55.* <https://www.elitigation.sg/gd/s/2017_SGCA_55>
+
+[^tky-damages]: **Tan Kok Yong Steve v Itochu Singapore Pte Ltd** — "The Defendant has failed to produce any evidence to show the nexus between the Plaintiff's breach of the Non-Competition Undertaking and the loss, if any, suffered by the Defendant." *Tan Kok Yong Steve v Itochu Singapore Pte Ltd [2018] SGHC 85.* <https://www.elitigation.sg/gd/s/2018_SGHC_85>
+
+[^q10-springboard]: **Goh Seng Heng v RSP Investments Pte Ltd** — "There was also no doubt that Quikglow still enjoyed the unfair advantage which it had obtained as a result of these wrongs." *Goh Seng Heng v RSP Investments Pte Ltd [2016] SGHC 275; [2017] 3 SLR 657.* <https://www.elitigation.sg/gd/s/2016_SGHC_275>
+
+[^mom-cos]: **MOM SMS Speech at Committee of Supply 2026** — "We are discussing with tripartite partners on how and when restrictive clauses in employment contracts can and should be used, and the guidelines will be based on established principles that the Courts have articulated." *MOM, Speech by SMS for Manpower at the Committee of Supply 2026 (3 Mar 2026).* <https://www.mom.gov.sg/newsroom/speeches/2026/0303-sms-speech-for-cos-2026>
+
+[^mom-pq]: **MOM Written Answer to PQ on Tripartite Guidelines on Restraint of Trade Clauses** — "The Ministry of Manpower is discussing with its tripartite partners – the National Trades Union Congress and the Singapore National Employers Federation – on how and when restrictive clauses in employment contracts can and should be used, based on established principles that the Courts have articulated." *MOM, Written Answer to PQ on Tripartite Guidelines on Restraint of Trade Clauses in Employment Contracts (7 Jan 2025).* <https://www.mom.gov.sg/newsroom/parliament-questions-and-replies/2025/0107-written-answer-to-pq-on-tripartite-guidelines-on-restraint-of-trade-clauses>

--- a/skills/non-compete-contract-explainer/content/south-carolina.md
+++ b/skills/non-compete-contract-explainer/content/south-carolina.md
@@ -1,0 +1,226 @@
+---
+jurisdiction: "South Carolina"
+slug: south-carolina
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-03"
+canonicalUrl: https://openagreements.org/legal/non-compete/south-carolina
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/south-carolina · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in South Carolina[^about]
+
+South Carolina enforces non-competes only when the restraint is reasonable under common law, strictly construes them against the employer, and will not blue-pencil an overbroad covenant.
+
+
+## At a glance
+
+| Question | South Carolina |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed if reasonable |
+| **Bottom line** | South Carolina has no non-compete statute and enforces a covenant only if it meets all five common-law reasonableness factors, strictly construes it against the employer, and will not blue-pencil or reform an overbroad covenant. |
+| **Main law or case** | Team IA, Inc. v. Lucas, 717 S.E.2d 103 (S.C. Ct. App. 2011) (five-factor test from Standard Register Co. v. Kerrigan) |
+| **Main exceptions** | Sale-of-business reviewed more leniently (Palmetto Mortuary); pending H.4767 physician-ban bill not enacted |
+| **Can a court narrow it?** | No |
+| **Applies to contractors?** | Unclear |
+| **Restriction extended during a breach?** | Points against it — extending past stated end date is against public policy (Stonhard) |
+| **Maximum length set by law** | No statutory cap |
+
+## Are employee non-compete agreements enforceable in South Carolina? {#employee-noncompetes}
+
+**Short answer.** Yes, sometimes. South Carolina has no general non-compete statute, so enforceability turns on common law: a covenant is upheld only if it is necessary to protect a legitimate interest, reasonably limited in time and place, not unduly harsh on the employee, reasonable as a matter of public policy, and supported by valuable consideration [^team-ia-five-factor-test][^kerrigan-restraint-of-trade].
+
+Because a non-compete is a restraint on trade that is against public policy, South Carolina courts disfavor these covenants [^kerrigan-restraint-of-trade]. The reasonableness analysis is rooted in *Standard Register Co. v. Kerrigan* and is applied today as a conjunctive list — every one of the five elements must be met or the covenant fails [^team-ia-five-factor-test].
+
+"A covenant not to compete will be upheld only if it is: (1) necessary for the protection of the legitimate interest of the employer; (2) reasonably limited in its operation with respect to time and place; (3) not unduly harsh and oppressive in curtailing the legitimate efforts of the employee to earn a livelihood; (4) reasonable from the standpoint of sound public policy; and (5) supported by valuable consideration."[^team-ia-five-factor-test]
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not assume South Carolina will trim an overbroad covenant down to something enforceable — as the dedicated question below explains, it will not. Because the five factors are conjunctive, a covenant that fails any single one of them is unenforceable [^team-ia-five-factor-test][^kerrigan-restraint-of-trade].
+
+## What legitimate business interests can support a South Carolina non-compete? {#protectable-interests}
+
+**Short answer.** The core interest that justifies a non-compete is the employer's customer relationships and goodwill. South Carolina separately enforces covenants protecting an employer's contractual relationships with its own employees, and it protects trade secrets by statute independent of any covenant [^kerrigan-customer-protection][^oxman-employee-nonsolicit][^trade-secrets-act-employee-duty].
+
+A restraint is reasonable when it is designed to protect the employer against the loss of customers the employee could divert; protecting against ordinary competition, untethered to such an interest, is not enough [^kerrigan-customer-protection]. South Carolina also recognizes an employer's interest in its relationships with its own employees: in *Oxman v. Sherman*, the court read a covenant as barring inducement of other employees to breach their contracts rather than as a blanket bar on hiring [^oxman-employee-nonsolicit].
+
+Trade secrets are protected by statute independent of any covenant. Under the *South Carolina Trade Secrets Act*, every employee who knows of an employer's trade secret has a duty to refrain from using or disclosing it, separate from and in addition to any written agreement [^trade-secrets-act-employee-duty]. That statutory protection endures until the secret is disclosed or discovered by proper means [^trade-secrets-act-endures].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not rely on a non-compete to protect information that the *South Carolina Trade Secrets Act* already covers. A focused confidentiality and trade-secret strategy can reach misappropriation without the strict-construction risk that attaches to a covenant not to compete [^trade-secrets-act-employee-duty][^trade-secrets-act-endures].
+
+## How narrow must a customer non-solicitation covenant be in South Carolina? {#customer-non-solicitation}
+
+**Short answer.** It must be tied to the customers the employee actually dealt with. South Carolina enforces a customer non-solicitation covenant limited to customers the employee had contact with during a defined look-back period — and such a limit can even substitute for a geographic restriction — but a covenant barring solicitation of every customer on the employer's books advances no legitimate interest and is unenforceable [^vessel-personal-contact][^fournil-ordinary-competition].
+
+Federal courts applying South Carolina law draw the line at the employee's own customer relationships. In *Vessel Medical, Inc. v. Elliott*, the District of South Carolina upheld a non-solicitation covenant precisely because it reached only customers the employee had contact with during his last twelve months of employment [^vessel-personal-contact]. By contrast, *Fournil v. Turbeville Insurance Agency, Inc.* refused to enforce a covenant that also barred soliciting customers the employee had never serviced, because prohibiting those contacts protected no legitimate interest of the employer [^fournil-no-legitimate-interest]. The governing principle is that an employer may protect its customer relationships but may not enforce a covenant that simply prevents ordinary competition [^fournil-ordinary-competition].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not write an *any customer on our books* non-solicitation clause. Limit the restriction to customers the departing employee actually serviced or contacted within a defined look-back period; a blanket customer ban is treated as an unenforceable restraint on ordinary competition rather than the protection of a legitimate interest [^vessel-personal-contact][^fournil-no-legitimate-interest].
+
+## Is continued at-will employment enough consideration for a South Carolina non-compete? {#continued-employment-consideration}
+
+**Short answer.** Not by itself. When a covenant is signed after employment has already begun, South Carolina requires separate, independent consideration — continued at-will employment alone is not enough [^poole-separate-consideration].
+
+*Poole v. Incentives Unlimited, Inc.* is the controlling rule. The court held that a covenant entered after the inception of employment needs new consideration beyond the continuation of at-will work [^poole-separate-consideration]. In *Poole* itself, the employee's duties, position, and salary were left unchanged after she signed, so there was nothing to supply that separate consideration [^poole-duties-unchanged].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not ask a current employee to sign a non-compete on the strength of keeping the same job. Pair the covenant with genuine new consideration — a raise, bonus, promotion, or a change in status — and document it, because an unchanged role will not support the restraint [^poole-separate-consideration][^poole-duties-unchanged].
+
+## What duration and geographic scope are reasonable for a South Carolina non-compete? {#duration-geography}
+
+**Short answer.** There is no statutory cap; reasonableness is judged on the facts. The territory may be no broader than necessary to protect the employer's legitimate interest, and both time and place must independently be reasonably limited [^kerrigan-territorial-scope][^q4-team-ia-five-factor-test].
+
+Geography is tied to the employer's actual customer base. A territorial restriction is unreasonable when it sweeps in an area broader than necessary to protect the legitimate interest of the employer [^kerrigan-territorial-scope]. Because the test is conjunctive, each of time and place must be reasonable on its own; as a practical matter, a wide territory paired with a long duration is harder to defend than a restraint matched to where the employee actually worked and the customers the employee actually served [^q4-team-ia-five-factor-test].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not copy a duration or radius from another state's form. Match the territory to the employee's real customer contacts and keep the time period to what the record can justify, because a South Carolina court will not narrow an overbroad scope to save the covenant [^kerrigan-territorial-scope][^q4-team-ia-five-factor-test].
+
+## Will a South Carolina court blue-pencil or narrow an overbroad non-compete? {#court-narrowing}
+
+**Short answer.** No. South Carolina is a strict no-blue-pencil, no-reformation jurisdiction: a court will not rewrite an unreasonable covenant, and the agreement must stand or fall on its own terms [^poynter-no-blue-pencil][^stonhard-no-reformation].
+
+In *Poynter Investments, Inc. v. Century Builders of Piedmont, Inc.*, the South Carolina Supreme Court held that the restrictions in a non-compete cannot be rewritten by a court or limited by the parties' later agreement, but must stand or fall on their own terms [^poynter-no-blue-pencil]. The court reversed an order that had purported to enforce the covenant on narrower terms than the parties wrote [^poynter-rewrite-error]. *Stonhard, Inc. v. Carolina Flooring Specialists, Inc.* refused to supply a missing territorial limitation, reasoning that adding a term the parties never negotiated would itself violate public policy [^stonhard-no-reformation].
+
+There is one narrow lever: an alternative, *already-drafted* fallback. In *Team IA, Inc. v. Lucas*, the Court of Appeals indicated that a narrower alternative territory written into the original agreement could remain enforceable even when the primary territory was overbroad — because the court would be enforcing language the parties actually agreed to, not inventing it [^team-ia-step-down].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not rely on a savings clause asking a court to reduce an overbroad restraint to whatever is reasonable — South Carolina will not do it. Build tiered, severable, narrower alternatives directly into the agreement so a court has enforceable text to fall back on rather than a term it must create [^poynter-no-blue-pencil][^team-ia-step-down].
+
+## Are confidentiality and nondisclosure agreements treated like non-competes in South Carolina? {#confidentiality-ndas}
+
+**Short answer.** It depends on how broad they are. A genuine confidentiality or invention-assignment clause is not a restraint of trade and is not strictly construed against the employee — but an NDA that operates like a non-compete is judged like one [^milliken-not-restraint][^fay-functional-noncompete].
+
+In *Milliken & Co. v. Morin*, the South Carolina Supreme Court held that confidentiality and invention-assignment clauses are not in restraint of trade and should not be strictly construed in favor of the employee [^milliken-not-restraint]. Even so, those agreements are still restrictive covenants whose scope is subject to judicial review for reasonableness [^milliken-reasonableness-review].
+
+The line matters because a sweeping NDA can collapse into a functional non-compete. In *Fay v. Total Quality Logistics, LLC*, nondisclosure provisions that had the effect of a covenant not to compete required a reasonable time restriction like any other non-compete [^fay-functional-noncompete]. Because those provisions operated as non-competes with no reasonable time limit, they violated South Carolina public policy [^fay-no-time-limit].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not draft an open-ended NDA that bars an employee from doing similar work indefinitely. If a nondisclosure provision functions as a non-compete, South Carolina courts apply non-compete scrutiny — including a reasonable time limit — and an unlimited duration can void it [^fay-functional-noncompete][^fay-no-time-limit].
+
+## Does South Carolina treat sale-of-business non-competes differently? {#sale-of-business}
+
+**Short answer.** Yes. A covenant tied to the sale of a business is scrutinized at a more relaxed level than an employment covenant, so broader restraints may be easier to defend [^palmetto-relaxed-scrutiny].
+
+In *Palmetto Mortuary Transport, Inc. v. Knight Systems, Inc.*, the South Carolina Supreme Court applied this relaxed standard to a covenant executed with an asset purchase [^palmetto-relaxed-scrutiny]. Reviewing the restraint under that standard, the court upheld the territorial restriction as reasonable and enforceable [^palmetto-enforced]. The rationale is that a buyer is paying for goodwill, and the seller bargained for the price that the covenant helps protect [^palmetto-relaxed-scrutiny].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not assume the relaxed sale-of-business standard rescues an ordinary employment non-compete. The looser scrutiny applies because the covenant is part of a business sale; a covenant a worker signs as a condition of employment is still judged under the strict five-factor test [^palmetto-relaxed-scrutiny][^palmetto-enforced].
+
+## Does a South Carolina non-compete toll or extend during breach or litigation? {#tolling-extension}
+
+**Short answer.** South Carolina law points against it. In *Stonhard*, the Supreme Court held that extending a covenant's time period beyond its stated expiration would be against public policy, and no South Carolina decision endorses automatic judicial tolling during a breach [^stonhard-no-extension][^q8-team-ia-five-factor-test].
+
+The closest authority is *Stonhard, Inc. v. Carolina Flooring Specialists, Inc.*, which reasoned that judicially extending the restrained period would be arbitrary and would let a court disrupt the parties' private right to contract [^stonhard-no-extension]. That reflects the same strict-construction instinct behind South Carolina's no-reformation rule: a court will hold the parties to the period they wrote rather than lengthen it.
+
+A contractual tolling clause — language in the agreement that pauses the clock during a breach — is a different question that no surveyed South Carolina case squarely decides. Any such clause still has to satisfy the five-factor reasonableness test, and a clause that converts a fixed restraint into an open-ended one invites the same public-policy objection *Stonhard* raised [^q8-team-ia-five-factor-test].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Open question: South Carolina has not clearly decided whether a contractual extension-on-breach clause is enforceable, and *Stonhard* rejects judicially extending a covenant past its stated end date. Draft any tolling provision as a separate, reasonable term tied to the duration of the breach, and do not assume a court will lengthen an expired covenant [^stonhard-no-extension][^q8-team-ia-five-factor-test].
+
+## Are physician and healthcare non-competes enforceable in South Carolina? {#physician-healthcare}
+
+**Short answer.** For now, yes, under the same common-law test — South Carolina has no enacted physician-specific ban, though a bill to void physician non-competes passed the House in 2026 and is pending in the Senate [^h4767-physician-bill][^q9-team-ia-five-factor-test].
+
+A physician non-compete is currently analyzed under the ordinary five-factor reasonableness test, with the public-interest factor — patient access to care — as a likely pressure point [^q9-team-ia-five-factor-test]. That could change. H.4767, the Physician Noncompete Contract Prohibition Act, would add a new chapter declaring that contracts with physicians containing noncompete clauses are against South Carolina public policy [^h4767-physician-bill]. As of this review the bill had passed the House and received a favorable Senate committee report, but it had not been enacted.
+
+The bill is physician-specific — not a general healthcare-worker ban — and it is not an absolute prohibition. It would still let an employer recoup documented relocation, signing, retention, and training costs from a physician who leaves within a set period, and it preserves the employer's ability to protect trade secrets and confidential information; its limits would apply only to contracts or renewals entered on or after its effective date [^h4767-physician-bill].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Watch this bill, but do not treat it as law yet. H.4767 has not passed the Senate or been signed, so physician non-competes in South Carolina are still governed by common-law reasonableness; recheck the bill's status before relying on either the current rule or the proposed ban [^h4767-physician-bill][^q9-team-ia-five-factor-test].
+
+## Did the FTC's federal non-compete rule change South Carolina non-compete law? {#federal-ftc-overlay}
+
+**Short answer.** No. The FTC's 2024 nationwide Non-Compete Rule was set aside by a federal court before it took effect, so South Carolina non-competes remain governed by South Carolina common law [^ryan-ftc-set-aside].
+
+*Ryan LLC v. Federal Trade Commission* held that the FTC lacked statutory authority to issue the rule and that the rule was arbitrary and capricious [^ryan-ftc-unlawful]. The court set the rule aside and held it would not be enforced or take effect [^ryan-ftc-set-aside]. That removes the federal rule as a nationwide overlay but does not make any particular South Carolina covenant enforceable — the common-law reasonableness test still controls.
+
+"The Non-Compete Rule, 16 C.F.R. § 910.1–.6, is hereby SET ASIDE and shall not be enforced or otherwise take effect on September 4, 2024, or thereafter."[^ryan-ftc-set-aside]
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-03. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not South Carolina. This article synthesizes South Carolina primary law and is not legal advice from a South Carolina-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^team-ia-five-factor-test]: **Team IA, Inc. v. Lucas** — "A covenant not to compete will be upheld only if it is: (1) necessary for the protection of the legitimate interest of the employer; (2) reasonably limited in its operation with respect to time and place; (3) not unduly harsh and oppressive in curtailing the legitimate efforts of the employee to earn a livelihood; (4) reasonable from the standpoint of sound public policy; and (5) supported by valuable consideration." *Team IA, Inc. v. Lucas, 395 S.C. 237, 717 S.E.2d 103 (Ct. App. 2011).* <https://www.courtlistener.com/opinion/2507693/team-ia-inc-v-lucas/#:~:text=A%20covenant%20not%20to%20compete,(5)%20supported%20by%20valuable%20consideration.>
+
+[^kerrigan-restraint-of-trade]: **Standard Register Co. v. Kerrigan** — "The reason that contracts against competition are held to be unenforceable unless they meet certain criteria, is that they constitute a restraint upon trade which is against public policy." *Standard Register Co. v. Kerrigan, 238 S.C. 54, 119 S.E.2d 533 (1961).* <https://www.courtlistener.com/opinion/1356432/standard-register-co-v-kerrigan/#:~:text=The%20reason%20that%20contracts%20against,which%20is%20against%20public%20policy.>
+
+[^kerrigan-customer-protection]: **Standard Register Co. v. Kerrigan** — "A restrictive covenant, therefore, is reasonable if it is designed to protect the employer against loss of his customers." *Standard Register Co. v. Kerrigan, 238 S.C. 54, 119 S.E.2d 533 (1961).* <https://www.courtlistener.com/opinion/1356432/standard-register-co-v-kerrigan/#:~:text=A%20restrictive%20covenant%2C%20therefore%2C%20is,against%20loss%20of%20his%20customers.>
+
+[^oxman-employee-nonsolicit]: **Oxman v. Sherman** — "We construe the first covenant mentioned as restraining appellant from seeking to induce any of respondents' employees to breach their contract of employment and not as preventing him from seeking the services of such employees so long as there is no interference with their contractual relations with respondents." *Oxman v. Sherman, 239 S.C. 218, 122 S.E.2d 559 (1961).* <https://www.courtlistener.com/opinion/1336916/oxman-v-sherman/#:~:text=We%20construe%20the%20first%20covenant,their%20contractual%20relations%20with%20respondents.>
+
+[^trade-secrets-act-employee-duty]: **S.C. Code Ann. § 39-8-30** — "Every employee who is informed of or should reasonably have known from the circumstances of the existence of any employer's trade secret has a duty to refrain from using or disclosing the trade secret without the employer's permission independently of and in addition to any written contract of employment, secrecy agreement, noncompete agreement, nondisclosure agreement, or other agreement between the employer and the employee." *S.C. Code Ann. § 39-8-30(B).* <https://www.scstatehouse.gov/code/t39c008.php>
+
+[^trade-secrets-act-endures]: **S.C. Code Ann. § 39-8-30** — "A trade secret endures and is protectable and enforceable until it is disclosed or discovered by proper means." *S.C. Code Ann. § 39-8-30(A).* <https://www.scstatehouse.gov/code/t39c008.php>
+
+[^vessel-personal-contact]: **Vessel Medical, Inc. v. Elliott** — "Here, Elliott is restricted from soliciting customers with whom he had contact during his last 12 months of employment and such covenants have withstood overbreadth challenges." *Vessel Med., Inc. v. Elliott, No. 6:15-cv-00330-MGL, 2015 U.S. Dist. LEXIS 122436 (D.S.C. Sept. 15, 2015).* <https://www.courtlistener.com/docket/5358739/vessel-medical-inc-v-elliott/#:~:text=Here%2C%20Elliott%20is%20restricted%20from,covenants%20have%20withstood%20overbreadth%20challenges.>
+
+[^fournil-ordinary-competition]: **Fournil v. Turbeville Insurance Agency, Inc.** — "An employer is not, however, entitled to enforce an agreement preventing ordinary competition." *Fournil v. Turbeville Ins. Agency, Inc., No. 3:07-cv-03836-JFA (D.S.C. Mar. 2, 2009).* <https://www.courtlistener.com/docket/4822524/fournil-v-turbeville-insurance-agency-inc/#:~:text=An%20employer%20is%20not%2C%20however%2C,an%20agreement%20preventing%20ordinary%20competition.>
+
+[^fournil-no-legitimate-interest]: **Fournil v. Turbeville Insurance Agency, Inc.** — "The magistrate found that prohibiting such contacts was not related to any legitimate interest of Turbeville, and this conclusion was well-founded." *Fournil v. Turbeville Ins. Agency, Inc., No. 3:07-cv-03836-JFA (D.S.C. Mar. 2, 2009).* <https://www.courtlistener.com/docket/4822524/fournil-v-turbeville-insurance-agency-inc/#:~:text=The%20magistrate%20found%20that%20prohibiting,and%20this%20conclusion%20was%20well%2Dfounded.>
+
+[^poole-separate-consideration]: **Poole v. Incentives Unlimited, Inc.** — "Therefore, we adopt the rule that when a covenant is entered into after the inception of employment, separate consideration, in addition to continued at-will employment, is necessary in order for the covenant to be enforceable." *Poole v. Incentives Unlimited, Inc., 345 S.C. 378, 548 S.E.2d 207 (2001).* <https://www.courtlistener.com/opinion/1328953/poole-v-incentives-unlimited-inc/#:~:text=Therefore%2C%20we%20adopt%20the%20rule,the%20covenant%20to%20be%20enforceable.>
+
+[^poole-duties-unchanged]: **Poole v. Incentives Unlimited, Inc.** — "In the instant case, Poole's duties, position, and salary were left unchanged." *Poole v. Incentives Unlimited, Inc., 345 S.C. 378, 548 S.E.2d 207 (2001).* <https://www.courtlistener.com/opinion/1328953/poole-v-incentives-unlimited-inc/#:~:text=In%20the%20instant%20case%2C%20Poole's,and%20salary%20were%20left%20unchanged.>
+
+[^kerrigan-territorial-scope]: **Standard Register Co. v. Kerrigan** — "Stated negatively, the territorial scope renders the restraint unreasonable if it covers an area broader than necessary to protect the legitimate interest of the employer." *Standard Register Co. v. Kerrigan, 238 S.C. 54, 119 S.E.2d 533 (1961).* <https://www.courtlistener.com/opinion/1356432/standard-register-co-v-kerrigan/#:~:text=Stated%20negatively%2C%20the%20territorial%20scope,legitimate%20interest%20of%20the%20employer.>
+
+[^q4-team-ia-five-factor-test]: **Team IA, Inc. v. Lucas** — "A covenant not to compete will be upheld only if it is: (1) necessary for the protection of the legitimate interest of the employer; (2) reasonably limited in its operation with respect to time and place; (3) not unduly harsh and oppressive in curtailing the legitimate efforts of the employee to earn a livelihood; (4) reasonable from the standpoint of sound public policy; and (5) supported by valuable consideration." *Team IA, Inc. v. Lucas, 395 S.C. 237, 717 S.E.2d 103 (Ct. App. 2011).* <https://www.courtlistener.com/opinion/2507693/team-ia-inc-v-lucas/#:~:text=A%20covenant%20not%20to%20compete,(5)%20supported%20by%20valuable%20consideration.>
+
+[^poynter-no-blue-pencil]: **Poynter Investments, Inc. v. Century Builders of Piedmont, Inc.** — "These cases stand for the proposition that, in South Carolina, the restrictions in a non-compete clause cannot be rewritten by a court or limited by the parties' agreement, but must stand or fall on their own terms." *Poynter Invs., Inc. v. Century Builders of Piedmont, Inc., 387 S.C. 583, 694 S.E.2d 15 (2010).* <https://www.courtlistener.com/opinion/1316178/poynter-investments-inc-v-century-builders-of-piedmont-inc/#:~:text=These%20cases%20stand%20for%20the,fall%20on%20their%20own%20terms.>
+
+[^stonhard-no-reformation]: **Stonhard, Inc. v. Carolina Flooring Specialists, Inc.** — "We hold, therefore, that the contract may not be reformed or blue-penciled so as to add an entirely new term to which neither of the parties agreed." *Stonhard, Inc. v. Carolina Flooring Specialists, Inc., 366 S.C. 156, 621 S.E.2d 352 (2005).* <https://www.courtlistener.com/opinion/1202971/stonhard-inc-v-carolina-flooring-specialists-inc/#:~:text=We%20hold%2C%20therefore%2C%20that%20the,neither%20of%20the%20parties%20agreed.>
+
+[^poynter-rewrite-error]: **Poynter Investments, Inc. v. Century Builders of Piedmont, Inc.** — "We reverse the order which purports to enforce a non-competition agreement on terms other than those agreed upon by the parties." *Poynter Invs., Inc. v. Century Builders of Piedmont, Inc., 387 S.C. 583, 694 S.E.2d 15 (2010).* <https://www.courtlistener.com/opinion/1316178/poynter-investments-inc-v-century-builders-of-piedmont-inc/#:~:text=We%20reverse%20the%20order%20which,agreed%20upon%20by%20the%20parties.>
+
+[^team-ia-step-down]: **Team IA, Inc. v. Lucas** — "However, we conclude the alternative territorial restriction contained in the parties' original agreement (South Carolina, North Carolina, Georgia, and Alabama) would remain valid and enforceable to the extent it is not overly broad after further development of the facts." *Team IA, Inc. v. Lucas, 395 S.C. 237, 717 S.E.2d 103 (Ct. App. 2011).* <https://www.courtlistener.com/opinion/2507693/team-ia-inc-v-lucas/#:~:text=However%2C%20we%20conclude%20the%20alternative,further%20development%20of%20the%20facts.>
+
+[^milliken-not-restraint]: **Milliken & Co. v. Morin** — "We therefore hold confidentiality and invention assignment clauses are not in restraint of trade and should not be strictly construed in favor of the employee." *Milliken & Co. v. Morin, 399 S.C. 23, 731 S.E.2d 288 (2012).* <https://www.courtlistener.com/opinion/8327160/milliken-co-v-morin/#:~:text=We%20therefore%20hold%20confidentiality%20and,in%20favor%20of%20the%20employee.>
+
+[^fay-functional-noncompete]: **Fay v. Total Quality Logistics, LLC** — "Because the nondisclosure provisions had the effect of a covenant not to compete, they required a reasonable time restriction like any other noncompete agreement." *Fay v. Total Quality Logistics, LLC, 419 S.C. 622, 799 S.E.2d 318 (Ct. App. 2017).* <https://www.courtlistener.com/opinion/8328279/fay-v-total-quality-logistics-llc/#:~:text=Because%20the%20nondisclosure%20provisions%20had,like%20any%20other%20noncompete%20agreement.>
+
+[^milliken-reasonableness-review]: **Milliken & Co. v. Morin** — "Nevertheless, these agreements are still restrictive covenants and public policy demands their scope be subject to judicial review for reasonableness." *Milliken & Co. v. Morin, 399 S.C. 23, 731 S.E.2d 288 (2012).* <https://www.courtlistener.com/opinion/8327160/milliken-co-v-morin/#:~:text=Nevertheless%2C%20these%20agreements%20are%20still,to%20judicial%20review%20for%20reasonableness.>
+
+[^fay-no-time-limit]: **Fay v. Total Quality Logistics, LLC** — "The nondisclosure provisions in paragraphs four and six operated as noncompete provisions with no reasonable time restriction, which violated the public policy of South Carolina." *Fay v. Total Quality Logistics, LLC, 419 S.C. 622, 799 S.E.2d 318 (Ct. App. 2017).* <https://www.courtlistener.com/opinion/8328279/fay-v-total-quality-logistics-llc/#:~:text=The%20nondisclosure%20provisions%20in%20paragraphs,public%20policy%20of%20South%20Carolina.>
+
+[^palmetto-relaxed-scrutiny]: **Palmetto Mortuary Transport, Inc. v. Knight Systems, Inc.** — "Non-compete covenants executed in conjunction with the sale of a business should be scrutinized at a more relaxed level than non-compete covenants executed in conjunction with employment contracts." *Palmetto Mortuary Transp., Inc. v. Knight Sys., Inc., 424 S.C. 444, 818 S.E.2d 724 (2018).* <https://www.courtlistener.com/opinion/8399125/palmetto-mortuary-transp-inc-v-knight-sys-inc/#:~:text=Non%2Dcompete%20covenants%20executed%20in%20conjunction,in%20conjunction%20with%20employment%20contracts.>
+
+[^palmetto-enforced]: **Palmetto Mortuary Transport, Inc. v. Knight Systems, Inc.** — "We hold the territorial restriction of the non-compete covenant is reasonable and enforceable, and we hold Knight's additional sustaining grounds are without merit." *Palmetto Mortuary Transp., Inc. v. Knight Sys., Inc., 424 S.C. 444, 818 S.E.2d 724 (2018).* <https://www.courtlistener.com/opinion/8399125/palmetto-mortuary-transp-inc-v-knight-sys-inc/#:~:text=We%20hold%20the%20territorial%20restriction,sustaining%20grounds%20are%20without%20merit.>
+
+[^stonhard-no-extension]: **Stonhard, Inc. v. Carolina Flooring Specialists, Inc.** — "Accordingly, any extension of the time period would be against public policy, because it would be arbitrary and set precedent allowing a court to disrupt a party's private right to contract." *Stonhard, Inc. v. Carolina Flooring Specialists, Inc., 366 S.C. 156, 621 S.E.2d 352 (2005).* <https://www.courtlistener.com/opinion/1202971/stonhard-inc-v-carolina-flooring-specialists-inc/#:~:text=Accordingly%2C%20any%20extension%20of%20the,party's%20private%20right%20to%20contract.>
+
+[^q8-team-ia-five-factor-test]: **Team IA, Inc. v. Lucas** — "A covenant not to compete will be upheld only if it is: (1) necessary for the protection of the legitimate interest of the employer; (2) reasonably limited in its operation with respect to time and place; (3) not unduly harsh and oppressive in curtailing the legitimate efforts of the employee to earn a livelihood; (4) reasonable from the standpoint of sound public policy; and (5) supported by valuable consideration." *Team IA, Inc. v. Lucas, 395 S.C. 237, 717 S.E.2d 103 (Ct. App. 2011).* <https://www.courtlistener.com/opinion/2507693/team-ia-inc-v-lucas/#:~:text=A%20covenant%20not%20to%20compete,(5)%20supported%20by%20valuable%20consideration.>
+
+[^h4767-physician-bill]: **H.4767, Physician Noncompete Contract Prohibition Act** — "Contracts with physicians containing noncompete clauses are considered interference with the establishment or maintenance of a patient's choice of physician and are against the public policy of the State of South Carolina." *H.4767, 126th Gen. Assemb., Reg. Sess. (S.C. 2026) (passed House Mar. 26, 2026; favorable Senate committee report May 5, 2026; not enacted).* <https://www.scstatehouse.gov/sess126_2025-2026/prever/4767_20260505.htm>
+
+[^q9-team-ia-five-factor-test]: **Team IA, Inc. v. Lucas** — "A covenant not to compete will be upheld only if it is: (1) necessary for the protection of the legitimate interest of the employer; (2) reasonably limited in its operation with respect to time and place; (3) not unduly harsh and oppressive in curtailing the legitimate efforts of the employee to earn a livelihood; (4) reasonable from the standpoint of sound public policy; and (5) supported by valuable consideration." *Team IA, Inc. v. Lucas, 395 S.C. 237, 717 S.E.2d 103 (Ct. App. 2011).* <https://www.courtlistener.com/opinion/2507693/team-ia-inc-v-lucas/#:~:text=A%20covenant%20not%20to%20compete,(5)%20supported%20by%20valuable%20consideration.>
+
+[^ryan-ftc-set-aside]: **Ryan LLC v. Federal Trade Commission** — "The Non-Compete Rule, 16 C.F.R. § 910.1–.6, is hereby SET ASIDE and shall not be enforced or otherwise take effect on September 4, 2024, or thereafter." *Ryan LLC v. Fed. Trade Comm'n, 746 F. Supp. 3d 369 (N.D. Tex. 2024).* <https://www.courtlistener.com/opinion/10205745/ryan-llc-v-federal-trade-commission/#:~:text=The%20Non%2DCompete%20Rule%2C%2016%20C.F.R.,September%204%2C%202024%2C%20or%20thereafter.>
+
+[^ryan-ftc-unlawful]: **Ryan LLC v. Federal Trade Commission** — "In sum, the Court concludes that the FTC lacks statutory authority to promulgate the Non- Compete Rule, and that the Rule is arbitrary and capricious." *Ryan LLC v. Fed. Trade Comm'n, 746 F. Supp. 3d 369 (N.D. Tex. 2024).* <https://www.courtlistener.com/opinion/10205745/ryan-llc-v-federal-trade-commission/#:~:text=In%20sum%2C%20the%20Court%20concludes%20that,Rule%20is%20arbitrary%20and%20capricious.>

--- a/skills/non-compete-contract-explainer/content/south-dakota.md
+++ b/skills/non-compete-contract-explainer/content/south-dakota.md
@@ -1,0 +1,222 @@
+---
+jurisdiction: "South Dakota"
+slug: south-dakota
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-02"
+canonicalUrl: https://openagreements.org/legal/non-compete/south-dakota
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/south-dakota · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in South Dakota[^about]
+
+A question-by-question summary of South Dakota non-compete law under SDCL chapter 53-9, including employee covenants, customer non-solicits, healthcare practitioners, sale-of-business covenants, independent contractors, and trade-secret alternatives.
+
+
+## At a glance
+
+| Question | South Dakota |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed if reasonable |
+| **Bottom line** | South Dakota voids restraints on a lawful profession, trade, or business unless they fit a narrowly construed statutory exception, and SDCL 53-9-11 permits an employee non-compete only within its two-year, geographic, existing-customer, and like-business limits. |
+| **Main law or case** | S.D. Codified Laws §§ 53-9-8 and 53-9-11 |
+| **Main exceptions** | Sale-of-goodwill (§ 53-9-9); partnership dissolution (§ 53-9-10); captive insurance agent contractors (§ 53-9-12); healthcare practitioner restrictions voidable for contracts on/after July 1, 2023 |
+| **Can a court narrow it?** | Yes — rewrites to reasonable |
+| **Applies to contractors?** | No |
+| **Restriction extended during a breach?** | Not addressed by statute |
+| **Maximum length set by law** | Two years or less for employee covenants (SDCL 53-9-11) |
+
+## Are employee non-compete agreements enforceable in South Dakota? {#employee-noncompetes}
+
+**Short answer.** Sometimes, but only inside the statutory exception. SDCL 53-9-8 voids restraints on a lawful profession, trade, or business[^sdcl-53-9-8-void-baseline] except for the chapter 53-9 exceptions, and SDCL 53-9-11 allows an employee covenant only within its time, geography, customer, and like-business limits [^sdcl-53-9-11-employee-exception].
+
+The practical rule is statutory first. South Dakota does not start with a free-floating reasonableness test for ordinary employee non-competes. A covenant must fit an exception, and South Dakota cases repeatedly say those exceptions are read narrowly [^american-rim-narrow-exception][^dolly-narrow-exception].
+
+For employees, the core drafting limits are two years or less, a specified county, first- or second-class municipality, or other specified area, existing customers only for a customer non-solicit, and a requirement that the employer continue a like business in the restricted area [^sdcl-53-9-11-employee-exception].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not treat statutory compliance as optional style. If the covenant restrains work but does not fit an exception in SDCL chapter 53-9, the baseline statute voids it to that extent [^sdcl-53-9-8-void-baseline].
+
+## Are customer non-solicitation agreements enforceable in South Dakota? {#customer-nonsolicits}
+
+**Short answer.** Yes, if they are true solicitation restrictions within SDCL 53-9-11. They cannot be expanded into a ban on accepting unsolicited business from former customers [^miller-unsolicited-business].
+
+South Dakota draws a sharp line between soliciting a customer and accepting customer work that the former employee did not solicit. *Miller* applied SDCL 53-9-11 and held that none of the statutory exceptions permit a covenant barring acceptance of unsolicited business [^miller-unsolicited-business].
+
+That reading is consistent with *Dolly*, which interpreted the closely similar captive-insurance-agent statute. *Dolly* held that an agreement not to solicit is not the same as an agreement not to sell to customers who ask for service on their own [^dolly-solicit-not-sell].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Avoid no-service, no-sale, and no-acceptance language in a South Dakota customer non-solicit. The safer clause targets affirmative solicitation of existing customers in the specified area and leaves unsolicited customer choice alone [^miller-unsolicited-business][^dolly-solicit-not-sell].
+
+## Can South Dakota independent contractors be bound by non-competes? {#independent-contractors}
+
+**Short answer.** Usually not under the employee exception. In *Aqreva*, South Dakota's Supreme Court refused to apply SDCL 53-9-11 where the agreement said the worker was an independent contractor and not an employee [^aqreva-employee-exception-limited].
+
+The contractor label does not solve every case by itself, but it can be fatal when the party seeking enforcement relies on the employee exception. *Aqreva* treated the contract language disclaiming an agency or employment relationship as controlling for SDCL 53-9-11 [^aqreva-employee-exception-limited].
+
+South Dakota does have a separate statutory exception for a narrow insurance category: captive insurance agents who are independent contractors and work exclusively for a single insurer or affiliated group. That exception is in SDCL 53-9-12, not the general employee statute [^sdcl-53-9-12-captive-agent].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not assume that reclassifying a worker as a contractor preserves an employee non-compete. If the relationship is not employee-employer, the drafter needs a different statutory hook, and most contractors will not fit the captive-agent exception [^aqreva-employee-exception-limited][^sdcl-53-9-12-captive-agent].
+
+## Can a no-hire agreement with a customer or vendor restrict a South Dakota worker? {#no-hire-third-party}
+
+**Short answer.** Not as a backdoor employee restraint. A no-hire or no-recruit clause between two businesses is enforceable only where it supplements an employee covenant that is itself valid under SDCL 53-9-11; an employer cannot bind its own worker through a contract with a third party [^densmore-third-party-restraint].
+
+In *Densmore*, a company tried to keep a departing worker in place by relying on a clause in its services contract with another business that barred that business from hiring, soliciting, or recruiting its employees. The South Dakota Supreme Court treated the no-recruit clause as a variation on the covenant not to compete governed by SDCL 53-9-11 and the baseline rule of SDCL 53-9-8, and held that the employer could not use a third-party agreement to restrain an employee who had signed no valid covenant of his own [^densmore-third-party-restraint].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not rely on a no-poach or no-hire clause in a customer, vendor, or services agreement to lock in a South Dakota worker. If the worker has signed no valid SDCL 53-9-11 covenant, the third-party clause will not supply one [^densmore-third-party-restraint].
+
+## What special non-compete rules apply to South Dakota healthcare practitioners? {#healthcare-practitioners}
+
+**Short answer.** For contracts entered into on or after July 1, 2023, covered practitioner restrictions are voidable if they restrict the practitioner from practicing or otherwise providing professional services after the relationship ends [^sdcl-53-9-11-2-practitioner-voidable].
+
+The healthcare rule is broader than a physician-only rule. SDCL 53-9-11.1 defines practitioner for section 53-9-11.2 and includes physicians, physician assistants, emergency medical personnel, respiratory care practitioners, nurses, dentists, pharmacists, psychologists, social workers, counselors, therapists, podiatrists, optometrists, chiropractors, and several other licensed roles [^sdcl-53-9-11-1-practitioner-list].
+
+The statute preserves two important categories. It does not apply to a contractual provision effective on the sale of a practice or an interest in a practice, and it does not bar a practitioner patient or client non-solicit if the solicitation restriction complies with the geographic and temporal limits referenced in SDCL 53-9-11 [^sdcl-53-9-11-2-practitioner-exceptions].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Use the statutory word *voidable*, not *void*, for covered practitioner restrictions. Also separate a practice restriction from a compliant current-patient or current-client solicitation restriction because section 53-9-11.2 treats those differently [^sdcl-53-9-11-2-practitioner-voidable][^sdcl-53-9-11-2-practitioner-exceptions].
+
+## Are sale-of-business non-competes enforceable in South Dakota? {#sale-of-business}
+
+**Short answer.** Yes, when they fit the sale-of-goodwill exception and stay within its limits. SDCL 53-9-9 allows a seller of goodwill to refrain from carrying on a similar business in a specified area while the buyer or successor carries on a like business there [^sdcl-53-9-9-goodwill-exception].
+
+The sale exception is still not open-ended. *Franklin* treated a restaurant-sale covenant as within the goodwill-sale framework, but narrowed overbroad language that reached isolated, insubstantial, or non-detrimental activity rather than carrying on a similar business [^franklin-overbroad-goodwill].
+
+The key drafting move is to tie the restriction to purchased goodwill. A buyer may protect against detrimental competition from the seller, but the covenant should not reach tangential roles, passive interests, or activities that do not fairly count as carrying on a similar competing business [^franklin-similar-business].
+
+South Dakota also recognizes a parallel exception for partnerships. On or in anticipation of dissolution, partners may agree not to carry on a similar business, though the permitted geography is tighter than the goodwill-sale rule, reaching only the same municipality where the partnership did business [^sdcl-53-9-10-partnership-dissolution].
+
+## Will South Dakota courts narrow an overbroad non-compete? {#overbroad-covenants}
+
+**Short answer.** Sometimes. South Dakota recognizes partial enforcement, but that does not let a drafter ignore the statute; the court modifies only to conform the covenant to statutory limits [^franklin-partial-enforcement].
+
+In *Franklin*, the court held that the sale-of-business covenant was broader than SDCL 53-9-9 allowed, but it did not invalidate the entire provision. It remanded for relief consistent with the narrower statutory construction [^franklin-partial-enforcement].
+
+For employment covenants, *Rezatto* also matters because SDCL 53-9-8 voids a contract only to the extent it restrains trade, and divisible nondisclosure or confidentiality promises can survive even when a non-compete fails [^rezatto-divisible-nda].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Partial enforcement is a backstop, not a drafting strategy. South Dakota cases still construe exceptions narrowly and refuse to invent statutory exceptions that the Legislature did not adopt [^franklin-partial-enforcement][^miller-no-new-exception].
+
+## Does continued employment or termination status matter for South Dakota non-competes? {#consideration-termination}
+
+**Short answer.** Yes, but carefully. SDCL 53-9-11 permits an employee to agree at the time of employment or during employment, while older case law treats continued employment as sufficient consideration in that setting [^sdcl-53-9-11-during-employment][^zakinski-continued-employment].
+
+The continued-employment point comes from *Zakinski*, so it should be used with age and context in mind. The case also drew a practical distinction between employees who quit or are fired for cause and employees fired through no fault of their own. For the latter, the court required a reasonableness balancing inquiry [^zakinski-fired-no-fault].
+
+That makes discharge facts relevant to enforcement strategy. A covenant that appears statutory on paper can still face equitable limits if the employer terminated the employee through no fault of the employee and then seeks to restrain later work [^zakinski-fired-no-fault].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not overstate *Zakinski* as a modern blank-check consideration rule. It is useful South Dakota authority for continued employment, but the same opinion requires more analysis when the employee was fired through no fault of their own [^zakinski-continued-employment][^zakinski-fired-no-fault].
+
+## Can an out-of-state choice-of-law clause save a South Dakota non-compete? {#choice-of-law}
+
+**Short answer.** Not if applying the other state's law would contravene South Dakota public policy. *Miller* applied South Dakota law despite an Iowa choice-of-law clause because the challenged non-solicit violated South Dakota policy in part [^miller-choice-law-public-policy].
+
+The public-policy point is important because SDCL 53-9-8 is not merely a private contract default. *Miller* relied on South Dakota's policy against restraints of a lawful profession, trade, or business, then refused to enforce a no-acceptance restriction under another state's law [^miller-choice-law-public-policy].
+
+For drafting, that means a South Dakota worker, South Dakota restricted territory, or South Dakota customer base should be analyzed under South Dakota chapter 53-9 even if the template names another state's law.
+
+## Are trade-secret and confidentiality protections still available in South Dakota? {#trade-secrets-ndas}
+
+**Short answer.** Yes. South Dakota non-compete limits do not eliminate confidentiality and trade-secret tools, and the South Dakota Uniform Trade Secrets Act includes fee-shifting and a three-year limitations period [^rezatto-confidentiality-public-policy][^sdcl-37-29-4-fees][^sdcl-37-29-6-limitations].
+
+*Rezatto* distinguishes nondisclosure restrictions from general non-competes and explains why confidential-information protection can support fair competition. That said, confidentiality covenants are still strictly construed and enforced only to the extent reasonably necessary to protect the employer's interest in confidential information [^rezatto-confidentiality-public-policy].
+
+The statutory trade-secret remedies can matter in both directions. Bad-faith misappropriation claims, bad-faith injunction fights, and willful and malicious misappropriation can trigger attorney-fee awards, and a misappropriation claim must be brought within three years after discovery or when reasonable diligence should have discovered it [^sdcl-37-29-4-fees][^sdcl-37-29-6-limitations].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not use an NDA as a disguised work ban. South Dakota supports confidential-information protection, but *Rezatto* enforces those covenants only to the extent reasonably necessary to protect confidential information [^rezatto-confidentiality-public-policy].
+
+## What survival-drafting issue should South Dakota non-compete templates avoid? {#survival-drafting}
+
+**Short answer.** If the agreement has a fixed term, restrictive covenants need clear survival language. In *Wilbur-Ellis*, the Eighth Circuit held that the covenants ended with the agreement because they did not expressly survive its termination [^wilbur-ellis-no-survival].
+
+The case is a drafting warning, not a new statutory exception. In the acquisition setting, the covenants were meant to give the buyer time to transition the business and protect purchased goodwill during the specified duration [^wilbur-ellis-statutory-context].
+
+For templates, align the duration clause, agreement term, termination language, and restrictive-covenant survival clause. A covenant that appears enforceable under SDCL 53-9-11 may still fail if the contract itself ends before the restriction is triggered.
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-02. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not South Dakota. This article synthesizes South Dakota primary law and is not legal advice from a South Dakota-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^sdcl-53-9-8-void-baseline]: **S.D. Codified Laws § 53-9-8** — "Any contract restraining exercise of a lawful profession, trade, or business is void to that extent, except as provided by §§ 53-9-9 to 53-9-12, inclusive." *S.D. Codified Laws § 53-9-8.* <https://sdlegislature.gov/Statutes/53-9-8>
+
+[^sdcl-53-9-11-employee-exception]: **S.D. Codified Laws § 53-9-11** — "Except as otherwise provided in § 53-9-11.2, an employee may agree with an employer at the time of employment or at any time during employment not to engage directly or indirectly in the same business or profession as that of the employer for any period not exceeding two years from the date of termination of the agreement and not to solicit existing customers of the employer within a specified county, first- or second-class municipality, or other specified area for any period not exceeding two years from the date of termination of the agreement, if the employer continues to carry on a like business therein." *S.D. Codified Laws § 53-9-11.* <https://sdlegislature.gov/Statutes/53-9-11>
+
+[^american-rim-narrow-exception]: **American Rim & Brake, Inc. v. Zoellner** — "In reading the exception, we must construe it narrowly so as to promote the proscription against general restraints on trade." *American Rim & Brake, Inc. v. Zoellner, 382 N.W.2d 421, 424 (S.D. 1986).* <https://www.courtlistener.com/opinion/1585102/american-rim-brake-inc-v-zoellner/#:~:text=In%20reading%20the%20exception%2C%20we,against%20general%20restraints%20on%20trade.>
+
+[^dolly-narrow-exception]: **Farm Bureau Life Ins. Co. v. Dolly** — "As such, SDCL 53-9-12 ‘must be construed narrowly so as to promote the prohibition against contracts in restraint of trade.’" *Farm Bureau Life Ins. Co. v. Dolly, 2018 S.D. 28, ¶ 13, 910 N.W.2d 196.* <https://www.courtlistener.com/opinion/4479790/farm-bureau-life-ins-co-v-dolly/#:~:text=As%20such%2C%20SDCL%2053%2D9%2D12%20%E2%80%9Cmust,contracts%20in%20restraint%20of%20trade.%E2%80%9D>
+
+[^miller-unsolicited-business]: **Miller v. Honkamp Krueger Financial Services, Inc.** — "None of the enumerated statutory exceptions allow for agreements not to accept unsolicited business." *Miller v. Honkamp Krueger Fin. Servs., Inc., 9 F.4th 1011, 1019 (8th Cir. 2021).* <https://www.courtlistener.com/opinion/5040408/cara-miller-v-honkamp-krueger-financial/#:~:text=None%20of%20the%20enumerated%20statutory,not%20to%20accept%20unsolicited%20business.>
+
+[^dolly-solicit-not-sell]: **Farm Bureau Life Ins. Co. v. Dolly** — "The circuit court’s conclusion that SDCL 53-9-12 permits an agreement not to solicit—rather than not to sell to—an insurer’s existing customers is the only reasonable interpretation of that statute." *Farm Bureau Life Ins. Co. v. Dolly, 2018 S.D. 28, ¶ 10, 910 N.W.2d 196.* <https://www.courtlistener.com/opinion/4479790/farm-bureau-life-ins-co-v-dolly/#:~:text=The%20circuit%20court%E2%80%99s%20conclusion%20that,reasonable%20interpretation%20of%20that%20statute.>
+
+[^aqreva-employee-exception-limited]: **Aqreva, LLC v. Eide Bailly, LLP** — "Per the plain language of SDCL 53-9-11, the Legislature has limited the provisions of this statute to an ‘employee’s covenant not to compete with his employer.’" *Aqreva, LLC v. Eide Bailly, LLP, 2020 S.D. 59, ¶ 32, 950 N.W.2d 774.* <https://www.courtlistener.com/opinion/9507869/aqreva-llc-v-eide-bailly-llp/#:~:text=Per%20the%20plain%20language%20of,to%20compete%20with%20his%20employer.%E2%80%9D>
+
+[^sdcl-53-9-12-captive-agent]: **S.D. Codified Laws § 53-9-12** — "Any independent contractor who is an insurance producer as defined in subdivision 58-1-2(16) and is a captive agent who is not an independent agent and who works exclusively for a single insurance company or an affiliated group of insurance companies, even if the single insurance company allows its captive agents to market the products of another insurance company pursuant to contract, may agree with an insurer at the time of contracting or at any time during the term of the contract:" *S.D. Codified Laws § 53-9-12.* <https://sdlegislature.gov/Statutes/53-9-12>
+
+[^densmore-third-party-restraint]: **Communication Technical Sys., Inc. v. Densmore** — "Instead, CTS sought to bind its employee through an agreement with a third party. As we have stated, this it may not do." *Communication Technical Sys., Inc. v. Densmore, 1998 S.D. 87, ¶ 27, 583 N.W.2d 125.* <https://www.courtlistener.com/opinion/1882124/communication-technical-systems-inc-v-densmore/#:~:text=Instead%2C%20CTS%20sought%20to%20bind,this%20it%20may%20not%20do.>
+
+[^sdcl-53-9-11-2-practitioner-voidable]: **S.D. Codified Laws § 53-9-11.2** — "Notwithstanding § 53-9-11, a provision of a contract, entered into on or after July 1, 2023, is voidable if it restricts a practitioner, as defined in § 53-9-11.1, from practicing or otherwise providing professional services in accordance with the applicable scope of practice, after the conclusion of the practitioner's employment or after the dissolution of a partnership or other form of professional relationship." *S.D. Codified Laws § 53-9-11.2.* <https://sdlegislature.gov/Statutes/53-9-11.2>
+
+[^sdcl-53-9-11-1-practitioner-list]: **S.D. Codified Laws § 53-9-11.1** — "For purposes of § 53-9-11.2, a practitioner means: (1) A physician licensed in accordance with chapter 36-4; (2) A physician assistant licensed in accordance with chapter 36-4A; (3) A paramedic or emergency medical technician licensed in accordance with chapter 36-4B; (4) A respiratory care practitioner licensed in accordance with chapter 36-4C; (5) A chiropractor licensed in accordance with chapter 36-5;" *S.D. Codified Laws § 53-9-11.1.* <https://sdlegislature.gov/Statutes/53-9-11.1>
+
+[^sdcl-53-9-11-2-practitioner-exceptions]: **S.D. Codified Laws § 53-9-11.2** — "This section does not apply to any contractual provision that: (1) Is effective upon the sale of a practice or interest in a practice; or (2) Restricts a practitioner from soliciting current patients or clients of the former employer, partnership, or other professional relationship, provided the solicitation complies with the geographic and temporal limitations as referenced in § 53-9-11." *S.D. Codified Laws § 53-9-11.2(1)-(2).* <https://sdlegislature.gov/Statutes/53-9-11.2>
+
+[^sdcl-53-9-9-goodwill-exception]: **S.D. Codified Laws § 53-9-9** — "Any person who sells the good will of a business may agree with the buyer to refrain from carrying on a similar business within a specified county, city, or other specified area, as long as the buyer or person deriving title to the good will from the seller carries on a like business within the specified geographical area." *S.D. Codified Laws § 53-9-9.* <https://sdlegislature.gov/Statutes/53-9-9>
+
+[^franklin-overbroad-goodwill]: **Franklin v. Forever Venture, Inc.** — "Therefore, to the extent that the agreement may restrain Franklin from activities which could not fairly be characterized as ‘carrying on a similar business,’ it is void as against public policy." *Franklin v. Forever Venture, Inc., 2005 S.D. 53, ¶ 14, 696 N.W.2d 545.* <https://www.courtlistener.com/opinion/901375/franklin-v-forever-venture-inc/#:~:text=Therefore%2C%20to%20the%20extent%20that,void%20as%20against%20public%20policy.>
+
+[^franklin-similar-business]: **Franklin v. Forever Venture, Inc.** — "We conclude that a determination of what constitutes ‘carrying on a similar business’ in SDCL 53-9-9 should not include businesses or activities that are isolated, insubstantial, or non-detrimental." *Franklin v. Forever Venture, Inc., 2005 S.D. 53, ¶ 13, 696 N.W.2d 545.* <https://www.courtlistener.com/opinion/901375/franklin-v-forever-venture-inc/#:~:text=We%20conclude%20that%20a%20determination,are%20isolated%2C%20insubstantial%2C%20or%20non%2Ddetrimental.>
+
+[^sdcl-53-9-10-partnership-dissolution]: **S.D. Codified Laws § 53-9-10** — "Partners may, upon or in anticipation of a dissolution of the partnership, agree that none of them will carry on a similar business within the same municipality where the partnership business has been transacted or within a specified part thereof." *S.D. Codified Laws § 53-9-10.* <https://sdlegislature.gov/Statutes/53-9-10>
+
+[^franklin-partial-enforcement]: **Franklin v. Forever Venture, Inc.** — "Yet, despite the covenant being overbroad in its restraint, we need not invalidate the entire provision." *Franklin v. Forever Venture, Inc., 2005 S.D. 53, ¶ 15, 696 N.W.2d 545.* <https://www.courtlistener.com/opinion/901375/franklin-v-forever-venture-inc/#:~:text=Yet%2C%20despite%20the%20covenant%20being,not%20invalidate%20the%20entire%20provision.>
+
+[^rezatto-divisible-nda]: **1st American Systems, Inc. v. Rezatto** — "The trial court erred in completely voiding the instant contract since it is divisible and paragraph 7 is not a general restraint on trade." *1st American Systems, Inc. v. Rezatto, 311 N.W.2d 51, 57 (S.D. 1981).* <https://www.courtlistener.com/opinion/2193337/1st-american-systems-inc-v-rezatto/#:~:text=The%20trial%20court%20erred%20in,a%20general%20restraint%20on%20trade.>
+
+[^miller-no-new-exception]: **Miller v. Honkamp Krueger Financial Services, Inc.** — "We will not read into the statute an exception that the South Dakota legislature did not adopt." *Miller v. Honkamp Krueger Fin. Servs., Inc., 9 F.4th 1011, 1019 (8th Cir. 2021).* <https://www.courtlistener.com/opinion/5040408/cara-miller-v-honkamp-krueger-financial/#:~:text=We%20will%20not%20read%20into,Dakota%20legislature%20did%20not%20adopt.>
+
+[^sdcl-53-9-11-during-employment]: **S.D. Codified Laws § 53-9-11** — "Except as otherwise provided in § 53-9-11.2, an employee may agree with an employer at the time of employment or at any time during employment not to engage directly or indirectly in the same business or profession as that of the employer for any period not exceeding two years from the date of termination of the agreement and not to solicit existing customers of the employer within a specified county, first- or second-class municipality, or other specified area for any period not exceeding two years from the date of termination of the agreement, if the employer continues to carry on a like business therein." *S.D. Codified Laws § 53-9-11.* <https://sdlegislature.gov/Statutes/53-9-11>
+
+[^zakinski-continued-employment]: **Central Monitoring Service, Inc. v. Zakinski** — "That the Non-Compete and Confidentiality Agreement executed by Zakinski on June 9, 1992, required no additional consideration to be binding and enforceable." *Central Monitoring Serv., Inc. v. Zakinski, 1996 S.D. 116, 553 N.W.2d 513.* <https://www.courtlistener.com/opinion/899991/central-monitoring-service-inc-v-zakinski/#:~:text=That%20the%20Non%2DCompete%20and%20Confidentiality,to%20be%20binding%20and%20enforceable.>
+
+[^zakinski-fired-no-fault]: **Central Monitoring Service, Inc. v. Zakinski** — "However, if an employee is fired for no fault of his own, the court needs to go further to determine whether the agreement is reasonable." *Central Monitoring Serv., Inc. v. Zakinski, 1996 S.D. 116, 553 N.W.2d 513.* <https://www.courtlistener.com/opinion/899991/central-monitoring-service-inc-v-zakinski/#:~:text=However%2C%20if%20an%20employee%20is,whether%20the%20agreement%20is%20reasonable.>
+
+[^miller-choice-law-public-policy]: **Miller v. Honkamp Krueger Financial Services, Inc.** — "Under South Dakota law, courts honor contractual choice-of-law provisions unless they contravene South Dakota public policy." *Miller v. Honkamp Krueger Fin. Servs., Inc., 9 F.4th 1011, 1018 (8th Cir. 2021).* <https://www.courtlistener.com/opinion/5040408/cara-miller-v-honkamp-krueger-financial/#:~:text=Under%20South%20Dakota%20law%2C%20courts,contravene%20South%20Dakota%20public%20policy.>
+
+[^rezatto-confidentiality-public-policy]: **1st American Systems, Inc. v. Rezatto** — "Because this dialectic exists, covenants, like paragraph 7, are strictly construed and enforced only to the extent reasonably necessary to protect the employer’s interest in confidential information." *1st American Systems, Inc. v. Rezatto, 311 N.W.2d 51, 57 (S.D. 1981).* <https://www.courtlistener.com/opinion/2193337/1st-american-systems-inc-v-rezatto/#:~:text=Because%20this%20dialectic%20exists%2C%20covenants%2C,employer%E2%80%99s%20interest%20in%20confidential%20information.>
+
+[^sdcl-37-29-4-fees]: **S.D. Codified Laws § 37-29-4** — "If (i) a claim of misappropriation is made in bad faith, (ii) a motion to terminate an injunction is made or resisted in bad faith, or (iii) willful and malicious misappropriation exists, the court may award reasonable attorney's fees to the prevailing party." *S.D. Codified Laws § 37-29-4.* <https://sdlegislature.gov/Statutes/37-29-4>
+
+[^sdcl-37-29-6-limitations]: **S.D. Codified Laws § 37-29-6** — "An action for misappropriation must be brought within three years after the misappropriation is discovered or by the exercise of reasonable diligence should have been discovered." *S.D. Codified Laws § 37-29-6.* <https://sdlegislature.gov/Statutes/37-29-6>
+
+[^wilbur-ellis-no-survival]: **Wilbur-Ellis Co. v. Erikson** — "Here, however, Erikson and Wilbur-Ellis performed the obligations they owed each other, and thus, the Agreement terminated on March 31, 2019, as did the Restrictive Covenants." *Wilbur-Ellis Co. v. Erikson, 103 F.4th 1352, 1357 (8th Cir. 2024).* <https://www.courtlistener.com/opinion/9511796/wilbur-ellis-company-v-kevin-erikson/#:~:text=Here%2C%20however%2C%20Erikson%20and%20Wilbur%2DEllis,as%20did%20the%20Restrictive%20Covenants.>
+
+[^wilbur-ellis-statutory-context]: **Wilbur-Ellis Co. v. Erikson** — "This gives Wilbur-Ellis time to transition the business and protects the goodwill it purchased should an employee leave during the specified duration." *Wilbur-Ellis Co. v. Erikson, 103 F.4th 1352, 1356 (8th Cir. 2024).* <https://www.courtlistener.com/opinion/9511796/wilbur-ellis-company-v-kevin-erikson/#:~:text=This%20gives%20Wilbur%2DEllis%20time%20to,leave%20during%20the%20specified%20duration.>

--- a/skills/non-compete-contract-explainer/content/tennessee.md
+++ b/skills/non-compete-contract-explainer/content/tennessee.md
@@ -1,0 +1,251 @@
+---
+jurisdiction: "Tennessee"
+slug: tennessee
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-03"
+canonicalUrl: https://openagreements.org/legal/non-compete/tennessee
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/tennessee · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in Tennessee[^about]
+
+Tennessee enforces non-competes that are reasonable and protect a legitimate business interest, and a 2026 statute effective July 1, 2026 adds rebuttable time-reasonableness presumptions and voids non-competes against employees earning under $70,000 a year.
+
+
+## At a glance
+
+| Question | Tennessee |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed if reasonable |
+| **Bottom line** | Tennessee enforces a non-compete that is reasonable and protects a legitimate business interest; a 2026 statute effective July 1, 2026 will void covenants against employees earning under $70,000 and add rebuttable time-reasonableness presumptions. |
+| **Main law or case** | common law (Hasty v. Rent-A-Driver, Inc., 671 S.W.2d 471 (Tenn. 1984)); Tenn. Code Ann. §§ 50-1-210, 50-1-211 (2026 Tenn. Pub. Acts, ch. 934, eff. July 1, 2026) |
+| **Main exceptions** | Coming July 1, 2026 — $70,000 pay-threshold ban; health-care-provider safe harbor (§ 63-1-148; emergency-medicine physicians excluded, covenants void under Udom); sale-of-business longer presumption; non-solicits/NDAs preserved |
+| **Can a court narrow it?** | Yes — rewrites to reasonable |
+| **Applies to contractors?** | Yes |
+| **Restriction extended during a breach?** | Open question — 2026 statute silent |
+| **Maximum length set by law** | Rebuttable presumptions: 2 yrs employee/contractor; 3 yrs distributor; 5 yrs+ seller; health-care safe harbor 2 yrs |
+
+## Are employee non-compete agreements enforceable in Tennessee? {#enforceability}
+
+**Short answer.** Sometimes. Tennessee enforces a non-compete that is reasonable and protects a legitimate business interest, but it treats the covenant as a disfavored restraint of trade. A new statute effective July 1, 2026 adds rebuttable time-reasonableness presumptions and makes a non-compete void against any employee earning less than $70,000 a year [^hasty-disfavored][^s50-1-211-threshold][^s50-1-210-presumptions].
+
+Tennessee has no general statute banning all ordinary employee non-competes; enforceability is governed by common law, supplemented by the 2026 statute's time presumptions and its bar on covenants for employees earning under $70,000. Under that common law, covenants not to compete are *not favored* because they restrain trade, but they are not void on their face and will be enforced when reasonable under the circumstances [^hasty-disfavored]. Tennessee's general restraint-of-trade statute separately declares competition-lessening combinations void as a matter of public policy, which is the policy backdrop courts invoke when they call non-competes disfavored [^s47-25-101-restraint].
+
+The 2026 legislation does not displace that reasonableness analysis. It layers two statutory rules on top of it: time presumptions a court must apply, and an outright bar on non-competes for lower-paid employees. Both take effect July 1, 2026 and apply to proceedings occurring and to agreements entered into, renewed, or amended on or after that date [^s50-1-210-presumptions].
+
+"They are not, however, invalid per se and may be enforced, provided, they are reasonable under the particular circumstances."[^hasty-disfavored]
+
+## What makes a non-compete reasonable in Tennessee? {#reasonableness-test}
+
+**Short answer.** A protectable business interest plus terms no broader than needed to protect it. Tennessee courts ask whether the time and territory of the covenant are greater than necessary to protect the employer's legitimate business interest, weighing the consideration given, the danger to the employer without the covenant, the hardship to the employee, and the public interest [^allright-ultimate-question][^allright-factors].
+
+There is a threshold requirement before the factors even matter: the employer must have a legitimately protectable interest, something beyond ordinary competition. An employer cannot use a covenant to restrain ordinary competition, and the general knowledge, skill, and experience an employee brings or develops on the job belong to the employee, not the employer [^hasty-no-ordinary-competition][^hasty-special-facts]. The special facts that qualify typically involve trade secrets or confidential information, an employer's investment in special training, or customer relationships in which the employee is the face of the business [^hasty-special-facts].
+
+Once a protectable interest exists, reasonableness is fact-specific and turns on the balance of the four considerations rather than any fixed formula [^allright-factors].
+
+"An employer, however, cannot by contract restrain ordinary competition."[^hasty-no-ordinary-competition]
+
+## Can a Tennessee employer use a non-compete against an employee earning under $70,000? {#income-threshold}
+
+**Short answer.** No, for enforcement proceedings occurring on or after July 1, 2026 and for agreements entered into, renewed, or amended on or after that date. New Tenn. Code Ann. § 50-1-211 prohibits an employer from requiring, requesting, or enforcing a non-compete against an employee whose annualized compensation is less than $70,000, and a non-compete signed in violation is void as a matter of public policy [^threshold-rule][^threshold-void].
+
+Annualized compensation is defined broadly to include wages, salary, commissions, nondiscretionary bonuses, and other remuneration; for an hourly employee it is calculated as the hourly rate times 40 times 52 [^threshold-hourly]. The bar reaches more than enforcement: an employer may not even *request* that a below-threshold employee sign a covenant [^threshold-rule].
+
+> [!NOTE]
+> **Practice note.**
+>
+> The prohibition attaches to asking a below-threshold employee to sign, not only to suing on the covenant. Before presenting a Tennessee non-compete on or after July 1, 2026, confirm the employee's annualized compensation clears $70,000 using the statutory definition, and recalculate for hourly workers using the rate-times-40-times-52 formula [^threshold-rule][^threshold-hourly].
+
+"Notwithstanding a law to the contrary, an employer shall not require, request, or enforce a noncompete agreement against an employee whose annualized compensation is less than seventy thousand dollars ($70,000)."[^threshold-rule]
+
+## How long can a Tennessee non-compete last? {#time-limits}
+
+**Short answer.** For agreements governed by the 2026 statute, a court presumes a restraint is unreasonable in time if it runs longer than the period set for the relevant relationship: two years for a former employee or independent contractor, three years for a distributor, dealer, franchisee, lessee, or licensee, and the longer of five years or the payout period for the seller of a business [^time-presumption-rule][^time-employee-2yr][^time-distributor-3yr][^time-seller-5yr].
+
+These are rebuttable presumptions, not hard caps. A court must presume that a time restraint longer than the applicable period is unreasonable, but a party can try to overcome the presumption, and a covenant within the period is not automatically reasonable on its other terms [^time-presumption-rule]. The presumptions address only the time dimension; geographic scope and the protectable-interest requirement still come from the common-law reasonableness analysis [^allright-ultimate-question-time].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> For employee covenants entered into, renewed, or amended on or after July 1, 2026, draft the duration at or under two years to stay inside the presumption of reasonableness in time. A longer term is presumptively unreasonable, so the party seeking enforcement should expect to rebut that presumption, on top of the separate requirement that the covenant protect a legitimate interest and be reasonable in geography [^time-employee-2yr][^time-presumption-rule].
+
+## Is continued at-will employment enough consideration for a Tennessee non-compete? {#consideration}
+
+**Short answer.** Yes, when the employment actually continues. Under *Central Adjustment Bureau, Inc. v. Ingram*, a covenant an existing employee signs is supported by consideration where the employee then remains employed for an appreciable period, so a non-compete signed after hire does not fail for lack of fresh consideration [^central-consideration].
+
+The court enforced covenants signed after employment began because each employee continued working for the company; the length of the continued employment supplied the consideration [^central-consideration]. Tennessee has not fixed how long the continued employment must last, so the question is fact-specific: a very short tenure after signing weakens the argument, and the safer course is still to pair the covenant with employment that continues for an appreciable time or with separate consideration [^central-consideration].
+
+## Will a Tennessee court narrow or reform an overbroad non-compete? {#court-narrowing}
+
+**Short answer.** Often yes, but not always. Tennessee follows the *rule of reasonableness* rather than the strict blue-pencil rule, so a court may modify an unreasonable covenant to make it reasonable instead of striking it — but it can refuse and void the covenant entirely when the employer drafted it in a deliberately unreasonable or oppressive way [^central-reasonableness][^central-oppressive][^vantage-modify].
+
+In *Central Adjustment Bureau*, the Tennessee Supreme Court adopted the rule of reasonableness, under which a court may enforce an overbroad covenant to the extent it is reasonable rather than rewriting only severable words [^central-reasonableness]. *Vantage Technology, LLC v. Cross* shows the rule in action: the court modified an overbroad territory and limited the restriction to the customer locations where the employee had actually worked [^vantage-modify]. The 2026 statute carries the same idea forward for covenants it governs, expressly authorizing a court to modify a restrictive covenant to render it reasonable and enforceable [^s50-1-210-modify].
+
+Reformation is discretionary, not guaranteed. A court may decline to save an oppressive covenant, and it may refuse enforcement entirely where the hardship to the employee and the harm to the public outweigh the employer's interest, as the court did in *Columbus Medical Services, LLC v. Thomas* [^central-oppressive][^columbus-refused].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not rely on a Tennessee court to rewrite an aggressive covenant. A deliberately unreasonable or oppressive covenant can be voided rather than trimmed, so draft duration, geography, and scope to the minimum the legitimate interest actually requires [^central-oppressive][^vantage-modify].
+
+"The most recent trend, therefore, has been to abandon the ‘blue pencil’ rule in favor of a rule of reasonableness."[^central-reasonableness]
+
+## Are non-competes enforceable against Tennessee physicians and healthcare providers? {#health-care-providers}
+
+**Short answer.** Yes, within statutory limits. A healthcare-provider covenant is deemed reasonable if it is in writing, runs two years or less, and stays within the greater of a 10-mile radius or the provider's county (or a facility-based limit). Emergency-medicine physicians fall outside that statutory authorization, so their covenants remain void under *Udom* [^s63-1-148-deemed-reasonable][^s63-1-148-emergency][^udom-void].
+
+Before the statute, Tennessee voided physician non-competes outright as contrary to public policy. In *Murfreesboro Medical Clinic, P.A. v. Udom*, the Tennessee Supreme Court held that, except as specifically allowed by statute, physician covenants not to compete are unenforceable and void [^udom-void]. The legislature responded with Tenn. Code Ann. § 63-1-148, which authorizes covenants for covered providers within the duration and geographic limits above and applies to providers licensed under Title 63, chapters 3, 4, 5, 6, 8, 9, and 11 [^s63-1-148-deemed-reasonable][^s63-1-148-scope]. A covenant tied to the sale of a provider's practice gets a rebuttable presumption that its agreed duration and area are reasonable [^s63-1-148-sale]. Meeting the safe harbor makes a covenant deemed reasonable in time and area; it does not by itself guarantee enforcement, because the covenant must still rest on a legitimate interest and satisfy the other common-law limits [^s63-1-148-deemed-reasonable].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not impose a non-compete on an emergency-medicine physician. Section 63-1-148(d) removes them from the statute's safe harbor, and because no statute then authorizes the covenant, it remains void under *Udom*. For other covered providers, keep the term at or under two years and the area within the greater of a 10-mile radius or the county of the primary practice site to stay within the statutory safe harbor [^s63-1-148-emergency][^udom-void][^s63-1-148-deemed-reasonable].
+
+"We hold that except for those specifically prescribed by statute, physicians' covenants not to compete are unenforceable and void."[^udom-void]
+
+## Are customer non-solicits, employee non-solicits, and confidentiality agreements still allowed in Tennessee? {#non-solicitation-confidentiality}
+
+**Short answer.** Yes. The 2026 statute that regulates non-competes expressly preserves an employer's ability to enforce a confidentiality or nondisclosure agreement, a customer non-solicitation agreement, and an employee non-solicitation agreement [^s50-1-210-carveouts].
+
+Section 50-1-210(c) preserves these covenants from the time-presumption rules, and the $70,000 bar in § 50-1-211 applies only to *noncompete* agreements — so a true non-solicit or confidentiality clause sits outside both [^s50-1-210-carveouts][^threshold-rule-nonsolicit]. They are not automatically enforceable, though: a non-solicit or confidentiality clause that operates as a de facto non-compete can still be attacked as an unreasonable restraint, and a confidentiality clause that protects trade secrets is backed by the Tennessee Uniform Trade Secrets Act.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Keep a confidentiality or non-solicitation covenant tied to genuine confidential information, customers, or employees rather than drafting it so broadly that it bars the worker from competing at all. A clause that functions as a disguised non-compete invites the same reasonableness scrutiny — and, for a below-threshold employee, the same voidness risk — as an express non-compete [^s50-1-210-carveouts][^threshold-rule-nonsolicit].
+
+"This section does not prohibit an employer from enforcing: (1) A confidentiality or nondisclosure agreement; (2) A client or customer nonsolicitation agreement; or (3) An employee nonsolicitation agreement."[^s50-1-210-carveouts]
+
+## How does the Tennessee Uniform Trade Secrets Act interact with non-competes? {#trade-secrets}
+
+**Short answer.** It runs alongside them. The Tennessee Uniform Trade Secrets Act displaces overlapping tort remedies for trade-secret misappropriation but expressly preserves contractual remedies, and it confirms that a confidentiality duty is not void merely for lacking a time or geographic limit [^tutsa-contractual].
+
+That preservation matters for drafting: an employer can protect trade secrets through both a contract covenant and a TUTSA claim, and a contractual duty to protect a trade secret is not void merely for lacking the durational and geographic limits a non-compete needs — though a broader confidentiality clause reaching non-trade-secret information is still tested under ordinary contract and restraint principles [^tutsa-contractual]. Where misappropriation is willful and malicious, the Act allows exemplary damages of up to twice the compensatory award, which can make a trade-secret claim a stronger remedy than enforcing a marginal non-compete [^tutsa-exemplary].
+
+## Are sale-of-business non-competes treated differently in Tennessee? {#sale-of-business}
+
+**Short answer.** Yes, more generously. For a covenant enforced against the owner or seller of a business, the 2026 statute presumes a restraint reasonable in time for the longer of five years or the period during which sale payments are made — well beyond the two-year presumption for ordinary employees [^sale-seller-5yr].
+
+This fits the sale-of-business context, where a buyer paying for a business is protecting purchased goodwill rather than merely restraining a former employee. In the healthcare setting, a covenant tied to the purchase or sale of a provider's practice likewise gets a rebuttable presumption that its agreed duration and area are reasonable [^sale-healthcare].
+
+## Does a Tennessee non-compete toll or extend during a breach or while litigation is pending? {#tolling-extension}
+
+**Short answer.** This is an open question in Tennessee. No Tennessee statute or appellate decision squarely endorses automatically tolling or extending the restricted period while the employee is in breach or while enforcement litigation is pending, and the 2026 statute does not address tolling [^tolling-statute-silent][^tolling-reasonableness].
+
+Because Tennessee measures reasonableness in time and may reform an unreasonable term, an extension-on-breach clause is best treated as unsettled rather than reliably enforceable. The 2026 statute fixes the start of the period at the date the relationship terminates and is otherwise silent on tolling, so an extension-on-breach theory has no clear statutory footing either way; an overlong effective restraint would also face the same reasonableness scrutiny as any other duration [^tolling-statute-silent][^tolling-reasonableness].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Open question: Tennessee law does not clearly resolve whether a clause that tolls or extends the restricted period during breach or litigation is enforceable. Do not assume a court will extend an expired Tennessee covenant; if an extension provision matters, draft a defined, reasonable cap rather than an open-ended tolling clause, and expect a court to test the total effective duration for reasonableness [^tolling-reasonableness][^tolling-statute-silent].
+
+## Can another state's law or court govern a Tennessee worker's non-compete? {#choice-of-law}
+
+**Short answer.** Sometimes, if the choice is genuine. A Tennessee court honors a contractual choice of another state's law only when certain requirements are met, beginning with the requirement that the choice-of-law provision be executed in good faith [^vantage-choice-intent][^vantage-good-faith].
+
+Those requirements limit the common tactic of using an out-of-state choice-of-law clause to escape Tennessee's reasonableness rules. A clause picking the law of a state with no genuine connection to the parties, or one used to override Tennessee's protections — including the new $70,000 bar — is vulnerable [^vantage-choice-intent][^vantage-good-faith].
+
+## What are the key recent developments in Tennessee non-compete law? {#recent-developments}
+
+**Short answer.** The headline change is the 2026 statute that, effective July 1, 2026, voids non-competes for employees earning under $70,000 and sets rebuttable time presumptions for the rest [^dev-enacted][^dev-effective].
+
+- 
+- 
+- 
+
+> [!NOTE]
+> **Practice note.**
+>
+> Treat July 1, 2026 as a hard line. Agreements entered into, renewed, or amended on or after that date are subject to the new $70,000 bar and the time presumptions, so review form non-competes and any covenant up for renewal before that date, and confirm each covered employee clears the compensation threshold [^dev-effective][^dev-threshold].
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-03. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not Tennessee. This article synthesizes Tennessee primary law and is not legal advice from a Tennessee-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^hasty-disfavored]: **Hasty v. Rent-A-Driver, Inc.** — "They are not, however, invalid per se and may be enforced, provided, they are reasonable under the particular circumstances." *Hasty v. Rent-A-Driver, Inc., 671 S.W.2d 471, 472 (Tenn. 1984).* <https://www.courtlistener.com/opinion/2366827/hasty-v-rent-a-driver-inc/#:~:text=They%20are%20not%2C%20however%2C%20invalid,reasonable%20under%20the%20particular%20circumstances.>
+
+[^s50-1-211-threshold]: **2026 Tenn. Pub. Acts, ch. 934 (HB 1034)** — "Notwithstanding a law to the contrary, an employer shall not require, request, or enforce a noncompete agreement against an employee whose annualized compensation is less than seventy thousand dollars ($70,000)." *Tenn. Code Ann. § 50-1-211(a) (2026 Tenn. Pub. Acts, ch. 934) (eff. July 1, 2026).* <https://publications.tnsosfiles.com/acts/114/pub/pc0934.pdf>
+
+[^s50-1-210-presumptions]: **2026 Tenn. Pub. Acts, ch. 934 (HB 1034)** — "This act takes effect July 1, 2026, the public welfare requiring it, and applies to proceedings occurring and agreements entering into, renewed, or amended, on or after that date." *2026 Tenn. Pub. Acts, ch. 934, § 3.* <https://publications.tnsosfiles.com/acts/114/pub/pc0934.pdf>
+
+[^s47-25-101-restraint]: **Tenn. Code Ann. § 47-25-101** — "All arrangements, contracts, agreements, trusts, or combinations between persons or corporations made with a view to lessen, or which tend to lessen, full and free competition in trade or commerce affecting this state, and all arrangements, contracts, agreements, trusts, or combinations between persons or corporations designed or which tend to advance, reduce, or control the price or the cost to the producer or the consumer of any product or service in trade or commerce affecting this state, are declared to be against public policy, unlawful, and void." *Tenn. Code Ann. § 47-25-101 (2024 Tenn. Pub. Acts, ch. 776).* <https://publications.tnsosfiles.com/acts/113/pub/pc0776.pdf>
+
+[^allright-ultimate-question]: **Allright Auto Parks, Inc. v. Berry** — "Based upon the foregoing, the ultimate question presented in the case sub judice appears to be whether or not the time and territorial limits of the noncompetition agreement are greater than is required to protect the business interest of the complainant." *Allright Auto Parks, Inc. v. Berry, 409 S.W.2d 361, 363 (Tenn. 1966).* <https://www.courtlistener.com/opinion/1784276/allright-auto-parks-inc-v-berry/#:~:text=Based%20upon%20the%20foregoing%2C%20the,business%20interest%20of%20the%20complainant.>
+
+[^allright-factors]: **Allright Auto Parks, Inc. v. Berry** — "Among these are: the consideration supporting the agreements; the threatened danger to the employer in the absence of such an agreement; the economic hardship imposed on the employee by such a covenant; and whether or not such a covenant should be inimical to public interest." *Allright Auto Parks, Inc. v. Berry, 409 S.W.2d 361, 363 (Tenn. 1966).* <https://www.courtlistener.com/opinion/1784276/allright-auto-parks-inc-v-berry/#:~:text=Among%20these%20are%3A%20the%20consideration,be%20inimical%20to%20public%20interest.>
+
+[^hasty-no-ordinary-competition]: **Hasty v. Rent-A-Driver, Inc.** — "An employer, however, cannot by contract restrain ordinary competition." *Hasty v. Rent-A-Driver, Inc., 671 S.W.2d 471, 473 (Tenn. 1984).* <https://www.courtlistener.com/opinion/2366827/hasty-v-rent-a-driver-inc/#:~:text=An%20employer%2C%20however%2C%20cannot%20by%20contract%20restrain%20ordinary%20competition.>
+
+[^hasty-special-facts]: **Hasty v. Rent-A-Driver, Inc.** — "In order for an employer to be entitled to protection, there must be special facts present over and above ordinary competition." *Hasty v. Rent-A-Driver, Inc., 671 S.W.2d 471, 473 (Tenn. 1984).* <https://www.courtlistener.com/opinion/2366827/hasty-v-rent-a-driver-inc/#:~:text=In%20order%20for%20an%20employer,over%20and%20above%20ordinary%20competition.>
+
+[^threshold-rule]: **2026 Tenn. Pub. Acts, ch. 934 (HB 1034)** — "Notwithstanding a law to the contrary, an employer shall not require, request, or enforce a noncompete agreement against an employee whose annualized compensation is less than seventy thousand dollars ($70,000)." *Tenn. Code Ann. § 50-1-211(a) (2026 Tenn. Pub. Acts, ch. 934) (eff. July 1, 2026).* <https://publications.tnsosfiles.com/acts/114/pub/pc0934.pdf>
+
+[^threshold-void]: **2026 Tenn. Pub. Acts, ch. 934 (HB 1034)** — "A noncompete agreement executed in violation of this section is void and unenforceable as a matter of public policy." *Tenn. Code Ann. § 50-1-211(c) (2026 Tenn. Pub. Acts, ch. 934) (eff. July 1, 2026).* <https://publications.tnsosfiles.com/acts/114/pub/pc0934.pdf>
+
+[^threshold-hourly]: **2026 Tenn. Pub. Acts, ch. 934 (HB 1034)** — "Annualized compensation for an hourly employee must be calculated by multiplying the employee's hourly rate by forty (40) and multiplying the product by fifty-two (52)." *Tenn. Code Ann. § 50-1-211(b)(2) (2026 Tenn. Pub. Acts, ch. 934) (eff. July 1, 2026).* <https://publications.tnsosfiles.com/acts/114/pub/pc0934.pdf>
+
+[^time-presumption-rule]: **2026 Tenn. Pub. Acts, ch. 934 (HB 1034)** — "In determining the reasonableness in time of a restrictive covenant sought to be enforced after the termination of an employment or business relationship, a court shall apply the rebuttable presumptions established in this section. A court shall presume that a time restraint greater than the applicable restraint described in subdivision (b)(1), (b)(2), or (b)(3) is unreasonable." *Tenn. Code Ann. § 50-1-210(a) (2026 Tenn. Pub. Acts, ch. 934) (eff. July 1, 2026).* <https://publications.tnsosfiles.com/acts/114/pub/pc0934.pdf>
+
+[^time-employee-2yr]: **2026 Tenn. Pub. Acts, ch. 934 (HB 1034)** — "A court shall presume to be reasonable in time a restraint sought to be enforced against a former employee or independent contractor that: (A) Is two (2) years or less in duration, measured from the date the employment or business relationship terminates; and" *Tenn. Code Ann. § 50-1-210(b)(1) (2026 Tenn. Pub. Acts, ch. 934) (eff. July 1, 2026).* <https://publications.tnsosfiles.com/acts/114/pub/pc0934.pdf>
+
+[^time-distributor-3yr]: **2026 Tenn. Pub. Acts, ch. 934 (HB 1034)** — "A court shall presume to be reasonable in time a restraint three (3) years or less in duration, measured from the date of termination of the business relationship in the case of a restrictive covenant sought to be enforced against a current or former distributor, dealer, franchisee, lessee of real or personal property, or licensee of a trademark, trade dress, or service mark, and not associated with the sale of all or a material part of:" *Tenn. Code Ann. § 50-1-210(b)(2) (2026 Tenn. Pub. Acts, ch. 934) (eff. July 1, 2026).* <https://publications.tnsosfiles.com/acts/114/pub/pc0934.pdf>
+
+[^time-seller-5yr]: **2026 Tenn. Pub. Acts, ch. 934 (HB 1034)** — "A court shall presume to be reasonable in time a restraint that is the longer of five (5) years or less, or a period equal to the time during which payments are made to the owner or seller, in the case of a restrictive covenant sought to be enforced against the owner or seller of all or a material part of:" *Tenn. Code Ann. § 50-1-210(b)(3) (2026 Tenn. Pub. Acts, ch. 934) (eff. July 1, 2026).* <https://publications.tnsosfiles.com/acts/114/pub/pc0934.pdf>
+
+[^allright-ultimate-question-time]: **Allright Auto Parks, Inc. v. Berry** — "Based upon the foregoing, the ultimate question presented in the case sub judice appears to be whether or not the time and territorial limits of the noncompetition agreement are greater than is required to protect the business interest of the complainant." *Allright Auto Parks, Inc. v. Berry, 409 S.W.2d 361, 363 (Tenn. 1966).* <https://www.courtlistener.com/opinion/1784276/allright-auto-parks-inc-v-berry/#:~:text=Based%20upon%20the%20foregoing%2C%20the,business%20interest%20of%20the%20complainant.>
+
+[^central-consideration]: **Central Adjustment Bureau, Inc. v. Ingram** — "We find that because of the length of employment of each defendant, the covenant is binding against them." *Central Adjustment Bureau, Inc. v. Ingram, 678 S.W.2d 28, 35 (Tenn. 1984).* <https://www.courtlistener.com/opinion/2437065/central-adjustment-bureau-inc-v-ingram/#:~:text=We%20find%20that%20because%20of,covenant%20is%20binding%20against%20them.>
+
+[^central-reasonableness]: **Central Adjustment Bureau, Inc. v. Ingram** — "The most recent trend, therefore, has been to abandon the ‘blue pencil’ rule in favor of a rule of reasonableness." *Central Adjustment Bureau, Inc. v. Ingram, 678 S.W.2d 28, 33 (Tenn. 1984).* <https://www.courtlistener.com/opinion/2437065/central-adjustment-bureau-inc-v-ingram/#:~:text=The%20most%20recent%20trend%2C%20therefore%2C,of%20a%20rule%20of%20reasonableness.>
+
+[^central-oppressive]: **Central Adjustment Bureau, Inc. v. Ingram** — "If there is credible evidence to sustain a finding that a contract is deliberately unreasonable and oppressive, then the covenant is invalid." *Central Adjustment Bureau, Inc. v. Ingram, 678 S.W.2d 28, 33 (Tenn. 1984).* <https://www.courtlistener.com/opinion/2437065/central-adjustment-bureau-inc-v-ingram/#:~:text=If%20there%20is%20credible%20evidence,then%20the%20covenant%20is%20invalid.>
+
+[^vantage-modify]: **Vantage Technology, LLC v. Cross** — "Hence, a court may modify an unreasonable covenant so as to render it reasonable." *Vantage Technology, LLC v. Cross, 17 S.W.3d 637, 647 (Tenn. Ct. App. 1999).* <https://www.courtlistener.com/opinion/1561156/vantage-technology-llc-v-cross/#:~:text=Hence%2C%20a%20court%20may%20modify,as%20to%20render%20it%20reasonable.>
+
+[^s50-1-210-modify]: **2026 Tenn. Pub. Acts, ch. 934 (HB 1034)** — "A court may modify a restrictive covenant governed by this section to render it reasonable and enforceable." *Tenn. Code Ann. § 50-1-210(d) (2026 Tenn. Pub. Acts, ch. 934) (eff. July 1, 2026).* <https://publications.tnsosfiles.com/acts/114/pub/pc0934.pdf>
+
+[^columbus-refused]: **Columbus Medical Services, LLC v. Thomas** — "We reverse, concluding that, while the plaintiff agency had a legitimate protectable business interest, the non-compete covenants are not enforceable in light of the hardship to the defendant therapists and the adverse impact on the public interest." *Columbus Medical Services, LLC v. Thomas, 308 S.W.3d 368, 374 (Tenn. Ct. App. 2009).* <https://www.courtlistener.com/opinion/1050674/columbus-medical-services-llc-v-thomas/#:~:text=We%20reverse%2C%20concluding%20that%2C%20while,impact%20on%20the%20public%20interest.>
+
+[^s63-1-148-deemed-reasonable]: **Tenn. Code Ann. § 63-1-148** — "A restriction on the right of an employed or contracted healthcare provider to practice the healthcare provider's profession upon termination or conclusion of the employment or contractual relationship shall be deemed reasonable if: (1) The restriction is set forth in an employment agreement or other written document signed by the healthcare provider and the employing or contracting entity; and (2) The duration of the restriction is two (2) years or less and either: (A) The maximum allowable geographic restriction is the greater of: (i) A ten-mile radius from the primary practice site of the healthcare provider while employed or contracted; or (ii) The county in which the primary practice of the healthcare provider while employed or contracted is located;" *Tenn. Code Ann. § 63-1-148(a).* <https://advance.lexis.com/document/?pdmfid=1000516&pddocfullpath=/shared/document/statutes-legislation/urn:contentItem:563H-T9F0-R03M-50DW-00008-00>
+
+[^s63-1-148-emergency]: **Tenn. Code Ann. § 63-1-148** — "This section shall not apply to physicians who specialize in the practice of emergency medicine." *Tenn. Code Ann. § 63-1-148(d).* <https://advance.lexis.com/document/?pdmfid=1000516&pddocfullpath=/shared/document/statutes-legislation/urn:contentItem:563H-T9F0-R03M-50DW-00008-00>
+
+[^udom-void]: **Murfreesboro Medical Clinic, P.A. v. Udom** — "We hold that except for those specifically prescribed by statute, physicians' covenants not to compete are unenforceable and void." *Murfreesboro Medical Clinic, P.A. v. Udom, 166 S.W.3d 674, 684 (Tenn. 2005).* <https://www.courtlistener.com/opinion/1058272/murfreesboro-medical-clinic-pa-v-udom/#:~:text=We%20hold%20that%20except%20for,compete%20are%20unenforceable%20and%20void.>
+
+[^s63-1-148-scope]: **Tenn. Code Ann. § 63-1-148** — "This section shall apply to healthcare providers licensed under chapters 3, 4, 5, 6, 8, 9 and 11 of this title." *Tenn. Code Ann. § 63-1-148(c).* <https://advance.lexis.com/document/?pdmfid=1000516&pddocfullpath=/shared/document/statutes-legislation/urn:contentItem:563H-T9F0-R03M-50DW-00008-00>
+
+[^s63-1-148-sale]: **Tenn. Code Ann. § 63-1-148** — "There shall be a rebuttable presumption that the duration and area of restriction agreed upon by the parties in such an agreement are reasonable." *Tenn. Code Ann. § 63-1-148(b).* <https://advance.lexis.com/document/?pdmfid=1000516&pddocfullpath=/shared/document/statutes-legislation/urn:contentItem:563H-T9F0-R03M-50DW-00008-00>
+
+[^s50-1-210-carveouts]: **2026 Tenn. Pub. Acts, ch. 934 (HB 1034)** — "This section does not prohibit an employer from enforcing: (1) A confidentiality or nondisclosure agreement; (2) A client or customer nonsolicitation agreement; or (3) An employee nonsolicitation agreement." *Tenn. Code Ann. § 50-1-210(c) (2026 Tenn. Pub. Acts, ch. 934) (eff. July 1, 2026).* <https://publications.tnsosfiles.com/acts/114/pub/pc0934.pdf>
+
+[^threshold-rule-nonsolicit]: **2026 Tenn. Pub. Acts, ch. 934 (HB 1034)** — "Notwithstanding a law to the contrary, an employer shall not require, request, or enforce a noncompete agreement against an employee whose annualized compensation is less than seventy thousand dollars ($70,000)." *Tenn. Code Ann. § 50-1-211(a) (2026 Tenn. Pub. Acts, ch. 934) (eff. July 1, 2026).* <https://publications.tnsosfiles.com/acts/114/pub/pc0934.pdf>
+
+[^tutsa-contractual]: **Tenn. Code Ann. § 47-25-1708** — "a contractual duty to maintain secrecy or limit use of a trade secret shall not be deemed to be void or unenforceable solely for lack of durational or geographical limitation on the duty" *Tenn. Code Ann. § 47-25-1708(b)(1).* <https://publications.tnsosfiles.com/acts/101/pub/pc647.pdf>
+
+[^tutsa-exemplary]: **Tenn. Code Ann. § 47-25-1704** — "If willful and malicious misappropriation exists, the court may award exemplary damages in an amount not exceeding twice any award made under subsection (a)." *Tenn. Code Ann. § 47-25-1704(b).* <https://publications.tnsosfiles.com/acts/101/pub/pc647.pdf>
+
+[^sale-seller-5yr]: **2026 Tenn. Pub. Acts, ch. 934 (HB 1034)** — "A court shall presume to be reasonable in time a restraint that is the longer of five (5) years or less, or a period equal to the time during which payments are made to the owner or seller, in the case of a restrictive covenant sought to be enforced against the owner or seller of all or a material part of:" *Tenn. Code Ann. § 50-1-210(b)(3) (2026 Tenn. Pub. Acts, ch. 934) (eff. July 1, 2026).* <https://publications.tnsosfiles.com/acts/114/pub/pc0934.pdf>
+
+[^sale-healthcare]: **Tenn. Code Ann. § 63-1-148** — "There shall be a rebuttable presumption that the duration and area of restriction agreed upon by the parties in such an agreement are reasonable." *Tenn. Code Ann. § 63-1-148(b).* <https://advance.lexis.com/document/?pdmfid=1000516&pddocfullpath=/shared/document/statutes-legislation/urn:contentItem:563H-T9F0-R03M-50DW-00008-00>
+
+[^tolling-statute-silent]: **2026 Tenn. Pub. Acts, ch. 934 (HB 1034)** — "A court shall presume to be reasonable in time a restraint sought to be enforced against a former employee or independent contractor that: (A) Is two (2) years or less in duration, measured from the date the employment or business relationship terminates; and" *Tenn. Code Ann. § 50-1-210(b)(1) (2026 Tenn. Pub. Acts, ch. 934) (eff. July 1, 2026).* <https://publications.tnsosfiles.com/acts/114/pub/pc0934.pdf>
+
+[^tolling-reasonableness]: **Vantage Technology, LLC v. Cross** — "Hence, a court may modify an unreasonable covenant so as to render it reasonable." *Vantage Technology, LLC v. Cross, 17 S.W.3d 637, 647 (Tenn. Ct. App. 1999).* <https://www.courtlistener.com/opinion/1561156/vantage-technology-llc-v-cross/#:~:text=Hence%2C%20a%20court%20may%20modify,as%20to%20render%20it%20reasonable.>
+
+[^vantage-choice-intent]: **Vantage Technology, LLC v. Cross** — "If the parties manifest an intent to instead apply the laws of another jurisdiction, then that intent will be honored provided certain requirements are met." *Vantage Technology, LLC v. Cross, 17 S.W.3d 637, 650 (Tenn. Ct. App. 1999).* <https://www.courtlistener.com/opinion/1561156/vantage-technology-llc-v-cross/#:~:text=If%20the%20parties%20manifest%20an,provided%20certain%20requirements%20are%20met.>
+
+[^vantage-good-faith]: **Vantage Technology, LLC v. Cross** — "The choice of law provision must be executed in good faith." *Vantage Technology, LLC v. Cross, 17 S.W.3d 637, 650 (Tenn. Ct. App. 1999).* <https://www.courtlistener.com/opinion/1561156/vantage-technology-llc-v-cross/#:~:text=The%20choice%20of%20law%20provision,be%20executed%20in%20good%20faith.>
+
+[^dev-enacted]: **2026 Tenn. Pub. Acts, ch. 934 (HB 1034)** — "AN ACT to amend Tennessee Code Annotated, Title 50; Title 63 and Title 68, relative to covenants not to compete." *2026 Tenn. Pub. Acts, ch. 934 (HB 1034).* <https://publications.tnsosfiles.com/acts/114/pub/pc0934.pdf>
+
+[^dev-effective]: **2026 Tenn. Pub. Acts, ch. 934 (HB 1034)** — "This act takes effect July 1, 2026, the public welfare requiring it, and applies to proceedings occurring and agreements entering into, renewed, or amended, on or after that date." *2026 Tenn. Pub. Acts, ch. 934, § 3.* <https://publications.tnsosfiles.com/acts/114/pub/pc0934.pdf>
+
+[^dev-threshold]: **2026 Tenn. Pub. Acts, ch. 934 (HB 1034)** — "Notwithstanding a law to the contrary, an employer shall not require, request, or enforce a noncompete agreement against an employee whose annualized compensation is less than seventy thousand dollars ($70,000)." *Tenn. Code Ann. § 50-1-211(a) (2026 Tenn. Pub. Acts, ch. 934) (eff. July 1, 2026).* <https://publications.tnsosfiles.com/acts/114/pub/pc0934.pdf>

--- a/skills/non-compete-contract-explainer/content/texas.md
+++ b/skills/non-compete-contract-explainer/content/texas.md
@@ -1,0 +1,297 @@
+---
+jurisdiction: "Texas"
+slug: texas
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-03"
+canonicalUrl: https://openagreements.org/legal/non-compete/texas
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/texas · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in Texas[^about]
+
+A question-by-question summary of Texas non-compete law under the Covenants Not to Compete Act, Tex. Bus. & Com. Code §§ 15.50–15.52, including the ancillary-agreement requirement, the Light–Sheshunoff–Marsh consideration line, the reasonable time-geography-scope test, mandatory reformation of overbroad covenants, the pre-reformation damages bar, the attorney's-fee preemption question, the physician and SB 1318 health-care-practitioner limits, choice-of-law and forum rules, tolling, and trade-secret alternatives.
+
+
+## At a glance
+
+| Question | Texas |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed if reasonable |
+| **Bottom line** | Texas enforces non-competes that are ancillary to an otherwise enforceable agreement and reasonable in time, geography, and scope, with overbroad covenants reformed rather than voided. |
+| **Main law or case** | Tex. Bus. & Com. Code § 15.50 (Covenants Not to Compete Act) |
+| **Main exceptions** | Physician buyout/1-yr limits & good-cause rule (§ 15.50(b),(d)); dentist/nurse/PA buyout limits (§ 15.501) |
+| **Can a court narrow it?** | Yes — rewrites to reasonable |
+| **Applies to contractors?** | Unclear |
+| **Restriction extended during a breach?** | Unsettled — any extension must satisfy § 15.50(a) reasonableness |
+| **Maximum length set by law** | No statutory limit (1 year for covered physicians/health-care) |
+
+## Are employee non-compete agreements enforceable in Texas? {#employee-noncompetes}
+
+**Short answer.** Yes, within statutory limits. Texas is a reasonableness state: a non-compete is enforceable when it is ancillary to or part of an otherwise enforceable agreement and is limited as to time, geographic area, and scope of activity in a way that is reasonable and no broader than necessary to protect the employer's goodwill or other business interest [^bc-1550a-test].
+
+Unlike states that void most worker non-competes outright, Texas enforces them when they satisfy a single statute, the Covenants Not to Compete Act, Tex. Bus. & Com. Code §§ 15.50–15.52. Section 15.50(a) states the core test, combining an *ancillary agreement* requirement with a reasonableness requirement.
+
+"a covenant not to compete is enforceable if it is ancillary to or part of an otherwise enforceable agreement at the time the agreement is made to the extent that it contains limitations as to time, geographical area, and scope of activity to be restrained that are reasonable and do not impose a greater restraint than is necessary to protect the goodwill or other business interest of the promisee."[^bc-1550a-test]
+
+Both halves of that sentence carry weight. A covenant that is reasonable in its limits still fails if it is not tied to an otherwise enforceable agreement, and a covenant that is properly ancillary still fails to the extent its limits are unreasonable. The sections that follow walk through how Texas courts apply each requirement.
+
+## What framework governs Texas non-competes, and does it displace the common law? {#governing-framework}
+
+**Short answer.** The Covenants Not to Compete Act governs, and it is exclusive. The criteria in §§ 15.50 and 15.501 and the procedures and remedies in § 15.51 preempt other law, including the common law, so a Texas non-compete dispute is decided under the statute rather than under judge-made rules [^bc-1552-preempt].
+
+Texas once analyzed non-competes under common-law reasonableness doctrine. The Act replaced that body of law with a statutory test and made the replacement explicit in § 15.52.
+
+"The criteria for enforceability of a covenant not to compete provided by Sections 15.50 and 15.501 and the procedures and remedies in an action to enforce a covenant not to compete provided by Section 15.51 are exclusive and preempt other law, including common law."[^bc-1552-preempt]
+
+The preemption clause is more than housekeeping. It is the reason a Texas court will not graft a common-law gloss onto the statutory test, and it sits at the center of the unsettled attorney's-fee question discussed below. When you analyze a Texas covenant, start and end with the statute and the cases construing it.
+
+## What consideration must support a Texas non-compete? {#consideration}
+
+**Short answer.** Consideration that is reasonably related to a business interest the Act protects. Since *Marsh USA Inc. v. Cook*, the consideration supporting the covenant need only be reasonably related to an interest worthy of protection, such as goodwill, and it need not itself give rise to the employer's interest [^marsh-reasonably-related]. The older, stricter framing in *Light v. Centel* has been relaxed [^light-ancillary].
+
+The consideration question has a long doctrinal history in Texas. In *Light v. Centel Cellular Co. of Texas*, the Texas Supreme Court read the ancillary requirement strictly and held that the covenant before it was not tied to the parties' otherwise enforceable agreement [^light-ancillary].
+
+"Although Light and United did have an otherwise enforceable agreement between them, the covenant was not ancillary to or a part of that otherwise enforceable agreement."[^light-ancillary]
+
+The court relaxed that approach in *Marsh USA Inc. v. Cook*, holding that consideration in the form of stock options was reasonably related to the company's interest in protecting its goodwill, which the Act recognizes as worthy of protection [^marsh-reasonably-related].
+
+"We hold that, under the terms of the Covenants Not to Compete Act (Act), the consideration for the noncompete agreement (stock options) is reasonably related to the company's interest in protecting its goodwill, a business interest the Act recognizes as worthy of protection."[^marsh-reasonably-related]
+
+The practical upshot from these cases is that consideration tied to a protectable interest, such as stock options connected to goodwill or promised confidential information that is actually provided, can support a Texas covenant. What is risky is relying on nothing more than continued at-will employment, because a promise the employer can revoke at any moment raises the illusory-promise problem the next question addresses.
+
+## When does an at-will employee's non-compete become enforceable? {#at-will-enforceability}
+
+**Short answer.** When the employer performs its side of the bargain. An at-will covenant that looks illusory at signing becomes enforceable once the employer actually delivers the promised consideration, such as confidential information [^sheshunoff-performance]. And where the job by its nature requires confidential information, the employer's promise to provide it can be implied [^mann-frankfort-implied].
+
+The illusory-promise problem arises because an at-will employer can fire the employee at any moment, so a promise tied to continued employment may appear unenforceable when made. In *Alex Sheshunoff Management Services, L.P. v. Johnson*, the Texas Supreme Court resolved this by focusing on performance rather than the moment of signing [^sheshunoff-performance].
+
+"The fact that the employer was not bound to perform because he could have fired the employee is irrelevant; if he has performed, he has accepted the employee's offer and created a binding unilateral contract."[^sheshunoff-performance]
+
+The court went further in *Mann Frankfort Stein & Lipp Advisors, Inc. v. Fielding*, holding that when the nature of the work necessarily requires the employer to supply confidential information, a promise to provide it can be implied even if the contract does not spell it out [^mann-frankfort-implied].
+
+"When the nature of the work the employee is hired to perform requires confidential information to be provided for the work to be performed by the employee, the employer impliedly promises confidential information will be provided."[^mann-frankfort-implied]
+
+For drafting, the lesson is to make the consideration concrete and to actually deliver it. An agreement that expressly promises access to confidential information, training, or equity, and that the employer honors, stands on far firmer ground than one resting on continued employment alone.
+
+## What time, geography, and scope limits are reasonable in Texas? {#reasonable-scope}
+
+**Short answer.** Limits tailored to the employer's actual protectable interest, no broader than necessary. The Act requires reasonable limits on time, geographic area, and scope of activity, and a restraint greater than needed to protect goodwill or another business interest is unreasonable [^q5-bc-1550a-scope]. There are no fixed numeric ceilings outside the health-care provisions; reasonableness is fact-specific.
+
+Texas does not publish bright-line maximums for ordinary covenants. Instead, § 15.50(a) ties every limit back to the employer's protectable interest, and § 15.51 lets a court cut anything that exceeds it [^q5-bc-1550a-scope].
+
+"a covenant not to compete is enforceable if it is ancillary to or part of an otherwise enforceable agreement at the time the agreement is made to the extent that it contains limitations as to time, geographical area, and scope of activity to be restrained that are reasonable and do not impose a greater restraint than is necessary to protect the goodwill or other business interest of the promisee."[^q5-bc-1550a-scope]
+
+Texas publishes no numeric ceiling for ordinary covenants, so reasonableness is assessed case by case against the employer's actual protectable interest. As a practical matter, a restraint keyed to where the employee actually worked or where the employer competes, and a scope tied to the specific customers the employee served or the specific line of business, is easier to defend than a blanket bar on working anywhere in the industry, because the Act requires the restraint to be no greater than necessary [^q5-bc-1550a-scope]. Texas courts generally analyze customer non-solicitation clauses under the same Act and the same reasonableness test rather than a separate, looser standard [^q5-bc-1550a-scope].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not assume a covenant that bars an employee from an entire industry across a wide region will be enforced. The Act requires the restraint to be no greater than necessary to protect a specific business interest, and an overbroad covenant is exposed to reformation down to the minimum a court finds reasonable [^q5-bc-1550a-scope].
+
+## Will a Texas court reform an overbroad non-compete instead of voiding it? {#reformation}
+
+**Short answer.** Yes, reformation is mandatory. If a covenant is ancillary to an otherwise enforceable agreement but its limits are unreasonable, the court shall reform it to the minimum reasonable restraint and enforce it as reformed [^bc-1551c-reform]. A federal court applying Texas law has said reformation should be considered even at the preliminary-injunction stage [^calhoun-pi-reform].
+
+Texas is a true reformation state, and the statute uses mandatory language. Under § 15.51(c), a court faced with an overbroad-but-ancillary covenant does not simply void it; it rewrites the limits and enforces the narrowed version [^bc-1551c-reform].
+
+"the court shall reform the covenant to the extent necessary to cause the limitations contained in the covenant as to time, geographical area, and scope of activity to be restrained to be reasonable and to impose a restraint that is not greater than necessary to protect the goodwill or other business interest of the promisee and enforce the covenant as reformed, except that the court may not award the promisee damages for a breach of the covenant before its reformation and the relief granted to the promisee shall be limited to injunctive relief."[^bc-1551c-reform]
+
+On timing, in a Fifth Circuit opinion that was later withdrawn as moot after the parties settled, *Calhoun v. Jack Doheny Cos.* indicated that a district court should consider reformation as part of deciding a preliminary-injunction motion, rather than deferring it to a later stage [^calhoun-pi-reform]. Because the opinion was withdrawn, treat it as persuasive context rather than binding precedent.
+
+"As we shall show, it should have considered reformation of the agreement in the process of deciding the preliminary injunction motion."[^calhoun-pi-reform]
+
+Because reformation is the default, the strategic calculus in Texas differs from no-reformation states. An overbroad Texas covenant is usually not a total loss for the employer; it is more often trimmed. But, as the next question explains, overbreadth carries its own price in the remedies the employer can recover.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not treat reformation as a free safety net for an intentionally overbroad covenant. Section 15.51(c) bars damages for any breach occurring before reformation and limits the employer to injunctive relief, and the same subsection separately lets an employer that knowingly over-enforced an overbroad covenant be charged with the employee's defense fees, as the attorney's-fee question explains [^bc-1551c-reform][^calhoun-pi-reform].
+
+## What remedies apply, and who bears the burden of proof? {#remedies-burden}
+
+**Short answer.** Damages and injunctive relief, but with limits, and the burden depends on the contract's purpose. A court may award the employer damages, injunctive relief, or both [^bc-1551a-remedies], yet no damages are available for a breach before an overbroad covenant is reformed [^q7-bc-1551c-damages]. In a personal-services contract, the employer bears the burden of proving the covenant meets the § 15.50 criteria [^bc-1551b-burden].
+
+Section 15.51 sets both the menu of remedies and the allocation of proof. The statute authorizes damages, injunctive relief, or both for breach of an enforceable covenant [^bc-1551a-remedies]. The most consequential limit is the pre-reformation damages bar: if a covenant has to be reformed because it was overbroad, the employer cannot recover damages for breaches that happened before the reformation and is confined to injunctive relief [^q7-bc-1551c-damages].
+
+The burden of proof then turns on what the agreement is mainly for. Under § 15.51(b), if the agreement's primary purpose is to obligate the worker to render personal services, the employer must prove the covenant satisfies § 15.50 [^bc-1551b-burden].
+
+"If the primary purpose of the agreement to which the covenant is ancillary is to obligate the promisor to render personal services, for a term or at will, the promisee has the burden of establishing that the covenant meets the criteria specified by Section 15.50 of this code."[^bc-1551b-burden]
+
+That allocation matters because most employee covenants are ancillary to personal-services agreements, so the employer carries the burden. Where the agreement has a different primary purpose, such as a sale of a business, § 15.51(b) flips the burden: the promisor must establish that the covenant does not meet the statutory criteria [^bc-1551b-burden-flip].
+
+## Can a party recover attorney's fees in a Texas non-compete dispute? {#attorneys-fees}
+
+**Short answer.** Partly, and only one way. The Act has no general prevailing-party fee rule, but § 15.51(c) lets a court award the employee defense costs and attorney's fees where the employer knew the covenant was overbroad and tried to over-enforce it [^bc-1551c-fee-shift]. Whether the general contract-fee statute can supply fees for enforcing a covenant despite § 15.52's exclusivity is unresolved on the authorities here [^q8-bc-1552-preempt], and a parallel trade-secret claim has its own fee path [^tutsa-fees].
+
+The Act itself contains one express, one-directional fee rule. Under § 15.51(c), in a personal-services covenant case, if the employee proves the employer knew at signing that the covenant's limits were unreasonable and nonetheless sought to enforce it beyond what was necessary, the court may award the employee its defense costs and reasonable attorney's fees [^bc-1551c-fee-shift].
+
+"the court may award the promisor the costs, including reasonable attorney's fees, actually and reasonably incurred by the promisor in defending the action to enforce the covenant."[^bc-1551c-fee-shift]
+
+What the Act does not supply is a general prevailing-party fee award for the employer that wins enforcement. Because § 15.52 makes the Act's remedies exclusive [^q8-bc-1552-preempt], whether the general breach-of-contract fee statute, Tex. Civ. Prac. & Rem. Code ch. 38, can fill that gap is contested and not resolved by the authorities collected here, so an employer should not count on recovering its fees.
+
+"The criteria for enforceability of a covenant not to compete provided by Sections 15.50 and 15.501 and the procedures and remedies in an action to enforce a covenant not to compete provided by Section 15.51 are exclusive and preempt other law, including common law."[^q8-bc-1552-preempt]
+
+Employers often pair a non-compete claim with a trade-secret claim precisely because the Texas Uniform Trade Secrets Act has its own fee-shifting rule. Under § 134A.005, a court may award reasonable attorney's fees to the prevailing party in defined circumstances, including willful and malicious misappropriation [^tutsa-fees].
+
+"The court may award reasonable attorney's fees to the prevailing party if: (1) a claim of misappropriation is made in bad faith; (2) a motion to terminate an injunction is made or resisted in bad faith; or (3) willful and malicious misappropriation exists."[^tutsa-fees]
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not promise an employer client that it will recover its attorney's fees by winning enforcement of a Texas non-compete. The Act's only express fee rule under § 15.51(c) runs to the employee, and whether chapter 38 supplies fees for enforcement despite § 15.52's exclusivity is unresolved, so employer fee recovery should be treated as uncertain and, where possible, anchored to a separate claim such as trade-secret misappropriation [^bc-1551c-fee-shift][^q8-bc-1552-preempt][^tutsa-fees].
+
+## What special rules apply to Texas physician non-competes? {#physician-noncompetes}
+
+**Short answer.** Several statutory conditions, plus a 2025 good-cause rule. A physician covenant is enforceable only if it meets § 15.50(b)'s conditions, including a buyout capped at the physician's total annual salary and wages [^bc-1550b-buyout]. As amended by SB 1318, a physician covenant is void if the physician is involuntarily discharged without good cause [^bc-1550d-goodcause].
+
+Texas has regulated physician non-competes for decades through § 15.50(b), which layers specific requirements on top of the general test, including patient-list access, medical-record access, continuity-of-care protection, and a buyout option. The buyout cap is a defining feature: the covenant must let the physician buy out of the restraint for no more than the physician's total annual salary and wages at the time of termination [^bc-1550b-buyout].
+
+Senate Bill 1318, effective September 1, 2025, tightened these rules. Among other changes, it added a good-cause condition: a physician non-compete is void and unenforceable if the physician is involuntarily discharged without good cause [^bc-1550d-goodcause].
+
+"a covenant not to compete relating to the practice of medicine is void and unenforceable against a person licensed as a physician by the Texas Medical Board if the physician is involuntarily discharged from contract or employment without good cause."[^bc-1550d-goodcause]
+
+The statute supplies its own definition. Good cause means a reasonable basis for discharge that is directly related to the physician's conduct, job performance, or employment record, so a discharge for genuine performance or conduct problems can leave the covenant intact, while a no-fault termination cannot [^bc-1550d-goodcause].
+
+Section 15.50(b) also caps a physician covenant at a one-year duration and a five-mile radius from the physician's primary practice location and requires the terms to be clearly and conspicuously stated in writing [^bc-1550b4-limits]. Those are statutory ceilings for the covered physician covenant, not a safe harbor that makes any covenant within them automatically reasonable in other contexts. A separate carve-out protects ownership: the physician requirements do not apply to a physician's business ownership interest in a licensed hospital or licensed ambulatory surgical center [^bc-1550c-ownership]. And for integrated-care structures, the statute provides that practicing medicine, for these purposes, does not include managing or directing medical services in an administrative capacity [^bc-1550b1-admin], which preserves room for certain management arrangements.
+
+"the practice of medicine does not include managing or directing medical services in an administrative capacity for a medical practice or other health care provider."[^bc-1550b1-admin]
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not reuse a general Texas non-compete for a physician. Section 15.50(b) requires patient-list and record access, continuity-of-care terms, and a salary-capped buyout, and since September 1, 2025 the covenant is void if the physician is fired without good cause [^bc-1550b-buyout][^bc-1550d-goodcause].
+
+## What does SB 1318 require for dentists, nurses, and physician assistants? {#health-care-practitioners}
+
+**Short answer.** A new statutory cap, effective September 1, 2025. Section 15.501, added by SB 1318, makes a non-compete unenforceable against a dentist, professional or vocational nurse, or physician assistant unless it provides a salary-capped buyout, expires within one year, is limited to a five-mile radius, and is clearly and conspicuously in writing [^bc-15501-hcp].
+
+Before 2025, the statutory buyout-and-limits regime applied chiefly to physicians. SB 1318 extended a parallel set of limits to a broader group of health-care practitioners by enacting § 15.501, effective September 1, 2025 [^bc-15501-hcp]. The section defines that group precisely as licensed dentists, professional or vocational nurses, and physician assistants [^bc-15501a-def].
+
+"A covenant not to compete relating to the practice of dentistry or nursing, or practice as a physician assistant, as applicable, is not enforceable against a health care practitioner unless the covenant: (1) provides for a buyout of the covenant by the health care practitioner in an amount that is not greater than the practitioner's total annual salary and wages at the time of termination of the practitioner's contract or employment; (2) expires not later than the one-year anniversary of the date the contract or employment has been terminated; (3) limits the geographical area subject to the covenant to no more than a five-mile radius from the location at which the health care practitioner primarily practiced before the contract or employment terminated; and (4) has terms and conditions that are clearly and conspicuously stated in writing."[^bc-15501-hcp]
+
+These four requirements mirror the physician buyout, one-year, and five-mile structure, so an employer that already complies with the physician rules has a template for the broader group. Because § 15.501 is new, added by SB 1318 effective September 1, 2025, there is little appellate gloss yet on terms like *primarily practiced*, and practitioners and employers should expect open questions until courts interpret it.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not apply an unlimited or out-of-state non-compete to a Texas dentist, nurse, or physician assistant on or after September 1, 2025. Section 15.501 makes such a covenant unenforceable unless it includes a salary-capped buyout, a one-year expiry, a five-mile limit, and clear, conspicuous written terms [^bc-15501-hcp].
+
+## Can a choice-of-law or forum-selection clause change the outcome in Texas? {#choice-of-law-forum}
+
+**Short answer.** Sometimes for forum, rarely to escape Texas policy. Texas courts will enforce a mandatory forum-selection clause through mandamus [^autonation-forum]. But Texas treats enforcement of non-competes as a matter of fundamental policy, and in *DeSantis v. Wackenhut* the court applied Texas law, not the contractually chosen law, and found the covenant unenforceable [^desantis-texas-law].
+
+Multistate employers often try to select a more favorable state's law or a particular forum. The two devices fare differently in Texas. A forum-selection clause is generally enforceable; in *In re AutoNation, Inc.*, the Texas Supreme Court used mandamus to enforce a mandatory forum-selection clause in a non-compete dispute [^autonation-forum].
+
+"AutoNation now seeks mandamus relief to enforce the mandatory forum-selection clause, and we conditionally grant it."[^autonation-forum]
+
+A choice-of-law clause is harder to use as an end-run around Texas policy. In *DeSantis v. Wackenhut Corp.*, the Texas Supreme Court refused to apply the contract's chosen law where doing so would offend Texas's fundamental policy on covenants not to compete [^desantis-texas-law].
+
+"We hold that Texas law, not Florida law, applies in this case, and that under Texas law, the noncompetition agreement is unenforceable."[^desantis-texas-law]
+
+The federal courts apply the same conflicts analysis. In *Cardoni v. Prosperity Bank*, the Fifth Circuit walked through the Texas-versus-other-state policy comparison, noting that Texas generally permits covenants that are reasonably limited in time and geography [^cardoni-conflicts]. The combined lesson is that forum clauses tend to hold, while a choice-of-law clause selecting a more employer-friendly state may yield to Texas policy when a Texas worker and Texas interests are involved, and conversely Texas policy may yield where another state's fundamental policy controls.
+
+## Does a tolling clause extend a Texas non-compete during breach or litigation? {#tolling-during-breach}
+
+**Short answer.** Texas law does not clearly bless contractual tolling. No Texas statute or Texas Supreme Court decision squarely authorizes extending a non-compete's clock for the time an employee spent breaching or litigating, and any such extension still has to satisfy the Act's reasonableness limit [^q12-bc-1550a-reasonable]. The more dependable protection against ongoing violations is injunctive relief, which the Act expressly authorizes [^q12-bc-1551a-injunction].
+
+Many national templates add a tolling clause so the employer gets the full benefit of the restricted period even if the former employee competes during it. Texas has no statute on point, and the question is best treated as unsettled. Whatever a tolling clause says, the resulting restraint must still be reasonable under § 15.50(a); a clause that effectively extends the restriction for an indefinite period of breach or litigation is in tension with the requirement that the limit on time be reasonable and no greater than necessary [^q12-bc-1550a-reasonable].
+
+"a covenant not to compete is enforceable if it is ancillary to or part of an otherwise enforceable agreement at the time the agreement is made to the extent that it contains limitations as to time, geographical area, and scope of activity to be restrained that are reasonable and do not impose a greater restraint than is necessary to protect the goodwill or other business interest of the promisee."[^q12-bc-1550a-reasonable]
+
+In practice, rather than relying on a contractual tolling provision, a Texas employer can seek injunctive relief, which the Act authorizes for breach of an enforceable covenant [^q12-bc-1551a-injunction]; an injunction running from the date of the order can effectively extend protection past the covenant's nominal end date when violations are ongoing. There is no Texas Supreme Court decision squarely approving or rejecting a contractual tolling clause, so this conclusion rests on the statutory reasonableness requirement and the availability of injunctive relief rather than a case directly on tolling.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not assume a Texas court will add back time to a non-compete for a period of breach or litigation based on a tolling clause. Texas law is unsettled on contractual tolling, and any extended restraint still must satisfy § 15.50(a)'s reasonableness limit, so the more reliable path is to seek injunctive relief for ongoing violations [^q12-bc-1550a-reasonable].
+
+## Are trade-secret and confidentiality protections available in Texas? {#trade-secrets}
+
+**Short answer.** Yes. The Texas Uniform Trade Secrets Act lets a court enjoin actual or threatened misappropriation, independent of any covenant [^tutsa-injunction]. A confidentiality agreement is also available, but it cannot be drafted so broadly that it functions as a disguised non-compete and triggers the Act's reasonableness test [^q13-bc-1550a-disguised].
+
+Because covenant enforcement carries the reformation and damages limits discussed above, Texas employers frequently lean on trade-secret and confidentiality protections as a complement. The Texas Uniform Trade Secrets Act provides injunctive relief that does not depend on any non-compete [^tutsa-injunction].
+
+"Actual or threatened misappropriation may be enjoined if the order does not prohibit a person from using general knowledge, skill, and experience that person acquired during employment."[^tutsa-injunction]
+
+That statutory carve-out for *general knowledge, skill, and experience* is important: a trade-secret injunction protects genuine secrets, not the ordinary expertise an employee carries to a new job [^tutsa-injunction]. Beyond an injunction, the Act also lets a claimant recover damages for misappropriation [^tutsa-damages]. A non-disclosure agreement complements these protections by contract, and the Act leaves contractual remedies in place whether or not they rest on trade-secret misappropriation [^tutsa-contract-remedies]. But an NDA is not a way around § 15.50: a confidentiality clause drafted so broadly that it effectively bars the former employee from working in the field invites a court to treat it as a non-compete and apply the Act's reasonableness test [^q13-bc-1550a-disguised].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not draft a Texas confidentiality or non-disclosure clause so broadly that it operates as a covert non-compete. The trade-secret statute supports an injunction against misappropriation but excludes general knowledge, skill, and experience, and an NDA that effectively prevents the employee from working can be recharacterized as a non-compete subject to § 15.50 [^tutsa-injunction][^q13-bc-1550a-disguised].
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-03. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not Texas. This article synthesizes Texas primary law and is not legal advice from a Texas-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^bc-1550a-test]: **Tex. Bus. & Com. Code § 15.50** — "a covenant not to compete is enforceable if it is ancillary to or part of an otherwise enforceable agreement at the time the agreement is made to the extent that it contains limitations as to time, geographical area, and scope of activity to be restrained that are reasonable and do not impose a greater restraint than is necessary to protect the goodwill or other business interest of the promisee." *Tex. Bus. & Com. Code § 15.50(a).* <https://statutes.capitol.texas.gov/Docs/BC/htm/BC.15.htm>
+
+[^bc-1552-preempt]: **Tex. Bus. & Com. Code § 15.52** — "The criteria for enforceability of a covenant not to compete provided by Sections 15.50 and 15.501 and the procedures and remedies in an action to enforce a covenant not to compete provided by Section 15.51 are exclusive and preempt other law, including common law." *Tex. Bus. & Com. Code § 15.52.* <https://statutes.capitol.texas.gov/Docs/BC/htm/BC.15.htm>
+
+[^marsh-reasonably-related]: **Marsh USA Inc. v. Cook** — "We hold that, under the terms of the Covenants Not to Compete Act (Act), the consideration for the noncompete agreement (stock options) is reasonably related to the company's interest in protecting its goodwill, a business interest the Act recognizes as worthy of protection." *Marsh USA Inc. v. Cook, 354 S.W.3d 764 (Tex. 2011).* <https://www.courtlistener.com/opinion/2541088/marsh-usa-inc-v-cook/#:~:text=We%20hold%20that%2C%20under%20the,recognizes%20as%20worthy%20of%20protection.>
+
+[^light-ancillary]: **Light v. Centel Cellular Co. of Texas** — "Although Light and United did have an otherwise enforceable agreement between them, the covenant was not ancillary to or a part of that otherwise enforceable agreement." *Light v. Centel Cellular Co. of Tex., 883 S.W.2d 642 (Tex. 1994).* <https://www.courtlistener.com/opinion/1525150/light-v-centel-cellular-co-of-texas/#:~:text=Although%20Light%20and%20United%20did,of%20that%20otherwise%20enforceable%20agreement.>
+
+[^sheshunoff-performance]: **Alex Sheshunoff Management Services, L.P. v. Johnson** — "The fact that the employer was not bound to perform because he could have fired the employee is irrelevant; if he has performed, he has accepted the employee's offer and created a binding unilateral contract." *Alex Sheshunoff Mgmt. Servs., L.P. v. Johnson, 209 S.W.3d 644 (Tex. 2006).* <https://www.courtlistener.com/opinion/894789/alex-sheshunoff-management-services-lp-v-johnson/#:~:text=The%20fact%20that%20the%20employer,created%20a%20binding%20unilateral%20contract.>
+
+[^mann-frankfort-implied]: **Mann Frankfort Stein & Lipp Advisors, Inc. v. Fielding** — "When the nature of the work the employee is hired to perform requires confidential information to be provided for the work to be performed by the employee, the employer impliedly promises confidential information will be provided." *Mann Frankfort Stein & Lipp Advisors, Inc. v. Fielding, 289 S.W.3d 844 (Tex. 2009).* <https://www.courtlistener.com/opinion/895104/mann-frankfort-stein-lipp-advisors-inc-v-fielding/#:~:text=When%20the%20nature%20of%20the,confidential%20information%20will%20be%20provided.>
+
+[^q5-bc-1550a-scope]: **Tex. Bus. & Com. Code § 15.50** — "a covenant not to compete is enforceable if it is ancillary to or part of an otherwise enforceable agreement at the time the agreement is made to the extent that it contains limitations as to time, geographical area, and scope of activity to be restrained that are reasonable and do not impose a greater restraint than is necessary to protect the goodwill or other business interest of the promisee." *Tex. Bus. & Com. Code § 15.50(a).* <https://statutes.capitol.texas.gov/Docs/BC/htm/BC.15.htm>
+
+[^bc-1551c-reform]: **Tex. Bus. & Com. Code § 15.51** — "the court shall reform the covenant to the extent necessary to cause the limitations contained in the covenant as to time, geographical area, and scope of activity to be restrained to be reasonable and to impose a restraint that is not greater than necessary to protect the goodwill or other business interest of the promisee and enforce the covenant as reformed, except that the court may not award the promisee damages for a breach of the covenant before its reformation and the relief granted to the promisee shall be limited to injunctive relief." *Tex. Bus. & Com. Code § 15.51(c).* <https://statutes.capitol.texas.gov/Docs/BC/htm/BC.15.htm>
+
+[^calhoun-pi-reform]: **Calhoun v. Jack Doheny Companies, Inc.** — "As we shall show, it should have considered reformation of the agreement in the process of deciding the preliminary injunction motion." *Calhoun v. Jack Doheny Cos., 969 F.3d 232 (5th Cir. 2020) (later withdrawn as moot).* <https://www.courtlistener.com/opinion/4773823/donald-calhoun-v-jack-doheny-companies-inc/#:~:text=As%20we%20shall%20show%2C%20it,deciding%20the%20preliminary%20injunction%20motion.>
+
+[^bc-1551a-remedies]: **Tex. Bus. & Com. Code § 15.51** — "a court may award the promisee under a covenant not to compete damages, injunctive relief, or both damages and injunctive relief for a breach by the promisor of the covenant." *Tex. Bus. & Com. Code § 15.51(a).* <https://statutes.capitol.texas.gov/Docs/BC/htm/BC.15.htm>
+
+[^q7-bc-1551c-damages]: **Tex. Bus. & Com. Code § 15.51** — "the court may not award the promisee damages for a breach of the covenant before its reformation and the relief granted to the promisee shall be limited to injunctive relief." *Tex. Bus. & Com. Code § 15.51(c).* <https://statutes.capitol.texas.gov/Docs/BC/htm/BC.15.htm>
+
+[^bc-1551b-burden]: **Tex. Bus. & Com. Code § 15.51** — "If the primary purpose of the agreement to which the covenant is ancillary is to obligate the promisor to render personal services, for a term or at will, the promisee has the burden of establishing that the covenant meets the criteria specified by Section 15.50 of this code." *Tex. Bus. & Com. Code § 15.51(b).* <https://statutes.capitol.texas.gov/Docs/BC/htm/BC.15.htm>
+
+[^bc-1551b-burden-flip]: **Tex. Bus. & Com. Code § 15.51** — "If the agreement has a different primary purpose, the promisor has the burden of establishing that the covenant does not meet those criteria." *Tex. Bus. & Com. Code § 15.51(b).* <https://statutes.capitol.texas.gov/Docs/BC/htm/BC.15.htm>
+
+[^bc-1551c-fee-shift]: **Tex. Bus. & Com. Code § 15.51** — "the court may award the promisor the costs, including reasonable attorney's fees, actually and reasonably incurred by the promisor in defending the action to enforce the covenant." *Tex. Bus. & Com. Code § 15.51(c).* <https://statutes.capitol.texas.gov/Docs/BC/htm/BC.15.htm>
+
+[^q8-bc-1552-preempt]: **Tex. Bus. & Com. Code § 15.52** — "The criteria for enforceability of a covenant not to compete provided by Sections 15.50 and 15.501 and the procedures and remedies in an action to enforce a covenant not to compete provided by Section 15.51 are exclusive and preempt other law, including common law." *Tex. Bus. & Com. Code § 15.52.* <https://statutes.capitol.texas.gov/Docs/BC/htm/BC.15.htm>
+
+[^tutsa-fees]: **Tex. Civ. Prac. & Rem. Code § 134A.005** — "The court may award reasonable attorney's fees to the prevailing party if: (1) a claim of misappropriation is made in bad faith; (2) a motion to terminate an injunction is made or resisted in bad faith; or (3) willful and malicious misappropriation exists." *Tex. Civ. Prac. & Rem. Code § 134A.005.* <https://statutes.capitol.texas.gov/Docs/CP/htm/CP.134A.htm>
+
+[^bc-1550b-buyout]: **Tex. Bus. & Com. Code § 15.50** — "the covenant must provide for a buyout of the covenant by the physician in an amount that is not greater than the physician's total annual salary and wages at the time of termination of the contract or employment;" *Tex. Bus. & Com. Code § 15.50(b)(2).* <https://statutes.capitol.texas.gov/Docs/BC/htm/BC.15.htm>
+
+[^bc-1550d-goodcause]: **Tex. Bus. & Com. Code § 15.50** — "a covenant not to compete relating to the practice of medicine is void and unenforceable against a person licensed as a physician by the Texas Medical Board if the physician is involuntarily discharged from contract or employment without good cause. For purposes of this subsection, ‘good cause’ means a reasonable basis for discharge of a physician from contract or employment that is directly related to the physician's conduct, including the physician's conduct on the job or otherwise, job performance, and contract or employment record." *Tex. Bus. & Com. Code § 15.50(d).* <https://statutes.capitol.texas.gov/Docs/BC/htm/BC.15.htm>
+
+[^bc-1550b4-limits]: **Tex. Bus. & Com. Code § 15.50** — "(A) expire not later than the one-year anniversary of the date the contract or employment has been terminated; (B) limit the geographical area subject to the covenant to no more than a five-mile radius from the location at which the physician primarily practiced before the contract or employment terminated; and (C) have terms and conditions clearly and conspicuously stated in writing." *Tex. Bus. & Com. Code § 15.50(b)(4).* <https://statutes.capitol.texas.gov/Docs/BC/htm/BC.15.htm>
+
+[^bc-1550c-ownership]: **Tex. Bus. & Com. Code § 15.50** — "Subsection (b) does not apply to a physician's business ownership interest in a licensed hospital or licensed ambulatory surgical center." *Tex. Bus. & Com. Code § 15.50(c).* <https://statutes.capitol.texas.gov/Docs/BC/htm/BC.15.htm>
+
+[^bc-1550b1-admin]: **Tex. Bus. & Com. Code § 15.50** — "the practice of medicine does not include managing or directing medical services in an administrative capacity for a medical practice or other health care provider." *Tex. Bus. & Com. Code § 15.50(b-1).* <https://statutes.capitol.texas.gov/Docs/BC/htm/BC.15.htm>
+
+[^bc-15501-hcp]: **Tex. Bus. & Com. Code § 15.501** — "A covenant not to compete relating to the practice of dentistry or nursing, or practice as a physician assistant, as applicable, is not enforceable against a health care practitioner unless the covenant: (1) provides for a buyout of the covenant by the health care practitioner in an amount that is not greater than the practitioner's total annual salary and wages at the time of termination of the practitioner's contract or employment; (2) expires not later than the one-year anniversary of the date the contract or employment has been terminated; (3) limits the geographical area subject to the covenant to no more than a five-mile radius from the location at which the health care practitioner primarily practiced before the contract or employment terminated; and (4) has terms and conditions that are clearly and conspicuously stated in writing." *Tex. Bus. & Com. Code § 15.501(b).* <https://statutes.capitol.texas.gov/Docs/BC/htm/BC.15.htm>
+
+[^bc-15501a-def]: **Tex. Bus. & Com. Code § 15.501** — "(1) a person licensed by the State Board of Dental Examiners to practice dentistry in this state; (2) a person licensed under Chapter 301 , Occupations Code, to engage in professional or vocational nursing; or (3) a physician assistant licensed under Chapter 204 , Occupations Code." *Tex. Bus. & Com. Code § 15.501(a).* <https://statutes.capitol.texas.gov/Docs/BC/htm/BC.15.htm>
+
+[^autonation-forum]: **In re AutoNation, Inc.** — "AutoNation now seeks mandamus relief to enforce the mandatory forum-selection clause, and we conditionally grant it." *In re AutoNation, Inc., 228 S.W.3d 663 (Tex. 2007).* <https://www.courtlistener.com/opinion/894883/in-re-autonation-inc/#:~:text=AutoNation%20now%20seeks%20mandamus%20relief,and%20we%20conditionally%20grant%20it.>
+
+[^desantis-texas-law]: **DeSantis v. Wackenhut Corp.** — "We hold that Texas law, not Florida law, applies in this case, and that under Texas law, the noncompetition agreement is unenforceable." *DeSantis v. Wackenhut Corp., 793 S.W.2d 670 (Tex. 1990).* <https://www.courtlistener.com/opinion/2376061/desantis-v-wackenhut-corp/#:~:text=We%20hold%20that%20Texas%20law%2C,the%20noncompetition%20agreement%20is%20unenforceable.>
+
+[^cardoni-conflicts]: **Cardoni v. Prosperity Bank** — "Texas generally allows them so long as they are limited both geographically and temporally." *Cardoni v. Prosperity Bank, 805 F.3d 573 (5th Cir. 2015).* <https://www.courtlistener.com/opinion/3150844/chris-cardoni-v-prosperity-bank/#:~:text=Texas%20generally%20allows%20them%20so,limited%20both%20geographically%20and%20temporally.>
+
+[^q12-bc-1550a-reasonable]: **Tex. Bus. & Com. Code § 15.50** — "a covenant not to compete is enforceable if it is ancillary to or part of an otherwise enforceable agreement at the time the agreement is made to the extent that it contains limitations as to time, geographical area, and scope of activity to be restrained that are reasonable and do not impose a greater restraint than is necessary to protect the goodwill or other business interest of the promisee." *Tex. Bus. & Com. Code § 15.50(a).* <https://statutes.capitol.texas.gov/Docs/BC/htm/BC.15.htm>
+
+[^q12-bc-1551a-injunction]: **Tex. Bus. & Com. Code § 15.51** — "a court may award the promisee under a covenant not to compete damages, injunctive relief, or both damages and injunctive relief for a breach by the promisor of the covenant." *Tex. Bus. & Com. Code § 15.51(a).* <https://statutes.capitol.texas.gov/Docs/BC/htm/BC.15.htm>
+
+[^tutsa-injunction]: **Tex. Civ. Prac. & Rem. Code § 134A.003** — "Actual or threatened misappropriation may be enjoined if the order does not prohibit a person from using general knowledge, skill, and experience that person acquired during employment." *Tex. Civ. Prac. & Rem. Code § 134A.003.* <https://statutes.capitol.texas.gov/Docs/CP/htm/CP.134A.htm>
+
+[^q13-bc-1550a-disguised]: **Tex. Bus. & Com. Code § 15.50** — "a covenant not to compete is enforceable if it is ancillary to or part of an otherwise enforceable agreement at the time the agreement is made to the extent that it contains limitations as to time, geographical area, and scope of activity to be restrained that are reasonable and do not impose a greater restraint than is necessary to protect the goodwill or other business interest of the promisee." *Tex. Bus. & Com. Code § 15.50(a).* <https://statutes.capitol.texas.gov/Docs/BC/htm/BC.15.htm>
+
+[^tutsa-damages]: **Tex. Civ. Prac. & Rem. Code § 134A.004** — "In addition to or in lieu of injunctive relief, a claimant is entitled to recover damages for misappropriation." *Tex. Civ. Prac. & Rem. Code § 134A.004(a).* <https://statutes.capitol.texas.gov/Docs/CP/htm/CP.134A.htm>
+
+[^tutsa-contract-remedies]: **Tex. Civ. Prac. & Rem. Code § 134A.007** — "This chapter does not affect: (1) contractual remedies, whether or not based upon misappropriation of a trade secret" *Tex. Civ. Prac. & Rem. Code § 134A.007(b).* <https://statutes.capitol.texas.gov/Docs/CP/htm/CP.134A.htm>

--- a/skills/non-compete-contract-explainer/content/us-virgin-islands.md
+++ b/skills/non-compete-contract-explainer/content/us-virgin-islands.md
@@ -1,0 +1,193 @@
+---
+jurisdiction: "U.S. Virgin Islands"
+slug: us-virgin-islands
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-03"
+canonicalUrl: https://openagreements.org/legal/non-compete/us-virgin-islands
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/us-virgin-islands · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in the U.S. Virgin Islands[^about]
+
+The U.S. Virgin Islands may enforce a reasonable non-compete but has no statute on point; the Superior Court in Arvidson v. Buchar judges covenants under an indigenous common-law reasonableness test selected through the Banks methodology, and a small-island economy plus a no-at-will Wrongful Discharge Act make aggressive restraints hard to enforce.
+
+
+## At a glance
+
+| Question | U.S. Virgin Islands |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed if reasonable |
+| **Bottom line** | The U.S. Virgin Islands enforces a non-compete only if it is reasonable in duration, area, and scope under a single trial-court decision, and aggressive restraints are hard to enforce in a small-island, non-at-will economy. |
+| **Main law or case** | Arvidson v. Buchar, 2019 VI SUPER 122 (Super. Ct. V.I. 2019) (common law via 1 V.I.C. § 4) |
+| **Can a court narrow it?** | Yes — rewrites to reasonable |
+| **Applies to contractors?** | Unclear |
+| **Restriction extended during a breach?** | Silent — no statute or case addresses tolling |
+| **Maximum length set by law** | No statutory limit |
+
+## Are employee non-compete agreements enforceable in the U.S. Virgin Islands? {#employee-noncompetes}
+
+**Short answer.** Sometimes. The Virgin Islands is a *reasonableness* jurisdiction, not a per se ban like California or North Dakota. A covenant can be enforced if it is ancillary to a valid relationship, supported by consideration, and no broader than necessary to protect a legitimate business interest. But there is no non-compete statute, the leading authority is a single trial-court decision with no V.I. Supreme Court ruling behind it, and that decision struck the covenant in front of it down — so enforcement is real but fact-dependent and far from automatic [^arvidson-enforceable].
+
+The Virgin Islands is an unincorporated U.S. territory. An employment-covenant dispute is decided in the first instance by the Superior Court of the Virgin Islands applying territorial law, with appeals to the Supreme Court of the Virgin Islands (established 2007) and a parallel federal track in the District Court of the Virgin Islands under the Third Circuit. There is no code section that governs employee non-competes; enforceability is a matter of territorial common law, which the courts build through the methodology described below.
+
+Because the law lives in case decisions rather than a statute, most of the operating rules here are anchored to one opinion — *Arvidson v. Buchar* — and to the reception statute that tells Virgin Islands courts where to find their common law [^vic-1-4]. A covenant that would survive comfortably in a blue-pencil state still carries genuine first-impression risk in the territory.
+
+## What test does the Superior Court apply to a Virgin Islands non-compete? {#governing-test}
+
+**Short answer.** The Superior Court applies a common-law rule of reasonableness. Under *Arvidson*, a partial restraint of trade is valid only when it is ancillary to a valid contract or transaction, supported by valid consideration, protects a legitimate business interest, and is reasonable in its duration, geographic area, and the scope of activity it restricts [^arvidson-rule]. Reasonableness is then measured against five factors the court drew from earlier Virgin Islands case law [^arvidson-factors].
+
+The court frames the inquiry as a balance among the employer's legitimate business interest, the hardship the restraint imposes on the employee, and the public interest — assessed through the covenant's *time, place, and manner*. The five factors restate that balance as concrete questions:
+
+"This test of reasonableness must be applied to the following five factors 1 Is the duration of the restriction reasonable? 2 Is the area of restriction reasonable? 3 Is the interest of the employer reasonably protected? 4 Is undue hardship imposed on the employee? 5 Is the public interest reasonably protected?"[^arvidson-factors]
+
+The ultimate determination of reasonableness is a question of law, but it is a fact-intensive one: the court weighs the totality of the circumstances rather than applying a fixed formula [^arvidson-factintensive]. For in-house counsel that means a covenant is judged on its specific facts, and a clause that omits any durational, territorial, or activity limit will not survive.
+
+## If there is no statute, where does the non-compete rule come from? {#common-law-source}
+
+**Short answer.** From the territory's common law, which the courts now build deliberately rather than by copying the Restatements. Historically, 1 V.I.C. § 4 directed Virgin Islands courts to apply the Restatements as their rules of decision [^banks-section4]. In *Banks v. International Rental & Leasing Corp.*, the Supreme Court of the Virgin Islands held that the Legislature did not intend that statute to force mechanical application of the latest Restatement [^banks-method], and in *Connor* it set out the three-factor analysis Virgin Islands courts use to choose a rule [^connor-factors].
+
+This matters for non-competes because *Arvidson* did not simply lift Restatement (Second) of Contracts § 188 off the shelf. It ran the *Banks* analysis and chose an indigenous reasonableness rule, which is why the Virgin Islands standard is a common-law balance rather than a verbatim Restatement test.
+
+"We conclude that the Legislature did not intend for section 4 of title 1 to compel this Court to mechanically apply the most recent Restatement."[^banks-method]
+
+Under *Connor*, when the law is unsettled the court does not default to the majority rule automatically; it asks which approach is soundest for the territory:
+
+"Rather, this Court has instructed that, instead of mechanistically following the Restatements, courts should consider ‘three non-dispositive factors’ to determine Virgin Islands common law: ‘(1) whether any Virgin Islands courts have previously adopted a particular rule; (2) the position taken by a majority of courts from other jurisdictions; and (3) most importantly, which approach represents the soundest rule for the Virgin Islands.’"[^connor-factors]
+
+The practical takeaway: a covenant should be defended on Virgin Islands terms. Citing only mainland precedent or the Restatement as if it controlled invites a *Banks* challenge that the rule was never properly adopted here.
+
+## How do courts judge a covenant's duration, geographic area, and scope? {#duration-geography-scope}
+
+**Short answer.** By asking whether each dimension is no broader than necessary to protect a legitimate interest. *Arvidson* struck its covenant precisely because it gave no durational, territorial, or activity limit and never identified the interest it was meant to protect [^arvidson-scope]. The older decision in *V.I. Diving Schools v. Dixon* voided a covenant on the same ground — that it was an unreasonable restraint greater than necessary to protect the employer's business interest [^dixon-void].
+
+Geography deserves special attention. The territory is three small islands — St. Thomas, St. Croix, and St. John — so a territory-wide or *worldwide* restraint is hard to justify as the narrowest protection of a genuine interest. The same logic that makes a 50-mile radius unremarkable on the mainland can make an all-islands restraint look like a naked barrier to earning a living.
+
+"restrictive clauses of the agreement are void and unenforceable as against public policy on the ground that they are unreasonable restraint on competition."[^dixon-void]
+
+A covenant should therefore state an explicit duration, a defined geographic area tied to where the employer actually competes, and a scope limited to the activities that threaten the protected interest. *Dixon* is a 1983 Territorial Court decision predating *Banks*, so treat it as persuasive illustration rather than binding doctrine — but its reasoning tracks the modern *Arvidson* test.
+
+## What consideration supports a Virgin Islands non-compete, and is continued employment enough? {#consideration}
+
+**Short answer.** *Arvidson* makes valid consideration an element of an enforceable covenant, but no Virgin Islands decision squarely holds whether continued employment alone is sufficient for a covenant signed mid-employment [^arvidson-consideration]. The wrinkle is that the territory is not an at-will jurisdiction: the Wrongful Discharge Act lets an employer dismiss an employee for only nine enumerated reasons [^arvidson-wda], so the mainland argument that an employer gives value by merely refraining from firing is weaker here.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Because the Wrongful Discharge Act limits when an employer may fire, a court could view a bare promise of continued employment as adding little new value. The conservative practice is to support a mid-employment covenant with fresh, independent consideration — a bonus, a raise, a promotion, or specialized training — rather than rely on continued employment alone [^q5-arvidson-wda].
+
+No on-point Virgin Islands case resolves the question, so this is a planning judgment rather than a settled rule. Obtaining the covenant at hire — when the offer of employment is itself the consideration — avoids the mid-employment problem, though even a covenant signed at hire must still satisfy *Arvidson*'s ancillary, protectable-interest, and reasonable-scope requirements.
+
+## Will a court narrow an overbroad covenant, or void it entirely? {#overbroad-narrowing}
+
+**Short answer.** *Arvidson* chose *equitable reformation* as the soundest rule for Virgin Islands non-competes, rejecting both the rigid blue-pencil rule and the all-or-nothing approach [^q6-arvidson]. But the court adopted reformation with an express *greater willingness to refuse to reform* agreements that are not reasonable on their face [^q6-arvidson-strict], and it declined to rewrite the covenant in front of it because that clause had no time, place, or scope limit to salvage. An employer therefore cannot assume a court will rescue an overbroad clause.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Draft to the narrowest defensible scope from the start. Reformation is theoretically available in the Virgin Islands, but *Arvidson* applies it strictly — a court is reluctant to rewrite an agreement that is not reasonable on its face or that would require supplying essential terms [^q6-arvidson-strict]. A clause with no reasonable core to enforce risks losing entirely, as both *Arvidson* and the older *Dixon* decision show [^q6-dixon].
+
+A savings or step-down clause may improve the odds of partial enforcement, but only if enough reasonable terms already exist for a court to enforce without effectively writing a new covenant. The safer assumption is that the covenant as drafted is the covenant the court will judge.
+
+## Does the restricted period toll or extend if the employee breaches? {#tolling}
+
+**Short answer.** No Virgin Islands statute or decision addresses tolling — whether the clock pauses, or the restricted period is extended, while a former employee is violating the covenant or litigation is pending. This is an open question in the territory [^q7-arvidson].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Treat any tolling or extension-on-breach clause as untested in the Virgin Islands. Because the controlling test asks whether the *total* restraint is reasonable in duration [^q7-arvidson], an extension that lengthens the covenant well beyond its stated term could itself be challenged as unreasonable. If you include a tolling clause, cap the maximum extension and keep the underlying period conservative so the worst-case total still looks reasonable.
+
+Because there is no on-point authority, a Virgin Islands court asked to enforce a tolling provision would likely reason from the same reasonableness principles that govern duration generally, and from persuasive mainland authority — but the outcome cannot be predicted with confidence.
+
+## If a non-compete is shaky, what protects trade secrets and confidential information? {#trade-secrets}
+
+**Short answer.** The Virgin Islands has adopted the Uniform Trade Secrets Act, which gives an employer a statutory remedy for misappropriation independent of any covenant [^vic-11-1001]. It defines a trade secret broadly [^vic-11-1002], preserves contractual remedies alongside the Act [^vic-11-1008], and the evidence code adds a privilege to resist disclosing trade secrets in litigation [^vic-5-858].
+
+This matters because trade-secret and confidentiality protection does not depend on the reasonableness test that makes non-competes hard to enforce. The Act both displaces conflicting common-law misappropriation remedies and preserves contractual ones, so a confidentiality agreement and the statutory claim work together [^vic-11-1008]. A narrowly drafted confidentiality and trade-secret program is often the more durable protection in the territory, and *Dixon* shows the risk of relying on a covenant without a documented protectable interest — the employer there failed to prove any trade secret worth protecting [^dixon-notrade].
+
+## Can an overbroad covenant run afoul of the Virgin Islands Antimonopoly Law? {#antimonopoly}
+
+**Short answer.** It may supply an additional, untested ground of attack. The Virgin Islands Antimonopoly Law makes it a violation to unreasonably restrain trade or commerce by *contract, combination, or conspiracy* [^vic-11-1503]. An employee challenging a sweeping covenant — especially in a small market where the restraint could foreclose competition — might invoke that statute alongside the common-law reasonableness defense.
+
+This is a secondary tool rather than the main event, and an untested one: the statute's concerted-action language (*combination or conspiracy with one or more other persons*) fits horizontal market conduct more naturally than a two-party employment covenant, and no Virgin Islands case has applied § 1503 to an employee non-compete. The day-to-day enforceability question is decided under the *Arvidson* reasonableness test. But the statute reinforces why a covenant that goes beyond protecting a legitimate interest is vulnerable, because the same overreach that fails the reasonableness test can also look like an unreasonable restraint of trade.
+
+## How are non-solicits, NDAs, and sale-of-business or LLC covenants treated? {#other-covenants}
+
+**Short answer.** An employee non-solicit that restrains competitive activity should be drafted to satisfy *Arvidson*'s reasonableness principles, because a restraint dressed up as a non-solicit is still a partial restraint of trade [^q10-arvidson]. Confidentiality and trade-secret clauses are supported separately by contract law and the Uniform Trade Secrets Act rather than by the non-compete test — though an overbroad confidentiality clause that operates as a de facto non-compete may draw similar scrutiny. Entity-governance covenants have a clear statutory foothold: the LLC statute expressly contemplates a court-ordered *covenant not to compete* as a term of a member buyout [^vic-13-1702].
+
+Broader sale-of-business covenants should still be analyzed under the same reasonableness principles. Mainland practice often treats a seller or departing owner who is paid for goodwill more favorably than an ordinary employee, because the legitimate interest is stronger and the hardship is offset by the purchase price — but in the Virgin Islands that more-favorable treatment is an inference from common-law context, not a territorial appellate holding. A sale-of-business covenant is still measured for reasonable duration, area, and scope, and a *worldwide* restraint on a Virgin Islands business will draw the same skepticism a worldwide employee covenant would.
+
+## Does the federal FTC non-compete ban apply, and which court decides a dispute? {#ftc-and-courts}
+
+**Short answer.** No. The Federal Trade Commission's 2024 Non-Compete Rule never took effect — a federal court set it aside, the FTC acceded to that result, and the Commission has now removed the rule from the Code of Federal Regulations [^ftc-removal]. Virgin Islands non-compete disputes are governed by territorial common law and decided in the first instance by the Superior Court, with appeals to the Supreme Court of the Virgin Islands and a separate federal track in the District Court of the Virgin Islands.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not rely on guidance — including parts of the 2024–2025 commentary — that treats the FTC ban as live. As of February 2026 the rule has been removed from the CFR and is not operative [^ftc-removal]; enforceability turns entirely on Virgin Islands law. Separately, the FTC may still challenge individual covenants case-by-case under its general authority, but there is no across-the-board federal ban.
+
+For planning, the audience that matters is a Virgin Islands judge applying the *Arvidson* reasonableness test — not a federal rule. Where a dispute lands in the District Court on diversity or federal-question grounds, that court still applies Virgin Islands substantive law, informed by Third Circuit procedure.
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-03. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not U.S. Virgin Islands. This article synthesizes U.S. Virgin Islands primary law and is not legal advice from a U.S. Virgin Islands-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^arvidson-enforceable]: **Arvidson v. Buchar** — "Accordingly, the Arvidsons have met their summary judgment burden, and the Court finds the covenant to not compete invalid and unenforceable as a matter of law" *Arvidson v. Buchar, 2019 VI SUPER 122 (Super. Ct. V.I. Sept. 10, 2019).* <https://usvipublicportal-api.vicourts.org/courts/87edff36-c02b-4073-aea4-c0652bc123d9/cms/case/7432A3F8-AD71-45C5-B028-B4471D746A4E/docketentrydocuments/27b98266-7d9f-405f-b7ba-c221f8db0a97>
+
+[^vic-1-4]: **1 V.I.C. § 4 — Application of common law; restatements** — "shall be the rules of decision in the courts of the Virgin Islands in cases to which they apply, in the absence of local laws to the contrary." *1 V.I.C. § 4.* <https://advance.lexis.com/container?config=014DJAA3OWU1MmYyMC1kNzRhLTQ4NDAtYTMxZS01YzJhMzBkZDA0NDMKAFBvZENhdGFsb2dSOvVciRp0EcGxvMymeAXd>
+
+[^arvidson-rule]: **Arvidson v. Buchar** — "In accordance, this Court similarly adopts the same rule of reasonableness" *Arvidson v. Buchar, 2019 VI SUPER 122 (Super. Ct. V.I. Sept. 10, 2019).* <https://usvipublicportal-api.vicourts.org/courts/87edff36-c02b-4073-aea4-c0652bc123d9/cms/case/7432A3F8-AD71-45C5-B028-B4471D746A4E/docketentrydocuments/27b98266-7d9f-405f-b7ba-c221f8db0a97>
+
+[^arvidson-factors]: **Arvidson v. Buchar** — "This test of reasonableness must be applied to the following five factors 1 Is the duration of the restriction reasonable? 2 Is the area of restriction reasonable? 3 Is the interest of the employer reasonably protected? 4 Is undue hardship imposed on the employee? 5 Is the public interest reasonably protected?" *Arvidson v. Buchar, 2019 VI SUPER 122 (Super. Ct. V.I. Sept. 10, 2019).* <https://usvipublicportal-api.vicourts.org/courts/87edff36-c02b-4073-aea4-c0652bc123d9/cms/case/7432A3F8-AD71-45C5-B028-B4471D746A4E/docketentrydocuments/27b98266-7d9f-405f-b7ba-c221f8db0a97>
+
+[^arvidson-factintensive]: **Arvidson v. Buchar** — "reasonableness is a fact intensive inquiry that depends on weighing the totality of the circumstances" *Arvidson v. Buchar, 2019 VI SUPER 122 (Super. Ct. V.I. Sept. 10, 2019).* <https://usvipublicportal-api.vicourts.org/courts/87edff36-c02b-4073-aea4-c0652bc123d9/cms/case/7432A3F8-AD71-45C5-B028-B4471D746A4E/docketentrydocuments/27b98266-7d9f-405f-b7ba-c221f8db0a97>
+
+[^banks-section4]: **Banks v. International Rental & Leasing Corp.** — "The rules of the common law, as expressed in the restatements of the law approved by the American Law Institute, and to the extent not so expressed, as generally understood and applied in the United States, shall be the rules of decision in the courts of the Virgin Islands in cases to which they apply, in the absence of local laws to the contrary." *Banks v. Int'l Rental & Leasing Corp., 55 V.I. 967 (V.I. 2011).* <https://www.courtlistener.com/opinion/8676262/banks-v-international-rental-leasing-corp/#:~:text=The%20rules%20of%20the%20common,local%20laws%20to%20the%20contrary.>
+
+[^banks-method]: **Banks v. International Rental & Leasing Corp.** — "We conclude that the Legislature did not intend for section 4 of title 1 to compel this Court to mechanically apply the most recent Restatement." *Banks v. Int'l Rental & Leasing Corp., 55 V.I. 967 (V.I. 2011).* <https://www.courtlistener.com/opinion/8676262/banks-v-international-rental-leasing-corp/#:~:text=We%20conclude%20that%20the%20Legislature,apply%20the%20most%20recent%20Restatement.>
+
+[^connor-factors]: **Government of the Virgin Islands v. Connor** — "Rather, this Court has instructed that, instead of mechanistically following the Restatements, courts should consider ‘three non-dispositive factors’ to determine Virgin Islands common law: ‘(1) whether any Virgin Islands courts have previously adopted a particular rule; (2) the position taken by a majority of courts from other jurisdictions; and (3) most importantly, which approach represents the soundest rule for the Virgin Islands.’" *Gov't of the V.I. v. Connor, 60 V.I. 597 (V.I. 2014).* <https://cdnsm5-hosted.civiclive.com/UserFiles/Servers/Server_12810860/File/Opinions/Published/2014/File16.pdf>
+
+[^arvidson-scope]: **Arvidson v. Buchar** — "The Covenant to not compete does not pass the three pronged business interest test and, by failing to provide time, place, and manner restrictions, is overly broad and invalid" *Arvidson v. Buchar, 2019 VI SUPER 122 (Super. Ct. V.I. Sept. 10, 2019).* <https://usvipublicportal-api.vicourts.org/courts/87edff36-c02b-4073-aea4-c0652bc123d9/cms/case/7432A3F8-AD71-45C5-B028-B4471D746A4E/docketentrydocuments/27b98266-7d9f-405f-b7ba-c221f8db0a97>
+
+[^dixon-void]: **V.I. Diving Schools/Supplies, Inc. v. Dixon** — "restrictive clauses of the agreement are void and unenforceable as against public policy on the ground that they are unreasonable restraint on competition." *V.I. Diving Schools/Supplies, Inc. v. Dixon, Civ. No. 1046/1982 (Terr. Ct. V.I. Oct. 7, 1983).* <https://cdnsm5-hosted.civiclive.com/UserFiles/Servers/Server_12810747/File/Opinions/Archive/VI%20Diving%20Sch%20v.%20Dixon%20%28IAM%29.pdf>
+
+[^arvidson-consideration]: **Arvidson v. Buchar** — "is supported by valid consideration" *Arvidson v. Buchar, 2019 VI SUPER 122 (Super. Ct. V.I. Sept. 10, 2019).* <https://usvipublicportal-api.vicourts.org/courts/87edff36-c02b-4073-aea4-c0652bc123d9/cms/case/7432A3F8-AD71-45C5-B028-B4471D746A4E/docketentrydocuments/27b98266-7d9f-405f-b7ba-c221f8db0a97>
+
+[^arvidson-wda]: **Arvidson v. Buchar** — "24 V I C § 76 (the Virgin Islands Wrongful Discharge Act enumerating only nine reasons for which an employer may lawfully discharge an employee after qualifying for protection under the statute)" *Arvidson v. Buchar, 2019 VI SUPER 122 (Super. Ct. V.I. Sept. 10, 2019) (citing 24 V.I.C. § 76).* <https://usvipublicportal-api.vicourts.org/courts/87edff36-c02b-4073-aea4-c0652bc123d9/cms/case/7432A3F8-AD71-45C5-B028-B4471D746A4E/docketentrydocuments/27b98266-7d9f-405f-b7ba-c221f8db0a97>
+
+[^q5-arvidson-wda]: **Arvidson v. Buchar** — "24 V I C § 76 (the Virgin Islands Wrongful Discharge Act enumerating only nine reasons for which an employer may lawfully discharge an employee after qualifying for protection under the statute)" *Arvidson v. Buchar, 2019 VI SUPER 122 (Super. Ct. V.I. Sept. 10, 2019) (citing 24 V.I.C. § 76).* <https://usvipublicportal-api.vicourts.org/courts/87edff36-c02b-4073-aea4-c0652bc123d9/cms/case/7432A3F8-AD71-45C5-B028-B4471D746A4E/docketentrydocuments/27b98266-7d9f-405f-b7ba-c221f8db0a97>
+
+[^q6-arvidson]: **Arvidson v. Buchar** — "the soundest rule for the Virgin Islands is the equitable reformation approach" *Arvidson v. Buchar, 2019 VI SUPER 122 (Super. Ct. V.I. Sept. 10, 2019).* <https://usvipublicportal-api.vicourts.org/courts/87edff36-c02b-4073-aea4-c0652bc123d9/cms/case/7432A3F8-AD71-45C5-B028-B4471D746A4E/docketentrydocuments/27b98266-7d9f-405f-b7ba-c221f8db0a97>
+
+[^q6-arvidson-strict]: **Arvidson v. Buchar** — "Accordingly, the Court implements this rule with a greater willingness to refuse to reform agreements that are not reasonable on their face" *Arvidson v. Buchar, 2019 VI SUPER 122 (Super. Ct. V.I. Sept. 10, 2019).* <https://usvipublicportal-api.vicourts.org/courts/87edff36-c02b-4073-aea4-c0652bc123d9/cms/case/7432A3F8-AD71-45C5-B028-B4471D746A4E/docketentrydocuments/27b98266-7d9f-405f-b7ba-c221f8db0a97>
+
+[^q6-dixon]: **V.I. Diving Schools/Supplies, Inc. v. Dixon** — "restrictive clauses of the agreement are void and unenforceable as against public policy on the ground that they are unreasonable restraint on competition." *V.I. Diving Schools/Supplies, Inc. v. Dixon, Civ. No. 1046/1982 (Terr. Ct. V.I. Oct. 7, 1983).* <https://cdnsm5-hosted.civiclive.com/UserFiles/Servers/Server_12810747/File/Opinions/Archive/VI%20Diving%20Sch%20v.%20Dixon%20%28IAM%29.pdf>
+
+[^q7-arvidson]: **Arvidson v. Buchar** — "reasonableness is a fact intensive inquiry that depends on weighing the totality of the circumstances" *Arvidson v. Buchar, 2019 VI SUPER 122 (Super. Ct. V.I. Sept. 10, 2019).* <https://usvipublicportal-api.vicourts.org/courts/87edff36-c02b-4073-aea4-c0652bc123d9/cms/case/7432A3F8-AD71-45C5-B028-B4471D746A4E/docketentrydocuments/27b98266-7d9f-405f-b7ba-c221f8db0a97>
+
+[^vic-11-1001]: **11 V.I.C. § 1001 — Uniform Trade Secrets Act (short title)** — "This chapter may be cited as the Uniform Trade Secrets Act." *11 V.I.C. § 1001.* <https://advance.lexis.com/document/?pdmfid=1000516&pddocfullpath=/shared/document/statutes-legislation/urn:contentItem:56WP-9KS1-6G1M-90D3-00008-00>
+
+[^vic-11-1002]: **11 V.I.C. § 1002 — Definitions** — "‘Trade secret’ means information, including a formula, pattern, compilation, program, device, method, technique, or process" *11 V.I.C. § 1002.* <https://advance.lexis.com/document/?pdmfid=1000516&pddocfullpath=/shared/document/statutes-legislation/urn:contentItem:56WP-9KS1-6G1M-90D5-00008-00>
+
+[^vic-11-1008]: **11 V.I.C. § 1008 — Effect of other law** — "This chapter does not affect: (1) contractual remedies, whether or not based upon misappropriation of a trade secret" *11 V.I.C. § 1008.* <https://advance.lexis.com/document/?pdmfid=1000516&pddocfullpath=/shared/document/statutes-legislation/urn:contentItem:56WP-9KS1-6G1M-90DK-00008-00>
+
+[^vic-5-858]: **5 V.I.C. § 858 — Trade secrets privilege** — "A person has a privilege which may be claimed by him or his agent or employee, to refuse to disclose and to prevent other persons from disclosing a trade secret, owned by him, if the allowance of the privilege will not tend to conceal fraud or otherwise work injustice." *5 V.I.C. § 858.* <https://advance.lexis.com/document/?pdmfid=1000516&pddocfullpath=/shared/document/statutes-legislation/urn:contentItem:56WP-9JF1-6G1M-90PJ-00008-00>
+
+[^dixon-notrade]: **V.I. Diving Schools/Supplies, Inc. v. Dixon** — "Plaintiff Virgin Islands Diving Schools presented no evidence of any trade secrets which the Defendants obtained that is worthy of protection." *V.I. Diving Schools/Supplies, Inc. v. Dixon, Civ. No. 1046/1982 (Terr. Ct. V.I. Oct. 7, 1983).* <https://cdnsm5-hosted.civiclive.com/UserFiles/Servers/Server_12810747/File/Opinions/Archive/VI%20Diving%20Sch%20v.%20Dixon%20%28IAM%29.pdf>
+
+[^vic-11-1503]: **11 V.I.C. § 1503 — Violations enumerated** — "By contract, combination, or conspiracy with one or more other persons unreasonably restrain trade or commerce" *11 V.I.C. § 1503.* <https://advance.lexis.com/document/?pdmfid=1000516&pddocfullpath=/shared/document/statutes-legislation/urn:contentItem:56WP-9KS1-6G1M-90M3-00008-00>
+
+[^q10-arvidson]: **Arvidson v. Buchar** — "a contract which is only in partial restraint of trade may be valid and enforceable when it" *Arvidson v. Buchar, 2019 VI SUPER 122 (Super. Ct. V.I. Sept. 10, 2019).* <https://usvipublicportal-api.vicourts.org/courts/87edff36-c02b-4073-aea4-c0652bc123d9/cms/case/7432A3F8-AD71-45C5-B028-B4471D746A4E/docketentrydocuments/27b98266-7d9f-405f-b7ba-c221f8db0a97>
+
+[^vic-13-1702]: **13 V.I.C. § 1702 — Court action to determine fair value of distributional interest** — "a covenant not to compete or other restriction on a dissociated member" *13 V.I.C. § 1702.* <https://advance.lexis.com/document/?pdmfid=1000516&pddocfullpath=/shared/document/statutes-legislation/urn:contentItem:56WP-9M71-6G1M-90VX-00008-00>
+
+[^ftc-removal]: **Removal of the Non-Compete Rule from the CFR** — "this final rule removes the Non-Compete Rule codified at 16 CFR part 910 from the Code of Federal Regulations" *Removal of the Non-Compete Rule, 91 Fed. Reg. 6507 (Feb. 12, 2026).* <https://www.federalregister.gov/documents/2026/02/12/2026-02866/revision-of-the-negative-option-rule-withdrawal-of-the-cars-rule-removal-of-the-non-compete-rule-to>

--- a/skills/non-compete-contract-explainer/content/utah.md
+++ b/skills/non-compete-contract-explainer/content/utah.md
@@ -1,0 +1,250 @@
+---
+jurisdiction: "Utah"
+slug: utah
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-02"
+canonicalUrl: https://openagreements.org/legal/non-compete/utah
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/utah · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in Utah[^about]
+
+Utah caps employee non-competes at one year under the Post-Employment Restrictions Act (Utah Code § 34-51-201), voids longer covenants, shifts fees to employers who enforce invalid ones, keeps the common-law Rose Park reasonableness test, and bans healthcare and veterinarian non-competes from May 6, 2026.
+
+
+## At a glance
+
+| Question | Utah |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed if reasonable |
+| **Bottom line** | Utah enforces employee non-competes only if they satisfy both the common-law Rose Park reasonableness test and a hard one-year statutory cap, and it bans healthcare and veterinarian non-competes entered on or after May 6, 2026. |
+| **Main law or case** | Utah Code § 34-51-201 (Post-Employment Restrictions Act) |
+| **Main exceptions** | Health-care worker & veterinarian bans (5% owner carve-out) from May 6, 2026; sale-of-business; reasonable severance; narrow broadcasting exception |
+| **Can a court narrow it?** | No |
+| **Applies to contractors?** | — |
+| **Restriction extended during a breach?** | No safe extension — one-year cap runs from separation; equitable tolling within the cap open |
+| **Maximum length set by law** | 1 year (a longer covenant is void) |
+
+## Are employee non-compete agreements enforceable in Utah? {#employee-noncompetes}
+
+**Short answer.** Yes, but on a short leash. Utah enforces employee non-competes when they satisfy both the statute and the common law, yet the Post-Employment Restrictions Act caps any post-employment non-compete entered on or after May 10, 2016 at one year and voids anything longer [^upera-one-year].
+
+The result is a two-layer test. The statute sets a hard ceiling on duration, and the common-law *Rose Park* framework still governs everything else: consideration, good faith, a legitimate protectable interest, and reasonable limits on time and area [^england-rose-park-test].
+
+Because the statute supplements rather than replaces the common law, a covenant that fits inside the one-year cap can still fail if it is unreasonable or protects nothing more than ordinary competition [^robbins-legitimate-interests].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not treat compliance with the one-year cap as the whole analysis. A Utah non-compete must clear the statutory ceiling *and* the common-law reasonableness test; satisfying one does not cure a defect in the other [^upera-one-year][^england-rose-park-test].
+
+## How long can a Utah non-compete last before it is void? {#duration-one-year}
+
+**Short answer.** One year. For non-competes entered on or after May 10, 2016, an employer and employee may not agree to a post-employment restriction longer than one year from separation, and a covenant that violates the cap is void [^dur-one-year][^dur-void].
+
+The statute says *void*, not voidable. That word choice matters: the legislature treated an over-length covenant as a nullity from the start, which is a strong textual signal that a court cannot simply trim a two-year covenant down to a lawful twelve months [^dur-void].
+
+Broadcasting is the one narrow statutory exception with its own rules. A non-compete between a broadcasting company and a broadcasting employee is valid only if the employee is an *exempt broadcasting employee*, the covenant sits inside a written contract of reasonable duration, and the company either terminates for cause or the employee breaches [^dur-broadcasting].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> A covenant drafted for eighteen months or two years should not be expected to be trimmed to one year by a Utah court; the statute makes it void, and trying to enforce it exposes the employer to the statute's fee-shifting penalty. Draft to one year or less from the outset [^dur-void][^dur-one-year].
+
+## What makes a Utah non-compete reasonable under the common law? {#reasonableness-test}
+
+**Short answer.** Utah applies the four-part *Rose Park* test: the covenant must be supported by consideration, negotiated without bad faith, necessary to protect the business's goodwill, and reasonable in its time and area restrictions [^reason-four-part].
+
+Reasonableness is fact-specific, decided case by case on the particular circumstances rather than a fixed formula [^reason-case-by-case]. The covenant must protect a real interest such as goodwill, confidential information, or extraordinary training, not merely shield the employer from a former employee's ordinary skills [^reason-legitimate-interests].
+
+Good faith is a live part of the test, not a formality. The Court of Appeals noted that the good-faith prong could be implicated where an employer quickly hires and fires an at-will employee with the sole intent of binding them to a long restrictive covenant [^reason-good-faith].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Tie the restriction to a specific, provable interest. A covenant that reaches an employee's general skills or ordinary competition, rather than the employer's goodwill or confidential information, risks being held unreasonable even within the one-year cap [^reason-legitimate-interests][^reason-four-part].
+
+## Is continued or at-will employment enough consideration for a Utah non-compete? {#consideration}
+
+**Short answer.** Yes. Utah departs from the stricter national trend: an offer of employment, including continued at-will employment, can be sufficient consideration for a non-compete, even when the employee signs after starting work [^consid-england].
+
+This rule traces back to *Allen v. Rose Park Pharmacy*, where the Utah Supreme Court upheld a covenant despite the employee's argument that an at-will contract lacked consideration, reasoning that a contract does not lack mutuality merely because its terms are harsh or unequal [^consid-allen]. In 2024, the Court of Appeals reaffirmed the point, calling it settled Utah law [^consid-england].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Utah employers do not need fresh consideration such as a bonus or promotion to bind an existing at-will employee, but the good-faith prong still applies; a covenant extracted through a sham hire-and-fire can fail on that ground rather than on consideration [^consid-england][^consid-good-faith].
+
+## How do Utah courts judge a non-compete's geographic scope? {#geographic-scope}
+
+**Short answer.** By the employer's actual market, not by arbitrary mileage. A restrictive covenant is generally enforceable if it covers an area no greater than the territory the business actually serves [^geo-no-greater].
+
+That makes scope proportional. A purely local employer cannot lock down the whole state, but a genuinely national business can support a national restriction. In *England Logistics*, the Court of Appeals rejected the argument that a nationwide scope was unreasonable, because the refrigerated-trucking employer's operations themselves ran coast to coast [^geo-footprint].
+
+> [!NOTE]
+> **Practice note.**
+>
+> A nationwide non-compete is not automatically overbroad in Utah, but the employer must be able to prove a matching national footprint; a wide geographic clause untethered from where the business actually competes remains vulnerable [^geo-no-greater][^geo-footprint].
+
+## What happens if an employer tries to enforce an unenforceable non-compete? {#fee-shifting}
+
+**Short answer.** The employer pays. If an employer pursues arbitration or a civil action to enforce a non-compete that is then found unenforceable, the statute makes the employer liable for the employee's arbitration costs, attorney fees and court costs, and actual damages [^fee-shift].
+
+This asymmetric fee-shifting is the teeth of the Act. It applies not only to non-competes but also to healthcare non-competes, nondisclosure clauses, and nonsolicitation agreements that an employer tries and fails to enforce [^fee-shift]. The practical effect is to discourage employers from using overbroad covenants as a low-cost deterrent.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Before sending an enforcement demand or filing suit on a Utah non-compete, weigh the downside: losing on enforceability does not just void the clause, it transfers the employee's fees, costs, and damages to the employer [^fee-shift].
+
+## Do Utah's one-year cap and penalties apply to non-solicitation and nondisclosure agreements? {#non-solicitation-nda}
+
+**Short answer.** The one-year cap does not, but the penalty can. The Act's definition of a *non-compete agreement* expressly excludes nonsolicitation, nondisclosure, and confidentiality agreements, so those covenants are not bound by the one-year cap and instead answer to the common-law reasonableness test [^carve-definition][^carve-exclusion].
+
+The statutory non-compete is narrow: an agreement that the employee will not compete by providing a product, process, or service similar to the employer's [^carve-definition]. Because non-solicits and NDAs fall outside that definition, they can run longer than a year, but a clause that is a non-compete in everything but name can still be treated as one and pulled back under the cap.
+
+The carve-out is from the one-year cap, not from the Act's enforcement penalty. If an employer pursues and loses an enforcement action on a nondisclosure clause or nonsolicitation agreement, § 34-51-301 still shifts the employee's arbitration costs, attorney fees, and actual damages onto the employer [^carve-fee-shift].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Label is not protection. A nonsolicitation or confidentiality clause drafted so broadly that it effectively blocks the employee from working in the field invites a court to treat it as a *de facto* non-compete, reimposing the one-year cap and the fee-shifting exposure [^carve-definition][^carve-exclusion].
+
+## Are sale-of-business and severance non-competes exempt from the one-year cap? {#sale-severance}
+
+**Short answer.** Yes. The Act does not prohibit a reasonable severance agreement agreed in good faith at or after termination, nor a non-compete tied to the sale of a business where the restricted person receives value from the sale [^exc-severance][^exc-sale].
+
+These exceptions exist because the situations differ from ordinary employment. A buyer paying for a business's goodwill needs to protect that investment, and a negotiated severance is a freely bargained exchange. Both can run longer than the one-year employment ceiling.
+
+> [!NOTE]
+> **Practice note.**
+>
+> The exceptions remove the statutory cap, not the common-law test. A severance-based covenant still remains subject to common-law reasonableness, so an unbounded duration or scope can still fail [^exc-severance-commonlaw][^exc-severance].
+
+## Are non-competes banned for healthcare workers and veterinarians in Utah? {#healthcare-veterinarian}
+
+**Short answer.** Yes, as of May 6, 2026. A person and a healthcare worker may not enter into a healthcare non-compete agreement, and a person and a veterinarian may not enter into a veterinarian non-compete agreement unless the veterinarian holds at least a 5% ownership interest in the business [^hc-ban][^vet-ban][^vet-exception].
+
+The bans reach beyond pure non-competes. From the same date, a healthcare nonsolicitation agreement may not prevent a healthcare worker from telling a patient where they currently or will work [^hc-nonsolicit]. *Healthcare worker* is a defined statutory term tied to specific clinical licenses, and the ban's coverage turns on whether the worker's role actually requires practicing under that license [^hc-worker-def].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Treat the May 6, 2026 healthcare and veterinarian provisions as the current rule, not pending legislation; they are codified in the Post-Employment Restrictions Act and took effect on that date. The bans apply to agreements *entered into* on or after May 6, 2026, so audit your templates and any covenant with clinical staff or veterinarians that you sign, renew, or amend on or after that date [^hc-ban][^vet-ban].
+
+## Will a Utah court blue-pencil or rewrite an overbroad non-compete? {#court-narrowing}
+
+**Short answer.** Probably not for the duration problem, and the broader reformation question is unsettled. The statute makes an over-length covenant void rather than voidable, which most commentary reads as stripping courts of the power to trim it to a lawful term [^narrow-void].
+
+For overbreadth in scope or activity, Utah's common law has historically been reluctant to rewrite restraints, preferring to enforce only covenants that were carefully drawn in the first place [^narrow-careful-drafting]. There is no modern Utah Supreme Court decision squarely reconciling the equitable blue-pencil doctrine with the 2016 statute's *void* language, so the safest assumption is that a Utah court will not rescue a defective covenant.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not rely on a savings or reformation clause to backstop an overbroad Utah non-compete. The statutory *void* rule for over-length covenants and the common-law preference for carefully drawn restraints both cut against judicial rewriting [^narrow-void][^narrow-careful-drafting].
+
+## Does the restricted period toll or extend during breach or litigation in Utah? {#tolling-extension}
+
+**Short answer.** Utah has no statute or staged case squarely deciding judicial tolling, but the structure of the Act cuts hard against an extension clause. Because a non-compete may not exceed one year and a longer one is void, a clause that lengthens the restricted period during breach or litigation risks pushing the covenant past the statutory ceiling and voiding it [^toll-one-year][^toll-void].
+
+The one-year cap is measured from the day employment ends, not from the day the employee stops competing [^toll-one-year]. An extension-on-breach or tolling clause that keeps the restriction alive while litigation runs is therefore in direct tension with that fixed measuring point, and the *void* consequence applies to any covenant that exceeds one year [^toll-void].
+
+No source in this corpus resolves whether a Utah court would order equitable tolling for a covenant that already complies with the one-year cap, so that narrower question should be treated as open.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not draft a Utah non-compete that tolls or extends during breach or litigation past the one-year mark. The statute fixes the period at one year from separation and voids longer covenants, so an extension clause is a concrete overbreadth and void risk, not a safe equitable backstop [^toll-one-year][^toll-void].
+
+## What can Utah employers use instead of a non-compete? {#alternatives}
+
+**Short answer.** Utah employers can lean on nonsolicitation and nondisclosure agreements, which sit outside the statutory non-compete definition, and on the Utah Uniform Trade Secrets Act, which protects genuinely secret, valuable information independent of any covenant [^alt-carveout][^alt-trade-secret-def].
+
+The trade-secret route has real remedies. Actual or threatened misappropriation may be enjoined, and a court may award exemplary damages up to twice the compensatory award for willful and malicious misappropriation [^alt-injunction][^alt-exemplary]. But the protection attaches to the secret information, not to competition generally, so it does not substitute for a covenant against working for a rival.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Keep confidentiality and trade-secret protections tied to actual secret information and reasonable secrecy efforts. A definition that sweeps in ordinary know-how will not qualify as a trade secret and a confidentiality clause that functions as a work ban can be recharacterized as a non-compete [^alt-trade-secret-def][^alt-carveout].
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-02. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not Utah. This article synthesizes Utah primary law and is not legal advice from a Utah-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^upera-one-year]: **Utah Code § 34-51-201** — "an employer and an employee may not enter into a non-compete agreement for a period of more than one year from the day on which the employee is no longer employed by the employer." *Utah Code Ann. § 34-51-201(1)(a).* <https://le.utah.gov/xcode/Title34/Chapter51/34-51-S201.html>
+
+[^england-rose-park-test]: **England Logistics, Inc. v. Kelle's Transport Service, LLC** — "These requirements are: (1) the covenant must ‘be supported by consideration,’ (2) ‘no bad faith’ was involved ‘in the negotiation of the contract,’ (3) the covenant must ‘be necessary to protect the goodwill of the business,’ and (4) the covenant must ‘be reasonable in its restrictions as to time and area." *England Logistics, Inc. v. Kelle's Transp. Serv., LLC, 2024 UT App 137.* <https://www.courtlistener.com/opinion/10141125/england-logistics-v-kelles-transport-service/#:~:text=These%20requirements%20are%3A%20(1)%20the,as%20to%20time%20and%20area.>
+
+[^robbins-legitimate-interests]: **Robbins v. Finlay** — "Covenants not to compete are enforceable if carefully drawn to protect only the legitimate interests of the employer." *Robbins v. Finlay, 645 P.2d 623 (Utah 1982).* <https://www.courtlistener.com/opinion/1231169/robbins-v-finlay/#:~:text=Covenants%20not%20to%20compete%20are,legitimate%20interests%20of%20the%20employer.>
+
+[^dur-one-year]: **Utah Code § 34-51-201** — "an employer and an employee may not enter into a non-compete agreement for a period of more than one year from the day on which the employee is no longer employed by the employer." *Utah Code Ann. § 34-51-201(1)(a).* <https://le.utah.gov/xcode/Title34/Chapter51/34-51-S201.html>
+
+[^dur-void]: **Utah Code § 34-51-201** — "A non-compete agreement that violates this Subsection (1) is void." *Utah Code Ann. § 34-51-201(1)(c).* <https://le.utah.gov/xcode/Title34/Chapter51/34-51-S201.html>
+
+[^dur-broadcasting]: **Utah Code § 34-51-201** — "a non-compete agreement between a broadcasting company and a broadcasting employee is valid only if: (i) the broadcasting employee is an exempt broadcasting employee; (ii) the non-compete agreement is part of a written employment contract of reasonable duration" *Utah Code Ann. § 34-51-201(2)(a).* <https://le.utah.gov/xcode/Title34/Chapter51/34-51-S201.html>
+
+[^reason-four-part]: **England Logistics, Inc. v. Kelle's Transport Service, LLC** — "These requirements are: (1) the covenant must ‘be supported by consideration,’ (2) ‘no bad faith’ was involved ‘in the negotiation of the contract,’ (3) the covenant must ‘be necessary to protect the goodwill of the business,’ and (4) the covenant must ‘be reasonable in its restrictions as to time and area." *England Logistics, Inc. v. Kelle's Transp. Serv., LLC, 2024 UT App 137.* <https://www.courtlistener.com/opinion/10141125/england-logistics-v-kelles-transport-service/#:~:text=These%20requirements%20are%3A%20(1)%20the,as%20to%20time%20and%20area.>
+
+[^reason-case-by-case]: **England Logistics, Inc. v. Kelle's Transport Service, LLC** — "The reasonableness of the restraints in a restrictive covenant is determined on a case-by-case basis, taking into account the particular facts and circumstances surrounding the case and the subject covenant." *England Logistics, Inc. v. Kelle's Transp. Serv., LLC, 2024 UT App 137.* <https://www.courtlistener.com/opinion/10141125/england-logistics-v-kelles-transport-service/#:~:text=The%20reasonableness%20of%20the%20restraints,case%20and%20the%20subject%20covenant.>
+
+[^reason-legitimate-interests]: **Robbins v. Finlay** — "Covenants not to compete are enforceable if carefully drawn to protect only the legitimate interests of the employer." *Robbins v. Finlay, 645 P.2d 623 (Utah 1982).* <https://www.courtlistener.com/opinion/1231169/robbins-v-finlay/#:~:text=Covenants%20not%20to%20compete%20are,legitimate%20interests%20of%20the%20employer.>
+
+[^reason-good-faith]: **England Logistics, Inc. v. Kelle's Transport Service, LLC** — "Addressing the employee’s concerns about potential inequities, the court reasoned that the good faith prong of the noncompete analysis might be implicated if an employer quickly hires and fires an at will employee with the sole intent of binding that employee to a long restrictive covenant." *England Logistics, Inc. v. Kelle's Transp. Serv., LLC, 2024 UT App 137.* <https://www.courtlistener.com/opinion/10141125/england-logistics-v-kelles-transport-service/#:~:text=Addressing%20the%20employee%E2%80%99s%20concerns%20about,to%20a%20long%20restrictive%20covenant.>
+
+[^consid-england]: **England Logistics, Inc. v. Kelle's Transport Service, LLC** — "Regardless of what other jurisdictions have held, it’s settled in Utah that an offer of employment can constitute consideration for a noncompete agreement." *England Logistics, Inc. v. Kelle's Transp. Serv., LLC, 2024 UT App 137.* <https://www.courtlistener.com/opinion/10141125/england-logistics-v-kelles-transport-service/#:~:text=Regardless%20of%20what%20other%20jurisdictions,consideration%20for%20a%20noncompete%20agreement.>
+
+[^consid-allen]: **Allen v. Rose Park Pharmacy** — "a contract does not lack mutuality merely because its terms are harsh or its obligations unequal, or because every obligation of one party is not met by an equivalent counter obligation of the other party." *Allen v. Rose Park Pharmacy, 237 P.2d 823 (Utah 1951).* <https://www.courtlistener.com/opinion/1199226/allen-v-rose-park-pharmacy/#:~:text=a%20contract%20does%20not%20lack,obligation%20of%20the%20other%20party.>
+
+[^consid-good-faith]: **England Logistics, Inc. v. Kelle's Transport Service, LLC** — "Addressing the employee’s concerns about potential inequities, the court reasoned that the good faith prong of the noncompete analysis might be implicated if an employer quickly hires and fires an at will employee with the sole intent of binding that employee to a long restrictive covenant." *England Logistics, Inc. v. Kelle's Transp. Serv., LLC, 2024 UT App 137.* <https://www.courtlistener.com/opinion/10141125/england-logistics-v-kelles-transport-service/#:~:text=Addressing%20the%20employee%E2%80%99s%20concerns%20about,to%20a%20long%20restrictive%20covenant.>
+
+[^geo-no-greater]: **England Logistics, Inc. v. Kelle's Transport Service, LLC** — "a restrictive covenant is generally enforceable if it specifies an area no greater than that to which the business extends." *England Logistics, Inc. v. Kelle's Transp. Serv., LLC, 2024 UT App 137.* <https://www.courtlistener.com/opinion/10141125/england-logistics-v-kelles-transport-service/#:~:text=a%20restrictive%20covenant%20is%20generally,to%20which%20the%20business%20extends.>
+
+[^geo-footprint]: **England Logistics, Inc. v. Kelle's Transport Service, LLC** — "We disagree with the assertion that the geographic scope was unreasonable." *England Logistics, Inc. v. Kelle's Transp. Serv., LLC, 2024 UT App 137.* <https://www.courtlistener.com/opinion/10141125/england-logistics-v-kelles-transport-service/#:~:text=We%20disagree%20with%20the%20assertion,the%20geographic%20scope%20was%20unreasonable.>
+
+[^fee-shift]: **Utah Code § 34-51-301** — "the employer is liable for the employee's: (1) costs associated with arbitration; (2) attorney fees and court costs; and (3) actual damages." *Utah Code Ann. § 34-51-301.* <https://le.utah.gov/xcode/Title34/Chapter51/34-51-S301.html>
+
+[^carve-definition]: **Utah Code § 34-51-102** — "‘Non-compete agreement’ means an agreement, written or oral, between an employer and employee under which the employee agrees that on or after the day on which the employer no longer employs the employee, the employee, either alone or as an employee of another person, will not compete with the employer in providing a product, process, or service that is similar to the employer's product, process, or service." *Utah Code Ann. § 34-51-102(8)(a).* <https://le.utah.gov/xcode/Title34/Chapter51/34-51-S102.html>
+
+[^carve-exclusion]: **Utah Code § 34-51-102** — "‘Non-compete agreement’ does not include: (i) a nonsolicitation agreement; (ii) a nondisclosure agreement; or (iii) a confidentiality agreement." *Utah Code Ann. § 34-51-102(8)(b).* <https://le.utah.gov/xcode/Title34/Chapter51/34-51-S102.html>
+
+[^carve-fee-shift]: **Utah Code § 34-51-301** — "the employer is liable for the employee's: (1) costs associated with arbitration; (2) attorney fees and court costs; and (3) actual damages." *Utah Code Ann. § 34-51-301.* <https://le.utah.gov/xcode/Title34/Chapter51/34-51-S301.html>
+
+[^exc-severance]: **Utah Code § 34-51-202** — "a reasonable severance agreement mutually and freely agreed upon in good faith at or after the time of termination that includes a non-compete agreement or a healthcare non-compete agreement" *Utah Code Ann. § 34-51-202(1)(a).* <https://le.utah.gov/xcode/Title34/Chapter51/34-51-S202.html>
+
+[^exc-sale]: **Utah Code § 34-51-202** — "a non-compete agreement or a healthcare non-compete agreement related to or arising out of the sale of a business, if the individual subject to the non-compete agreement or healthcare non-compete agreement receives value related to the sale of the business." *Utah Code Ann. § 34-51-202(1)(b).* <https://le.utah.gov/xcode/Title34/Chapter51/34-51-S202.html>
+
+[^exc-severance-commonlaw]: **Utah Code § 34-51-202** — "a severance agreement remains subject to any requirements imposed under common law." *Utah Code Ann. § 34-51-202(2).* <https://le.utah.gov/xcode/Title34/Chapter51/34-51-S202.html>
+
+[^hc-ban]: **Utah Code § 34-51-201** — "On or after May 6, 2026, a person and a healthcare worker may not enter into a healthcare non-compete agreement." *Utah Code Ann. § 34-51-201(1)(b).* <https://le.utah.gov/xcode/Title34/Chapter51/34-51-S201.html>
+
+[^vet-ban]: **Utah Code § 34-51-201** — "on or after May 6, 2026, a person and a veterinarian may not enter into a veterinarian non-compete agreement." *Utah Code Ann. § 34-51-201(3)(a).* <https://le.utah.gov/xcode/Title34/Chapter51/34-51-S201.html>
+
+[^vet-exception]: **Utah Code § 34-51-201** — "Subsection (3)(a) does not apply if the veterinarian has at least a 5% ownership interest in the person's business." *Utah Code Ann. § 34-51-201(3)(b).* <https://le.utah.gov/xcode/Title34/Chapter51/34-51-S201.html>
+
+[^hc-nonsolicit]: **Utah Code § 34-51-203** — "On or after May 6, 2026, a person and a healthcare worker may not enter into nonsolicitation agreement that prevents a healthcare worker from informing a patient of any of the following: (a) the healthcare worker's current place of employment; or (b) the healthcare worker's future place of employment." *Utah Code Ann. § 34-51-203(1).* <https://le.utah.gov/xcode/Title34/Chapter51/34-51-S203.html>
+
+[^hc-worker-def]: **Utah Code § 34-51-102** — "‘Healthcare worker’ does not include an individual: (i) who holds a license described in Subsection (5)(a)(i) through (xxxiii) ; and (ii) whose employment or contractual agreement does not require or involve practicing under the scope of the individual's license." *Utah Code Ann. § 34-51-102(5)(b).* <https://le.utah.gov/xcode/Title34/Chapter51/34-51-S102.html>
+
+[^narrow-void]: **Utah Code § 34-51-201** — "A non-compete agreement that violates this Subsection (1) is void." *Utah Code Ann. § 34-51-201(1)(c).* <https://le.utah.gov/xcode/Title34/Chapter51/34-51-S201.html>
+
+[^narrow-careful-drafting]: **Robbins v. Finlay** — "Covenants not to compete are enforceable if carefully drawn to protect only the legitimate interests of the employer." *Robbins v. Finlay, 645 P.2d 623 (Utah 1982).* <https://www.courtlistener.com/opinion/1231169/robbins-v-finlay/#:~:text=Covenants%20not%20to%20compete%20are,legitimate%20interests%20of%20the%20employer.>
+
+[^toll-one-year]: **Utah Code § 34-51-201** — "an employer and an employee may not enter into a non-compete agreement for a period of more than one year from the day on which the employee is no longer employed by the employer." *Utah Code Ann. § 34-51-201(1)(a).* <https://le.utah.gov/xcode/Title34/Chapter51/34-51-S201.html>
+
+[^toll-void]: **Utah Code § 34-51-201** — "A non-compete agreement that violates this Subsection (1) is void." *Utah Code Ann. § 34-51-201(1)(c).* <https://le.utah.gov/xcode/Title34/Chapter51/34-51-S201.html>
+
+[^alt-carveout]: **Utah Code § 34-51-102** — "‘Non-compete agreement’ does not include: (i) a nonsolicitation agreement; (ii) a nondisclosure agreement; or (iii) a confidentiality agreement." *Utah Code Ann. § 34-51-102(8)(b).* <https://le.utah.gov/xcode/Title34/Chapter51/34-51-S102.html>
+
+[^alt-trade-secret-def]: **Utah Code § 13-24-2** — "derives independent economic value, actual or potential, from not being generally known to, and not being readily ascertainable by proper means by, other persons who can obtain economic value from its disclosure or use; and (b) is the subject of efforts that are reasonable under the circumstances to maintain its secrecy." *Utah Code Ann. § 13-24-2(4).* <https://le.utah.gov/xcode/Title13/Chapter24/13-24-S2.html>
+
+[^alt-injunction]: **Utah Code § 13-24-3** — "Actual or threatened misappropriation may be enjoined." *Utah Code Ann. § 13-24-3(1).* <https://le.utah.gov/xcode/Title13/Chapter24/13-24-S3.html>
+
+[^alt-exemplary]: **Utah Code § 13-24-4** — "If willful and malicious misappropriation exists, the court may award exemplary damages in an amount not exceeding twice any award made under Subsection (1)" *Utah Code Ann. § 13-24-4(2).* <https://le.utah.gov/xcode/Title13/Chapter24/13-24-S4.html>

--- a/skills/non-compete-contract-explainer/content/vermont.md
+++ b/skills/non-compete-contract-explainer/content/vermont.md
@@ -1,0 +1,193 @@
+---
+jurisdiction: "Vermont"
+slug: vermont
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-01"
+canonicalUrl: https://openagreements.org/legal/non-compete/vermont
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/vermont · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in Vermont[^about]
+
+A question-by-question summary of Vermont's common-law reasonableness test for restrictive covenants, the leading Vermont Supreme Court cases, and the pending 2025-2026 legislative overhaul (H.205, H.334, H.583).
+
+
+## At a glance
+
+| Question | Vermont |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed if reasonable |
+| **Bottom line** | Vermont has no general non-compete statute and enforces covenants under a common-law reasonableness test, though a 2025-2026 legislative overhaul (H.205, H.583) could sharply curtail them if enacted. |
+| **Main law or case** | common law (Vt. Elec. Supply Co. v. Andrus, 132 Vt. 195 (1974); Restatement (Second) of Contracts § 188) |
+| **Main exceptions** | Barber/cosmetology training covenants void (26 V.S.A. § 281(c)); attorneys (R. Prof. Conduct 5.6); sale-of-business more leeway; pending H.583 health-care ban not in force |
+| **Can a court narrow it?** | Unsettled |
+| **Applies to contractors?** | Unclear |
+| **Restriction extended during a breach?** | No equitable rewriting of the time term (Roy's Orthopedic) |
+| **Maximum length set by law** | No statutory limit |
+
+## Are employee non-compete agreements enforceable in Vermont? {#employee-noncompetes}
+
+**Short answer.** Sometimes, under a common-law reasonableness test, but the framework is in active flux as the 2025-2026 legislature advances a sweeping prohibition.
+
+Vermont has no general non-compete statute in force as of June 2026. Enforcement is governed by a Vermont Supreme Court reasonableness test that runs back to *Vermont Electric Supply Co. v. Andrus* in 1974: courts enforce a covenant unless it is contrary to public policy, unnecessary for protection of the employer, or unnecessarily restrictive of the employee's rights[^andrus-reasonableness-test], with attention to the subject matter of the contract and the circumstances of performance.
+
+The modern articulation in *Systems & Software, Inc. v. Barnes* adopts Restatement-style framing: courts proceed with caution[^barnes-restatement-framing] when asked to enforce covenants against competitive employment because those restraints run counter to public policy favoring the right to engage in lawful commercial activity [^barnes-reasonableness-public-policy].
+
+> [!NOTE]
+> **Practice note.**
+>
+> The Vermont common-law reasonableness test [^andrus-reasonableness-test] still governs new restrictive covenants as of June 2026. But the General Assembly is actively advancing [H.205](https://legislature.vermont.gov/bill/status/2026/H.205) (a strike-all amendment that absorbed the prior H.334 stay-or-pay provisions) and [H.583](https://legislature.vermont.gov/bill/status/2026/H.583) (a healthcare-specific non-compete ban). Both bills are alive in the 2025-2026 session and would substantially supersede the common-law framework if enacted. Track status before relying on existing templates.
+
+## What does Vermont consider a reasonable restriction? {#reasonableness-test}
+
+**Short answer.** A restraint is reasonable only if it protects a legitimate employer interest, is no broader than needed, and does not outweigh the employee's hardship and the public's interest in free commerce.
+
+The Vermont Supreme Court has rejected the narrow view that non-competes may protect only trade secrets or confidential customer information. In *Systems & Software, Inc. v. Barnes*, the court held that protectable interests extend to things like customer relationships and employee-specific goodwill[^barnes-legitimate-interest-not-only-trade-secrets], not just confidential information already protected by trade-secret law.
+
+Vermont also requires the employer to actually prove a protectable interest — generic protection from competition is not enough. In *Barnes*, the Supreme Court accepted that "The trial court found that during his employment with plaintiff, defendant had acquired inside knowledge about the strengths and weaknesses of plaintiff’s products — knowledge that he could use to compete against plaintiff."[^barnes-inside-knowledge] That legitimate interest, in a small market, justified a six-month restraint. The employer carries the burden on reasonable necessity: as *Summits 7* puts it, "[t]he employer has the burden of proving the reasonable necessity of the restrictive covenant."[^summits7-employer-burden]
+
+Geography and duration are evaluated together and on a sliding scale. Vermont has upheld a five-year, single-county restraint in *Andrus* (kitchen-installation business in Rutland County) [^andrus-five-year-county], but in *Roy's Orthopedic '82* the Supreme Court reversed enforcement because "the trial court concluded that the restrictive covenant not to compete was reasonably limited to time and place without having made a finding as to what ‘place’ was covered by the agreement."[^roys-82-no-findings-on-place]
+
+## Is continued employment sufficient consideration for a non-compete signed mid-employment? {#mid-employment-consideration}
+
+**Short answer.** Yes. In *Summits 7, Inc. v. Kelly*, the Vermont Supreme Court held that continued at-will employment alone is sufficient consideration to support a non-compete entered into during the employment relationship.
+
+The court adopted the majority view, agreeing that continued employment alone is sufficient consideration[^summits7-continued-employment-sufficient] for a covenant signed after at-will employment has begun. The rationale is that the at-will employer can fire the employee at any time, so the consideration is the same whether the covenant is signed at hire or later.
+
+This sets Vermont apart from neighboring jurisdictions. Massachusetts and New Hampshire commentary generally treat mid-employment non-competes as requiring independent consideration beyond continued at-will employment; in Vermont, no separate signing bonus, raise, or promotion is required as a matter of doctrine.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Continued employment is enough consideration under *Summits 7*, but the covenant must still satisfy the reasonableness test on its own terms. Adequate consideration does not cure overbreadth in scope, geography, or duration, and the employer still bears the burden of proving reasonable necessity under *Summits 7* and the *Andrus* framework [^summits7-employer-burden-drafting][^andrus-reasonableness-test-drafting].
+
+## Will Vermont courts blue-pencil or reform an overbroad Vermont non-compete? {#court-narrowing}
+
+**Short answer.** Genuinely mixed. The Vermont Supreme Court will not *make* a contract for the parties — it will not, for example, extend an expired time term — but it has also endorsed the modern rule of enforcing covenants *to the extent reasonable* in dicta.
+
+The conservative anchor is *Roy's Orthopedic '85*. There, the Vermont Supreme Court refused to extend the covenant's time period because the litigation delay had run out the clock. The court explained that courts construe contracts but will not make them for the parties[^roys-85-no-make-contracts], and rejected the employer's attempt to relabel an extension as a postponed commencement date.
+
+The opposite signal comes from *Summits 7* and the Second Circuit. The Vermont Supreme Court observed that most modern courts agree that a trial court can enforce restrictive covenants to the extent that they are reasonable[^summits7-extent-reasonable], and cited *A.N. Deringer, Inc. v. Strough* — the Second Circuit's *Erie* prediction that Vermont would permit enforcement of a defective restrictive covenant to the limit of its validity[^deringer-vt-prediction].
+
+The two strands can be reconciled: Vermont will not rewrite a contract by inventing new terms (no extending time, no judicially imposed geographic line), but a court may enforce only that subset of an overbroad covenant the conduct actually breaches when that subset is plainly within a reasonable restraint.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not draft an intentionally overbroad covenant on the assumption that a Vermont court will narrow it. *Roy's Orthopedic '85* makes clear that Vermont judges will not equitably rewrite the contract — including by extending or shifting a time term — and the partial-enforcement dicta in *Summits 7* and *Deringer* are case-bound rather than a free pass [^roys-85-no-make-contracts][^summits7-extent-reasonable].
+
+## Are sale-of-business non-competes treated differently in Vermont? {#sale-of-business}
+
+**Short answer.** Yes. Sale-of-business covenants get more breathing room than ordinary employment non-competes, especially on duration and geography, when the covenant is part of an arms-length transaction.
+
+In *Fine Foods, Inc. v. Dahlin*, the Vermont Supreme Court enforced a five-year, 25-mile restaurant covenant[^fine-foods-five-year-twenty-five-mile] delivered at the closing of a $240,000 sale, with $5,000 separately allocated to the covenant. The court read the covenant's term *occupation* broadly, found the restraint reasonable as to time and place, and rejected the seller's effort to escape it by taking a maître d' job inside the restricted area.
+
+*Foti Fuels, Inc. v. Kurrle Corp.* situates the sale-of-business covenant in damages doctrine. There, the asset-purchase agreement contained a five-year non-compete with $30,000 in dedicated consideration[^foti-fuels-five-year-sale], paid in five annual installments. Litigation over an alleged breach turned not on enforceability but on the measure of damages, and the Vermont Supreme Court rejected the trial court's rule that failure to prove lost profits is fatal — the buyer could measure loss by the value of the bargained-for non-compete itself.
+
+Sale-of-business reasoning has a contract-formation corollary in *Miller v. Flegenheimer*. The court held that a stock-sale agreement was not enforceable in part because the parties had left material terms open, including whether the contract would include a form of non-compete or non-solicitation agreement[^miller-non-compete-not-essential], the share price, and a claw-back structure. The takeaway: a non-compete is a distinct, bargained-for term in a Vermont stock sale, not an automatic incident.
+
+## What profession-specific or context-specific limits apply to Vermont non-competes? {#profession-specific}
+
+**Short answer.** Three categories matter: barber/cosmetology training, attorney practice, and franchisor no-poach enforcement. Healthcare may soon join the list if H.583 passes.
+
+Vermont's narrowest categorical bar is in 26 V.S.A. § 281(c), which provides that a school of barbering or cosmetology shall not require a covenant not to compete as a condition of training for licensure[^vt-26-281c-cosmetology-ban]. It is the only generally applicable Vermont statute that voids a category of restrictive covenant outright.
+
+Attorneys are separately governed by [Vermont Rule of Professional Conduct 5.6](https://www.vermontjudiciary.org/sites/default/files/documents/VermontRulesofProfessionalConduct.pdf), which prohibits partnership, shareholder, operating, and employment agreements that restrict a lawyer's right to practice after termination, except for agreements concerning retirement benefits. The rule also bars settlement agreements that restrict a lawyer's future right to practice.
+
+The Vermont Attorney General has used antitrust and consumer-protection authority to police franchisor *no-poach* clauses. The 2018 multistate [Five Guys Enterprises settlement](https://www.naag.org/wp-content/uploads/2020/10/731.civil.Five-Guys-Agreement_Executed.pdf) required removal of provisions that restricted franchisees from hiring or soliciting employees across franchise locations. That enforcement is independent of the common-law non-compete framework.
+
+Healthcare-professional non-competes are not yet categorically void, but [H.583](https://legislature.vermont.gov/bill/status/2026/H.583) is moving through the General Assembly: it passed the House on March 20, 2026, the Senate proposed amendments, and on May 22, 2026 the House concurred in the Senate proposal of amendment. If enacted, H.583 would explicitly void noncompetition, nondisclosure, and nondisparagement agreements between licensed healthcare professionals and their employers — with a narrow exception for covenants ancillary to the sale of a 25%-or-greater equity interest. Until H.583 is signed into law, physician non-competes are evaluated under the same *Andrus* / *Barnes* reasonableness test as other employment covenants.
+
+## What pending Vermont legislation matters for restrictive covenants? {#pending-legislation}
+
+**Short answer.** Two bills are alive in the 2025-2026 session and would substantially supersede the common-law framework: H.205 (general non-compete and stay-or-pay prohibition, absorbing former H.334) and H.583 (healthcare-professional non-compete ban) [^vt-h205-status-page][^vt-h583-status-page].
+
+**H.205 — general non-compete + stay-or-pay (strike-all amendment).** As of June 2026, [H.205](https://legislature.vermont.gov/bill/status/2026/H.205) is the umbrella vehicle for Vermont's pending non-compete legislation. A strike-all amendment introduced in early 2026 absorbed the stay-or-pay provisions of the separate H.334 bill, and committee markup continued through March 2026. The current bill would void most non-compete agreements with a narrowly drawn carve-out for executive employees above a wage threshold, impose a three-business-day notice period for executive offers, and regulate stay-or-pay and training-repayment agreements as unlawful employment practices unless they satisfy strict voluntariness and proportionality criteria. The bill is titled An act relating to agreements not to compete[^vt-h205-status-page] and was recommitted on March 13, 2026.
+
+**H.334 — original stay-or-pay bill (absorbed).** [H.334 as introduced](https://legislature.vermont.gov/Documents/2026/Docs/BILLS/H-0334/H-0334%20As%20Introduced.pdf) was framed as An act relating to limiting employer restrictions on individuals separating from employment[^vt-h334-introduced-pdf], and its substance was folded into the H.205 strike-all amendment. Practitioners tracking either bill should treat H.205 as the operative vehicle.
+
+**H.583 — healthcare non-compete ban.** [H.583](https://legislature.vermont.gov/bill/status/2026/H.583), titled An act relating to clinical decision making[^vt-h583-status-page], passed the Vermont House on March 20, 2026, the Senate proposed amendments, and the House concurred in the Senate proposal of amendment on May 22, 2026. If enacted, the bill would explicitly void noncompetition, nondisclosure, and nondisparagement agreements between licensed healthcare professionals and their employers or contracting entities, subject only to a narrow exception for covenants ancillary to the sale of a 25%-or-greater equity interest.
+
+> [!NOTE]
+> **Practice note.**
+>
+> None of these bills is in force as of June 2026. The common-law *Andrus* / *Barnes* / *Summits 7* framework still governs new covenants and existing covenants [^andrus-reasonableness-test-pending]. But because H.205 and H.583 contemplate retroactive notice obligations and an anticipated July 1, 2026 effective date, Vermont employers should not rely on existing template rollovers without monitoring the status pages for both bills.
+
+## What alternatives do Vermont employers have if a non-compete isn't enforceable? {#alternatives}
+
+**Short answer.** The strongest alternatives are statutory trade-secret protection under the Vermont Trade Secrets Act, narrowly drawn confidentiality and nondisclosure agreements, sale-of-business carve-outs, and garden-leave structures.
+
+**Trade-secret protection.** The Vermont Trade Secrets Act (9 V.S.A. §§ 4601-4609) gives employers a statutory remedy that does not depend on a contractual non-compete. Section 4602 provides that a court may enjoin actual or threatened misappropriation of a trade secret[^vtsa-4602-injunctive], with the injunction continued for a reasonable period to eliminate any commercial advantage that would otherwise be derived from misappropriation. Damages, royalties, and exceptional-circumstances royalty-condition orders are also available [^vtsa-4603-damages].
+
+**Narrow confidentiality and NDA terms.** Vermont's reasonableness scrutiny in *Andrus* and *Barnes* applies to restrictive covenants generally, so NDA terms that operate as practical work bans carry non-compete risk. Confidentiality clauses tied to actual confidential information and trade-secret subject matter are easier to defend.
+
+**Sale-of-business covenants.** As *Fine Foods*, *Foti Fuels*, and *Miller v. Flegenheimer* together show, covenants ancillary to a real arms-length sale get more breathing room than employment covenants. Tie the covenant to dedicated transaction consideration and limit it to the geography of the acquired goodwill.
+
+**Garden leave.** A paid notice-period structure (employee remains employed but is not working) sidesteps the reasonableness problems of a post-termination restraint by keeping the employer-employee relationship intact. The pending H.205 strike-all amendment regulates stay-or-pay structures specifically, but a true garden-leave term is different in kind from a quit-fee provision.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not rely on a Vermont *inevitable disclosure* theory as a primary trade-secret strategy. The Vermont Supreme Court has never adopted inevitable disclosure as a standalone basis for enjoining a former employee, and the VTSA's *actual or threatened* misappropriation standard in § 4602 requires conduct- or threat-specific proof rather than a presumption from new employment alone [^vtsa-4602-injunctive-caution].
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-01. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not Vermont. This article synthesizes Vermont primary law and is not legal advice from a Vermont-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^andrus-reasonableness-test]: **Vermont Electric Supply Co. v. Andrus** — "enforcement will be ordered unless the agreement is found to be contrary to public policy, unnecessary for protection of the employer, or unnecessarily restrictive of the rights of the employee, with due regard being given to the subject matter of the contract and the circumstances and conditions under which it is to be performed." *Vt. Elec. Supply Co. v. Andrus, 132 Vt. 195, 315 A.2d 456 (1974).* <https://www.courtlistener.com/opinion/1972913/vermont-electric-supply-company-inc-v-andrus/#:~:text=enforcement%20will%20be%20ordered%20unless,it%20is%20to%20be%20performed.>
+
+[^barnes-restatement-framing]: **Systems & Software, Inc. v. Barnes** — "We have stated that ‘we will proceed with caution’ when asked to enforce covenants against competitive employment because such restraints run counter to public policy favoring the right of individuals to engage in the commercial activity of their choice." *Sys. & Software, Inc. v. Barnes, 2005 VT 95, 178 Vt. 389, 886 A.2d 762.* <https://www.courtlistener.com/opinion/2264199/systems-and-software-inc-v-barnes/#:~:text=We%20have%20stated%20that%20%E2%80%9Cwe,commercial%20activity%20of%20their%20choice.>
+
+[^barnes-reasonableness-public-policy]: **Systems & Software, Inc. v. Barnes** — "is unreasonably in restraint of trade if (a) the restraint is greater than is needed to protect the promisee’s legitimate interest, or (b) the promisee’s need is outweighed by the hardship to the promisor and the likely injury to the public." *Sys. & Software, Inc. v. Barnes, 2005 VT 95, ¶ 4, 178 Vt. 389, 886 A.2d 762 (quoting Restatement (Second) of Contracts § 188(1) (1981)).* <https://www.courtlistener.com/opinion/2264199/systems-and-software-inc-v-barnes/#:~:text=is%20unreasonably%20in%20restraint%20of,likely%20injury%20to%20the%20public.>
+
+[^barnes-legitimate-interest-not-only-trade-secrets]: **Systems & Software, Inc. v. Barnes** — "noncompetition agreements may protect legitimate employer interests such as customer relationships and employee-specific goodwill that are ‘significantly broader’ than proprietary information such as trade secrets and confidential customer information." *Sys. & Software, Inc. v. Barnes, 2005 VT 95, ¶ 5, 178 Vt. 389, 886 A.2d 762.* <https://www.courtlistener.com/opinion/2264199/systems-and-software-inc-v-barnes/#:~:text=noncompetition%20agreements%20may%20protect%20legitimate,secrets%20and%20confidential%20customer%20information.>
+
+[^barnes-inside-knowledge]: **Systems & Software, Inc. v. Barnes** — "The trial court found that during his employment with plaintiff, defendant had acquired inside knowledge about the strengths and weaknesses of plaintiff’s products — knowledge that he could use to compete against plaintiff." *Sys. & Software, Inc. v. Barnes, 2005 VT 95, ¶ 6, 178 Vt. 389, 886 A.2d 762.* <https://www.courtlistener.com/opinion/2264199/systems-and-software-inc-v-barnes/#:~:text=The%20trial%20court%20found%20that%20during,use%20to%20compete%20against%20plaintiff.>
+
+[^summits7-employer-burden]: **Summits 7, Inc. v. Kelly** — "[t]he employer has the burden of proving the reasonable necessity of the restrictive covenant." *Summits 7, Inc. v. Kelly, 2005 VT 97, ¶ 14, 178 Vt. 396, 886 A.2d 365.* <https://www.courtlistener.com/opinion/8209851/summits-7-inc-v-kelly/#:~:text=%5Bt%5Dhe%20employer%20has%20the%20burden,necessity%20of%20the%20restrictive%20covenant.>
+
+[^andrus-five-year-county]: **Vermont Electric Supply Co. v. Andrus** — "The area involved was Rutland County, and the defendants had elected to establish their business outside of that county already. After five years,' all restrictions were at an end." *Vt. Elec. Supply Co. v. Andrus, 132 Vt. 195, 199, 315 A.2d 456, 458 (1974).* <https://www.courtlistener.com/opinion/1972913/vermont-electric-supply-company-inc-v-andrus/#:~:text=The%20area%20involved%20was%20Rutland,restrictions%20were%20at%20an%20end.>
+
+[^roys-82-no-findings-on-place]: **Roy's Orthopedic, Inc. v. Lavigne (first appeal)** — "the trial court concluded that the restrictive covenant not to compete was reasonably limited to time and place without having made a finding as to what ‘place’ was covered by the agreement." *Roy's Orthopedic, Inc. v. Lavigne, 142 Vt. 347, 454 A.2d 1242 (1982).* <https://www.courtlistener.com/opinion/2367186/roys-orthopedic-inc-v-lavigne/#:~:text=the%20trial%20court%20concluded%20that%20the,was%20covered%20by%20the%20agreement.>
+
+[^summits7-continued-employment-sufficient]: **Summits 7, Inc. v. Kelly** — "we agree with the superior court, the majority of other courts, and the recent Restatement draft that continued employment alone is sufficient consideration to support a covenant not to compete entered into during an at-will employment relationship." *Summits 7, Inc. v. Kelly, 2005 VT 97, ¶ 18, 178 Vt. 396, 886 A.2d 365.* <https://www.courtlistener.com/opinion/8209851/summits-7-inc-v-kelly/#:~:text=we%20agree%20with%20the%20superior%20court%2C,during%20an%20at%2Dwill%20employment%20relationship.>
+
+[^summits7-employer-burden-drafting]: **Summits 7, Inc. v. Kelly** — "[t]he employer has the burden of proving the reasonable necessity of the restrictive covenant." *Summits 7, Inc. v. Kelly, 2005 VT 97, ¶ 14, 178 Vt. 396, 886 A.2d 365.* <https://www.courtlistener.com/opinion/8209851/summits-7-inc-v-kelly/#:~:text=%5Bt%5Dhe%20employer%20has%20the%20burden,necessity%20of%20the%20restrictive%20covenant.>
+
+[^andrus-reasonableness-test-drafting]: **Vermont Electric Supply Co. v. Andrus** — "enforcement will be ordered unless the agreement is found to be contrary to public policy, unnecessary for protection of the employer, or unnecessarily restrictive of the rights of the employee, with due regard being given to the subject matter of the contract and the circumstances and conditions under which it is to be performed." *Vt. Elec. Supply Co. v. Andrus, 132 Vt. 195, 315 A.2d 456 (1974).* <https://www.courtlistener.com/opinion/1972913/vermont-electric-supply-company-inc-v-andrus/#:~:text=enforcement%20will%20be%20ordered%20unless,it%20is%20to%20be%20performed.>
+
+[^roys-85-no-make-contracts]: **Roy's Orthopedic, Inc. v. Lavigne (second appeal)** — "The term of the noncompetition agreement was a matter of contract between the parties. This Court will construe contracts but it will not make them for the parties." *Roy's Orthopedic, Inc. v. Lavigne, 145 Vt. 324, 487 A.2d 173 (1985).* <https://www.courtlistener.com/opinion/2359631/roys-orthopedic-inc-v-lavigne/#:~:text=The%20term%20of%20the%20noncompetition,make%20them%20for%20the%20parties.>
+
+[^summits7-extent-reasonable]: **Summits 7, Inc. v. Kelly** — "Most modem courts agree that a trial court can enforce restrictive covenants to the extent that they are reasonable." *Summits 7, Inc. v. Kelly, 2005 VT 97, ¶ 23, 178 Vt. 396, 886 A.2d 365.* <https://www.courtlistener.com/opinion/8209851/summits-7-inc-v-kelly/#:~:text=Most%20modem%20courts%20agree%20that,extent%20that%20they%20are%20reasonable.>
+
+[^deringer-vt-prediction]: **A.N. Deringer, Inc. v. Strough** — "we conclude that Vermont would permit enforcement of a defective restrictive covenant to the limit of its validity." *A.N. Deringer, Inc. v. Strough, 103 F.3d 243, 247-48 (2d Cir. 1996).* <https://www.courtlistener.com/opinion/732308/an-deringer-inc-v-john-m-strough-and-fritz-companies-inc/#:~:text=we%20conclude%20that%20Vermont%20would,the%20limit%20of%20its%20validity.>
+
+[^fine-foods-five-year-twenty-five-mile]: **Fine Foods, Inc. v. Dahlin** — "In addition, a sum of five thousand dollars was paid for the executed covenant alone. Under the circumstances, the restrictions agreed to were reasonable to time and place." *Fine Foods, Inc. v. Dahlin, 147 Vt. 599, 523 A.2d 1228 (1986).* <https://www.courtlistener.com/opinion/1927334/fine-foods-inc-v-dahlin/#:~:text=In%20addition%2C%20a%20sum%20of,reasonable%20to%20time%20and%20place.>
+
+[^foti-fuels-five-year-sale]: **Foti Fuels, Inc. v. Kurrle Corp.** — "The asset-purchase agreement contained a five-year non-competition provision for $30,000 in consideration, to be paid in five equal annual installments." *Foti Fuels, Inc. v. Kurrle Corp., 2013 VT 111, 195 Vt. 524, 90 A.3d 885.* <https://www.courtlistener.com/opinion/2646010/foti-fuels-inc-and-robert-a-foti-v-kurrle-corporation-payjack-llc-and/#:~:text=The%20asset%2Dpurchase%20agreement%20contained%20a,in%20five%20equal%20annual%20installments.>
+
+[^miller-non-compete-not-essential]: **Miller v. Flegenheimer** — "whether or not the contract includes a form of non compete or non solicitation agreement, the price to be paid for the shares (as opposed to the Non-Compete Agreement), and the structure of the claw-back provision." *Miller v. Flegenheimer, 2016 VT 125, ¶ 21, 203 Vt. 620, 161 A.3d 524.* <https://www.courtlistener.com/opinion/4328779/kenneth-w-miller-ii-v-eric-flegenheimer/#:~:text=whether%20or%20not%20the%20contract,structure%20of%20the%20claw%2Dback%20provision.>
+
+[^vt-26-281c-cosmetology-ban]: **26 V.S.A. § 281(c)** — "A school of barbering or cosmetology shall not require, as a condition of training for licensure, that a person enter into a covenant not to compete with the training organization or an affiliate." *26 V.S.A. § 281(c).* <https://legislature.vermont.gov/statutes/fullchapter/26/006>
+
+[^vt-h205-status-page]: **Vt. H.205 (2025-2026) — Bill Status** — "An act relating to agreements not to compete" *H.205, 2025-2026 Gen. Assemb., Reg. Sess. (Vt. 2026) (recommitted Mar. 13, 2026).* <https://legislature.vermont.gov/bill/status/2026/H.205>
+
+[^vt-h583-status-page]: **Vt. H.583 (2025-2026) — Bill Status** — "An act relating to clinical decision making" *H.583, 2025-2026 Gen. Assemb., Reg. Sess. (Vt. 2026) (passed House Mar. 20, 2026; House concurred in Senate proposal of amendment, May 22, 2026).* <https://legislature.vermont.gov/bill/status/2026/H.583>
+
+[^vt-h334-introduced-pdf]: **Vt. H.334 (2025-2026) — As Introduced** — "An act relating to limiting employer restrictions on individuals separating" *H.334, 2025-2026 Gen. Assemb., Reg. Sess. (Vt. 2025) (as introduced).* <https://legislature.vermont.gov/Documents/2026/Docs/BILLS/H-0334/H-0334%20As%20Introduced.pdf>
+
+[^andrus-reasonableness-test-pending]: **Vermont Electric Supply Co. v. Andrus** — "enforcement will be ordered unless the agreement is found to be contrary to public policy, unnecessary for protection of the employer, or unnecessarily restrictive of the rights of the employee, with due regard being given to the subject matter of the contract and the circumstances and conditions under which it is to be performed." *Vt. Elec. Supply Co. v. Andrus, 132 Vt. 195, 315 A.2d 456 (1974).* <https://www.courtlistener.com/opinion/1972913/vermont-electric-supply-company-inc-v-andrus/#:~:text=enforcement%20will%20be%20ordered%20unless,it%20is%20to%20be%20performed.>
+
+[^vtsa-4602-injunctive]: **9 V.S.A. § 4602 — Injunctive relief** — "A court may enjoin actual or threatened misappropriation of a trade secret. Upon application to the court, an injunction shall be terminated when the trade secret has ceased to exist, but the injunction may be continued for an additional reasonable period of time in order to eliminate commercial advantage that otherwise would be derived from the misappropriation." *9 V.S.A. § 4602(a).* <https://legislature.vermont.gov/statutes/fullchapter/09/143>
+
+[^vtsa-4603-damages]: **9 V.S.A. § 4603 — Damages** — "Except to the extent that a material and prejudicial change of position prior to acquiring knowledge or reason to know of misappropriation renders a monetary recovery inequitable, a complainant is entitled to recover damages for misappropriation." *9 V.S.A. § 4603(a)(1).* <https://legislature.vermont.gov/statutes/fullchapter/09/143>
+
+[^vtsa-4602-injunctive-caution]: **9 V.S.A. § 4602 — Injunctive relief** — "A court may enjoin actual or threatened misappropriation of a trade secret." *9 V.S.A. § 4602(a).* <https://legislature.vermont.gov/statutes/fullchapter/09/143>

--- a/skills/non-compete-contract-explainer/content/virginia.md
+++ b/skills/non-compete-contract-explainer/content/virginia.md
@@ -1,0 +1,213 @@
+---
+jurisdiction: "Virginia"
+slug: virginia
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-02"
+canonicalUrl: https://openagreements.org/legal/non-compete/virginia
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/virginia · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in Virginia[^about]
+
+Virginia non-compete law combines Va. Code § 40.1-28.7:8, a common-law reasonableness test, no blue-pencil rule, low-wage and FLSA-non-exempt bans, July 1, 2026 changes, and trade-secret alternatives.
+
+
+## At a glance
+
+| Question | Virginia |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed above a pay level |
+| **Bottom line** | Virginia bans non-competes outright for statutory low-wage and FLSA non-exempt employees, while higher-paid workers remain subject to a strict common-law reasonableness test with no judicial blue-penciling. |
+| **Main law or case** | Va. Code § 40.1-28.7:8; common law (Omniplex World Servs. Corp. v. U.S. Investigations Servs., 270 Va. 246 (2005)) |
+| **Main exceptions** | Low-wage/FLSA-non-exempt ban (commission/incentive-earner exclusion); health-care-professional ban and severance-or-disclosed-comp rule eff. July 1, 2026; NDAs/trade-secret preserved |
+| **When the ban took effect** | Low-wage ban eff. July 1, 2020 (FLSA-non-exempt July 1, 2025; 2026 threshold under $1,507.01/week); health-care ban July 1, 2026 |
+| **Can a court narrow it?** | No |
+| **Applies to contractors?** | Yes |
+| **Restriction extended during a breach?** | Not resolved — strict construction makes an extension clause an overbreadth risk |
+| **Maximum length set by law** | No statutory limit |
+| **Must the employer pay to enforce?** | Yes — severance or disclosed pay if fired without cause |
+
+## Are employee non-compete agreements enforceable in Virginia? {#employee-noncompetes}
+
+**Short answer.** Sometimes. Virginia remains a reasonableness state for workers outside the statutory ban, but Va. Code § 40.1-28.7:8 flatly prohibits employers from entering into, enforcing, or threatening to enforce non-competes with covered *low-wage employees* [^statutory-ban-baseline].
+
+The result is a dual track. For covered workers, the statute controls first. For everyone else, the common-law test controls, and the employer must prove a restraint is narrowly drawn, not unduly burdensome on earning a living, and consistent with public policy [^omniplex-basic-test].
+
+The statutory track is broad after the 2025 amendment. The Virginia Department of Workforce Development and Advancement calculates the 2026 wage threshold at less than $1,507.01 per week, and the protected class also includes FLSA non-exempt employees regardless of earnings [^doli-current-threshold].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not treat Virginia as either a total-ban state or a simple reasonableness state. The first question is whether § 40.1-28.7:8 bars the covenant for the worker; only then does common-law reasonableness matter [^statutory-ban-baseline][^omniplex-basic-test].
+
+## What makes a Virginia non-compete reasonable or enforceable? {#reasonableness-test}
+
+**Short answer.** A Virginia employee non-compete must satisfy a three-part reasonableness test and must be evaluated through function, geography, and duration together [^omniplex-three-part-test][^preferred-elements-together].
+
+The employer bears the burden. Virginia courts ask whether the restraint protects a legitimate business interest, whether it is unduly harsh in limiting the employee's livelihood, and whether it fits sound public policy [^omniplex-three-part-test]. They then examine the function, geographic scope, and duration as an integrated whole rather than isolated drafting boxes [^preferred-elements-together].
+
+Function is often the trap. In *Home Paramount*, the Supreme Court of Virginia rejected a clause that barred pest-control work in any capacity because it was not confined to the employee's actual work or the employer's proved interest [^home-paramount-any-capacity]. In *Motion Control*, the court similarly rejected a restraint reaching a wide range of businesses unrelated to the employer's specialized business [^motion-control-similar-business].
+
+"the clear overbreadth of the function here cannot be saved by narrow tailoring of geographic scope and duration."[^home-paramount-overbreadth]
+
+Each case remains fact-specific. *Modern Environments* states that restrictive covenants are strictly construed, and the employer must produce the justification for the actual restraint it chose [^modern-environments-burden].
+
+## Which Virginia employees cannot be bound by non-competes under the statutory ban? {#protected-workers}
+
+**Short answer.** Virginia employers cannot use non-competes with statutory *low-wage employees*, a group that now includes workers below the 2026 weekly wage threshold and FLSA non-exempt employees regardless of pay [^statute-low-wage-threshold][^statute-low-wage-flsa][^doli-threshold][^doli-flsa].
+
+For 2026, the wage threshold is less than $1,507.01 per week, or about $78,364.52 per year. The statute also covers interns, students, apprentices, trainees, and certain lower-paid independent contractors, while excluding employees whose earnings are derived in whole or predominant part from sales commissions, incentives, or bonuses [^doli-threshold][^statute-interns-trainees][^statute-independent-contractors][^statute-commission-exclusion].
+
+The remedies have teeth. A covered worker may sue within the statutory limitations period; a court may void the covenant, enjoin conduct, award lost compensation, damages, liquidated damages, and attorney fees; DOLI may assess a $10,000 civil penalty for each violation; and employers must post the required notice [^statute-private-action-relief][^statute-fees][^statute-civil-penalty][^statute-posting].
+
+> [!NOTE]
+> **Practice note.**
+>
+> The FLSA-non-exempt expansion is independent of the dollar threshold. A highly paid non-exempt employee can still be protected by § 40.1-28.7:8 because the statute covers workers entitled to overtime regardless of average weekly earnings [^statute-low-wage-flsa][^doli-flsa].
+
+## Will a Virginia court narrow or blue-pencil an overbroad non-compete? {#court-narrowing}
+
+**Short answer.** No, not in the practical sense employers usually mean. Virginia courts strictly construe restrictive covenants, and a clear overbreadth problem can make the covenant unenforceable rather than narrowed by the court [^motion-control-strict-construction][^home-paramount-no-extrinsic-narrowing].
+
+The strict approach matters because overbreadth in one element can sink the whole restraint. *Home Paramount* refused to save an overbroad function restriction with narrower geography and duration, and rejected the employer's attempt to narrow clear text through extrinsic evidence [^home-paramount-overbreadth-no-save][^home-paramount-no-extrinsic-narrowing].
+
+That does not mean every enforceability question can be decided from the pleadings. In *Assurance Data*, the Supreme Court of Virginia warned that restraints are neither enforceable nor unenforceable in a factual vacuum; the court needs evidence before deciding whether the actual restraint is reasonable as a whole [^assurance-data-factual-vacuum].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not rely on a savings clause to rescue broad language. Virginia's cases put the burden on the employer to defend the language it chose, and clear overbreadth cannot be cured by asking the court to read the covenant as if it were narrower [^home-paramount-no-extrinsic-narrowing][^motion-control-strict-construction].
+
+## Does the restricted period toll or extend during breach or litigation in Virginia? {#tolling-extension}
+
+**Short answer.** Virginia law does not squarely answer this in the staged authorities. No source in this corpus resolves whether a non-compete period tolls during breach or litigation, or whether an extension-on-breach clause is enforceable; the available cases only supply strict-construction and overbreadth background [^tolling-motion-control-strict][^tolling-home-paramount-overbreadth].
+
+The risk-weighted answer is cautious. Virginia courts strictly construe non-competes as restraints of trade, and clear overbreadth can void a restraint rather than invite judicial narrowing [^tolling-motion-control-strict][^tolling-home-paramount-overbreadth]. That backdrop makes a clause that lengthens the restricted period a plausible overbreadth risk, especially if it creates an open-ended or litigation-driven restraint.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Treat extension-on-breach drafting as unsettled Virginia law, not as an automatic equitable remedy. The available Virginia authorities support strict construction and no rescue for clear overbreadth, but they do not decide tolling or extension-on-breach clauses specifically [^tolling-motion-control-strict][^tolling-home-paramount-overbreadth].
+
+## How do non-solicitation provisions fit in Virginia, especially for protected workers? {#non-solicitation}
+
+**Short answer.** Customer non-solicits can fit differently from non-competes, but the line is narrow. Va. Code § 40.1-28.7:8 says a covenant not to compete cannot block a former employee from serving a customer if the employee did not initiate contact or solicit the customer [^statute-customer-service-carveout].
+
+In unpublished *Sentry Force Security, LLC v. Barrera*, the Court of Appeals of Virginia read that sentence to permit a restriction against direct customer solicitation, even assuming the worker was low wage [^sentry-customer-solicitation]. The same opinion drew the opposite conclusion for customer-initiated business: if the customer approaches the former employee, the statute protects accepting that work [^sentry-passive-customer].
+
+The opinion also treated employee solicitation differently from customer solicitation for protected workers. It held that § 40.1-28.7:8 prevented enforcement of a covenant barring the former worker from soliciting Sentry Force's other employees [^sentry-employee-solicitation].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Use *Sentry Force* carefully. It is an unpublished Court of Appeals memorandum opinion, so it is useful Virginia-specific guidance but has limited precedential weight; draft customer provisions to target employee-initiated solicitation, not passive acceptance of customer-initiated work [^sentry-customer-solicitation][^sentry-passive-customer].
+
+## What is changing in Virginia non-compete law on July 1, 2026? {#july-2026-changes}
+
+**Short answer.** Two enacted changes take effect July 1, 2026: a severance-or-prior-disclosed-compensation rule for employees discharged without cause, and a health-care-professional non-compete ban [^gt-sb170-severance][^troutman-sb128-effective-healthcare].
+
+For SB 170, commentary reports that Governor Abigail Spanberger signed the bill on April 13, 2026. For agreements entered, amended, or renewed on or after July 1, 2026, the new rule makes a non-compete unenforceable if the employer terminates the employee without cause and the employee does not receive severance pay or other prior disclosed monetary compensation [^gt-sb170-severance].
+
+The SB 128 / HB 627 health-care change categorically bans non-competes for almost all health care professionals. Troutman Pepper Locke supports the July 1, 2026 effective-date status and the categorical health-care-professional ban; Ogletree remains useful for the covered-board scope, including professionals licensed, registered, or certified by the Boards of Medicine, Nursing, Counseling, Optometry, Psychology, or Social Work [^troutman-sb128-effective-healthcare][^ogletree-sb128-healthcare].
+
+> [!NOTE]
+> **Practice note.**
+>
+> The SB 170 change is prospective. Commentary says contracts, covenants, or agreements entered into, amended, or renewed before July 1, 2026, are not affected by SB 170 [^gt-sb170-prospective].
+
+## What can Virginia employers use instead of a non-compete? {#alternatives}
+
+**Short answer.** Virginia employers can still use properly tailored nondisclosure, confidentiality, and trade-secret protections. Section 40.1-28.7:8 expressly preserves nondisclosure agreements aimed at misappropriation and sharing of trade secrets, proprietary information, and confidential information [^statute-nda-preserved].
+
+That alternative has its own limits. The Virginia Uniform Trade Secrets Act defines a trade secret as information with independent economic value from not being generally known and subject to reasonable secrecy efforts [^vutsa-trade-secret-definition]. It also permits injunctions for actual or threatened misappropriation, but those injunctions are tied to the trade-secret problem rather than a general ban on competition [^vutsa-injunctive-relief].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Keep confidentiality and trade-secret covenants separate from a work ban. A clause labeled as confidentiality can still create non-compete risk if it restrains ordinary competition rather than protecting specific confidential, proprietary, or trade-secret information [^statute-nda-preserved][^vutsa-trade-secret-definition].
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-02. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not Virginia. This article synthesizes Virginia primary law and is not legal advice from a Virginia-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^statutory-ban-baseline]: **Va. Code § 40.1-28.7:8** — "No employer shall enter into, enforce, or threaten to enforce a covenant not to compete with any low-wage employee." *Va. Code Ann. § 40.1-28.7:8(B).* <https://law.lis.virginia.gov/vacode/40.1-28.7:8/>
+
+[^omniplex-basic-test]: **Omniplex World Services Corp. v. U.S. Investigations Services, Inc.** — "These considerations form the basis of the three-part test we use to determine the validity of restrictive covenants: (1) Is the restraint, from the standpoint of the employer, reasonable in the sense that it is no greater than necessary to protect the employer in some legitimate business interest? (2) From the standpoint of the employee, is the restraint reasonable in the sense that it is not unduly harsh and oppressive in curtailing his legitimate efforts to earn a livelihood? (3) Is the restraint reasonable from the standpoint of a sound public policy?" *Omniplex World Servs. Corp. v. U.S. Investigations Servs., Inc., 270 Va. 246, 618 S.E.2d 340 (2005).* <https://www.courtlistener.com/opinion/1058921/omniplex-world-services-v-us-inv/#:~:text=These%20considerations%20form%20the%20basis,of%20a%20sound%20public%20policy%3F>
+
+[^doli-current-threshold]: **Virginia DOLI Notice of the Average Weekly Wage for 2026** — "Effective July 1, 2025, a ‘low-wage employee’ also includes an employee who, regardless of average weekly earnings, is entitled to overtime compensation under the provisions of the Fair Labor Standards Act for any hours worked in excess of 40 hours in any one workweek." *Virginia Department of Workforce Development and Advancement, Notice of the Average Weekly Wage for 2026 (Jan. 6, 2026).* <https://doli.virginia.gov/2026/01/06/notice-of-the-average-weekly-wage-for-2026/>
+
+[^omniplex-three-part-test]: **Omniplex World Services Corp. v. U.S. Investigations Services, Inc.** — "These considerations form the basis of the three-part test we use to determine the validity of restrictive covenants: (1) Is the restraint, from the standpoint of the employer, reasonable in the sense that it is no greater than necessary to protect the employer in some legitimate business interest? (2) From the standpoint of the employee, is the restraint reasonable in the sense that it is not unduly harsh and oppressive in curtailing his legitimate efforts to earn a livelihood? (3) Is the restraint reasonable from the standpoint of a sound public policy?" *Omniplex World Servs. Corp. v. U.S. Investigations Servs., Inc., 270 Va. 246, 618 S.E.2d 340 (2005).* <https://www.courtlistener.com/opinion/1058921/omniplex-world-services-v-us-inv/#:~:text=These%20considerations%20form%20the%20basis,of%20a%20sound%20public%20policy%3F>
+
+[^preferred-elements-together]: **Preferred Systems Solutions, Inc. v. GP Consulting, LLC** — "We assess these elements together rather than as distinct inquiries." *Preferred Sys. Sols., Inc. v. GP Consulting, LLC, 284 Va. 382 (2012).* <https://www.courtlistener.com/opinion/1057833/preferred-systems-solutions-v-gp-consulting/#:~:text=We%20assess%20these%20elements%20together,rather%20than%20as%20distinct%20inquiries.>
+
+[^home-paramount-any-capacity]: **Home Paramount Pest Control Cos. v. Shaffer** — "Because Home Paramount did not confine the function element of the Provision to those activities it actually engaged in, it bore the burden of proving a legitimate business interest in prohibiting Shaffer from engaging in all reasonably conceivable activities while employed by a competitor." *Home Paramount Pest Control Cos. v. Shaffer, 282 Va. 412, 718 S.E.2d 762 (2011).* <https://www.courtlistener.com/opinion/1057978/home-paramount-pest-control-v-shaffer/#:~:text=Because%20Home%20Paramount%20did%20not,while%20employed%20by%20a%20competitor.>
+
+[^motion-control-similar-business]: **Motion Control Systems, Inc. v. East** — "Accordingly, we conclude that the trial court did not err in holding that the covenant not to compete in this case imposed restraints that exceeded those necessary to protect the legitimate business interests of MCS and, therefore, was unenforceable." *Motion Control Sys., Inc. v. East, 262 Va. 33, 546 S.E.2d 424 (2001).* <https://www.courtlistener.com/opinion/1059467/motion-control-systems-inc-v-east/#:~:text=Accordingly%2C%20we%20conclude%20that%20the,MCS%20and%2C%20therefore%2C%20was%20unenforceable.>
+
+[^home-paramount-overbreadth]: **Home Paramount Pest Control Cos. v. Shaffer** — "the clear overbreadth of the function here cannot be saved by narrow tailoring of geographic scope and duration." *Home Paramount Pest Control Cos. v. Shaffer, 282 Va. 412, 718 S.E.2d 762 (2011).* <https://www.courtlistener.com/opinion/1057978/home-paramount-pest-control-v-shaffer/#:~:text=the%20clear%20overbreadth%20of%20the,of%20geographic%20scope%20and%20duration.>
+
+[^modern-environments-burden]: **Modern Environments, Inc. v. Stinnett** — "Second, the employer bears the burden to show that the restraint is no greater than necessary to protect a legitimate business interest, is not unduly harsh or oppressive in curtailing an employee's ability to earn a livelihood, and is reasonable in light of sound public policy." *Modern Env'ts, Inc. v. Stinnett, 263 Va. 491, 561 S.E.2d 694 (2002).* <https://www.courtlistener.com/opinion/1059338/modern-environments-inc-v-stinnett/#:~:text=Second%2C%20the%20employer%20bears%20the,light%20of%20sound%20public%20policy.>
+
+[^statute-low-wage-threshold]: **Va. Code § 40.1-28.7:8** — "means an employee (i) whose average weekly earnings, calculated by dividing the employee's earnings during the period of 52 weeks immediately preceding the date of termination of employment by 52, or if an employee worked fewer than 52 weeks, by the number of weeks that the employee was actually paid during the 52-week period, are less than the average weekly wage of the Commonwealth as determined pursuant to subsection B of § 65.2-500" *Va. Code Ann. § 40.1-28.7:8(A).* <https://law.lis.virginia.gov/vacode/40.1-28.7:8/>
+
+[^statute-low-wage-flsa]: **Va. Code § 40.1-28.7:8** — "who, regardless of his average weekly earnings, is entitled to overtime compensation under the provisions of 29 U.S.C. § 207 for any hours worked in excess of 40 hours in any one workweek." *Va. Code Ann. § 40.1-28.7:8(A).* <https://law.lis.virginia.gov/vacode/40.1-28.7:8/>
+
+[^doli-threshold]: **Virginia DOLI Notice of the Average Weekly Wage for 2026** — "Pursuant to Va. Code § 40.1-28.7:8, the term ‘low-wage employee’ as applied to covenants not to compete has been calculated by the Virginia Department of Workforce Development and Advancement to include all employees who earn an average of less than $1,507.01 per week." *Virginia Department of Workforce Development and Advancement, Notice of the Average Weekly Wage for 2026 (Jan. 6, 2026).* <https://doli.virginia.gov/2026/01/06/notice-of-the-average-weekly-wage-for-2026/>
+
+[^doli-flsa]: **Virginia DOLI Notice of the Average Weekly Wage for 2026** — "Effective July 1, 2025, a ‘low-wage employee’ also includes an employee who, regardless of average weekly earnings, is entitled to overtime compensation under the provisions of the Fair Labor Standards Act for any hours worked in excess of 40 hours in any one workweek." *Virginia Department of Workforce Development and Advancement, Notice of the Average Weekly Wage for 2026 (Jan. 6, 2026).* <https://doli.virginia.gov/2026/01/06/notice-of-the-average-weekly-wage-for-2026/>
+
+[^statute-interns-trainees]: **Va. Code § 40.1-28.7:8** — "includes interns, students, apprentices, or trainees employed, with or without pay, at a trade or occupation in order to gain work or educational experience." *Va. Code Ann. § 40.1-28.7:8(A).* <https://law.lis.virginia.gov/vacode/40.1-28.7:8/>
+
+[^statute-independent-contractors]: **Va. Code § 40.1-28.7:8** — "also includes an individual who has independently contracted with another person to perform services independent of an employment relationship and who is compensated for such services by such person at an hourly rate that is less than the median hourly wage for the Commonwealth for all occupations as reported, for the preceding year, by the Bureau of Labor Statistics of the U.S. Department of Labor." *Va. Code Ann. § 40.1-28.7:8(A).* <https://law.lis.virginia.gov/vacode/40.1-28.7:8/>
+
+[^statute-commission-exclusion]: **Va. Code § 40.1-28.7:8** — "shall not include any employee whose earnings are derived, in whole or in predominant part, from sales commissions, incentives, or bonuses paid to the employee by the employer." *Va. Code Ann. § 40.1-28.7:8(A).* <https://law.lis.virginia.gov/vacode/40.1-28.7:8/>
+
+[^statute-private-action-relief]: **Va. Code § 40.1-28.7:8** — "A low-wage employee may bring a civil action in a court of competent jurisdiction against any former employer or other person that attempts to enforce a covenant not to compete against such employee in violation of this section. An action under this section shall be brought within two years of the latter of (i) the date the covenant not to compete was signed, (ii) the date the low-wage employee learns of the covenant not to compete, (iii) the date the employment relationship is terminated, or (iv) the date the employer takes any step to enforce the covenant not to compete. The court shall have jurisdiction to void any covenant not to compete with a low-wage employee and to order all appropriate relief, including enjoining the conduct of any person or employer, ordering payment of liquidated damages, and awarding lost compensation, damages, and reasonable attorney fees and costs." *Va. Code Ann. § 40.1-28.7:8(D).* <https://law.lis.virginia.gov/vacode/40.1-28.7:8/>
+
+[^statute-fees]: **Va. Code § 40.1-28.7:8** — "If the court finds a violation of the provisions of this section, the plaintiff shall be entitled to recover reasonable costs, including costs and reasonable fees for expert witnesses, and attorney fees from the former employer or other person who attempts to enforce an unlawful covenant not to compete against such plaintiff." *Va. Code Ann. § 40.1-28.7:8(F).* <https://law.lis.virginia.gov/vacode/40.1-28.7:8/>
+
+[^statute-civil-penalty]: **Va. Code § 40.1-28.7:8** — "Any employer that violates the provisions of subsection B as determined by the Commissioner shall be subject to a civil penalty of $10,000 for each violation." *Va. Code Ann. § 40.1-28.7:8(E).* <https://law.lis.virginia.gov/vacode/40.1-28.7:8/>
+
+[^statute-posting]: **Va. Code § 40.1-28.7:8** — "Every employer shall post a copy of this section or a summary approved by the Department in the same location where other employee notices required by state or federal law are posted." *Va. Code Ann. § 40.1-28.7:8(G).* <https://law.lis.virginia.gov/vacode/40.1-28.7:8/>
+
+[^motion-control-strict-construction]: **Motion Control Systems, Inc. v. East** — "As a restraint of trade, the covenant must be strictly construed and, if ambiguous, it must be construed in favor of the employee." *Motion Control Sys., Inc. v. East, 262 Va. 33, 546 S.E.2d 424 (2001).* <https://www.courtlistener.com/opinion/1059467/motion-control-systems-inc-v-east/#:~:text=As%20a%20restraint%20of%20trade%2C,in%20favor%20of%20the%20employee.>
+
+[^home-paramount-no-extrinsic-narrowing]: **Home Paramount Pest Control Cos. v. Shaffer** — "Home Paramount thus was limited to adducing evidence to prove that the language it chose furthered its legitimate business interests, did not unduly burden Shaffer’s ability to earn a living, and was not contrary to public policy." *Home Paramount Pest Control Cos. v. Shaffer, 282 Va. 412, 718 S.E.2d 762 (2011).* <https://www.courtlistener.com/opinion/1057978/home-paramount-pest-control-v-shaffer/#:~:text=Home%20Paramount%20thus%20was%20limited,not%20contrary%20to%20public%20policy.>
+
+[^home-paramount-overbreadth-no-save]: **Home Paramount Pest Control Cos. v. Shaffer** — "the clear overbreadth of the function here cannot be saved by narrow tailoring of geographic scope and duration." *Home Paramount Pest Control Cos. v. Shaffer, 282 Va. 412, 718 S.E.2d 762 (2011).* <https://www.courtlistener.com/opinion/1057978/home-paramount-pest-control-v-shaffer/#:~:text=the%20clear%20overbreadth%20of%20the,of%20geographic%20scope%20and%20duration.>
+
+[^assurance-data-factual-vacuum]: **Assurance Data, Inc. v. Malyevac** — "The premise running through Simmons, Modern Environments, Home Paramount, and our other decisions is that restraints on competition are neither enforceable nor unenforceable in a factual vacuum." *Assurance Data, Inc. v. Malyevac, 286 Va. 137 (2013).* <https://www.courtlistener.com/opinion/1057728/assurance-data-inc-v-malyevac/#:~:text=The%20premise%20running%20through%20Simmons%2C,unenforceable%20in%20a%20factual%20vacuum.>
+
+[^tolling-motion-control-strict]: **Motion Control Systems, Inc. v. East** — "As a restraint of trade, the covenant must be strictly construed and, if ambiguous, it must be construed in favor of the employee." *Motion Control Sys., Inc. v. East, 262 Va. 33, 546 S.E.2d 424 (2001).* <https://www.courtlistener.com/opinion/1059467/motion-control-systems-inc-v-east/#:~:text=As%20a%20restraint%20of%20trade%2C,in%20favor%20of%20the%20employee.>
+
+[^tolling-home-paramount-overbreadth]: **Home Paramount Pest Control Cos. v. Shaffer** — "the clear overbreadth of the function here cannot be saved by narrow tailoring of geographic scope and duration." *Home Paramount Pest Control Cos. v. Shaffer, 282 Va. 412, 718 S.E.2d 762 (2011).* <https://www.courtlistener.com/opinion/1057978/home-paramount-pest-control-v-shaffer/#:~:text=the%20clear%20overbreadth%20of%20the,of%20geographic%20scope%20and%20duration.>
+
+[^statute-customer-service-carveout]: **Va. Code § 40.1-28.7:8** — "shall not restrict an employee from providing a service to a customer or client of the employer if the employee does not initiate contact with or solicit the customer or client." *Va. Code Ann. § 40.1-28.7:8(A).* <https://law.lis.virginia.gov/vacode/40.1-28.7:8/>
+
+[^sentry-customer-solicitation]: **Sentry Force Security, LLC v. Barrera** — "Thus, even assuming Barrera is a low-wage employee for the purposes of this interlocutory appeal (as the parties do), Barrera cannot solicit his former employer’s customers for his own company." *Sentry Force Sec., LLC v. Barrera, Record No. 1405-24-4, slip op. at 14 (Va. Ct. App. Jan. 27, 2026) (unpublished).* <https://www.vacourts.gov/opinions/opncavwp/1405244.pdf>
+
+[^sentry-passive-customer]: **Sentry Force Security, LLC v. Barrera** — "In short, if the customer approaches the former employee with its business, the former employee is not restricted from accepting that customer’s business—and doing work for that customer of the former employer." *Sentry Force Sec., LLC v. Barrera, Record No. 1405-24-4, slip op. at 15 (Va. Ct. App. Jan. 27, 2026) (unpublished).* <https://www.vacourts.gov/opinions/opncavwp/1405244.pdf>
+
+[^sentry-employee-solicitation]: **Sentry Force Security, LLC v. Barrera** — "However, we affirm the circuit court’s decision on Sentry Force’s second assignment of error because Code § 40.1-28.7:8 does prevent Sentry Force from enforcing a ‘covenant not to compete’ agreement against Barrera that stops Barrera (after he left Sentry Force) from soliciting Sentry Force’s other employees." *Sentry Force Sec., LLC v. Barrera, Record No. 1405-24-4, slip op. at 20 (Va. Ct. App. Jan. 27, 2026) (unpublished).* <https://www.vacourts.gov/opinions/opncavwp/1405244.pdf>
+
+[^gt-sb170-severance]: **Greenberg Traurig, Virginia Governor Signs Senate Bill 170, Targeting Noncompete Agreements** — "Under the bill, a noncompete agreement will be unenforceable if an employer terminates an employee without cause and the employee does not receive severance pay or other prior disclosed monetary compensation." *Greenberg Traurig, Virginia Governor Signs Senate Bill 170, Targeting Noncompete Agreements (Apr. 2026).* <https://www.gtlaw.com/en/insights/2026/4/virginia-governor-signs-senate-bill-170-targeting-noncompete-agreements>
+
+[^troutman-sb128-effective-healthcare]: **Virginia Enacts New Restrictions on the Use of Noncompetes** — "These obligations and several other new restrictions are part of Senate Bill 170 and House Bill 627 , landmark legislation recently passed by the General Assembly and slated to take effect on July 1, 2026. The new noncompete legislation applies to all employees and categorically bans noncompetes for almost all health care professionals, in sharp contrast to Virginia’s existing noncompete statutes, which currently cover only low-wage employees, including hourly employees." *Troutman Pepper Locke, Virginia Enacts New Restrictions on the Use of Noncompetes (2026).* <https://www.troutman.com/insights/virginia-enacts-new-restrictions-on-the-use-of-noncompetes/>
+
+[^ogletree-sb128-healthcare]: **Ogletree Deakins, Virginia Further Limits Noncompete Agreements** — "Meanwhile, the Virginia General Assembly also passed SB 128 , which would ban noncompete covenants for healthcare professionals , including any person licensed, registered, or certified by the Board of Medicine, Nursing, Counseling, Optometry, Psychology, or Social Work." *Ogletree Deakins, Virginia Further Limits Noncompete Agreements (2026).* <https://ogletree.com/insights-resources/blog-posts/virginia-further-limits-noncompete-agreements/>
+
+[^gt-sb170-prospective]: **Greenberg Traurig, Virginia Governor Signs Senate Bill 170, Targeting Noncompete Agreements** — "Contracts, covenants, or agreements entered into, amended, or renewed before July 1, 2026, are not affected by SB 170." *Greenberg Traurig, Virginia Governor Signs Senate Bill 170, Targeting Noncompete Agreements (Apr. 2026).* <https://www.gtlaw.com/en/insights/2026/4/virginia-governor-signs-senate-bill-170-targeting-noncompete-agreements>
+
+[^statute-nda-preserved]: **Va. Code § 40.1-28.7:8** — "Nothing in this section shall serve to limit the creation or application of nondisclosure agreements intended to prohibit the taking, misappropriating, threatening to misappropriate, or sharing of certain information to which an employee has access, including trade secrets, as defined in § 59.1-336, and proprietary or confidential information." *Va. Code Ann. § 40.1-28.7:8(C).* <https://law.lis.virginia.gov/vacode/40.1-28.7:8/>
+
+[^vutsa-trade-secret-definition]: **Va. Code § 59.1-336** — "Derives independent economic value, actual or potential, from not being generally known to, and not being readily ascertainable by proper means by, other persons who can obtain economic value from its disclosure or use, and 2. Is the subject of efforts that are reasonable under the circumstances to maintain its secrecy." *Va. Code Ann. § 59.1-336.* <https://law.lis.virginia.gov/vacode/59.1-336/>
+
+[^vutsa-injunctive-relief]: **Va. Code § 59.1-337** — "Actual or threatened misappropriation may be enjoined." *Va. Code Ann. § 59.1-337(A).* <https://law.lis.virginia.gov/vacode/59.1-337/>

--- a/skills/non-compete-contract-explainer/content/washington.md
+++ b/skills/non-compete-contract-explainer/content/washington.md
@@ -1,0 +1,296 @@
+---
+jurisdiction: "Washington"
+slug: washington
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-03"
+canonicalUrl: https://openagreements.org/legal/non-compete/washington
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/washington · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in Washington[^about]
+
+Washington enforces employee non-competes today only above high, inflation-adjusted earnings thresholds and under strict notice and consideration rules — and a near-total statutory ban takes effect June 30, 2027 under Engrossed Substitute House Bill 1155.
+
+
+## At a glance
+
+| Question | Washington |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed above a pay level |
+| **Bottom line** | Employee non-competes are void unless earnings exceed an inflation-adjusted threshold ($126,858.83 in 2026); a near-total ban takes effect June 30, 2027. |
+| **Main law or case** | RCW ch. 49.62 (ESHB 1155 ban from 2027) |
+| **Main exceptions** | Confidentiality, trade-secret, qualifying sale-of-business and franchise covenants; narrow non-solicits |
+| **When the ban took effect** | Near-total ban effective June 30, 2027 (ESHB 1155) |
+| **Can a court narrow it?** | Yes — rewrites to reasonable |
+| **Applies to contractors?** | Yes |
+| **Restriction extended during a breach?** | Not addressed by statute |
+| **Maximum length set by law** | 18 months (longer presumed unreasonable) |
+| **Must the employer pay to enforce?** | Yes — if laid off |
+
+## Are employee non-compete agreements enforceable in Washington? {#enforceability}
+
+**Short answer.** Today, only narrowly — and not for long. Washington's Noncompetition Covenants Act, chapter 49.62 RCW, makes an employee non-compete void unless the employer clears every statutory condition, including an earnings threshold that exceeds $126,858.83 for 2026 [^rcw-020-void-conditions][^lni-thresholds-enforceability]. A near-total ban on all non-competition covenants then takes effect on June 30, 2027 [^eshb1155-intent-enforceability][^eshb1155-effective-date-enforceability].
+
+The governing statute is RCW 49.62.020. It does not balance reasonableness the way the common law does; it lists conditions, and a covenant that misses any one of them is void and unenforceable as a matter of law. The conditions include a timely written disclosure, independent consideration for any post-hire covenant, an earnings threshold, and layoff compensation, with a separate eighteen-month outer limit on duration [^rcw-020-all-conditions].
+
+Two dates frame everything below. Covenants entered into now are governed by chapter 49.62 RCW as amended by Substitute Senate Bill 5935, effective June 6, 2024 [^ssb5935-amendments]. On June 30, 2027, Engrossed Substitute House Bill 1155 replaces that conditional regime with a near-total ban that voids non-competes regardless of income and adds an employer notice duty [^eshb1155-intent-enforceability][^eshb1155-effective-date-enforceability].
+
+"Unless the employee's earnings from the party seeking enforcement, when annualized, exceed one hundred thousand dollars per year."[^rcw-020-void-conditions]
+
+## When does a Washington employee earn enough to be bound by a non-compete? {#earnings-threshold}
+
+**Short answer.** Only when annualized earnings exceed the inflation-adjusted threshold, which is $126,858.83 for 2026. The statutory floor is $100,000, but RCW 49.62.040 requires the Department of Labor & Industries to raise it each year for inflation [^rcw-020-threshold][^rcw-040-adjustment][^lni-thresholds-earnings-threshold].
+
+Earnings are measured from the party seeking enforcement and annualized as of the earlier of the date enforcement is sought or the date of separation [^rcw-010-earnings]. Because the figure is reset annually, the controlling number is the one in effect when the covenant is tested, not the $100,000 base written into the statute [^rcw-040-adjustment][^lni-thresholds-earnings-threshold].
+
+> [!NOTE]
+> **Practice note.**
+>
+> The threshold is a floor, not a safe harbor. Clearing $126,858.83 only removes one of several independent grounds for voiding a covenant — the disclosure, consideration, layoff-pay, and duration rules below still apply, and after June 30, 2027 the threshold disappears entirely under the new ban [^rcw-020-threshold][^eshb1155-effective-date-earnings-threshold].
+
+## Can a Washington independent contractor be bound by a non-compete? {#independent-contractors}
+
+**Short answer.** Only at a much higher earnings level — over $317,147.09 for 2026, against a $250,000 statutory base — and a performer's non-compete is capped at three calendar days [^rcw-030-ic-threshold][^rcw-030-performer][^lni-thresholds-independent-contractors].
+
+RCW 49.62.030 sets a separate, higher threshold for independent contractors, adjusted annually under RCW 49.62.040 just like the employee figure [^rcw-030-ic-threshold][^lni-thresholds-independent-contractors]. It also includes an unusual rule for live entertainment: a covenant between a performer and a performance space cannot exceed three calendar days [^rcw-030-performer].
+
+Both of these rules are temporary. ESHB 1155 repeals RCW 49.62.030 outright effective June 30, 2027, after which an independent contractor's non-compete is void regardless of earnings — the same near-total ban that applies to employees [^eshb1155-repeals-ic].
+
+## What must a Washington employer do to make a non-compete valid at signing? {#disclosure-and-consideration}
+
+**Short answer.** Disclose the covenant in writing by the time the worker accepts the offer, and give independent consideration for any covenant signed after employment starts. Continued employment alone is not enough [^rcw-020-disclosure][^rcw-020-consideration][^labriola-independent-consideration].
+
+RCW 49.62.020 voids a non-compete unless the employer discloses its terms in writing no later than the time of the worker's initial oral or written acceptance of the offer of employment; a covenant produced later, in an onboarding packet, comes too late [^rcw-020-disclosure]. For a covenant entered into after employment begins, the employer must provide independent consideration [^rcw-020-consideration].
+
+That independent-consideration requirement codifies *Labriola v. Pollard Group, Inc.*, where the Washington Supreme Court held that a non-compete signed after hire is validly formed only with independent consideration and that simply keeping an existing at-will employee on the payroll does not count [^labriola-independent-consideration][^labriola-continued-employment].
+
+"A noncompete agreement entered into after employment has commenced is validly formed only when there is independent consideration at the time the agreement is reached."[^labriola-independent-consideration]
+
+## Can a laid-off Washington employee be held to a non-compete? {#layoff-pay}
+
+**Short answer.** Only if the employer pays for it. A covenant against a worker terminated by layoff is void unless the employer pays compensation equal to the worker's base salary for the enforcement period, offset by what the worker earns elsewhere [^rcw-020-layoff].
+
+This is Washington's garden-leave rule. An employer that lays a worker off cannot also enforce the non-compete for free; it must keep paying base salary during the restricted period, minus any compensation the former employee earns through subsequent employment [^rcw-020-layoff].
+
+## How long can a Washington non-compete last? {#duration}
+
+**Short answer.** Eighteen months is the practical ceiling. A court or arbitrator must presume that any non-compete longer than eighteen months after termination is unreasonable and unenforceable, and only clear and convincing evidence can rebut that presumption [^rcw-020-duration-duration].
+
+The presumption shifts the burden onto the employer: to enforce a covenant longer than eighteen months, the party seeking enforcement must prove by clear and convincing evidence that the longer term is necessary to protect its business or goodwill [^rcw-020-duration-duration].
+
+"A court or arbitrator must presume that any noncompetition covenant with a duration exceeding eighteen months after termination of employment is unreasonable and unenforceable."[^rcw-020-duration-duration]
+
+## What agreements count as non-competes under Washington law? {#what-counts}
+
+**Short answer.** A non-competition covenant is any agreement that restrains a worker from a lawful trade, and — since 2024 — any agreement that directly or indirectly prohibits accepting or transacting business with a customer. Confidentiality agreements, trade-secret covenants, qualifying sale-of-business covenants, and franchise-sale covenants are carved out [^rcw-010-definition][^rcw-010-acceptance-of-business-what-counts][^rcw-010-exclusions].
+
+The label on the document does not control. RCW 49.62.010 defines a non-competition covenant to include every written or oral covenant restraining a worker from a lawful profession, trade, or business [^rcw-010-definition]. Substitute Senate Bill 5935 then expanded the definition in 2024 to capture agreements that directly or indirectly prohibit the acceptance or transaction of business with a customer — so a no-business-with-customer clause is now a non-compete, subject to all the same conditions [^rcw-010-acceptance-of-business-what-counts].
+
+The statute carves out several covenants that are not non-competes: a nonsolicitation agreement, a confidentiality agreement, a covenant protecting trade secrets or inventions, a sale-of-business covenant where the signer holds at least one percent of the business, and a qualifying franchise covenant [^rcw-010-exclusions].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> A customer non-acceptance or no-business clause is not a safe substitute for a non-solicit. Because the 2024 amendment treats any agreement that directly or indirectly prohibits accepting or transacting business with a customer as a non-compete, drafting around the threshold by forbidding the customer relationship instead of the solicitation pulls the clause back inside RCW 49.62.020 [^rcw-010-acceptance-of-business-what-counts][^rcw-010-exclusions].
+
+## Are non-solicitation and franchise no-poach clauses still allowed in Washington? {#nonsolicitation}
+
+**Short answer.** Yes, but narrowly. A nonsolicitation agreement is exempt from the Act only if it is limited to soliciting the employer's employees or its current customers; and a franchisor cannot bar a franchisee from soliciting or hiring another franchisee's or the franchisor's employees [^rcw-010-nonsolicitation][^rcw-060-franchisor].
+
+The statutory definition of a nonsolicitation agreement is narrow: it reaches only solicitation, upon termination, of the employer's employees or of any current customer of the employer [^rcw-010-nonsolicitation]. A clause that goes beyond solicitation — for example, prohibiting the former worker from accepting business a customer brings to them — is treated as a non-compete instead [^rcw-010-acceptance-of-business-nonsolicitation].
+
+Washington also restricts franchise no-poach arrangements directly: a franchisor may not restrain a franchisee from soliciting or hiring employees of another franchisee of the same franchisor or of the franchisor itself [^rcw-060-franchisor].
+
+Non-solicitation agreements survive the 2027 ban, but on narrower terms. Effective June 30, 2027, ESHB 1155 rewrites the definition to require that the employee established or substantially developed a direct relationship with the customer and that the restriction last no longer than eighteen months [^eshb1155-nonsolicit-narrowing].
+
+## Can a Washington employer stop a low-wage employee from taking a second job? {#moonlighting}
+
+**Short answer.** No. An employer may not prohibit an employee earning less than twice the state minimum wage from taking an additional job, and the Washington Supreme Court has held that the duty-of-loyalty exception to that rule must be construed narrowly [^rcw-070-moonlighting][^david-second-jobs][^david-duty-of-loyalty].
+
+RCW 49.62.070 bars an employer from restraining an employee earning less than twice the applicable state minimum hourly wage from supplementing their income with another job, contract work, or self-employment, subject only to narrow safety and scheduling exceptions and the common-law duty of loyalty [^rcw-070-moonlighting].
+
+In *David v. Freedom Vans, LLC* (2025), the court applied that protection to strike down a blanket non-compete and refused to read the duty-of-loyalty exception broadly, warning that an expansive reading would render the chapter's worker protections meaningless [^david-second-jobs][^david-duty-of-loyalty].
+
+"In Washington, employers who pay their employees less than twice the minimum wage cannot prohibit them from working second jobs, subject to a few, limited exceptions."[^david-second-jobs]
+
+## Can an out-of-state choice-of-law or venue clause govern a Washington worker's non-compete? {#choice-of-law}
+
+**Short answer.** No. For a Washington-based worker, a provision requiring out-of-state adjudication, depriving the worker of the Act's protections, or applying another state's law is void and unenforceable [^rcw-050-choiceoflaw].
+
+RCW 49.62.050 forecloses the standard workaround of routing a Washington worker's covenant through a more employer-friendly state. A venue clause forcing adjudication elsewhere, a clause stripping the chapter's protections, and a choice-of-law clause applying non-Washington substantive law are each independently void as to a Washington-based worker [^rcw-050-choiceoflaw].
+
+## What are the penalties for an unenforceable Washington non-compete? {#penalties}
+
+**Short answer.** At least $5,000 per worker, plus fees — and the penalty is triggered even if a court only partially enforces or rewrites the covenant. The attorney general may also pursue relief [^rcw-080-penalty][^rcw-080-reformation-penalty-penalties][^rcw-080-ag].
+
+If a court or arbitrator finds a covenant violates the chapter, the violator must pay the aggrieved person the greater of actual damages or a $5,000 statutory penalty, plus reasonable attorneys' fees, expenses, and costs [^rcw-080-penalty]. Critically, the same penalty applies when a court reforms, rewrites, modifies, or only partially enforces the covenant — so an employer cannot rely on judicial blue-penciling to escape liability [^rcw-080-reformation-penalty-penalties].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Presenting an overbroad covenant and hoping a court will trim it is itself the risk. Because the penalty attaches even to a partially enforced or reformed covenant, the safer course is to draft within the statutory conditions from the outset rather than rely on a savings clause [^rcw-080-reformation-penalty-penalties][^rcw-080-penalty].
+
+## Are covenants outside the Act judged by a reasonableness test in Washington? {#common-law-reasonableness}
+
+**Short answer.** Yes. Chapter 49.62 RCW preserves the common law, and for a covenant the statute does not void, Washington courts apply a three-factor reasonableness test [^rcw-090-common-law][^perry-three-factors].
+
+The Act expressly does not revoke or impede the development of the common law [^rcw-090-common-law]. So a covenant that clears the statutory conditions — or one the statute does not reach — is still tested for reasonableness. Under *Perry v. Moran*, that test weighs three factors: whether the restraint is necessary to protect the employer's business or goodwill, whether it imposes a greater restraint than reasonably necessary, and the degree of injury to the public [^perry-three-factors]. *Emerick v. Cardiac Study Center, Inc.* confirms the modern formulation that a covenant is enforceable if reasonable [^emerick-enforceable-if-reasonable].
+
+"Whether a covenant is reasonable involves a consideration of three factors: (1) whether restraint is necessary for the protection of the business or goodwill of the employer, (2) whether it imposes upon the employee any greater restraint than is reasonably necessary to secure the employer's business or goodwill, and (3) whether the degree of injury to the public is such loss of the service and skill of the employee as to warrant nonenforcement of the covenant."[^perry-three-factors]
+
+> [!NOTE]
+> **Practice note.**
+>
+> This reasonableness analysis governs only until the 2027 ban. Once ESHB 1155 takes effect on June 30, 2027, a covered non-competition covenant is void regardless of how reasonable it is, so the common-law test will matter mainly for covenants the ban does not reach — such as true non-solicits and qualifying sale-of-business covenants [^eshb1155-ban-common-law][^rcw-090-common-law].
+
+## Will a Washington court rewrite or partially enforce an overbroad non-compete? {#court-narrowing}
+
+**Short answer.** A court can reform an overbroad covenant, but doing so triggers the statutory penalty. Washington courts have long enforced a covenant only to the extent it is reasonable, yet RCW 49.62.080 makes the employer pay the $5,000 penalty whenever a court reforms or partially enforces one [^woodmay-reasonable-extent-court-narrowing][^emerick-partial][^rcw-080-reformation-penalty-court-narrowing].
+
+Washington follows the reasonable-extent rule from *Wood v. May*: a court of equity enforces a restraint against a former employee only to the extent it is reasonable and necessary to protect a legitimate business interest [^woodmay-reasonable-extent-court-narrowing]. *Emerick* applies that to modern covenants, holding that when some terms are unreasonable the entire covenant does not fail — the court may modify it [^emerick-partial].
+
+But under the current statute, reformation is not free. RCW 49.62.080 imposes the $5,000 penalty (or greater actual damages) plus fees whenever a court reforms, rewrites, modifies, or only partially enforces a covenant [^rcw-080-reformation-penalty-court-narrowing].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not rely on a Washington court to save an overbroad covenant. Even though courts can reform, the act of reforming or partially enforcing triggers the statutory penalty against the employer, so scope, duration, and geography should be drafted to the minimum the legitimate interest requires [^rcw-080-reformation-penalty-court-narrowing][^woodmay-reasonable-extent-court-narrowing].
+
+## Does a Washington non-compete toll or extend during breach or litigation? {#tolling}
+
+**Short answer.** This is an open question, and the statute's structure cuts against automatic extension. Chapter 49.62 RCW does not address tolling or extending the restricted period during a breach or while litigation is pending, and the eighteen-month presumption caps duration regardless [^rcw-020-duration-tolling][^woodmay-reasonable-extent-tolling].
+
+Chapter 49.62 RCW does not address tolling or extension-on-breach clauses, and no controlling Washington decision squarely resolves whether such a clause is enforceable. Two features of Washington law point toward caution. First, RCW 49.62.020 presumes any covenant longer than eighteen months unreasonable, so a tolling clause that pushes enforcement past that window invites the presumption [^rcw-020-duration-tolling]. Second, *Wood v. May* limits a court to enforcing a restraint only to its reasonable extent, which sits uneasily with a clause that mechanically lengthens the restriction [^woodmay-reasonable-extent-tolling].
+
+> [!NOTE]
+> **Practice note.**
+>
+> Open question: Washington law is unsettled on whether a clause extending a non-compete during a period of breach or litigation is enforceable. Do not assume a court will toll or extend an expired Washington covenant, especially where the extension would carry the total restriction past eighteen months [^rcw-020-duration-tolling][^woodmay-reasonable-extent-tolling].
+
+## What changes when Washington's near-total non-compete ban takes effect on June 30, 2027? {#the-2027-ban}
+
+**Short answer.** Almost everything. Engrossed Substitute House Bill 1155 makes all non-competition covenants void regardless of income, turns enforcing or even threatening to enforce one into a violation, requires employers to notify affected workers by October 1, 2027, and repeals the income thresholds [^eshb1155-intent-the-2027-ban][^eshb1155-enforcement-violation][^eshb1155-notice-duty][^eshb1155-repeals].
+
+Signed on March 23, 2026 and effective June 30, 2027, ESHB 1155 (chapter 149, Laws of 2026) converts Washington from a conditional-enforceability state into a near-total ban [^eshb1155-intent-the-2027-ban][^eshb1155-effective-date-the-2027-ban]. Several changes matter for employers planning ahead:
+
+- 
+- 
+- 
+- 
+
+> [!NOTE]
+> **Practice note.**
+>
+> Start planning now, not in 2027. The ban applies regardless of when a covenant was signed and adds an October 1, 2027 notice obligation, so employers should inventory existing Washington covenants and prepare worker notices well before the effective date. Re-verify the enrolled text before acting, because implementing guidance may follow [^eshb1155-voidall][^eshb1155-notice-duty].
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-03. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not Washington. This article synthesizes Washington primary law and is not legal advice from a Washington-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^rcw-020-void-conditions]: **RCW 49.62.020** — "Unless the employee's earnings from the party seeking enforcement, when annualized, exceed one hundred thousand dollars per year." *RCW 49.62.020(1)(b).* <https://app.leg.wa.gov/RCW/default.aspx?cite=49.62.020>
+
+[^lni-thresholds-enforceability]: **Washington State Department of Labor & Industries — Non-Compete Agreements** — "Employees $116,593.18 $120,559.99 $123,394.17 $126,858.83 Independent Contractors $291,482.95 $301,399.98 $308,485.43 $317,147.09" *Wash. Dep't of Labor & Indus., Non-Compete Agreements (earnings thresholds, 2026).* <https://www.lni.wa.gov/workers-rights/workplace-policies/non-compete-agreements>
+
+[^eshb1155-intent-enforceability]: **Engrossed Substitute House Bill 1155, ch. 149, Laws of 2026** — "The legislature hereby intends to ban noncompetition covenants for all Washington-based workers and businesses." *Engrossed Substitute House Bill 1155, ch. 149, Laws of 2026, § 1(3).* <https://lawfilesext.leg.wa.gov/Biennium/2025-26/Htm/Bills/Session%20Laws/House/1155-S.SL.htm>
+
+[^eshb1155-effective-date-enforceability]: **Engrossed Substitute House Bill 1155, ch. 149, Laws of 2026** — "This act takes effect June 30, 2027." *Engrossed Substitute House Bill 1155, ch. 149, Laws of 2026, § 9.* <https://lawfilesext.leg.wa.gov/Biennium/2025-26/Htm/Bills/Session%20Laws/House/1155-S.SL.htm>
+
+[^rcw-020-all-conditions]: **RCW 49.62.020** — "(1) A noncompetition covenant is void and unenforceable: (a)(i) Unless the employer discloses the terms of the covenant in writing to the prospective employee no later than the time of the initial oral or written acceptance of the offer of employment and, if the agreement becomes enforceable only at a later date due to changes in the employee's compensation, the employer specifically discloses that the agreement may be enforceable against the employee in the future; or (ii) If the covenant is entered into after the commencement of employment, unless the employer provides independent consideration for the covenant; (b) Unless the employee's earnings from the party seeking enforcement, when annualized, exceed one hundred thousand dollars per year. This dollar amount must be adjusted annually in accordance with RCW 49.62.040 ; (c) If the employee is terminated as the result of a layoff, unless enforcement of the noncompetition covenant includes compensation equivalent to the employee's base salary at the time of termination for the period of enforcement minus compensation earned through subsequent employment during the period of enforcement." *RCW 49.62.020(1).* <https://app.leg.wa.gov/RCW/default.aspx?cite=49.62.020>
+
+[^ssb5935-amendments]: **Substitute Senate Bill 5935, ch. 36, Laws of 2024** — "AN ACT Relating to noncompetition covenants" *Substitute Senate Bill 5935, ch. 36, Laws of 2024.* <https://lawfilesext.leg.wa.gov/biennium/2023-24/Htm/Bills/Session%20Laws/Senate/5935-S.SL.htm>
+
+[^rcw-020-threshold]: **RCW 49.62.020** — "Unless the employee's earnings from the party seeking enforcement, when annualized, exceed one hundred thousand dollars per year. This dollar amount must be adjusted annually in accordance with RCW 49.62.040" *RCW 49.62.020(1)(b).* <https://app.leg.wa.gov/RCW/default.aspx?cite=49.62.020>
+
+[^rcw-040-adjustment]: **RCW 49.62.040** — "The dollar amounts specified in RCW 49.62.020 and 49.62.030 must be adjusted annually for inflation." *RCW 49.62.040.* <https://app.leg.wa.gov/RCW/default.aspx?cite=49.62.040>
+
+[^lni-thresholds-earnings-threshold]: **Washington State Department of Labor & Industries — Non-Compete Agreements** — "Employees $116,593.18 $120,559.99 $123,394.17 $126,858.83 Independent Contractors $291,482.95 $301,399.98 $308,485.43 $317,147.09" *Wash. Dep't of Labor & Indus., Non-Compete Agreements (earnings thresholds, 2026).* <https://www.lni.wa.gov/workers-rights/workplace-policies/non-compete-agreements>
+
+[^rcw-010-earnings]: **RCW 49.62.010** — "annualized and calculated as of the earlier of the date enforcement of the noncompetition covenant is sought or the date of separation from employment" *RCW 49.62.010(1).* <https://app.leg.wa.gov/RCW/default.aspx?cite=49.62.010>
+
+[^eshb1155-effective-date-earnings-threshold]: **Engrossed Substitute House Bill 1155, ch. 149, Laws of 2026** — "This act takes effect June 30, 2027." *Engrossed Substitute House Bill 1155, ch. 149, Laws of 2026, § 9.* <https://lawfilesext.leg.wa.gov/Biennium/2025-26/Htm/Bills/Session%20Laws/House/1155-S.SL.htm>
+
+[^rcw-030-ic-threshold]: **RCW 49.62.030** — "A noncompetition covenant is void and unenforceable against an independent contractor unless the independent contractor's earnings from the party seeking enforcement exceed two hundred fifty thousand dollars per year." *RCW 49.62.030(1).* <https://app.leg.wa.gov/RCW/default.aspx?cite=49.62.030>
+
+[^rcw-030-performer]: **RCW 49.62.030** — "The duration of a noncompetition covenant between a performer and a performance space, or a third party scheduling the performer for a performance space, must not exceed three calendar days." *RCW 49.62.030(2).* <https://app.leg.wa.gov/RCW/default.aspx?cite=49.62.030>
+
+[^lni-thresholds-independent-contractors]: **Washington State Department of Labor & Industries — Non-Compete Agreements** — "Employees $116,593.18 $120,559.99 $123,394.17 $126,858.83 Independent Contractors $291,482.95 $301,399.98 $308,485.43 $317,147.09" *Wash. Dep't of Labor & Indus., Non-Compete Agreements (earnings thresholds, 2026).* <https://www.lni.wa.gov/workers-rights/workplace-policies/non-compete-agreements>
+
+[^eshb1155-repeals-ic]: **Engrossed Substitute House Bill 1155, ch. 149, Laws of 2026** — "The following acts or parts of acts are each repealed: (1) RCW 49.62.030 (When void and unenforceable against independent contractors)" *Engrossed Substitute House Bill 1155, ch. 149, Laws of 2026, § 8.* <https://lawfilesext.leg.wa.gov/Biennium/2025-26/Htm/Bills/Session%20Laws/House/1155-S.SL.htm>
+
+[^rcw-020-disclosure]: **RCW 49.62.020** — "Unless the employer discloses the terms of the covenant in writing to the prospective employee no later than the time of the initial oral or written acceptance of the offer of employment" *RCW 49.62.020(1)(a)(i).* <https://app.leg.wa.gov/RCW/default.aspx?cite=49.62.020>
+
+[^rcw-020-consideration]: **RCW 49.62.020** — "If the covenant is entered into after the commencement of employment, unless the employer provides independent consideration for the covenant" *RCW 49.62.020(1)(a)(ii).* <https://app.leg.wa.gov/RCW/default.aspx?cite=49.62.020>
+
+[^labriola-independent-consideration]: **Labriola v. Pollard Group, Inc.** — "A noncompete agreement entered into after employment has commenced is validly formed only when there is independent consideration at the time the agreement is reached." *Labriola v. Pollard Group, Inc., 152 Wn.2d 828 (2004).* <https://www.courtlistener.com/opinion/4908367/labriola-v-pollard-group-inc/#:~:text=A%20noncompete%20agreement%20entered%20into,time%20the%20agreement%20is%20reached.>
+
+[^labriola-continued-employment]: **Labriola v. Pollard Group, Inc.** — "We hold that continued employment in this case did not serve as consideration by Employer in exchange for Employee's promise not to compete." *Labriola v. Pollard Group, Inc., 152 Wn.2d 828 (2004).* <https://www.courtlistener.com/opinion/4908367/labriola-v-pollard-group-inc/#:~:text=We%20hold%20that%20continued%20employment,Employee's%20promise%20not%20to%20compete.>
+
+[^rcw-020-layoff]: **RCW 49.62.020** — "If the employee is terminated as the result of a layoff, unless enforcement of the noncompetition covenant includes compensation equivalent to the employee's base salary at the time of termination for the period of enforcement minus compensation earned through subsequent employment during the period of enforcement." *RCW 49.62.020(1)(c).* <https://app.leg.wa.gov/RCW/default.aspx?cite=49.62.020>
+
+[^rcw-020-duration-duration]: **RCW 49.62.020** — "A court or arbitrator must presume that any noncompetition covenant with a duration exceeding eighteen months after termination of employment is unreasonable and unenforceable. A party seeking enforcement may rebut the presumption by proving by clear and convincing evidence that a duration longer than eighteen months is necessary to protect the party's business or goodwill." *RCW 49.62.020(2).* <https://app.leg.wa.gov/RCW/default.aspx?cite=49.62.020>
+
+[^rcw-010-definition]: **RCW 49.62.010** — "‘Noncompetition covenant’ includes every written or oral covenant, agreement, or contract by which an employee or independent contractor is prohibited or restrained from engaging in a lawful profession, trade, or business of any kind." *RCW 49.62.010(4).* <https://app.leg.wa.gov/RCW/default.aspx?cite=49.62.010>
+
+[^rcw-010-acceptance-of-business-what-counts]: **RCW 49.62.010** — "A ‘noncompetition covenant’ also includes an agreement that directly or indirectly prohibits the acceptance or transaction of business with a customer." *RCW 49.62.010(4).* <https://app.leg.wa.gov/RCW/default.aspx?cite=49.62.010>
+
+[^rcw-010-exclusions]: **RCW 49.62.010** — "A ‘noncompetition covenant’ does not include: (a) A nonsolicitation agreement; (b) a confidentiality agreement; (c) a covenant prohibiting use or disclosure of trade secrets or inventions; (d) a covenant entered into by a person purchasing or selling the goodwill of a business or otherwise acquiring or disposing of an ownership interest, but only if the person signing the covenant purchases, sells, acquires, or disposes of an interest representing one percent or more of the business; or (e) a covenant entered into by a franchisee when the franchise sale complies with RCW 19.100.020 (1)." *RCW 49.62.010(4).* <https://app.leg.wa.gov/RCW/default.aspx?cite=49.62.010>
+
+[^rcw-010-nonsolicitation]: **RCW 49.62.010** — "‘Nonsolicitation agreement’ means an agreement between an employer and employee that prohibits solicitation by an employee, upon termination of employment: (a) Of any employee of the employer to leave the employer; or (b) of any current customer of the employer to cease or reduce the extent to which it is doing business with the employer." *RCW 49.62.010(5).* <https://app.leg.wa.gov/RCW/default.aspx?cite=49.62.010>
+
+[^rcw-060-franchisor]: **RCW 49.62.060** — "No franchisor may restrict, restrain, or prohibit in any way a franchisee from soliciting or hiring any employee of a franchisee of the same franchisor. (2) No franchisor may restrict, restrain, or prohibit in any way a franchisee from soliciting or hiring any employee of the franchisor." *RCW 49.62.060(1)-(2).* <https://app.leg.wa.gov/RCW/default.aspx?cite=49.62.060>
+
+[^rcw-010-acceptance-of-business-nonsolicitation]: **RCW 49.62.010** — "A ‘noncompetition covenant’ also includes an agreement that directly or indirectly prohibits the acceptance or transaction of business with a customer." *RCW 49.62.010(4).* <https://app.leg.wa.gov/RCW/default.aspx?cite=49.62.010>
+
+[^eshb1155-nonsolicit-narrowing]: **Engrossed Substitute House Bill 1155, ch. 149, Laws of 2026** — "if the employee established or substantially developed a direct relationship with the customer, patient, client, or prospect through the employee's work for the employer and the prohibition expires no later than 18 months following termination of employment" *Engrossed Substitute House Bill 1155, ch. 149, Laws of 2026, § 3.* <https://lawfilesext.leg.wa.gov/Biennium/2025-26/Htm/Bills/Session%20Laws/House/1155-S.SL.htm>
+
+[^rcw-070-moonlighting]: **RCW 49.62.070** — "an employer may not restrict, restrain, or prohibit an employee earning less than twice the applicable state minimum hourly wage from having an additional job, supplementing their income by working for another employer, working as an independent contractor, or being self-employed." *RCW 49.62.070(1).* <https://app.leg.wa.gov/RCW/default.aspx?cite=49.62.070>
+
+[^david-second-jobs]: **David v. Freedom Vans, LLC** — "In Washington, employers who pay their employees less than twice the minimum wage cannot prohibit them from working second jobs, subject to a few, limited exceptions." *David v. Freedom Vans, LLC, 4 Wn.3d 242 (2025).* <https://www.courtlistener.com/opinion/10319821/springer-v-freedom-vans-llc/#:~:text=In%20Washington%2C%20employers%20who%20pay,to%20a%20few%2C%20limited%20exceptions.>
+
+[^david-duty-of-loyalty]: **David v. Freedom Vans, LLC** — "We decline to adopt this expansive view of the duty of loyalty, as it would render the employee protections in chapter 49.62 RCW meaningless and would require us to ignore the directive in the statute itself that the exceptions be construed narrowly." *David v. Freedom Vans, LLC, 4 Wn.3d 242 (2025).* <https://www.courtlistener.com/opinion/10319821/springer-v-freedom-vans-llc/#:~:text=We%20decline%20to%20adopt%20this,the%20exceptions%20be%20construed%20narrowly.>
+
+[^rcw-050-choiceoflaw]: **RCW 49.62.050** — "A provision in a noncompetition covenant signed by an employee or independent contractor who is Washington-based is void and unenforceable: (1) If the covenant requires the employee or independent contractor to adjudicate a noncompetition covenant outside of this state; (2) To the extent it deprives the employee or independent contractor of the protections or benefits of this chapter; or (3) If it allows or requires the application of choice of law principles or the substantive law of any jurisdiction other than Washington state." *RCW 49.62.050.* <https://app.leg.wa.gov/RCW/default.aspx?cite=49.62.050>
+
+[^rcw-080-penalty]: **RCW 49.62.080** — "If a court or arbitrator determines that a noncompetition covenant violates this chapter, the violator must pay the aggrieved person the greater of his or her actual damages or a statutory penalty of five thousand dollars, plus reasonable attorneys' fees, expenses, and costs incurred in the proceeding." *RCW 49.62.080(2).* <https://app.leg.wa.gov/RCW/default.aspx?cite=49.62.080>
+
+[^rcw-080-reformation-penalty-penalties]: **RCW 49.62.080** — "If a court or arbitrator reforms, rewrites, modifies, or only partially enforces any noncompetition covenant, the party seeking enforcement must pay the aggrieved person the greater of his or her actual damages or a statutory penalty of five thousand dollars, plus reasonable attorneys' fees, expenses, and costs incurred in the proceeding." *RCW 49.62.080(3).* <https://app.leg.wa.gov/RCW/default.aspx?cite=49.62.080>
+
+[^rcw-080-ag]: **RCW 49.62.080** — "Upon a violation of this chapter, the attorney general, on behalf of a person or persons, may pursue any and all relief." *RCW 49.62.080(1).* <https://app.leg.wa.gov/RCW/default.aspx?cite=49.62.080>
+
+[^rcw-090-common-law]: **RCW 49.62.090** — "Except as otherwise provided in this chapter, this chapter does not revoke, modify, or impede the development of the common law." *RCW 49.62.090(2).* <https://app.leg.wa.gov/RCW/default.aspx?cite=49.62.090>
+
+[^perry-three-factors]: **Perry v. Moran** — "Whether a covenant is reasonable involves a consideration of three factors: (1) whether restraint is necessary for the protection of the business or goodwill of the employer, (2) whether it imposes upon the employee any greater restraint than is reasonably necessary to secure the employer's business or goodwill, and (3) whether the degree of injury to the public is such loss of the service and skill of the employee as to warrant nonenforcement of the covenant." *Perry v. Moran, 109 Wn.2d 691 (1987).* <https://www.courtlistener.com/opinion/1453982/perry-v-moran/#:~:text=Whether%20a%20covenant%20is%20reasonable,warrant%20nonenforcement%20of%20the%20covenant.>
+
+[^emerick-enforceable-if-reasonable]: **Emerick v. Cardiac Study Center, Inc.** — "Under Washington law, noncompete covenants are enforceable if they are reasonable and lawful." *Emerick v. Cardiac Study Ctr., Inc., 189 Wn. App. 711 (2015).* <https://www.courtlistener.com/opinion/2830060/robert-emerick-v-cardiac-study-center-incps/#:~:text=Under%20Washington%20law%2C%20noncompete%20covenants,they%20are%20reasonable%20and%20lawful.>
+
+[^eshb1155-ban-common-law]: **Engrossed Substitute House Bill 1155, ch. 149, Laws of 2026** — "The legislature hereby intends to ban noncompetition covenants for all Washington-based workers and businesses." *Engrossed Substitute House Bill 1155, ch. 149, Laws of 2026, § 1(3).* <https://lawfilesext.leg.wa.gov/Biennium/2025-26/Htm/Bills/Session%20Laws/House/1155-S.SL.htm>
+
+[^woodmay-reasonable-extent-court-narrowing]: **Wood v. May** — "It is well settled that a court of equity will use its power to enforce a restriction against a former employee's competition only to the extent that such restriction is reasonable and necessary to protect a legitimate business interest of the employer." *Wood v. May, 73 Wn.2d 307 (1968).* <https://www.courtlistener.com/opinion/1207148/wood-v-may/#:~:text=It%20is%20well%20settled%20that,business%20interest%20of%20the%20employer.>
+
+[^emerick-partial]: **Emerick v. Cardiac Study Center, Inc.** — "If the trial court determines that certain terms of the covenant are unreasonable—such as the geographic and temporal scope of the restraint—the entire covenant does not fail." *Emerick v. Cardiac Study Ctr., Inc., 189 Wn. App. 711 (2015).* <https://www.courtlistener.com/opinion/2830060/robert-emerick-v-cardiac-study-center-incps/#:~:text=If%20the%20trial%20court%20determines,entire%20covenant%20does%20not%20fail.>
+
+[^rcw-080-reformation-penalty-court-narrowing]: **RCW 49.62.080** — "If a court or arbitrator reforms, rewrites, modifies, or only partially enforces any noncompetition covenant, the party seeking enforcement must pay the aggrieved person the greater of his or her actual damages or a statutory penalty of five thousand dollars, plus reasonable attorneys' fees, expenses, and costs incurred in the proceeding." *RCW 49.62.080(3).* <https://app.leg.wa.gov/RCW/default.aspx?cite=49.62.080>
+
+[^rcw-020-duration-tolling]: **RCW 49.62.020** — "A court or arbitrator must presume that any noncompetition covenant with a duration exceeding eighteen months after termination of employment is unreasonable and unenforceable." *RCW 49.62.020(2).* <https://app.leg.wa.gov/RCW/default.aspx?cite=49.62.020>
+
+[^woodmay-reasonable-extent-tolling]: **Wood v. May** — "It is well settled that a court of equity will use its power to enforce a restriction against a former employee's competition only to the extent that such restriction is reasonable and necessary to protect a legitimate business interest of the employer." *Wood v. May, 73 Wn.2d 307 (1968).* <https://www.courtlistener.com/opinion/1207148/wood-v-may/#:~:text=It%20is%20well%20settled%20that,business%20interest%20of%20the%20employer.>
+
+[^eshb1155-intent-the-2027-ban]: **Engrossed Substitute House Bill 1155, ch. 149, Laws of 2026** — "The legislature hereby intends to ban noncompetition covenants for all Washington-based workers and businesses." *Engrossed Substitute House Bill 1155, ch. 149, Laws of 2026, § 1(3).* <https://lawfilesext.leg.wa.gov/Biennium/2025-26/Htm/Bills/Session%20Laws/House/1155-S.SL.htm>
+
+[^eshb1155-enforcement-violation]: **Engrossed Substitute House Bill 1155, ch. 149, Laws of 2026** — "It is a violation of this chapter for an employer to enforce, attempt to enforce, or threaten to enforce against an employee or worker any noncompetition covenant, to represent that the employee or worker is subject to a noncompetition covenant, or to enter into or attempt to enter into a noncompetition covenant with an employee or worker." *Engrossed Substitute House Bill 1155, ch. 149, Laws of 2026, § 4(2).* <https://lawfilesext.leg.wa.gov/Biennium/2025-26/Htm/Bills/Session%20Laws/House/1155-S.SL.htm>
+
+[^eshb1155-notice-duty]: **Engrossed Substitute House Bill 1155, ch. 149, Laws of 2026** — "By October 1, 2027, an employer must make reasonable efforts to provide written notice to all current and former employees and independent contractors whose noncompetition covenant is still within its effective time period, that their noncompetition covenant is void and unenforceable." *Engrossed Substitute House Bill 1155, ch. 149, Laws of 2026, § 4(3).* <https://lawfilesext.leg.wa.gov/Biennium/2025-26/Htm/Bills/Session%20Laws/House/1155-S.SL.htm>
+
+[^eshb1155-repeals]: **Engrossed Substitute House Bill 1155, ch. 149, Laws of 2026** — "The following acts or parts of acts are each repealed: (1) RCW 49.62.030 (When void and unenforceable against independent contractors) and 2019 c 299 s 4; (2) RCW 49.62.040 (Dollar amounts adjusted) and 2019 c 299 s 5" *Engrossed Substitute House Bill 1155, ch. 149, Laws of 2026, § 8.* <https://lawfilesext.leg.wa.gov/Biennium/2025-26/Htm/Bills/Session%20Laws/House/1155-S.SL.htm>
+
+[^eshb1155-effective-date-the-2027-ban]: **Engrossed Substitute House Bill 1155, ch. 149, Laws of 2026** — "This act takes effect June 30, 2027." *Engrossed Substitute House Bill 1155, ch. 149, Laws of 2026, § 9.* <https://lawfilesext.leg.wa.gov/Biennium/2025-26/Htm/Bills/Session%20Laws/House/1155-S.SL.htm>
+
+[^eshb1155-voidall]: **Engrossed Substitute House Bill 1155, ch. 149, Laws of 2026** — "regardless of when the parties entered into the noncompetition covenant." *Engrossed Substitute House Bill 1155, ch. 149, Laws of 2026, § 4(1).* <https://lawfilesext.leg.wa.gov/Biennium/2025-26/Htm/Bills/Session%20Laws/House/1155-S.SL.htm>

--- a/skills/non-compete-contract-explainer/content/west-virginia.md
+++ b/skills/non-compete-contract-explainer/content/west-virginia.md
@@ -1,0 +1,187 @@
+---
+jurisdiction: "West Virginia"
+slug: west-virginia
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-02"
+canonicalUrl: https://openagreements.org/legal/non-compete/west-virginia
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/west-virginia · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in West Virginia[^about]
+
+West Virginia uses the common-law Reddy reasonableness test for employee non-competes, a strict anti-blue-pencil rule, an independent-consideration requirement for mid-employment covenants, special treatment for non-piracy clauses, a physician statute, and more flexible review for sale-of-business covenants.
+
+
+## At a glance
+
+| Question | West Virginia |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed if reasonable |
+| **Bottom line** | West Virginia enforces employee non-competes under the common-law Reddy reasonableness test, but a facially unreasonable covenant is void with no judicial narrowing, and a physician statute caps medical covenants at one year and thirty miles. |
+| **Main law or case** | common law (Reddy v. Cmty. Health Found. of Man, 171 W. Va. 368 (1982)) |
+| **Main exceptions** | Physician covenants capped at one year/30 road miles and void on employer termination (W. Va. Code § 47-11E); sale-of-business lesser scrutiny; non-piracy clauses less restrictive |
+| **Can a court narrow it?** | No |
+| **Applies to contractors?** | Unclear |
+| **Restriction extended during a breach?** | Open question |
+| **Maximum length set by law** | No general statutory limit; physician covenants capped at 1 year |
+
+## Are employee non-compete agreements enforceable in West Virginia? {#employee-noncompetes}
+
+**Short answer.** Sometimes. West Virginia does not ban ordinary employee non-competes, but the employer must satisfy *Reddy* by showing a legitimate protectable interest and a restraint that is no greater than needed, does not impose undue hardship, and is not injurious to the public [^reddy-employee-rule-of-reason].
+
+The threshold is not protection from ordinary competition. The employer must identify assets that justify restraint, such as trade secrets, customer lists, customer goodwill, or unusual employer-funded training. *Reddy* puts the burden on the employer to show the interest and explain how the former employee can injure it [^reddy-employer-burden].
+
+General skills are not enough. In *Helms Boys*, the court refused to enforce a furniture-store manager covenant because supervisory, merchandising, purchasing, and advertising skills were general managerial skills rather than protectable employer interests [^helms-general-managerial-skills]. *Voorhees* applied the same point to public customer information and ordinary sales work [^voorhees-no-protectable-interest].
+
+Recent application points the same way. In *Special Services Bureau*, the court affirmed denial of enforcement after the employer failed at the protectable-interest gate, so a separate reasonableness analysis was unnecessary [^special-services-protectable-interest-gate].
+
+## Will West Virginia courts narrow an overbroad non-compete? {#court-narrowing}
+
+**Short answer.** Only after the covenant passes the first screen. West Virginia's signature trap is that a covenant unreasonable on its face is void, and the court will not rescue it by rewriting or partially enforcing it [^reddy-facially-unreasonable-void].
+
+*Reddy* allows tailoring only after a covenant is facially reasonable and the employer proves legitimate interests. If the restraint is facially excessive in time, territory, or apparent purpose, the covenant is out before the court reaches partial enforcement [^reddy-facially-unreasonable-void][^huntington-eye-no-partial-enforcement].
+
+"An employee covenant not to compete is unreasonable on its face if its time or area limitations are excessively broad, or where the covenant appears designed to intimidate employees rather than to protect the employer’s business, and a court should hold any such covenant void and unenforceable, and not undertake even a partial enforcement of it, bearing in mind, however, that a standard of ‘unreasonable on its face’ is to be distinguished from the standard of ‘reasonableness’ used in inquiries adopted by other authorities to address the minor instances of overbreadth to which restrictive covenants are naturally prone."[^huntington-eye-no-partial-enforcement]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not draft a grasping West Virginia covenant on the assumption that a judge will fix it. The safer approach is to write the narrow restraint the employer can defend at signing, because facial overbreadth can make the covenant void rather than merely editable [^reddy-facially-unreasonable-void][^huntington-eye-no-partial-enforcement].
+
+## Does a West Virginia non-compete signed after employment starts need new consideration? {#mid-employment-consideration}
+
+**Short answer.** Yes. If employment began without a non-compete, a later covenant needs new, independent consideration; continued at-will employment alone is not enough under West Virginia law [^environmental-products-new-consideration].
+
+*Environmental Products* is the controlling West Virginia answer. The employee already had the same job, salary path, and generally available benefit plan when the covenant appeared, so the contract added limits without adding real employment benefits [^environmental-products-only-limitations].
+
+*Pemco* supplied the predecessor rule and reasoning: once the employment relationship exists without a covenant, a later non-compete must be a new contract supported by new consideration [^pemco-new-contract-new-consideration].
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> For a mid-employment West Virginia covenant, document the separate consideration in the agreement itself. A raise, bonus, promotion, equity grant, term extension, or other benefit must be real and covenant-linked; merely continuing the job is the fact pattern *Environmental Products* rejected [^environmental-products-new-consideration][^environmental-products-only-limitations].
+
+## Are customer non-solicitation clauses enforceable in West Virginia? {#customer-nonsolicits}
+
+**Short answer.** Yes, if they are true non-piracy provisions and not disguised non-competes. *Wood v. Acordia* treats customer non-solicits as less restrictive than non-competes because they restrict solicitation or use of confidential information while allowing general competition [^wood-nonpiracy-definition].
+
+The practical distinction matters. A non-compete bars similar work in a time and territory; a non-piracy provision targets solicitation of the former employer's customers or use of confidential information. Because the restriction follows customers and information rather than a map, *Wood* says non-piracy clauses ordinarily do not include territorial limits [^wood-no-territorial-limits].
+
+Validity still depends on a three-factor test: a protectable business interest, a provision that reasonably and fairly protects it, and no unjust restriction on the employee's chosen business activity. The employer bears the first two burdens, while the employee bears the unjust-restriction burden [^wood-three-factor-test].
+
+## Does the restricted period toll or extend during a breach or lawsuit in West Virginia? {#tolling}
+
+**Short answer.** This is an open West Virginia question. The staged West Virginia appellate corpus does not contain a decision squarely deciding whether a court may extend a non-compete period for time spent in breach or litigation, or whether an extension-on-breach clause is enforceable.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Treat tolling as unresolved and draft cautiously. *Reddy* says a facially unreasonable covenant is void [^reddy-tolling-facially-unreasonable], and *Huntington Eye* restates that courts should not undertake even partial enforcement of facially unreasonable employee covenants [^huntington-eye-tolling-no-partial-enforcement]. Those rules do not decide tolling, but they make judicially lengthening an expired restraint risky: a court that refuses to rewrite a grasping covenant may also resist adding time the parties did not validly supply. An express extension-on-breach clause is likewise a longer restraint, so it should independently satisfy *Reddy* reasonableness rather than being treated as automatic [^reddy-tolling-reasonableness-test].
+
+## What non-compete rules apply to West Virginia physicians? {#physician-rules}
+
+**Short answer.** West Virginia has a physician-specific statute. A physician employment non-compete is capped at one year and thirty road miles from the physician's primary practice location, and it is void and unenforceable if the employer terminates the physician's employment [^wv-47-11e-2-physician-limits][^wv-47-11e-2-employer-termination].
+
+The statute applies to written contracts between a physician and employer entered into, modified, renewed, or extended on or after July 1, 2017 [^wv-47-11e-5-applicability]. It defines covered covenants as restrictions on a physician's right to practice medicine in a West Virginia geographic area for a post-contract period or after employer termination [^wv-47-11e-1-definitions].
+
+The physician article preserves important alternatives. Unless the contract says otherwise, it does not limit provisions about employer property and patient records, repayment obligations, nondisclosure terms for confidential information and trade secrets, patient and employee non-solicits, liquidated damages, or other lawful provisions [^wv-47-11e-3-preserved-provisions].
+
+There are also statutory exemptions. The physician limits do not apply where the physician sold the practice or business to the employer, or to contracts between physicians who are shareholders, owners, partners, members, or directors of a health care practice, unless the contract provides otherwise [^wv-47-11e-4-exemptions].
+
+## Are sale-of-business non-competes treated differently in West Virginia? {#sale-of-business}
+
+**Short answer.** Yes. West Virginia applies reasonableness review to sale-of-business covenants, but with less scrutiny than employment covenants because the buyer is purchasing goodwill and the seller receives transaction value for the restraint [^weaver-lesser-scrutiny-sale][^weaver-sale-policy].
+
+*Weaver v. Ritchie* upheld a fifteen-year, fifty-mile restraint ancillary to the sale of an optometric practice, applying a sale-specific three-part inquiry: protection of the buyer, hardship on the seller, and public injury [^weaver-affirmed-injunction][^weaver-sale-three-part-test].
+
+The policy is different from employment. A sale covenant helps transfer goodwill and protect the price paid for the business; an employment covenant limits a person's ability to work after employment ends. That distinction is why West Virginia gives sale covenants more breathing room, but not unlimited enforcement [^weaver-sale-policy].
+
+## Are low-wage workers protected from non-competes in West Virginia? {#low-wage-workers}
+
+**Short answer.** There is no enacted West Virginia wage-threshold ban in the staged corpus. Low-wage protection instead comes through *Reddy*'s undue-hardship and public-interest prongs, plus the employer's burden to prove a legitimate protectable interest [^reddy-low-wage-undue-hardship].
+
+That means income level is not a standalone statutory cutoff the way it is in some states. It still matters factually. A restraint that makes an employee unable to earn a livelihood, while doing little to protect trade secrets, customer goodwill, or employer-funded training, is vulnerable under the same common-law reasonableness framework that governs other West Virginia employee covenants [^reddy-low-wage-undue-hardship][^helms-low-wage-general-skills].
+
+## Are trade-secret, NDA, and confidentiality tools available in West Virginia? {#trade-secrets-ndas}
+
+**Short answer.** Yes. West Virginia's Uniform Trade Secrets Act provides trade-secret remedies, allows attorney's fees in specified bad-faith or willful-malicious cases, and preserves contractual remedies while displacing conflicting tort, restitutionary, and other civil law for trade-secret misappropriation [^wv-47-22-4-attorney-fees][^wv-47-22-7-preserved-contract-remedies].
+
+For physicians, the non-compete statute expressly preserves nondisclosure provisions relating to confidential information and trade secrets, plus patient and employee non-solicits, unless the contract says otherwise [^wv-47-11e-3-nda-nonsolicit-preserved].
+
+For non-physician employees, ordinary contract and trade-secret tools are often cleaner than a work ban. *Reddy* identifies trade secrets and customer lists as classic protectable interests, but a confidentiality covenant should still be tied to actual confidential information rather than used as a practical non-compete [^reddy-trade-secrets-customer-lists].
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-02. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not West Virginia. This article synthesizes West Virginia primary law and is not legal advice from a West Virginia-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^reddy-employee-rule-of-reason]: **Reddy v. Community Health Foundation of Man** — "The three-dimensional method of inquiry has been summarized in a leading article: ‘A restraint is reasonable only if it (1) is no greater than is required for the protection of the employer, (2) does not impose undue hardship on the employee, and (3) is not injurious to the public,’ H.M. Blake, ‘Employee Agreements Not to Compete,’ supra, at 648." *Reddy v. Cmty. Health Found. of Man, 171 W. Va. 368, 298 S.E.2d 906 (1982).* <https://www.courtlistener.com/opinion/1309110/reddy-v-community-health-foundation-of-man/#:~:text=The%20three%2Ddimensional%20method%20of%20inquiry,to%20Compete%2C%E2%80%9D%20supra%2C%20at%20648.>
+
+[^reddy-employer-burden]: **Reddy v. Community Health Foundation of Man** — "The employer must first show that he has an interest requiring protection." *Reddy v. Cmty. Health Found. of Man, 171 W. Va. 368, 298 S.E.2d 906 (1982).* <https://www.courtlistener.com/opinion/1309110/reddy-v-community-health-foundation-of-man/#:~:text=The%20employer%20must%20first%20show,has%20an%20interest%20requiring%20protection.>
+
+[^helms-general-managerial-skills]: **Helms Boys, Inc. v. Brady** — "When the skills and information acquired by a former employee are of a general managerial nature, such as supervisory, merchandising, purchasing and advertising skills and information, a restrictive covenant in an employment contract will not be enforced because such skills are not protectible employer interests." *Helms Boys, Inc. v. Brady, 171 W. Va. 66, 297 S.E.2d 840 (1982).* <https://www.courtlistener.com/opinion/1356394/helms-boys-inc-v-brady/#:~:text=When%20the%20skills%20and%20information,are%20not%20protectible%20employer%20interests.>
+
+[^voorhees-no-protectable-interest]: **Voorhees v. Guyan Machinery Co.** — "In such circumstances, any information to which Mr. Voorhees was privy as a result of his position at Guyan Machinery was not subject to protection by the restrictive covenant." *Voorhees v. Guyan Mach. Co., 191 W. Va. 450, 446 S.E.2d 672 (1994).* <https://www.courtlistener.com/opinion/1347675/voorhees-v-guyan-machinery-co/#:~:text=In%20such%20circumstances%2C%20any%20information,protection%20by%20the%20restrictive%20covenant.>
+
+[^special-services-protectable-interest-gate]: **Special Services Bureau, Inc. v. Friend** — "The circuit court’s consideration of the reasonableness of the covenant was not necessary after the court found that the covenant failed on other grounds." *Special Servs. Bureau, Inc. v. Friend, No. 18-0478 (W. Va. Sept. 9, 2019) (mem. decision).* <https://www.courtlistener.com/opinion/4659311/special-services-bureau-inc-v-stacey-elizabeth-friend/#:~:text=The%20circuit%20court%E2%80%99s%20consideration%20of,covenant%20failed%20on%20other%20grounds.>
+
+[^reddy-facially-unreasonable-void]: **Reddy v. Community Health Foundation of Man** — "If the covenant is unreasonable on its face, then it is utterly void and unenforceable." *Reddy v. Cmty. Health Found. of Man, 171 W. Va. 368, 298 S.E.2d 906 (1982).* <https://www.courtlistener.com/opinion/1309110/reddy-v-community-health-foundation-of-man/#:~:text=If%20the%20covenant%20is%20unreasonable,is%20utterly%20void%20and%20unenforceable.>
+
+[^huntington-eye-no-partial-enforcement]: **Huntington Eye Associates, Inc. v. LoCascio** — "An employee covenant not to compete is unreasonable on its face if its time or area limitations are excessively broad, or where the covenant appears designed to intimidate employees rather than to protect the employer’s business, and a court should hold any such covenant void and unenforceable, and not undertake even a partial enforcement of it, bearing in mind, however, that a standard of ‘unreasonable on its face’ is to be distinguished from the standard of ‘reasonableness’ used in inquiries adopted by other authorities to address the minor instances of overbreadth to which restrictive covenants are naturally prone." *Huntington Eye Assocs., Inc. v. LoCascio, 210 W. Va. 76, 553 S.E.2d 773 (2001).* <https://www.courtlistener.com/opinion/1298767/huntington-eye-associates-inc-v-locascio/#:~:text=An%20employee%20covenant%20not%20to,restrictive%20covenants%20are%20naturally%20prone.>
+
+[^environmental-products-new-consideration]: **Environmental Products Co. v. Duncan** — "If a covenant not to compete is contracted after employment has been commenced without restriction, there must be new consideration to support it." *Env't Prods. Co. v. Duncan, 168 W. Va. 349, 285 S.E.2d 889 (1981).* <https://www.courtlistener.com/opinion/8217635/environmental-products-co-v-duncan/#:~:text=If%20a%20covenant%20not%20to,new%20consideration%20to%20support%20it.>
+
+[^environmental-products-only-limitations]: **Environmental Products Co. v. Duncan** — "His contract, therefore, did not alter any benefits, conditions or terms of employment; it only imposed limitations." *Env't Prods. Co. v. Duncan, 168 W. Va. 349, 285 S.E.2d 889 (1981).* <https://www.courtlistener.com/opinion/8217635/environmental-products-co-v-duncan/#:~:text=His%20contract%2C%20therefore%2C%20did%20not,employment%3B%20it%20only%20imposed%20limitations.>
+
+[^pemco-new-contract-new-consideration]: **Pemco Corp. v. Rose** — "We believe Virginia’s highest court would probably follow the holding in Kistler that when the relationship of employer and employee is established without a restrictive covenant not to compete, any agreement thereafter not to compete, must be in the nature of a new contract based upon a new consideration." *Pemco Corp. v. Rose, 163 W. Va. 420, 257 S.E.2d 885 (1979).* <https://www.courtlistener.com/opinion/8217515/pemco-corp-v-rose/#:~:text=We%20believe%20Virginia%E2%80%99s%20highest%20court,based%20upon%20a%20new%20consideration.>
+
+[^wood-nonpiracy-definition]: **Wood v. Acordia of West Virginia, Inc.** — "Accordingly, this Court holds that whereas a covenant not to compete in an employment agreement between an employer and an employee restricts the employee from engaging in business similar to that of the employer within a designated time and territory after the employment should cease, a non-piracy provision, also known as a non-solicitation or hands-off provision, in an employment agreement, restricts the employee, should the employment cease, from soliciting the employer's customers or making use of the employer's confidential information." *Wood v. Acordia of W. Va., Inc., 217 W. Va. 406, 618 S.E.2d 415 (2005).* <https://www.courtlistener.com/opinion/1289040/wood-v-acordia-of-west-virginia-inc/#:~:text=Accordingly%2C%20this%20Court%20holds%20that,of%20the%20employer's%20confidential%20information.>
+
+[^wood-no-territorial-limits]: **Wood v. Acordia of West Virginia, Inc.** — "Although both covenants not to compete and non-piracy provisions are utilized to safeguard an employer's protectable business interests, non-piracy provisions, which ordinarily do not include territorial limits, are less restrictive on the employee and the economic forces of the marketplace." *Wood v. Acordia of W. Va., Inc., 217 W. Va. 406, 618 S.E.2d 415 (2005).* <https://www.courtlistener.com/opinion/1289040/wood-v-acordia-of-west-virginia-inc/#:~:text=Although%20both%20covenants%20not%20to,economic%20forces%20of%20the%20marketplace.>
+
+[^wood-three-factor-test]: **Wood v. Acordia of West Virginia, Inc.** — "In addition, we hold that although a non-piracy provision in an employment agreement may appear reasonable on its face when viewed within the four corners of the agreement, the ultimate validity of such a provision is dependent upon: (1) whether the employer has a protectable business interest to be safeguarded in relation to the employee, (2) the extent to which the non-piracy provision reasonably and fairly protects that interest and (3) whether the non-piracy provision unjustly restricts the employee from engaging in the business activity he or she seeks to pursue." *Wood v. Acordia of W. Va., Inc., 217 W. Va. 406, 618 S.E.2d 415 (2005).* <https://www.courtlistener.com/opinion/1289040/wood-v-acordia-of-west-virginia-inc/#:~:text=In%20addition%2C%20we%20hold%20that,or%20she%20seeks%20to%20pursue.>
+
+[^reddy-tolling-facially-unreasonable]: **Reddy v. Community Health Foundation of Man** — "If the covenant is unreasonable on its face, then it is utterly void and unenforceable." *Reddy v. Cmty. Health Found. of Man, 171 W. Va. 368, 298 S.E.2d 906 (1982).* <https://www.courtlistener.com/opinion/1309110/reddy-v-community-health-foundation-of-man/#:~:text=If%20the%20covenant%20is%20unreasonable,is%20utterly%20void%20and%20unenforceable.>
+
+[^huntington-eye-tolling-no-partial-enforcement]: **Huntington Eye Associates, Inc. v. LoCascio** — "An employee covenant not to compete is unreasonable on its face if its time or area limitations are excessively broad, or where the covenant appears designed to intimidate employees rather than to protect the employer’s business, and a court should hold any such covenant void and unenforceable, and not undertake even a partial enforcement of it, bearing in mind, however, that a standard of ‘unreasonable on its face’ is to be distinguished from the standard of ‘reasonableness’ used in inquiries adopted by other authorities to address the minor instances of overbreadth to which restrictive covenants are naturally prone." *Huntington Eye Assocs., Inc. v. LoCascio, 210 W. Va. 76, 553 S.E.2d 773 (2001).* <https://www.courtlistener.com/opinion/1298767/huntington-eye-associates-inc-v-locascio/#:~:text=An%20employee%20covenant%20not%20to,restrictive%20covenants%20are%20naturally%20prone.>
+
+[^reddy-tolling-reasonableness-test]: **Reddy v. Community Health Foundation of Man** — "The three-dimensional method of inquiry has been summarized in a leading article: ‘A restraint is reasonable only if it (1) is no greater than is required for the protection of the employer, (2) does not impose undue hardship on the employee, and (3) is not injurious to the public,’ H.M. Blake, ‘Employee Agreements Not to Compete,’ supra, at 648." *Reddy v. Cmty. Health Found. of Man, 171 W. Va. 368, 298 S.E.2d 906 (1982).* <https://www.courtlistener.com/opinion/1309110/reddy-v-community-health-foundation-of-man/#:~:text=The%20three%2Ddimensional%20method%20of%20inquiry,to%20Compete%2C%E2%80%9D%20supra%2C%20at%20648.>
+
+[^wv-47-11e-2-physician-limits]: **W. Va. Code § 47-11E-2** — "A covenant not to compete contained in a contract between a physician and an employer shall be limited to not more than: (1) One year in duration; and (2) Thirty road miles from the physician’s primary place of practice with the employer." *W. Va. Code § 47-11E-2.* <https://code.wvlegislature.gov/47-11E-2/>
+
+[^wv-47-11e-2-employer-termination]: **W. Va. Code § 47-11E-2** — "A covenant not to compete shall be void and unenforceable upon the termination of the physician’s employment by the employer." *W. Va. Code § 47-11E-2.* <https://code.wvlegislature.gov/47-11E-2/>
+
+[^wv-47-11e-5-applicability]: **W. Va. Code § 47-11E-5** — "This article applies to any contract between a physician and his or her employer entered into, modified, renewed or extended on or after July 1, 2017: Provided, That the provisions of this article do not otherwise apply to or abrogate any contract in effect on or before June 30, 2017." *W. Va. Code § 47-11E-5.* <https://code.wvlegislature.gov/47-11E-5/>
+
+[^wv-47-11e-1-definitions]: **W. Va. Code § 47-11E-1** — "Covenant not to compete’ means any contract that restricts the right of a physician to practice medicine in any geographic area of the state for any period of time following the expiration of the physician’s contract with his or her employer, or upon the termination of the physician’s contract by the physician’s employer." *W. Va. Code § 47-11E-1.* <https://code.wvlegislature.gov/47-11E-1/>
+
+[^wv-47-11e-3-preserved-provisions]: **W. Va. Code § 47-11E-3** — "Provided that the contract does not state otherwise, nothing in this article limits the enforceability of: (1) Provisions prohibiting a physician from taking any property, patient lists or records of the employer with him or her upon the termination or expiration of the contract; (2) Provisions requiring a physician to repay an employer all or a portion of: (A) A loan; (B) Relocation expenses; (C) A signing bonus; (D) Remuneration to induce the physician to relocate or establish a physician practice in a specific geographic area; or (E) Recruiting, education and training expenses; (3) A nondisclosure provision relating to confidential information and trade secrets; (4) A nonsolicitation provision with respect to patients and employees of the employer; (5) A provision for liquidated damages; or (6) Any other provision of a contract that is not in violation of law." *W. Va. Code § 47-11E-3.* <https://code.wvlegislature.gov/47-11E-3/>
+
+[^wv-47-11e-4-exemptions]: **W. Va. Code § 47-11E-4** — "The limitations set forth in this article do not apply to any of the following unless the contract terms provide otherwise: (1) In the case where the physician has sold his or her business or practice in the form of a sale of assets, stock, membership interests or otherwise to his or her employer; or (2) To contracts between physicians who are shareholders, owners, partners, members or directors of a health care practice." *W. Va. Code § 47-11E-4.* <https://code.wvlegislature.gov/47-11E-4/>
+
+[^weaver-lesser-scrutiny-sale]: **Weaver v. Ritchie** — "Because the motivation and purpose of the restrictive covenant embraced in a sales agreement are substantially different from a covenant in an employment agreement, the rule of reason is applied with a lesser scrutiny in a sales contract than the covenant ancillary to an employment agreement." *Weaver v. Ritchie, 197 W. Va. 690, 478 S.E.2d 363 (1996).* <https://www.courtlistener.com/opinion/1328666/weaver-v-ritchie/#:~:text=Because%20the%20motivation%20and%20purpose,ancillary%20to%20an%20employment%20agreement.>
+
+[^weaver-sale-policy]: **Weaver v. Ritchie** — "A restriction imposed upon the seller of a business affords a person the freedom to sell something that has been acquired by virtue of their labor, skill or talent at the highest possible price." *Weaver v. Ritchie, 197 W. Va. 690, 478 S.E.2d 363 (1996).* <https://www.courtlistener.com/opinion/1328666/weaver-v-ritchie/#:~:text=A%20restriction%20imposed%20upon%20the,at%20the%20highest%20possible%20price.>
+
+[^weaver-affirmed-injunction]: **Weaver v. Ritchie** — "After a bench trial of several days, the trial court made findings of fact and conclusions of law holding that the covenant was valid and enforceable and entered a permanent injunction enjoining the appellant from practicing optometry within an area measured by a radius of fifty (50) miles from Vienna, West Virginia, and for a period of fifteen (15) years after the date of the sale. We affirm." *Weaver v. Ritchie, 197 W. Va. 690, 478 S.E.2d 363 (1996).* <https://www.courtlistener.com/opinion/1328666/weaver-v-ritchie/#:~:text=After%20a%20bench%20trial%20of,of%20the%20sale.%20We%20affirm.>
+
+[^weaver-sale-three-part-test]: **Weaver v. Ritchie** — "To determine if a covenant not to compete ancillary to a sale of a business is reasonable we use a three-part inquiry: A covenant not to compete is reasonable only if it (1) is no greater than is required for the protection of the buyer; (2) does not impose an undue hardship upon the seller, and (3) is not injurious to the public." *Weaver v. Ritchie, 197 W. Va. 690, 478 S.E.2d 363 (1996).* <https://www.courtlistener.com/opinion/1328666/weaver-v-ritchie/#:~:text=To%20determine%20if%20a%20covenant,not%20injurious%20to%20the%20public.>
+
+[^reddy-low-wage-undue-hardship]: **Reddy v. Community Health Foundation of Man** — "The three-dimensional method of inquiry has been summarized in a leading article: ‘A restraint is reasonable only if it (1) is no greater than is required for the protection of the employer, (2) does not impose undue hardship on the employee, and (3) is not injurious to the public,’ H.M. Blake, ‘Employee Agreements Not to Compete,’ supra, at 648." *Reddy v. Cmty. Health Found. of Man, 171 W. Va. 368, 298 S.E.2d 906 (1982).* <https://www.courtlistener.com/opinion/1309110/reddy-v-community-health-foundation-of-man/#:~:text=The%20three%2Ddimensional%20method%20of%20inquiry,to%20Compete%2C%E2%80%9D%20supra%2C%20at%20648.>
+
+[^helms-low-wage-general-skills]: **Helms Boys, Inc. v. Brady** — "When the skills and information acquired by a former employee are of a general managerial nature, such as supervisory, merchandising, purchasing and advertising skills and information, a restrictive covenant in an employment contract will not be enforced because such skills are not protectible employer interests." *Helms Boys, Inc. v. Brady, 171 W. Va. 66, 297 S.E.2d 840 (1982).* <https://www.courtlistener.com/opinion/1356394/helms-boys-inc-v-brady/#:~:text=When%20the%20skills%20and%20information,are%20not%20protectible%20employer%20interests.>
+
+[^wv-47-22-4-attorney-fees]: **W. Va. Code § 47-22-4** — "If (a) a claim of misappropriation is made in bad faith, or (b) a motion to terminate an injunction is made or resisted in bad faith, or (c) willful and malicious misappropriation occurs, the court may award reasonable attorney's fees to the prevailing party." *W. Va. Code § 47-22-4.* <https://code.wvlegislature.gov/47-22-4/>
+
+[^wv-47-22-7-preserved-contract-remedies]: **W. Va. Code § 47-22-7** — "Except as provided in subsection (b), of this section, this article displaces conflicting tort, restitutionary and other law of this state providing civil remedies for misappropriation of a trade secret. (b) This article does not affect: (1) Contractual remedies, whether or not based upon misappropriation of a trade secret; (2) Other civil remedies that are not based upon misappropriation of a trade secret; or (3) Criminal remedies, whether or not based upon misappropriation of a trade secret." *W. Va. Code § 47-22-7.* <https://code.wvlegislature.gov/47-22-7/>
+
+[^wv-47-11e-3-nda-nonsolicit-preserved]: **W. Va. Code § 47-11E-3** — "Provided that the contract does not state otherwise, nothing in this article limits the enforceability of: (1) Provisions prohibiting a physician from taking any property, patient lists or records of the employer with him or her upon the termination or expiration of the contract; (2) Provisions requiring a physician to repay an employer all or a portion of: (A) A loan; (B) Relocation expenses; (C) A signing bonus; (D) Remuneration to induce the physician to relocate or establish a physician practice in a specific geographic area; or (E) Recruiting, education and training expenses; (3) A nondisclosure provision relating to confidential information and trade secrets; (4) A nonsolicitation provision with respect to patients and employees of the employer; (5) A provision for liquidated damages; or (6) Any other provision of a contract that is not in violation of law." *W. Va. Code § 47-11E-3.* <https://code.wvlegislature.gov/47-11E-3/>
+
+[^reddy-trade-secrets-customer-lists]: **Reddy v. Community Health Foundation of Man** — "Trade secrets are very unlikely to have been paid for, and this is reflected by the reluctance of courts to permit their use by former employees in the competitive market. Customer lists, too, are seldom paid for, and courts are therefore reluctant to permit their competitive use." *Reddy v. Cmty. Health Found. of Man, 171 W. Va. 368, 298 S.E.2d 906 (1982).* <https://www.courtlistener.com/opinion/1309110/reddy-v-community-health-foundation-of-man/#:~:text=Trade%20secrets%20are%20very%20unlikely,to%20permit%20their%20competitive%20use.>

--- a/skills/non-compete-contract-explainer/content/wisconsin.md
+++ b/skills/non-compete-contract-explainer/content/wisconsin.md
@@ -1,0 +1,293 @@
+---
+jurisdiction: "Wisconsin"
+slug: wisconsin
+countryCode: US
+snapshotAsOf: "2026-06-08"
+lastReviewed: "2026-06-03"
+canonicalUrl: https://openagreements.org/legal/non-compete/wisconsin
+license: CC BY 4.0
+stale: false
+---
+
+> [!IMPORTANT]
+> **Informational only — not legal advice.** This is a snapshot of an OpenAgreements practice note,
+> provided for general information. It is not legal advice, does not create an attorney-client
+> relationship, and is not a substitute for a licensed attorney in the relevant jurisdiction.
+> Laws change; verify against the canonical version before relying on it.
+>
+> **Canonical:** https://openagreements.org/legal/non-compete/wisconsin · **Snapshot as of:** 2026-06-08 · License: CC BY 4.0 · © UseJunior
+
+# Non-Competes in Wisconsin[^about]
+
+A question-by-question summary of Wisconsin non-compete law under Wis. Stat. § 103.465, including the five-factor reasonableness test, the no-blue-pencil rule, divisibility of separate covenants, employee and customer non-solicitation, consideration, tolling and extension-during-breach clauses, choice of law, the 2025-26 legislative attempts, and trade-secret alternatives.
+
+
+## At a glance
+
+| Question | Wisconsin |
+| --- | --- |
+| **Are non-competes enforceable?** | Allowed if reasonable |
+| **Bottom line** | Wisconsin enforces employee non-competes only if they are reasonably necessary to protect a legitimate employer interest under a demanding five-factor test, and an overbroad covenant is voided in full because courts will not blue-pencil it. |
+| **Main law or case** | Wis. Stat. § 103.465 |
+| **Main exceptions** | Sale-of-business/equity covenants judged under common-law rule of reason; lawyers barred (SCR 20:5.6) |
+| **Can a court narrow it?** | No |
+| **Applies to contractors?** | Unclear |
+| **Restriction extended during a breach?** | No — an extension-during-breach clause voids the entire covenant (H&R Block v. Swenson) |
+| **Maximum length set by law** | No statutory limit |
+
+## Are employee non-compete agreements enforceable in Wisconsin? {#employee-noncompetes}
+
+**Short answer.** Yes, but only if they are reasonably necessary to protect a legitimate employer interest. Wisconsin is not a ban state, yet Wis. Stat. § 103.465 makes a restrictive covenant lawful and enforceable *only if* the restrictions imposed are reasonably necessary for the protection of the employer, and the courts apply a demanding five-factor test that an overbroad covenant fails [^q1-103465-core][^q1-star-direct-test].
+
+Wisconsin enforces employee non-competes, but it is a notably employee-protective reasonableness state. The governing statute, Wis. Stat. § 103.465, starts from the premise that a covenant is enforceable only when it is no broader than necessary to protect the employer.
+
+"A covenant by an assistant, servant or agent not to compete with his or her employer or principal during the term of the employment or agency, or after the termination of that employment or agency, within a specified territory and during a specified time is lawful and enforceable only if the restrictions imposed are reasonably necessary for the protection of the employer or principal."[^q1-103465-core]
+
+The Wisconsin Supreme Court has distilled that standard into five prerequisites, every one of which a covenant must satisfy. A failure on any single factor is fatal.
+
+"A restrictive covenant must: (1) be necessary for the protection of the employer, that is, the employer must have a protectable interest justifying the restriction imposed on the activity of the employee; (2) provide a reasonable time limit; (3) provide a reasonable territorial limit; (4) not be harsh or oppressive as to the employee; and (5) not be contrary to public policy."[^q1-star-direct-test]
+
+The practical consequence, explored in the questions below, is that drafting precision matters more in Wisconsin than in most states: a covenant that reaches even slightly too far is not narrowed by the court — it is struck down in full.
+
+## Can a Wisconsin court blue-pencil or narrow an overbroad non-compete? {#blue-pencil}
+
+**Short answer.** No. Wis. Stat. § 103.465 declares that a covenant imposing an unreasonable restraint is void and unenforceable *even as to any part* that would have been a reasonable restraint, so Wisconsin courts do not rewrite, narrow, or blue-pencil an overbroad covenant. The Court of Appeals has confirmed that a contractual modification or savings clause cannot rescue a covenant that violates the statute [^q2-103465-void][^q2-diamond-modification].
+
+This is the defining feature of Wisconsin restrictive-covenant law. In most reasonableness states a court can trim an overbroad covenant to a lawful scope; Wisconsin's statute forbids it.
+
+"Any covenant, described in this section, imposing an unreasonable restraint is illegal, void and unenforceable even as to any part of the covenant or performance that would be a reasonable restraint."[^q2-103465-void]
+
+Employers sometimes try to engineer around the rule with a clause authorizing a court to modify the covenant to whatever scope is enforceable. Wisconsin courts give such clauses no effect, because a provision that conflicts with § 103.465 cannot itself supply the missing reasonableness.
+
+"Given that the modification provision is contrary to WIS. STAT. § 103.465, it could have no effect here."[^q2-diamond-modification]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not rely on a reformation, savings, or *court-may-modify* clause to backstop an aggressive Wisconsin non-compete. Section 103.465 voids an unreasonable restraint even as to the part that would have been reasonable, and *Diamond Assets* held that a modification clause contrary to the statute has no effect [^q2-103465-void][^q2-diamond-modification].
+
+## Are separate restrictive covenants in one Wisconsin agreement severable? {#divisibility}
+
+**Short answer.** Yes, if they are genuinely distinct. Although a court cannot narrow a single overbroad covenant, *Star Direct, Inc. v. Dal Pra* holds that separate covenants supporting different interests that can be independently read and enforced are divisible, so one invalid covenant does not automatically doom a stand-alone confidentiality or non-solicitation clause [^q3-star-direct-divisible].
+
+Divisibility is different from blue-penciling. Blue-penciling means rewriting the words of one covenant; divisibility means treating two truly separate covenants as separate. Wisconsin forbids the first but allows the second.
+
+"Restrictive covenants are divisible when the contract contains different covenants supporting different interests that can be independently read and enforced."[^q3-star-direct-divisible]
+
+The structural lesson is to draft each restraint — non-compete, customer non-solicit, employee non-solicit, confidentiality — as a self-contained covenant that can stand or fall on its own, rather than as interlocking parts of one sprawling clause.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Write each restraint as a separate, independently enforceable covenant. Under *Star Direct*, distinct covenants supporting different interests are divisible, so isolating each one limits the damage if a court voids the most aggressive restraint [^q3-star-direct-divisible].
+
+## Are employee and customer non-solicitation covenants governed by § 103.465? {#nonsolicitation}
+
+**Short answer.** Yes. In *Manitowoc Co. v. Lanning*, the Wisconsin Supreme Court held that an employee non-solicitation provision is a restraint of trade governed by Wis. Stat. § 103.465, and it struck down a clause barring solicitation of any Manitowoc employee as overbroad on its face — voiding the covenant and undoing an award that had included roughly $1 million in attorney fees [^q4-lanning-governed][^q4-lanning-overbroad].
+
+Customer non-solicitation clauses have long been analyzed as § 103.465 restraints. The harder question was employee non-solicitation — no-poach clauses — which do not bar the departing employee from competing at all. *Lanning* resolved it: they are § 103.465 covenants too.
+
+"Accordingly, we conclude that Lanning's non-solicitation of employees provision is a restraint of trade governed by Wis. Stat. § 103.465."[^q4-lanning-governed]
+
+Because the clause swept in every Manitowoc employee — regardless of role, location, or whether the departing employee had any relationship with them — it failed the reasonableness test and was void in its entirety.
+
+"In applying the prerequisites that must be met under Wis. Stat. § 103.465, we conclude, as did the court of appeals, that the non-solicitation of employees provision is overbroad on its face."[^q4-lanning-overbroad]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Narrow an employee non-solicitation clause to the employees the departing worker actually worked with or supervised, not the whole company. *Manitowoc v. Lanning* treats employee non-solicitation as a § 103.465 restraint and voided an all-employees clause as overbroad on its face [^q4-lanning-governed][^q4-lanning-overbroad].
+
+## What consideration supports a Wisconsin non-compete signed during employment? {#consideration}
+
+**Short answer.** Conditioned continued employment is enough — at least formally. In *Runzheimer International, Ltd. v. Friedlen*, the Wisconsin Supreme Court held that an employer's forbearance in exercising its right to terminate an at-will employee is lawful consideration for signing a restrictive covenant, so an employer that actually forbears from termination in exchange for the covenant does not necessarily have to pay extra to bind an existing worker [^q5-runzheimer].
+
+The question in *Runzheimer* was whether merely keeping an at-will employee on the payroll could support a non-compete the employee was asked to sign mid-employment. The court said yes.
+
+"We hold that an employer's forbearance in exercising its right to terminate an at-will employee constitutes lawful consideration for signing a restrictive covenant."[^q5-runzheimer]
+
+The court paired that holding with a caution against bad faith: an employer that fires an employee immediately after extracting the signature may face other contract doctrines. Many Wisconsin practitioners therefore advise giving the employee something tangible — a raise, bonus, promotion, or new access — both to reduce litigation risk and to strengthen the reasonableness case.
+
+> [!NOTE]
+> **Practice note.**
+>
+> Even though continued at-will employment is technically sufficient consideration under *Runzheimer*, pairing a mid-employment covenant with new value (a raise, bonus, or promotion) is the safer course, because the court conditioned its holding on genuine forbearance rather than a sign-then-fire maneuver [^q5-runzheimer].
+
+## Can a Wisconsin non-compete be tolled or extended during a breach? {#tolling-during-breach}
+
+**Short answer.** No — and trying voids the covenant. In *H&R Block Eastern Enterprises, Inc. v. Swenson*, the Court of Appeals held that a clause extending the restricted period by any time the employee was in violation made the duration indefinite and unreasonable, so the entire clause was void under § 103.465 even if it would otherwise have been reasonable. A tolling or extension-during-breach clause is a void-trigger in Wisconsin, not an enforcement aid [^q6-hrblock-extension][^q6-hrblock-void].
+
+Many covenants include language stating that the clock pauses while the employee is breaching or while litigation is pending, so the employer gets the full period of compliance. In Wisconsin that drafting move backfires.
+
+"The effect of the extension provision thus makes the duration of the restraint not a fixed and definite time period but a time period that is contingent upon outcomes the employee cannot predict."[^q6-hrblock-extension]
+
+Because § 103.465 requires a reasonable — and therefore definite — time limit, an open-ended extension provision renders the whole restraint unreasonable. The court did not narrow the clause; it voided it.
+
+"Because this restraint in each clause is unreasonable, each clause is void and unenforceable even if each is otherwise reasonable."[^q6-hrblock-void]
+
+*Swenson* squarely addressed an extension-for-breach clause. A clause that instead tolls the period during *pending litigation* has not been tested by a Wisconsin court, but it raises the same definiteness problem — and the no-blue-pencil rule means a court that finds it unreasonable will void the restraint rather than save it.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Do not include a clause that extends a Wisconsin non-compete for periods of the employee's breach. *H&R Block v. Swenson* held that such an extension makes the duration indefinite and voids the entire clause under § 103.465, and Wisconsin courts will not blue-pencil it back to a fixed term; a pending-litigation tolling clause, while untested, carries the same risk [^q6-hrblock-extension][^q6-hrblock-void].
+
+## Are confidentiality and non-disclosure clauses subject to § 103.465 in Wisconsin? {#confidentiality-ndas}
+
+**Short answer.** They can be. In *Diamond Assets LLC v. Godina*, the Court of Appeals treated a broad confidentiality covenant as a restrictive covenant subject to Wis. Stat. § 103.465 and held it unenforceable on a motion to dismiss, regardless of any evidence the employer might later offer — because an overbroad confidentiality restraint fails the same reasonableness test as a non-compete [^q7-diamond-nda].
+
+A confidentiality clause that sweeps in ordinary, non-secret business information functions as a restraint on the employee's ability to work and is judged under § 103.465. If any part of the confidentiality covenant is unreasonable, the whole covenant fails.
+
+"As to the confidentiality covenant, we agree with Godina that it is properly subject to a motion to dismiss as unenforceable, regardless of the evidence Diamond might be able to submit."[^q7-diamond-nda]
+
+The takeaway is to scope confidentiality obligations to genuine trade secrets and competitively sensitive information, not to every fact the employee encountered. An NDA drafted as a catch-all is vulnerable to the same overbreadth attack as an aggressive non-compete.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Scope confidentiality and non-disclosure clauses to actual trade secrets and competitively sensitive information. *Diamond Assets* held an overbroad confidentiality covenant unenforceable under § 103.465 on a motion to dismiss, so a catch-all NDA can fall the same way an overbroad non-compete does [^q7-diamond-nda].
+
+## Are sale-of-business and ownership covenants treated differently in Wisconsin? {#sale-of-business}
+
+**Short answer.** Yes. A covenant given outside the employer-employee relationship — as part of a genuine business sale or equity transaction rather than as a condition of employment — falls outside § 103.465's exacting scrutiny and is judged under the common-law rule of reason. *Reiman Associates, Inc. v. R/A Advertising, Inc.* applied the more lenient rule of partial enforcement to a sale-of-business covenant, and *Selmer Co. v. Rinn* evaluated a covenant it found outside the employment relationship under the rule of reason instead of the statute [^q8-reiman][^q8-selmer].
+
+The statute by its terms governs covenants by an employee or agent. A covenant given by a seller of a business, or tied to an equity interest, is analyzed under the older common-law rule of reason — which, critically, *does* permit partial enforcement.
+
+"Additionally, covenants incidental to the sale of a business benefit from full application of the rule of partial enforcement: even an unreasonable restraint will be enforced to the extent necessary and reasonable under the circumstances."[^q8-reiman]
+
+*Selmer* confirms that the dividing line is the employment relationship, not the label on the document. A covenant connected to ownership or equity is measured against the common-law standard, not § 103.465.
+
+"Having determined Wis. Stat. § 103.465 does not apply, we must determine whether the covenant not to compete satisfies the common law's rule of reason."[^q8-selmer]
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Match the legal framework to the deal. A covenant given as part of a genuine business sale or equity transaction — one separable from the employment relationship and not imposed through the employer's hiring leverage — is judged under the common-law rule of reason, which allows partial enforcement, while an employee covenant is locked into § 103.465's all-or-nothing rule, so do not assume the two are interchangeable [^q8-reiman][^q8-selmer].
+
+## Can an out-of-state choice-of-law clause avoid Wisconsin's non-compete rules? {#choice-of-law}
+
+**Short answer.** Generally no. Wisconsin courts refuse to enforce a choice-of-law clause that would apply another state's more permissive covenant law in place of § 103.465, because doing so would violate Wisconsin's fundamental public policy. *Beilfuss v. Huffy Corp.* refused to apply Ohio law that permitted severability, and *Bush v. National School Studios* identified laws prohibiting covenants not to compete as the kind of fundamental policy that overrides a contractual choice of law [^q9-beilfuss][^q9-bush].
+
+A common strategy is to draft the agreement under the law of a state friendlier to non-competes. Wisconsin courts police that strategy when the covenant would be applied to Wisconsin work.
+
+"We hold the choice of law provision is unenforceable because it violates Wisconsin's long-standing public policy controlling covenants not to compete, in that Wisconsin does not permit severability as a matter of public policy, while Ohio does."[^q9-beilfuss]
+
+That public-policy override rests on the foundational choice-of-law analysis in *Bush*, which identified laws prohibiting covenants not to compete as an example of a policy strong enough to defeat a contractual choice of law.
+
+"In general, however, statutes or common law which make a particular type of contract enforceable, e.g., usury laws, or which make a particular contract provision unenforceable, e.g., laws prohibiting covenants not to compete, or that are designed to protect a weaker party against the unfair exercise of superior bargaining power by another party, are likely to embody an important state public policy."[^q9-bush]
+
+> [!NOTE]
+> **Practice note.**
+>
+> Do not assume a Delaware, Ohio, or other out-of-state choice-of-law clause will rescue a non-compete applied to Wisconsin employment. *Beilfuss* refused to enforce a choice-of-law clause that conflicted with § 103.465, relying on the fundamental-policy analysis of *Bush* [^q9-beilfuss][^q9-bush].
+
+## What remedies and litigation exposure apply to Wisconsin non-competes? {#remedies}
+
+**Short answer.** An employer can pursue injunctive relief and damages, and a recent decision recognizes disgorgement of profits as a remedy for tortious interference involving an employee non-compete; any attorney-fee award is in turn capped by a statutory reasonableness presumption. But the employee side has its own limits: under *Tatge v. Chambers & Owen, Inc.*, an at-will employee fired for refusing to sign a non-disclosure or non-compete agreement has no wrongful-discharge claim [^q10-frey][^q10-fees-presumption][^q10-tatge].
+
+On the employer side, *Frey Construction & Home Improvement, LLC v. Hasheider Roofing & Siding, Ltd.* recognized disgorgement as an available remedy where a competitor is found to have tortiously interfered with an employee non-compete.
+
+"However, we further conclude that disgorgement may be an appropriate remedy for an intentional interference with contract claim."[^q10-frey]
+
+On the employee side, Wisconsin does not turn an allegedly unreasonable covenant into a wrongful-discharge claim merely because an at-will employee refused to sign it.
+
+"We also hold that a contract cause of action for wrongful discharge may not be maintained under Brockmeyer where an at-will employee is terminated for failing to sign a non-disclosure/non-compete agreement."[^q10-tatge]
+
+Attorney-fee exposure deserves its own attention, because in restrictive-covenant litigation the fees can outrun the damages. Wisconsin's fee-reasonableness statute, Wis. Stat. § 814.045, presumes that reasonable attorney fees do not exceed three times the compensatory damages awarded, though a court may find a larger award reasonable after weighing the statutory factors.
+
+"In any action in which compensatory damages are awarded, the court shall presume that reasonable attorney fees do not exceed 3 times the amount of the compensatory damages awarded but this presumption may be overcome if the court determines, after considering the factors set forth in sub. (1) , that a greater amount is reasonable."[^q10-fees-presumption]
+
+The statute does not displace a contractual attorney-fee clause — common in non-compete agreements — and in fact presumes such an agreement is reasonable.
+
+"This section does not abrogate the rights of persons to enter into an agreement for attorney fees, and the court shall presume that such an agreement is reasonable."[^q10-fees-agreement]
+
+> [!NOTE]
+> **Practice note.**
+>
+> A competitor that hires away an employee bound by a Wisconsin non-compete can face a tortious-interference claim with disgorgement exposure under *Frey Construction*, while an employee fired for refusing to sign cannot rely on a wrongful-discharge theory under *Tatge* — so weigh the covenant's enforceability, not just the firing, before acting. Price in fee exposure too: § 814.045 anchors a fee award to a three-times-damages reasonableness presumption while still honoring a contractual fee clause [^q10-frey][^q10-tatge][^q10-fees-presumption][^q10-fees-agreement].
+
+## What recent legislation and industry-specific rules affect Wisconsin non-competes? {#legislation}
+
+**Short answer.** No statutory change took effect. In the 2025-26 session the legislature considered a broad ban (2025 Assembly Bill 567) and medical-practitioner restrictions (2025 Assembly Bill 675 and Senate Bill 657), but all three failed to pass at the end of the session, leaving § 103.465 unchanged. The main industry-specific rule already on the books is the lawyer non-compete bar in SCR 20:5.6 [^q11-ab567][^q11-ab675][^q11-sb657][^q11-scr].
+
+The most sweeping proposal, Assembly Bill 567, would have rewritten § 103.465 to bar most post-employment non-competes outright, with narrow carve-outs for certain customer-list and intellectual-property protections.
+
+"This bill makes most such covenants illegal, void, and unenforceable after the termination of employment or agency."[^q11-ab567]
+
+Two companion bills targeted health care, mirroring a national trend toward restricting physician and clinician non-competes.
+
+"This bill makes changes regarding covenants not to compete for advanced practice registered nurses, advanced practice nurse prescribers, physicians, physician assistants, and psychologists (‘medical practitioners’)."[^q11-ab675]
+
+All three measures failed to pass when the 2025-26 session ended, so none became law and § 103.465 continues to govern. One profession is already carved out by court rule: Wisconsin lawyers generally cannot be bound by non-competes.
+
+"A lawyer shall not participate in offering or making: (a) a partnership, shareholders, operating, employment, or other similar type of agreement that restricts the right of a lawyer to practice after termination of the relationship, except an agreement concerning benefits upon retirement; or (b) an agreement in which a restriction on the lawyer's right to practice is part of the settlement of a client controversy."[^q11-scr]
+
+> [!NOTE]
+> **Practice note.**
+>
+> Treat Wisconsin non-compete law as governed by § 103.465 and the case law, not by the 2025-26 bills. Assembly Bill 567 and the medical-practitioner bills (Assembly Bill 675 and Senate Bill 657) failed to pass, so re-check the legislature's status before relying on any of them, and remember that SCR 20:5.6 already bars most lawyer non-competes [^q11-ab567][^q11-scr].
+
+## How do trade-secret protections compare to a non-compete in Wisconsin? {#trade-secrets}
+
+**Short answer.** They are often the more reliable tool. Wisconsin has adopted the Uniform Trade Secrets Act at Wis. Stat. § 134.90, which protects qualifying information and authorizes injunctions and damages without the overbreadth risk that defeats so many non-competes — so an employer that cannot enforce a covenant may still protect genuine secrets [^q12-wutsa].
+
+Because a non-compete must clear § 103.465's all-or-nothing reasonableness test, many Wisconsin employers lean on trade-secret law, which turns on the nature of the information rather than the breadth of a contractual restraint. The statute defines what qualifies.
+
+"‘Trade secret’ means information, including a formula, pattern, compilation, program, device, method, technique or process to which all of the following apply: 1. The information derives independent economic value, actual or potential, from not being generally known to, and not being readily ascertainable by proper means by, other persons who can obtain economic value from its disclosure or use. 2. The information is the subject of efforts to maintain its secrecy that are reasonable under the circumstances."[^q12-wutsa]
+
+A trade-secret claim does not depend on a signed covenant and is not subject to § 103.465, so it survives even where a non-compete is void. The trade-off is that the employer must prove the information truly qualifies and that it took reasonable steps to keep it secret.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> Build the protection program around trade-secret safeguards — access controls, confidentiality designations, and exit procedures — rather than relying on a non-compete alone. Wis. Stat. § 134.90 protects qualifying secrets regardless of § 103.465, but only if the information meets the statutory definition and was kept reasonably secret [^q12-wutsa].
+
+[^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-06-03. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not Wisconsin. This article synthesizes Wisconsin primary law and is not legal advice from a Wisconsin-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
+
+[^q1-103465-core]: **Wis. Stat. § 103.465** — "A covenant by an assistant, servant or agent not to compete with his or her employer or principal during the term of the employment or agency, or after the termination of that employment or agency, within a specified territory and during a specified time is lawful and enforceable only if the restrictions imposed are reasonably necessary for the protection of the employer or principal." *Wis. Stat. § 103.465.* <https://docs.legis.wisconsin.gov/statutes/statutes/103/465>
+
+[^q1-star-direct-test]: **Star Direct, Inc. v. Dal Pra** — "A restrictive covenant must: (1) be necessary for the protection of the employer, that is, the employer must have a protectable interest justifying the restriction imposed on the activity of the employee; (2) provide a reasonable time limit; (3) provide a reasonable territorial limit; (4) not be harsh or oppressive as to the employee; and (5) not be contrary to public policy." *Star Direct, Inc. v. Dal Pra, 2009 WI 76, 319 Wis. 2d 274, 767 N.W.2d 898.* <https://www.courtlistener.com/opinion/1835915/star-direct-inc-v-dal-pra/#:~:text=A%20restrictive%20covenant%20must%3A%20(1),be%20contrary%20to%20public%20policy.>
+
+[^q2-103465-void]: **Wis. Stat. § 103.465** — "Any covenant, described in this section, imposing an unreasonable restraint is illegal, void and unenforceable even as to any part of the covenant or performance that would be a reasonable restraint." *Wis. Stat. § 103.465.* <https://docs.legis.wisconsin.gov/statutes/statutes/103/465>
+
+[^q2-diamond-modification]: **Diamond Assets LLC v. Godina** — "Given that the modification provision is contrary to WIS. STAT. § 103.465, it could have no effect here." *Diamond Assets LLC v. Godina, 2022 WI App 47.* <https://www.courtlistener.com/opinion/10110688/diamond-assets-llc-v-carlos-godina/#:~:text=Given%20that%20the%20modification%20provision,could%20have%20no%20effect%20here.>
+
+[^q3-star-direct-divisible]: **Star Direct, Inc. v. Dal Pra** — "Restrictive covenants are divisible when the contract contains different covenants supporting different interests that can be independently read and enforced." *Star Direct, Inc. v. Dal Pra, 2009 WI 76, 319 Wis. 2d 274, 767 N.W.2d 898.* <https://www.courtlistener.com/opinion/1835915/star-direct-inc-v-dal-pra/#:~:text=Restrictive%20covenants%20are%20divisible%20when,be%20independently%20read%20and%20enforced.>
+
+[^q4-lanning-governed]: **Manitowoc Co. v. Lanning** — "Accordingly, we conclude that Lanning's non-solicitation of employees provision is a restraint of trade governed by Wis. Stat. § 103.465." *Manitowoc Co. v. Lanning, 2018 WI 6.* <https://www.courtlistener.com/opinion/4460470/the-manitowoc-company-inc-v-john-m-lanning/#:~:text=Accordingly%2C%20we%20conclude%20that%20Lanning's,by%20Wis.%20Stat.%20%C2%A7%20103.465.>
+
+[^q4-lanning-overbroad]: **Manitowoc Co. v. Lanning** — "In applying the prerequisites that must be met under Wis. Stat. § 103.465, we conclude, as did the court of appeals, that the non-solicitation of employees provision is overbroad on its face." *Manitowoc Co. v. Lanning, 2018 WI 6.* <https://www.courtlistener.com/opinion/4460470/the-manitowoc-company-inc-v-john-m-lanning/#:~:text=In%20applying%20the%20prerequisites%20that,is%20overbroad%20on%20its%20face.>
+
+[^q5-runzheimer]: **Runzheimer Int'l, Ltd. v. Friedlen** — "We hold that an employer's forbearance in exercising its right to terminate an at-will employee constitutes lawful consideration for signing a restrictive covenant." *Runzheimer Int'l, Ltd. v. Friedlen, 2015 WI 45.* <https://www.courtlistener.com/opinion/2797640/runzheimer-international-ltd-v-david-friedlen/#:~:text=We%20hold%20that%20an%20employer's,for%20signing%20a%20restrictive%20covenant.>
+
+[^q6-hrblock-extension]: **H&R Block Eastern Enters., Inc. v. Swenson** — "The effect of the extension provision thus makes the duration of the restraint not a fixed and definite time period but a time period that is contingent upon outcomes the employee cannot predict." *H&R Block Eastern Enters., Inc. v. Swenson, 2008 WI App 3.* <https://www.courtlistener.com/opinion/1912635/hr-block-eastern-enterprises-inc-v-swenson/#:~:text=The%20effect%20of%20the%20extension,outcomes%20the%20employee%20cannot%20predict.>
+
+[^q6-hrblock-void]: **H&R Block Eastern Enters., Inc. v. Swenson** — "Because this restraint in each clause is unreasonable, each clause is void and unenforceable even if each is otherwise reasonable." *H&R Block Eastern Enters., Inc. v. Swenson, 2008 WI App 3.* <https://www.courtlistener.com/opinion/1912635/hr-block-eastern-enterprises-inc-v-swenson/#:~:text=Because%20this%20restraint%20in%20each,if%20each%20is%20otherwise%20reasonable.>
+
+[^q7-diamond-nda]: **Diamond Assets LLC v. Godina** — "As to the confidentiality covenant, we agree with Godina that it is properly subject to a motion to dismiss as unenforceable, regardless of the evidence Diamond might be able to submit." *Diamond Assets LLC v. Godina, 2022 WI App 47.* <https://www.courtlistener.com/opinion/10110688/diamond-assets-llc-v-carlos-godina/#:~:text=As%20to%20the%20confidentiality%20covenant%2C,might%20be%20able%20to%20submit.>
+
+[^q8-reiman]: **Reiman Assocs., Inc. v. R/A Advertising, Inc.** — "Additionally, covenants incidental to the sale of a business benefit from full application of the rule of partial enforcement: even an unreasonable restraint will be enforced to the extent necessary and reasonable under the circumstances." *Reiman Assocs., Inc. v. R/A Advertising, Inc., 102 Wis. 2d 305 (Ct. App. 1981).* <https://www.courtlistener.com/opinion/2033820/reiman-associates-inc-v-ra-advertising-inc/#:~:text=Additionally%2C%20covenants%20incidental%20to%20the,and%20reasonable%20under%20the%20circumstances.>
+
+[^q8-selmer]: **Selmer Co. v. Rinn** — "Having determined Wis. Stat. § 103.465 does not apply, we must determine whether the covenant not to compete satisfies the common law's rule of reason." *Selmer Co. v. Rinn, 2010 WI App 106.* <https://www.courtlistener.com/opinion/8238275/selmer-co-v-rinn/#:~:text=Having%20determined%20Wis.%20Stat.%20%C2%A7,common%20law's%20rule%20of%20reason.>
+
+[^q9-beilfuss]: **Beilfuss v. Huffy Corp.** — "We hold the choice of law provision is unenforceable because it violates Wisconsin's long-standing public policy controlling covenants not to compete, in that Wisconsin does not permit severability as a matter of public policy, while Ohio does." *Beilfuss v. Huffy Corp., 2004 WI App 118.* <https://www.courtlistener.com/opinion/2084488/beilfuss-v-huffy-corp/#:~:text=We%20hold%20the%20choice%20of%20law%20provision%20is,public%20policy%2C%20while%20Ohio%20does.>
+
+[^q9-bush]: **Bush v. National School Studios, Inc.** — "In general, however, statutes or common law which make a particular type of contract enforceable, e.g., usury laws, or which make a particular contract provision unenforceable, e.g., laws prohibiting covenants not to compete, or that are designed to protect a weaker party against the unfair exercise of superior bargaining power by another party, are likely to embody an important state public policy." *Bush v. National School Studios, Inc., 139 Wis. 2d 635 (1987).* <https://www.courtlistener.com/opinion/1236111/bush-v-national-school-studios-inc/#:~:text=In%20general%2C%20however%2C%20statutes%20or,an%20important%20state%20public%20policy.>
+
+[^q10-frey]: **Frey Construction & Home Improvement, LLC v. Hasheider Roofing & Siding, Ltd.** — "However, we further conclude that disgorgement may be an appropriate remedy for an intentional interference with contract claim." *Frey Construction & Home Improvement, LLC v. Hasheider Roofing & Siding, Ltd., 2025 WI App 4.* <https://www.courtlistener.com/opinion/10293559/frey-construction-home-improvement-llc-v-hasheider-roofing-siding/#:~:text=However%2C%20we%20further%20conclude%20that,intentional%20interference%20with%20contract%20claim.>
+
+[^q10-fees-presumption]: **Wis. Stat. § 814.045** — "In any action in which compensatory damages are awarded, the court shall presume that reasonable attorney fees do not exceed 3 times the amount of the compensatory damages awarded but this presumption may be overcome if the court determines, after considering the factors set forth in sub. (1) , that a greater amount is reasonable." *Wis. Stat. § 814.045(2)(a).* <https://docs.legis.wisconsin.gov/statutes/statutes/814/i/045>
+
+[^q10-tatge]: **Tatge v. Chambers & Owen, Inc.** — "We also hold that a contract cause of action for wrongful discharge may not be maintained under Brockmeyer where an at-will employee is terminated for failing to sign a non-disclosure/non-compete agreement." *Tatge v. Chambers & Owen, Inc., 219 Wis. 2d 99, 579 N.W.2d 217 (1998).* <https://www.courtlistener.com/opinion/2053665/tatge-v-chambers-owen-inc/#:~:text=We%20also%20hold%20that%20a,to%20sign%20a%20non%2Ddisclosure%2Fnon%2Dcompete%20agreement.>
+
+[^q10-fees-agreement]: **Wis. Stat. § 814.045** — "This section does not abrogate the rights of persons to enter into an agreement for attorney fees, and the court shall presume that such an agreement is reasonable." *Wis. Stat. § 814.045(3).* <https://docs.legis.wisconsin.gov/statutes/statutes/814/i/045>
+
+[^q11-ab567]: **2025 Wisconsin Assembly Bill 567** — "This bill makes most such covenants illegal, void, and unenforceable after the termination of employment or agency." *2025 Wisconsin Assembly Bill 567 (failed to pass, Mar. 23, 2026).* <https://docs.legis.wisconsin.gov/2025/related/proposals/ab567>
+
+[^q11-ab675]: **2025 Wisconsin Assembly Bill 675** — "This bill makes changes regarding covenants not to compete for advanced practice registered nurses, advanced practice nurse prescribers, physicians, physician assistants, and psychologists (‘medical practitioners’)." *2025 Wisconsin Assembly Bill 675 (failed to pass, Mar. 23, 2026).* <https://docs.legis.wisconsin.gov/2025/related/proposals/ab675>
+
+[^q11-sb657]: **2025 Wisconsin Senate Bill 657** — "The bill provides that a covenant by a medical practitioner not to compete with his or her employer after the termination of the employment imposes an unreasonable restraint and is illegal, void, and unenforceable if the covenant includes a restriction that prohibits working as a medical practitioner for more than 24 consecutive months after the first day of the medical practitioner's employment with the employer that is imposing the covenant not to compete." *2025 Wisconsin Senate Bill 657 (failed to pass, Mar. 23, 2026).* <https://docs.legis.wisconsin.gov/2025/related/proposals/sb657>
+
+[^q11-scr]: **Wis. SCR 20:5.6** — "A lawyer shall not participate in offering or making: (a) a partnership, shareholders, operating, employment, or other similar type of agreement that restricts the right of a lawyer to practice after termination of the relationship, except an agreement concerning benefits upon retirement; or (b) an agreement in which a restriction on the lawyer's right to practice is part of the settlement of a client controversy." *Wis. SCR 20:5.6.* <https://www.wicourts.gov/sc/rules/chap20b.pdf>
+
+[^q12-wutsa]: **Wis. Stat. § 134.90** — "‘Trade secret’ means information, including a formula, pattern, compilation, program, device, method, technique or process to which all of the following apply: 1. The information derives independent economic value, actual or potential, from not being generally known to, and not being readily ascertainable by proper means by, other persons who can obtain economic value from its disclosure or use. 2. The information is the subject of efforts to maintain its secrecy that are reasonable under the circumstances." *Wis. Stat. § 134.90(1)(c).* <https://docs.legis.wisconsin.gov/statutes/statutes/134/90>

--- a/skills/non-compete-contract-explainer/content/wyoming.md
+++ b/skills/non-compete-contract-explainer/content/wyoming.md
@@ -44,6 +44,21 @@ The statute covers covenants that restrict the right of any person to receive co
 
 The practical reading is that a standard post-employment employee non-compete should not be reused in Wyoming after the effective date unless it is deliberately drafted into one of the remaining statutory categories.
 
+The statute does not erase every Wyoming non-compete. Two categories fall outside the void and remain governed by Wyoming common law and its demanding reasonableness baseline: agreements entered into before July 1, 2025, which the act does not alter[^sf107-prospective-savings], and non-compete covenants drafted to fit a statutory exception. Fitting an exception keeps a non-compete out of the statutory void but does not make it automatically enforceable — such a covenant must still satisfy the common-law reasonableness elements[^malave-reasonableness-baseline], and Wyoming courts strictly construe[^brown-strict-construction-baseline] restraints against the employer. The next question covers what law still governs those covenants; the pre-2025 cohort also shrinks as those agreements age out.
+
+## What law governs Wyoming non-compete covenants the 2025 statute does not void? {#pre-2025-agreements}
+
+**Short answer.** Wyoming common law governs them, applying the same demanding reasonableness baseline that predated the statute. Two cohorts fall outside the statutory void: agreements entered into before July 1, 2025, which the act does not alter[^sf107-savings-clause], and non-compete covenants that fit a statutory exception.
+
+Falling outside the statutory void does not make either cohort easy to enforce. Wyoming common law uses traditional enforceability elements[^malave-five-elements]: the covenant must be written, part of an employment contract, supported by reasonable consideration, reasonable in duration and geography, and not against public policy.
+
+Wyoming cases also strictly construe non-competes[^brown-strict-construction] and put the burden on the employer to prove special circumstances that make the restraint reasonably necessary. For a post-hire covenant, continued employment alone is not enough consideration[^brown-separate-consideration]. The pre-2025 cohort shrinks as those agreements age out. Among the statutory exceptions, the ones that operate as non-competes — such as the executive-and-management carve-out — remain subject to this same reasonableness analysis, while the capped repayment carve-out is an expense-recovery mechanism judged on the statutory schedule rather than the reasonableness test. A later question covers the four exceptions in detail, and a separate question covers whether a court will narrow an overbroad covenant.
+
+> [!CAUTION]
+> **Drafting note.**
+>
+> No published Wyoming authority addresses tolling a non-compete during a breach. Wyoming strictly construes restrictive covenants and puts the burden on the employer to justify the restraint [^brown-strict-construction]. A tolling provision adds duration that faces the same reasonableness scrutiny as the original term — without judicial willingness to trim — so the realistic downside is voiding the covenant, not narrowing it.
+
 ## Does Wyoming's non-compete ban apply to independent contractors? {#independent-contractors}
 
 **Short answer.** Likely yes under the dominant 2025 law-firm commentary, but that is still an interpretation rather than a Wyoming appellate holding.
@@ -52,40 +67,29 @@ The reason is the statutory phrase "any person"[^wyo-1-23-any-person]. State-spe
 
 That is a strong drafting assumption for Wyoming templates, but a careful note should still say that Wyoming courts have not yet issued a controlling appellate decision on the contractor question.
 
-## What law governs Wyoming non-compete agreements signed before July 1, 2025? {#pre-2025-agreements}
+## Can a Wyoming court narrow an overbroad non-compete? {#court-narrowing}
 
-**Short answer.** Older agreements continue to be judged under Wyoming common law, because the 2025 act does not alter earlier contracts[^sf107-savings-clause].
-
-That does not mean older Wyoming non-competes are easy to enforce. Wyoming common law uses traditional enforceability elements[^malave-five-elements]: the covenant must be written, part of an employment contract, supported by reasonable consideration, reasonable in duration and geography, and not against public policy.
-
-Wyoming cases also strictly construe non-competes[^brown-strict-construction] and put the burden on the employer to prove special circumstances that make the restraint reasonably necessary. For a post-hire covenant, continued employment alone is not enough consideration[^brown-separate-consideration].
-
-> [!CAUTION]
-> **Drafting note.**
->
-> No published Wyoming authority addresses tolling a non-compete during a breach. Wyoming strictly construes restrictive covenants and puts the burden on the employer to justify the restraint [^brown-strict-construction]. A tolling provision adds duration that faces the same reasonableness scrutiny as the original term — without judicial willingness to trim — so the realistic downside is voiding the covenant, not narrowing it.
-
-## Can Wyoming courts blue-pencil or narrow an overbroad non-compete? {#court-narrowing}
-
-**Short answer.** No. The Wyoming Supreme Court rejected blue-penciling[^hassler-no-blue-pencil] for non-compete agreements.
+**Short answer.** No. The Wyoming Supreme Court will not rewrite an overbroad covenant[^hassler-no-blue-pencil] to bring it within the bounds of reason.
 
 The court held that the entire agreement was void because the duration and geographic terms were unreasonable. That makes overbreadth more expensive in Wyoming than in states where courts may trim an unreasonable covenant down to an enforceable scope.
 
 > [!CAUTION]
 > **Drafting note.**
 >
-> Do not assume a Wyoming court will rescue an overbroad covenant by narrowing it later. That caution applies to legacy agreements and to new agreements drafted inside a statutory exception [^holland-blue-pencil-warning].
+> A Wyoming court is unlikely to rescue an overbroad covenant by narrowing it later. That risk applies both to legacy agreements and to new agreements drafted inside a statutory exception [^holland-blue-pencil-warning].
 
 > [!CAUTION]
 > **Drafting note.**
 >
-> Tie duration and geography to specific business needs and document the reasonableness analysis at drafting time. Wyoming's no-blue-pencil rule means an overbroad covenant is voided whole rather than trimmed [^hassler-no-blue-pencil], so the upside of an aggressive scope is small relative to the risk of losing the covenant entirely.
+> Where a covenant falls within a statutory exception and enforceability matters, enforceability is more likely when duration and geography are tied to specific business needs and the reasonableness analysis is documented at drafting time. Because a Wyoming court will void an overbroad covenant whole rather than trim it [^hassler-no-blue-pencil], the upside of an aggressive scope is small relative to the risk of losing the covenant entirely.
 
 ## What non-compete restrictions are still allowed in Wyoming after July 1, 2025? {#available-restrictions}
 
 **Short answer.** Four categories remain in play: sale-of-business covenants, trade-secret covenants, capped repayment provisions, and covenants with executive and management personnel and their professional staff.
 
 The four statutory carveouts[^wyo-1-23-four-carveouts] are listed in Wyo. Stat. § 1-23-108(a). The repayment carveout is not a blank check; it is capped by the employee's tenure, with lower recovery percentages as service length increases.
+
+Fitting one of these categories keeps a covenant out of the statutory void, but it does not make the covenant automatically enforceable — an exception covenant that operates as a non-compete is still judged under the common-law reasonableness baseline covered in the earlier question on what law governs covenants the statute does not void.
 
 > [!CAUTION]
 > **Drafting note.**
@@ -95,7 +99,7 @@ The four statutory carveouts[^wyo-1-23-four-carveouts] are listed in Wyo. Stat. 
 > [!CAUTION]
 > **Drafting note.**
 >
-> The trade-secret exception covers covenants only to the extent they protect information that meets Wyoming's statutory trade-secret definition. Tie the contractual definition of protected information to that statutory bar and document why each category meets it, since how broadly Wyoming courts read the carveout remains an open question [^littler-trade-secret-unsettled].
+> The trade-secret exception covers covenants only to the extent they protect information that meets Wyoming's statutory trade-secret definition. Enforceability is more likely when the contractual definition of protected information is tied to that statutory bar and each category is documented as meeting it, since how broadly Wyoming courts read the carveout remains an open question [^littler-trade-secret-unsettled].
 
 ## Are customer non-solicitation agreements enforceable in Wyoming? {#customer-nonsolicits}
 
@@ -106,7 +110,7 @@ Brownstein takes the employer-friendly view that customer non-solicitation coven
 > [!CAUTION]
 > **Drafting note.**
 >
-> For drafting, separate a narrow customer-relationship restriction from language that prevents the person from earning compensation in a field, territory, or role. The closer the clause gets to a work ban, the more non-compete risk it carries [^fisher-classification-question].
+> A narrow customer-relationship restriction carries less risk than language that prevents the person from earning compensation in a field, territory, or role. The closer the clause gets to a work ban, the more non-compete risk it carries [^fisher-classification-question].
 
 ## Are employee non-solicitation agreements enforceable in Wyoming? {#employee-nonsolicits}
 
@@ -125,15 +129,15 @@ Brownstein says the statute does not affect nondisclosure or confidentiality agr
 > [!CAUTION]
 > **Drafting note.**
 >
-> Use confidentiality clauses to protect confidential information, not to prevent someone from working in a role, industry, or geography. The broader the definition of protected information, the more the clause begins to look like a non-compete substitute [^fisher-nda-question].
+> A confidentiality clause that protects confidential information carries less risk than one drafted to prevent someone from working in a role, industry, or geography. The broader the definition of protected information, the more the clause begins to look like a non-compete substitute [^fisher-nda-question].
 
-## Are anti-moonlighting clauses risky under Wyoming's non-compete law? {#anti-moonlighting}
+## Can Wyoming employers bind executives or managers to non-competes under the statutory exception? {#executives-managers}
 
-**Short answer.** Potentially. A narrow conflict-of-interest rule is different from a broad ban on outside work, but the statutory text creates risk for clauses that restrict compensation for labor.
+**Short answer.** Possibly, but the exception is not self-defining. Wyoming allows covenants with executive and management personnel and their professional staff, but the statute does not define those terms.
 
-The statute focuses on covenants that restrict compensation for skilled or unskilled labor [^wyo-1-23-compensation-focus]. Fisher Phillips specifically flags anti-moonlighting provisions as one of the adjacent covenant types Wyoming courts may need to classify under the 2025 statute [^fisher-anti-moonlighting].
+The statutory exception covers executive and management personnel[^wyo-1-23-exec-staff]. Law-firm commentary flags the drafting gap [^faegre-exec-undefined], and other law-firm commentary points to Colorado cases as possible nonbinding guidance because Colorado once used similar language [^fisher-actual-duties][^holland-colorado-analogy].
 
-This is useful to keep separate from non-competes because many employers do not call those clauses *non-competes*, even when they restrict outside work in a way that starts to resemble one.
+Those comparisons point toward function over title: supervision, autonomy, hiring or firing authority, and a meaningful role in implementing management functions. A *manager* label alone is not the safest basis for the Wyoming exception.
 
 ## Can a Wyoming non-compete prevent a physician from practicing medicine? {#physicians}
 
@@ -146,15 +150,15 @@ The harder question is the phrase "between physicians"[^wyo-1-23-between-physici
 > [!CAUTION]
 > **Drafting note.**
 >
-> Wyoming voids physician-to-physician practice restraints and protects the departing physician's right to share continuing-practice information with rare-disorder patients [^wyo-1-23-physician-bc]. Mirror that statutory protection in the clause itself, and avoid relying on the broader exec/management exception for physicians employed by non-physician entities — the "between physicians"[^wyo-1-23-between-physicians] language leaves that scope unsettled [^holland-between-physicians].
+> Wyoming voids physician-to-physician practice restraints and protects the departing physician's right to share continuing-practice information with rare-disorder patients [^wyo-1-23-physician-bc]. Mirroring that statutory protection in the clause itself reduces risk, and relying on the broader exec/management exception for physicians employed by non-physician entities is riskier — the "between physicians"[^wyo-1-23-between-physicians] language leaves that scope unsettled [^holland-between-physicians].
 
-## Can Wyoming employers bind executives or managers to non-competes under the statutory exception? {#executives-managers}
+## Are anti-moonlighting clauses risky under Wyoming's non-compete law? {#anti-moonlighting}
 
-**Short answer.** Possibly, but the exception is not self-defining. Wyoming allows covenants with executive and management personnel and their professional staff, but the statute does not define those terms.
+**Short answer.** Potentially. A narrow conflict-of-interest rule is different from a broad ban on outside work, but the statutory text creates risk for clauses that restrict compensation for labor.
 
-The statutory exception covers executive and management personnel[^wyo-1-23-exec-staff]. Law-firm commentary flags the drafting gap [^faegre-exec-undefined], and other law-firm commentary points to Colorado cases as possible nonbinding guidance because Colorado once used similar language [^fisher-actual-duties][^holland-colorado-analogy].
+The statute focuses on covenants that restrict compensation for skilled or unskilled labor [^wyo-1-23-compensation-focus]. Fisher Phillips specifically flags anti-moonlighting provisions as one of the adjacent covenant types Wyoming courts may need to classify under the 2025 statute [^fisher-anti-moonlighting].
 
-Those comparisons point toward function over title: supervision, autonomy, hiring or firing authority, and a meaningful role in implementing management functions. A *manager* label alone is not the safest basis for the Wyoming exception.
+This is useful to keep separate from non-competes because many employers do not call those clauses *non-competes*, even when they restrict outside work in a way that starts to resemble one.
 
 ## Can Wyoming employers recover relocation, education, or training expenses from departing employees? {#repayment-clauses}
 
@@ -165,13 +169,13 @@ Wyoming permits recovery of up to 100% of relocation, education, and training ex
 > [!CAUTION]
 > **Drafting note.**
 >
-> Draft this as an expense-recovery provision, not as a disguised penalty for competition. Tie the amount to actual relocation, education, or training expense and the statutory percentages [^ogletree-repayment-tier][^faegre-repayment-tier].
+> A clause drafted as an expense-recovery provision carries less risk than one that operates as a disguised penalty for competition. Enforceability is more likely when the amount is tied to actual relocation, education, or training expense and the statutory percentages [^ogletree-repayment-tier][^faegre-repayment-tier].
 
-## Do employers need to update Wyoming restrictive covenant templates after July 1, 2025? {#template-updates}
+## Should employers update or re-review Wyoming restrictive covenant templates after July 1, 2025? {#template-updates}
 
-**Short answer.** Yes. The new statute turns template rollover into a legal risk point, especially if an older covenant might have remained enforceable under common law.
+**Short answer.** Probably yes — and at least re-review. Any form that contains a non-compete outside a statutory exception should be updated, while a form with no non-compete may already conform; either way the new statute turns unreviewed template rollover into a legal risk point, especially where an older covenant might have remained enforceable under common law.
 
-Wyoming-specific commentary treats SF 107 as a major narrowing of employer practice, not a minor drafting tweak [^ogletree-review-revise]. Employers should review non-compete templates, offer letters, incentive agreements, physician agreements, non-solicits, NDAs, anti-moonlighting clauses, and repayment provisions together.
+Wyoming-specific commentary treats SF 107 as a major narrowing of employer practice, not a minor drafting tweak [^ogletree-review-revise]. A complete re-review usually covers non-compete templates, offer letters, incentive agreements, physician agreements, non-solicits, NDAs, anti-moonlighting clauses, and repayment provisions together.
 
 Commentary specifically warns employers to evaluate routine replacement or updating programs because a new agreement after July 1, 2025 may replace something that was enforceable with something void [^littler-rollover-warning]. Where a grandfathered covenant needs changes, commentary suggests amending or renewing it rather than signing a fresh agreement, when the existing terms allow that, so the covenant is not treated as newly entered into after the effective date [^holland-amend-not-replace]. The common-law cases also mean that even old-law Wyoming covenants required careful drafting [^brown-baseline][^malave-baseline][^hassler-baseline].
 
@@ -183,7 +187,7 @@ Commentary specifically warns employers to evaluate routine replacement or updat
 
 **July 1, 2025:** The new statute took effect for contracts entered into on or after that date. Earlier contracts were not altered, amended, or impaired by the act [^sf107-effective-date].
 
-**2021–2022 backdrop:** Wyoming's common-law baseline was already demanding because of strict construction, consideration, and no-blue-pencil cases [^brown-prima-facie][^malave-common-law-elements][^hassler-void-public-policy].
+**2021–2022 backdrop:** Wyoming's common-law baseline was already demanding because of strict construction, consideration, and no-narrowing cases [^brown-prima-facie][^malave-common-law-elements][^hassler-void-public-policy].
 
 [^about]: By Steven Obiajulu, J.D. Published by [openagreements.org](https://openagreements.org) · Maintained by [UseJunior](https://usejunior.com). Last reviewed 2026-04-14. License: CC BY 4.0. Steven Obiajulu, J.D. is admitted in New York, not Wyoming. This article synthesizes Wyoming primary law and is not legal advice from a Wyoming-admitted attorney. This article is for informational purposes only and does not create an attorney-client relationship.
 
@@ -199,13 +203,11 @@ Commentary specifically warns employers to evaluate routine replacement or updat
 
 [^holland-uphill-battle]: **Holland & Hart commentary** — "Employers still have an uphill battle to enforce a covenant not to compete in court." *Holland & Hart, Wyoming Legislature Takes a Bite Out of Covenants Not to Compete (2025).* <https://www.hollandhart.com/wyoming-legislature-takes-a-bite-out-of-covenants-not-to-compete-1>
 
-[^wyo-1-23-any-person]: **Wyo. Stat. § 1-23-108(a)** — "Any covenant not to compete that restricts the right of any person to receive compensation for performance of skilled or unskilled labor shall be void." *Wyo. Stat. § 1-23-108(a) (2025).* <https://wyoleg.gov/2025/Enroll/SF0107.pdf>
+[^sf107-prospective-savings]: **SF 107 § 2(b)** — "Nothing in this act shall be construed to alter, amend or impair any contract or agreement entered into before July 1, 2025." *S.F. 107, Enrolled Act No. 87, § 2(b), 68th Leg., Gen. Sess. (Wyo. 2025).* <https://wyoleg.gov/2025/Enroll/SF0107.pdf>
 
-[^littler-any-status]: **Littler Mendelson commentary** — "The Act contains language broad enough to make most non-compete covenants with workers void regardless of a worker's status as an employee or an independent contractor" *Littler Mendelson, Wyoming Bans Non-Compete Covenants with Some Exceptions (2025).* <https://www.littler.com/news-analysis/asap/wyoming-bans-non-compete-covenants-some-exceptions>
+[^malave-reasonableness-baseline]: **Malave v. Western Wyoming Beverages, Inc.** — "A valid and enforceable covenant not to compete requires a showing that the covenant is: (1) in writing; (2) part of a contract of employment; (3) based on reasonable consideration; (4) reasonable in durational and geographical limitations; and (5) not against public policy." *Malave v. Western Wyoming Beverages, Inc., 2022 WY 14, 503 P.3d 36.* <https://law.justia.com/cases/wyoming/supreme-court/2022/s-21-0140.html#:~:text=A%20valid%20and%20enforceable%20covenant,(5)%20not%20against%20public%20policy.>
 
-[^faegre-includes-contractors]: **Faegre Drinker commentary** — "Given that the law applies this restriction to agreements with any ‘person,’ this bans noncompete agreements with both employees and independent contractors" *Faegre Drinker, Wyoming Enacts Significant Restrictions on Noncompete Agreements (2025).* <https://www.faegredrinker.com/en/insights/publications/2025/3/wyoming-enacts-significant-restrictions-on-noncompete-agreements>
-
-[^fisher-colorado-any-person]: **Fisher Phillips commentary** — "any covenant not to compete that restricts the right of any person to receive compensation for performance of skilled or unskilled labor...several provisions closely mirror language found in Colorado's prior non-compete statute" *Fisher Phillips, New Law Voids Most Wyoming Non-Compete Agreements (2025).* <https://www.fisherphillips.com/en/insights/insights/new-law-voids-most-wyoming-non-compete-agreements>
+[^brown-strict-construction-baseline]: **Brown v. Best Home Health & Hospice, LLC** — "Contracts which hinder them from doing so are ‘strictly construed and rigidly scanned and are declared void unless necessary for the reasonable protection of the employer.’" *Brown v. Best Home Health & Hospice, LLC, 2021 WY 83, 491 P.3d 1021.* <https://www.courtlistener.com/opinion/9998787/jennifer-brown-fka-jennifer-stringer-nora-youngren-and-carol-wolfe-v/#:~:text=Contracts%20which%20hinder%20them%20from,reasonable%20protection%20of%20the%20employer.%22>
 
 [^sf107-savings-clause]: **SF 107 § 2(b)** — "Nothing in this act shall be construed to alter, amend or impair any contract or agreement entered into before July 1, 2025." *S.F. 107, Enrolled Act No. 87, § 2(b), 68th Leg., Gen. Sess. (Wyo. 2025).* <https://wyoleg.gov/2025/Enroll/SF0107.pdf>
 
@@ -214,6 +216,14 @@ Commentary specifically warns employers to evaluate routine replacement or updat
 [^brown-strict-construction]: **Brown v. Best Home Health & Hospice, LLC** — "Contracts which hinder them from doing so are ‘strictly construed and rigidly scanned and are declared void unless necessary for the reasonable protection of the employer.’" *Brown v. Best Home Health & Hospice, LLC, 2021 WY 83, 491 P.3d 1021.* <https://www.courtlistener.com/opinion/9998787/jennifer-brown-fka-jennifer-stringer-nora-youngren-and-carol-wolfe-v/#:~:text=Contracts%20which%20hinder%20them%20from,reasonable%20protection%20of%20the%20employer.%22>
 
 [^brown-separate-consideration]: **Brown v. Best Home Health & Hospice, LLC** — "when an employer requests an existing employee sign a non-compete agreement, the employer must provide ‘separate contemporaneous consideration’ for the new promise" *Brown v. Best Home Health & Hospice, LLC, 2021 WY 83, 491 P.3d 1021.* <https://www.courtlistener.com/opinion/9998787/jennifer-brown-fka-jennifer-stringer-nora-youngren-and-carol-wolfe-v/#:~:text=when%20an%20employer%20requests%20an,consideration%22%20for%20the%20new%20promise>
+
+[^wyo-1-23-any-person]: **Wyo. Stat. § 1-23-108(a)** — "Any covenant not to compete that restricts the right of any person to receive compensation for performance of skilled or unskilled labor shall be void." *Wyo. Stat. § 1-23-108(a) (2025).* <https://wyoleg.gov/2025/Enroll/SF0107.pdf>
+
+[^littler-any-status]: **Littler Mendelson commentary** — "The Act contains language broad enough to make most non-compete covenants with workers void regardless of a worker's status as an employee or an independent contractor" *Littler Mendelson, Wyoming Bans Non-Compete Covenants with Some Exceptions (2025).* <https://www.littler.com/news-analysis/asap/wyoming-bans-non-compete-covenants-some-exceptions>
+
+[^faegre-includes-contractors]: **Faegre Drinker commentary** — "Given that the law applies this restriction to agreements with any ‘person,’ this bans noncompete agreements with both employees and independent contractors" *Faegre Drinker, Wyoming Enacts Significant Restrictions on Noncompete Agreements (2025).* <https://www.faegredrinker.com/en/insights/publications/2025/3/wyoming-enacts-significant-restrictions-on-noncompete-agreements>
+
+[^fisher-colorado-any-person]: **Fisher Phillips commentary** — "any covenant not to compete that restricts the right of any person to receive compensation for performance of skilled or unskilled labor...several provisions closely mirror language found in Colorado's prior non-compete statute" *Fisher Phillips, New Law Voids Most Wyoming Non-Compete Agreements (2025).* <https://www.fisherphillips.com/en/insights/insights/new-law-voids-most-wyoming-non-compete-agreements>
 
 [^hassler-no-blue-pencil]: **Hassler v. Circle C Resources** — "Wyoming courts will no longer exceed the scope of their traditional authority in contract interpretation by redrafting noncompete agreements to bring them within the bounds of reason." *Hassler v. Circle C Resources, 2022 WY 28, 505 P.3d 169.* <https://www.courtlistener.com/opinion/9998701/charlene-hassler-v-circle-c-resources/#:~:text=Wyoming%20courts%20will%20no%20longer,within%20the%20bounds%20of%20reason.>
 
@@ -237,9 +247,13 @@ Commentary specifically warns employers to evaluate routine replacement or updat
 
 [^fisher-nda-question]: **Fisher Phillips commentary** — "What is not clear, however, is whether other common forms of restrictive covenants will likewise be interpreted to constitute ‘covenants not to compete.’" *Fisher Phillips, New Law Voids Most Wyoming Non-Compete Agreements (2025).* <https://www.fisherphillips.com/en/insights/insights/new-law-voids-most-wyoming-non-compete-agreements>
 
-[^wyo-1-23-compensation-focus]: **Wyo. Stat. § 1-23-108(a)** — "Any covenant not to compete that restricts the right of any person to receive compensation for performance of skilled or unskilled labor shall be void." *Wyo. Stat. § 1-23-108(a) (2025).* <https://wyoleg.gov/2025/Enroll/SF0107.pdf>
+[^wyo-1-23-exec-staff]: **Wyo. Stat. § 1-23-108(a)(iv)** — "Executive and management personnel and officers and employees who constitute professional staff to executive and management personnel." *Wyo. Stat. § 1-23-108(a)(iv) (2025).* <https://wyoleg.gov/2025/Enroll/SF0107.pdf>
 
-[^fisher-anti-moonlighting]: **Fisher Phillips commentary** — "For instance, will customer non-solicitation covenants fall into this definition? Employee non-solicitation covenants? Broad confidentiality agreements? ‘Anti-moonlighting’ agreements" *Fisher Phillips, New Law Voids Most Wyoming Non-Compete Agreements (2025).* <https://www.fisherphillips.com/en/insights/insights/new-law-voids-most-wyoming-non-compete-agreements>
+[^faegre-exec-undefined]: **Faegre Drinker commentary** — "The statute does not define the terms ‘executive and personnel management’ or ‘professional staff,’ so which specific employees would qualify for this exemption is an open question" *Faegre Drinker, Wyoming Enacts Significant Restrictions on Noncompete Agreements (2025).* <https://www.faegredrinker.com/en/insights/publications/2025/3/wyoming-enacts-significant-restrictions-on-noncompete-agreements>
+
+[^fisher-actual-duties]: **Fisher Phillips commentary** — "This analysis should focus on actual job responsibilities – not just job titles." *Fisher Phillips, New Law Voids Most Wyoming Non-Compete Agreements (2025).* <https://www.fisherphillips.com/en/insights/insights/new-law-voids-most-wyoming-non-compete-agreements>
+
+[^holland-colorado-analogy]: **Holland & Hart commentary** — "Whether Wyoming courts will follow those definitions remains to be seen." *Holland & Hart, Wyoming Legislature Takes a Bite Out of Covenants Not to Compete (2025).* <https://www.hollandhart.com/wyoming-legislature-takes-a-bite-out-of-covenants-not-to-compete-1>
 
 [^wyo-1-23-physician-bc]: **Wyo. Stat. § 1-23-108(b)–(c)** — "Any covenant not to compete provision of an employment, partnership or corporate agreement between physicians that restricts the right of a physician to practice medicine ... is void" *Wyo. Stat. § 1-23-108(b)–(c) (2025).* <https://wyoleg.gov/2025/Enroll/SF0107.pdf>
 
@@ -249,13 +263,9 @@ Commentary specifically warns employers to evaluate routine replacement or updat
 
 [^holland-between-physicians]: **Holland & Hart commentary** — "This language suggests that the law intends to invalidate covenants not to compete entered into between physicians who are members of or employed by a medical practice owned by physicians, and not those contracts with hospitals or other types of entities." *Holland & Hart, Wyoming Legislature Takes a Bite Out of Covenants Not to Compete (2025).* <https://www.hollandhart.com/wyoming-legislature-takes-a-bite-out-of-covenants-not-to-compete-1>
 
-[^wyo-1-23-exec-staff]: **Wyo. Stat. § 1-23-108(a)(iv)** — "Executive and management personnel and officers and employees who constitute professional staff to executive and management personnel." *Wyo. Stat. § 1-23-108(a)(iv) (2025).* <https://wyoleg.gov/2025/Enroll/SF0107.pdf>
+[^wyo-1-23-compensation-focus]: **Wyo. Stat. § 1-23-108(a)** — "Any covenant not to compete that restricts the right of any person to receive compensation for performance of skilled or unskilled labor shall be void." *Wyo. Stat. § 1-23-108(a) (2025).* <https://wyoleg.gov/2025/Enroll/SF0107.pdf>
 
-[^faegre-exec-undefined]: **Faegre Drinker commentary** — "The statute does not define the terms ‘executive and personnel management’ or ‘professional staff,’ so which specific employees would qualify for this exemption is an open question" *Faegre Drinker, Wyoming Enacts Significant Restrictions on Noncompete Agreements (2025).* <https://www.faegredrinker.com/en/insights/publications/2025/3/wyoming-enacts-significant-restrictions-on-noncompete-agreements>
-
-[^fisher-actual-duties]: **Fisher Phillips commentary** — "This analysis should focus on actual job responsibilities – not just job titles." *Fisher Phillips, New Law Voids Most Wyoming Non-Compete Agreements (2025).* <https://www.fisherphillips.com/en/insights/insights/new-law-voids-most-wyoming-non-compete-agreements>
-
-[^holland-colorado-analogy]: **Holland & Hart commentary** — "Whether Wyoming courts will follow those definitions remains to be seen." *Holland & Hart, Wyoming Legislature Takes a Bite Out of Covenants Not to Compete (2025).* <https://www.hollandhart.com/wyoming-legislature-takes-a-bite-out-of-covenants-not-to-compete-1>
+[^fisher-anti-moonlighting]: **Fisher Phillips commentary** — "For instance, will customer non-solicitation covenants fall into this definition? Employee non-solicitation covenants? Broad confidentiality agreements? ‘Anti-moonlighting’ agreements" *Fisher Phillips, New Law Voids Most Wyoming Non-Compete Agreements (2025).* <https://www.fisherphillips.com/en/insights/insights/new-law-voids-most-wyoming-non-compete-agreements>
 
 [^wyo-1-23-repayment-schedule]: **Wyo. Stat. § 1-23-108(a)(iii)** — "Any contractual provision providing for the recovery of all or a portion of the expense of relocating, educating and training an employee as follows" *Wyo. Stat. § 1-23-108(a)(iii) (2025).* <https://wyoleg.gov/2025/Enroll/SF0107.pdf>
 

--- a/skills/non-compete-contract-explainer/manifest.json
+++ b/skills/non-compete-contract-explainer/manifest.json
@@ -1,10 +1,532 @@
 {
   "topic": "non-compete",
   "snapshotAsOf": "2026-06-08",
-  "sourceCommit": "503a31e4f339f2f2c21ad8e7dcc3bc467475fd88",
+  "sourceCommit": "4a05ef4c7f0031c233548d2ea2d1d176b51e5e37",
   "canonicalBase": "https://openagreements.org/legal/non-compete",
   "license": "CC BY 4.0",
   "jurisdictions": [
+    {
+      "jurisdiction": "Alabama",
+      "slug": "alabama",
+      "countryCode": "US",
+      "file": "content/alabama.md",
+      "lastReviewed": "2026-06-03",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "Alaska",
+      "slug": "alaska",
+      "countryCode": "US",
+      "file": "content/alaska.md",
+      "lastReviewed": "2026-06-01",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "American Samoa",
+      "slug": "american-samoa",
+      "countryCode": "US",
+      "file": "content/american-samoa.md",
+      "lastReviewed": "2026-06-03",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "Arizona",
+      "slug": "arizona",
+      "countryCode": "US",
+      "file": "content/arizona.md",
+      "lastReviewed": "2026-06-03",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "Arkansas",
+      "slug": "arkansas",
+      "countryCode": "US",
+      "file": "content/arkansas.md",
+      "lastReviewed": "2026-06-02",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "California",
+      "slug": "california",
+      "countryCode": "US",
+      "file": "content/california.md",
+      "lastReviewed": "2026-06-03",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "Northern Mariana Islands",
+      "slug": "cnmi",
+      "countryCode": "US",
+      "file": "content/cnmi.md",
+      "lastReviewed": "2026-06-03",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "Colorado",
+      "slug": "colorado",
+      "countryCode": "US",
+      "file": "content/colorado.md",
+      "lastReviewed": "2026-06-03",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "Connecticut",
+      "slug": "connecticut",
+      "countryCode": "US",
+      "file": "content/connecticut.md",
+      "lastReviewed": "2026-06-02",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "Delaware",
+      "slug": "delaware",
+      "countryCode": "US",
+      "file": "content/delaware.md",
+      "lastReviewed": "2026-06-02",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "District of Columbia",
+      "slug": "district-of-columbia",
+      "countryCode": "US",
+      "file": "content/district-of-columbia.md",
+      "lastReviewed": "2026-06-03",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "Florida",
+      "slug": "florida",
+      "countryCode": "US",
+      "file": "content/florida.md",
+      "lastReviewed": "2026-06-03",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "Georgia",
+      "slug": "georgia",
+      "countryCode": "US",
+      "file": "content/georgia.md",
+      "lastReviewed": "2026-06-03",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "Guam",
+      "slug": "guam",
+      "countryCode": "US",
+      "file": "content/guam.md",
+      "lastReviewed": "2026-06-03",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "Hawaii",
+      "slug": "hawaii",
+      "countryCode": "US",
+      "file": "content/hawaii.md",
+      "lastReviewed": "2026-06-02",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "Idaho",
+      "slug": "idaho",
+      "countryCode": "US",
+      "file": "content/idaho.md",
+      "lastReviewed": "2026-06-02",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "Illinois",
+      "slug": "illinois",
+      "countryCode": "US",
+      "file": "content/illinois.md",
+      "lastReviewed": "2026-06-03",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "India",
+      "slug": "india",
+      "countryCode": "IN",
+      "file": "content/india.md",
+      "lastReviewed": "2026-06-03",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "Indiana",
+      "slug": "indiana",
+      "countryCode": "US",
+      "file": "content/indiana.md",
+      "lastReviewed": "2026-06-03",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "Iowa",
+      "slug": "iowa",
+      "countryCode": "US",
+      "file": "content/iowa.md",
+      "lastReviewed": "2026-06-02",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "Kansas",
+      "slug": "kansas",
+      "countryCode": "US",
+      "file": "content/kansas.md",
+      "lastReviewed": "2026-06-02",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "Kentucky",
+      "slug": "kentucky",
+      "countryCode": "US",
+      "file": "content/kentucky.md",
+      "lastReviewed": "2026-06-03",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "Louisiana",
+      "slug": "louisiana",
+      "countryCode": "US",
+      "file": "content/louisiana.md",
+      "lastReviewed": "2026-06-03",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "Maine",
+      "slug": "maine",
+      "countryCode": "US",
+      "file": "content/maine.md",
+      "lastReviewed": "2026-06-02",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "Maryland",
+      "slug": "maryland",
+      "countryCode": "US",
+      "file": "content/maryland.md",
+      "lastReviewed": "2026-06-03",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "Massachusetts",
+      "slug": "massachusetts",
+      "countryCode": "US",
+      "file": "content/massachusetts.md",
+      "lastReviewed": "2026-06-03",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "Michigan",
+      "slug": "michigan",
+      "countryCode": "US",
+      "file": "content/michigan.md",
+      "lastReviewed": "2026-06-03",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "Minnesota",
+      "slug": "minnesota",
+      "countryCode": "US",
+      "file": "content/minnesota.md",
+      "lastReviewed": "2026-05-27",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "Mississippi",
+      "slug": "mississippi",
+      "countryCode": "US",
+      "file": "content/mississippi.md",
+      "lastReviewed": "2026-06-03",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "Missouri",
+      "slug": "missouri",
+      "countryCode": "US",
+      "file": "content/missouri.md",
+      "lastReviewed": "2026-06-03",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "Montana",
+      "slug": "montana",
+      "countryCode": "US",
+      "file": "content/montana.md",
+      "lastReviewed": "2026-06-02",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "Nebraska",
+      "slug": "nebraska",
+      "countryCode": "US",
+      "file": "content/nebraska.md",
+      "lastReviewed": "2026-06-02",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "Nevada",
+      "slug": "nevada",
+      "countryCode": "US",
+      "file": "content/nevada.md",
+      "lastReviewed": "2026-06-02",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "New Hampshire",
+      "slug": "new-hampshire",
+      "countryCode": "US",
+      "file": "content/new-hampshire.md",
+      "lastReviewed": "2026-06-02",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "New Jersey",
+      "slug": "new-jersey",
+      "countryCode": "US",
+      "file": "content/new-jersey.md",
+      "lastReviewed": "2026-06-03",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "New Mexico",
+      "slug": "new-mexico",
+      "countryCode": "US",
+      "file": "content/new-mexico.md",
+      "lastReviewed": "2026-06-03",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "New York",
+      "slug": "new-york",
+      "countryCode": "US",
+      "file": "content/new-york.md",
+      "lastReviewed": "2026-06-03",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "North Carolina",
+      "slug": "north-carolina",
+      "countryCode": "US",
+      "file": "content/north-carolina.md",
+      "lastReviewed": "2026-06-03",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "North Dakota",
+      "slug": "north-dakota",
+      "countryCode": "US",
+      "file": "content/north-dakota.md",
+      "lastReviewed": "2026-06-02",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "Ohio",
+      "slug": "ohio",
+      "countryCode": "US",
+      "file": "content/ohio.md",
+      "lastReviewed": "2026-06-03",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "Oklahoma",
+      "slug": "oklahoma",
+      "countryCode": "US",
+      "file": "content/oklahoma.md",
+      "lastReviewed": "2026-06-03",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "Oregon",
+      "slug": "oregon",
+      "countryCode": "US",
+      "file": "content/oregon.md",
+      "lastReviewed": "2026-06-03",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "Pennsylvania",
+      "slug": "pennsylvania",
+      "countryCode": "US",
+      "file": "content/pennsylvania.md",
+      "lastReviewed": "2026-06-03",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "Philippines",
+      "slug": "philippines",
+      "countryCode": "PH",
+      "file": "content/philippines.md",
+      "lastReviewed": "2026-06-03",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "Puerto Rico",
+      "slug": "puerto-rico",
+      "countryCode": "US",
+      "file": "content/puerto-rico.md",
+      "lastReviewed": "2026-06-02",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "Rhode Island",
+      "slug": "rhode-island",
+      "countryCode": "US",
+      "file": "content/rhode-island.md",
+      "lastReviewed": "2026-06-02",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "Singapore",
+      "slug": "singapore",
+      "countryCode": "SG",
+      "file": "content/singapore.md",
+      "lastReviewed": "2026-06-03",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "South Carolina",
+      "slug": "south-carolina",
+      "countryCode": "US",
+      "file": "content/south-carolina.md",
+      "lastReviewed": "2026-06-03",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "South Dakota",
+      "slug": "south-dakota",
+      "countryCode": "US",
+      "file": "content/south-dakota.md",
+      "lastReviewed": "2026-06-02",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "Tennessee",
+      "slug": "tennessee",
+      "countryCode": "US",
+      "file": "content/tennessee.md",
+      "lastReviewed": "2026-06-03",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "Texas",
+      "slug": "texas",
+      "countryCode": "US",
+      "file": "content/texas.md",
+      "lastReviewed": "2026-06-03",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "U.S. Virgin Islands",
+      "slug": "us-virgin-islands",
+      "countryCode": "US",
+      "file": "content/us-virgin-islands.md",
+      "lastReviewed": "2026-06-03",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "Utah",
+      "slug": "utah",
+      "countryCode": "US",
+      "file": "content/utah.md",
+      "lastReviewed": "2026-06-02",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "Vermont",
+      "slug": "vermont",
+      "countryCode": "US",
+      "file": "content/vermont.md",
+      "lastReviewed": "2026-06-01",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "Virginia",
+      "slug": "virginia",
+      "countryCode": "US",
+      "file": "content/virginia.md",
+      "lastReviewed": "2026-06-02",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "Washington",
+      "slug": "washington",
+      "countryCode": "US",
+      "file": "content/washington.md",
+      "lastReviewed": "2026-06-03",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "West Virginia",
+      "slug": "west-virginia",
+      "countryCode": "US",
+      "file": "content/west-virginia.md",
+      "lastReviewed": "2026-06-02",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
+    {
+      "jurisdiction": "Wisconsin",
+      "slug": "wisconsin",
+      "countryCode": "US",
+      "file": "content/wisconsin.md",
+      "lastReviewed": "2026-06-03",
+      "snapshotAsOf": "2026-06-08",
+      "stale": false
+    },
     {
       "jurisdiction": "Wyoming",
       "slug": "wyoming",


### PR DESCRIPTION
Broadens the `non-compete-contract-explainer` skill from the Wyoming MVP (#417) to **all 59 jurisdictions** UseJunior/legal-explainer covers: 50 states + DC + 4 U.S. territories (American Samoa, CNMI, Guam, Puerto Rico, U.S. Virgin Islands) + 3 international (India, Philippines, Singapore).

Source: UseJunior/legal-explainer@4a05ef4c7f00
Snapshot as of 2026-06-08. Generated by `scripts/publish-noncompete-snapshot.ts` (quote-verify gate passed for all 59 notes against the legal-context snapshot DB).

Each `content/<slug>.md` carries its own UPL disclaimer + canonical link + "At a glance" survey table; `manifest.json` indexes all 59. `SKILL.md` (the router) is unchanged. Content is CC BY 4.0 (© UseJunior).