### PR TITLE
chore(release): 0.7.7

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "open-agreements",
   "displayName": "OpenAgreements",
   "description": "Open-source legal template automation for DOCX with MCP tooling.",
-  "version": "0.7.5",
+  "version": "0.7.7",
   "author": {
     "name": "Open Agreements",
     "email": "steven@usejunior.com"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "open-agreements",
-  "version": "0.7.5",
+  "version": "0.7.7",
   "description": "Local MCP extension for OpenAgreements workspace organization and contract template drafting.",
   "contextFileName": "GEMINI.md",
   "entrypoint": "GEMINI.md",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-agreements",
-  "version": "0.7.5",
+  "version": "0.7.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-agreements",
-      "version": "0.7.5",
+      "version": "0.7.7",
       "bundleDependencies": [
         "@usejunior/docx-core"
       ],
@@ -7846,7 +7846,7 @@
     },
     "packages/checklist-mcp": {
       "name": "@open-agreements/checklist-mcp",
-      "version": "0.7.5",
+      "version": "0.7.7",
       "license": "MIT",
       "dependencies": {
         "open-agreements": ">=0.3.1",
@@ -7861,7 +7861,7 @@
     },
     "packages/contract-templates-mcp": {
       "name": "@open-agreements/contract-templates-mcp",
-      "version": "0.7.5",
+      "version": "0.7.7",
       "license": "MIT",
       "dependencies": {
         "open-agreements": ">=0.3.1",
@@ -7892,7 +7892,7 @@
     },
     "packages/contracts-workspace-mcp": {
       "name": "@open-agreements/contracts-workspace-mcp",
-      "version": "0.7.5",
+      "version": "0.7.7",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.0",
@@ -7907,7 +7907,7 @@
     },
     "packages/signing": {
       "name": "@open-agreements/signing",
-      "version": "0.7.5",
+      "version": "0.7.7",
       "dependencies": {
         "@google-cloud/firestore": "^8.3.0",
         "@google-cloud/storage": "^7.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-agreements",
-  "version": "0.7.5",
+  "version": "0.7.7",
   "workspaces": [
     "packages/allure-test-factory",
     "packages/contract-templates-mcp",

--- a/packages/checklist-mcp/package.json
+++ b/packages/checklist-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agreements/checklist-mcp",
-  "version": "0.7.5",
+  "version": "0.7.7",
   "description": "Local stdio MCP server for OpenAgreements checklist memory operations",
   "type": "module",
   "bin": {

--- a/packages/contract-templates-mcp/package.json
+++ b/packages/contract-templates-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agreements/contract-templates-mcp",
-  "version": "0.7.5",
+  "version": "0.7.7",
   "mcpName": "io.github.open-agreements/open-agreements",
   "description": "Local stdio MCP server for OpenAgreements template discovery and filling",
   "type": "module",

--- a/packages/contracts-workspace-mcp/package.json
+++ b/packages/contracts-workspace-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agreements/contracts-workspace-mcp",
-  "version": "0.7.5",
+  "version": "0.7.7",
   "description": "Local stdio MCP server for contracts workspace operations",
   "type": "module",
   "bin": {

--- a/packages/signing/package.json
+++ b/packages/signing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agreements/signing",
-  "version": "0.7.5",
+  "version": "0.7.7",
   "private": true,
   "description": "DocuSign signing adapter for sending filled agreements; pluggable interface for additional providers.",
   "type": "module",


### PR DESCRIPTION
Bumps all `VERSION_FILES` 0.7.5 → **0.7.7** via `scripts/bump_version.mjs` (+ synced `package-lock.json`).

**Why 0.7.7 and not 0.7.6:** the manual `npm publish` of 0.7.6 ran from a checkout that predated #424/#423, so npm 0.7.6 shipped only the Wyoming MVP + employment-contract 0.2.0 — it does **not** contain the 59-jurisdiction non-compete skill or the employment-contract 0.3.0 refresh that are now on `main`. 0.7.6 is already taken on npm; this cuts a clean **0.7.7** from current `main` (which has both).

**After merge:** tag `v0.7.7` on the merge commit and push it → `release.yml` verifies the tag matches all VERSION_FILES + that the commit is on `main`, then publishes to npm. The 0.7.7 tarball will include `skills/non-compete-contract-explainer/` (SKILL.md + manifest.json with 59 entries + 59 `content/*.md`) and `skills/employment-contract/SKILL.md` @ 0.3.0.

No code changes — version manifests + lockfile only.