### PR TITLE
ci(release): fold server.json into version lockstep with bump-time registry guard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,21 @@ jobs:
             exit 1
           fi
 
+          SERVER_VERSION="$(node -p "require('./server.json').version")"
+          if [ "$TAG_VERSION" != "$SERVER_VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) must match server.json version ($SERVER_VERSION)."
+            exit 1
+          fi
+
+          SERVER_PKG_VERSION="$(node -p "require('./server.json').packages[0].version")"
+          if [ "$TAG_VERSION" != "$SERVER_PKG_VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) must match server.json packages[0].version ($SERVER_PKG_VERSION)."
+            exit 1
+          fi
+
+      - name: Verify version lockstep and MCP registry constraints
+        run: node scripts/bump_version.mjs --check
+
       - name: Verify release commit is on main
         run: |
           git fetch origin main

--- a/scripts/bump_version.mjs
+++ b/scripts/bump_version.mjs
@@ -4,6 +4,7 @@
  * Bump version across all manifests that the release preflight checks.
  *
  * Usage:  node scripts/bump_version.mjs <new-version>
+ *         node scripts/bump_version.mjs --check
  * Example: node scripts/bump_version.mjs 0.7.0
  *
  * Updates:
@@ -14,12 +15,17 @@
  *   - packages/signing/package.json
  *   - gemini-extension.json
  *   - .cursor-plugin/plugin.json
+ *   - server.json (top-level version AND packages[].version)
+ *
+ * --check verifies every file above carries the same version and that
+ * server.json satisfies MCP registry constraints, without writing anything.
  */
 
 import { readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const VERSION_FILES = [
+export const VERSION_FILES = [
   "package.json",
   "packages/contracts-workspace-mcp/package.json",
   "packages/contract-templates-mcp/package.json",
@@ -29,35 +35,135 @@ const VERSION_FILES = [
   ".cursor-plugin/plugin.json",
 ];
 
-const newVersion = process.argv[2];
-if (!newVersion) {
-  console.error("Usage: node scripts/bump_version.mjs <new-version>");
-  console.error("Example: node scripts/bump_version.mjs 0.7.0");
-  process.exit(1);
+export const SERVER_JSON = "server.json";
+
+// The official MCP registry rejects publishes whose description exceeds 100
+// chars — a 422 at publish time, after npm has already shipped. Gate it at
+// bump time instead (UseJunior/safe-docx#399).
+export const REGISTRY_DESCRIPTION_MAX = 100;
+
+const DEFAULT_ROOT = resolve(import.meta.dirname, "..");
+
+function readJson(root, relPath) {
+  return JSON.parse(readFileSync(resolve(root, relPath), "utf8"));
 }
 
-if (!/^\d+\.\d+\.\d+$/.test(newVersion)) {
-  console.error(`Invalid semver: ${newVersion}`);
-  process.exit(1);
+export function checkVersionSync(root = DEFAULT_ROOT) {
+  const versions = new Map();
+  const errors = [];
+
+  for (const relPath of VERSION_FILES) {
+    versions.set(relPath, readJson(root, relPath).version);
+  }
+
+  const serverJson = readJson(root, SERVER_JSON);
+  versions.set(SERVER_JSON, serverJson.version);
+  for (const [index, pkg] of (serverJson.packages ?? []).entries()) {
+    versions.set(`${SERVER_JSON} packages[${index}]`, pkg.version);
+  }
+
+  const uniqueVersions = new Set(versions.values());
+  if (uniqueVersions.size > 1) {
+    errors.push("Version mismatch detected:");
+    for (const [file, version] of versions) {
+      errors.push(`  ${version ?? "(missing)"}  ${file}`);
+    }
+  }
+
+  const description = serverJson.description ?? "";
+  if (description.length > REGISTRY_DESCRIPTION_MAX) {
+    errors.push(
+      `${SERVER_JSON} description is ${description.length} chars; ` +
+        `the MCP registry caps it at ${REGISTRY_DESCRIPTION_MAX}.`,
+    );
+  }
+
+  return { ok: errors.length === 0, errors, versions };
 }
 
-const root = resolve(import.meta.dirname, "..");
+export function bumpVersion(newVersion, root = DEFAULT_ROOT) {
+  for (const relPath of VERSION_FILES) {
+    const absPath = resolve(root, relPath);
+    const raw = readFileSync(absPath, "utf8");
+    const oldVersion = JSON.parse(raw).version;
+    // Replace only the first "version" value to preserve all other formatting
+    const updated = raw.replace(
+      /("version"\s*:\s*")([^"]+)(")/,
+      `$1${newVersion}$3`,
+    );
+    if (updated === raw && oldVersion !== newVersion) {
+      throw new Error(`${relPath}: failed to locate version field`);
+    }
+    writeFileSync(absPath, updated);
+    console.log(`  ${relPath}: ${oldVersion} -> ${newVersion}`);
+  }
 
-for (const relPath of VERSION_FILES) {
-  const absPath = resolve(root, relPath);
-  const raw = readFileSync(absPath, "utf8");
-  const oldVersion = JSON.parse(raw).version;
-  // Replace only the first "version" value to preserve all other formatting
-  const updated = raw.replace(
-    /("version"\s*:\s*")([^"]+)(")/,
+  // server.json carries the version twice: top-level and per registry
+  // package. Both must move together or the registry publish ships a
+  // wrong-versioned entry.
+  const serverAbsPath = resolve(root, SERVER_JSON);
+  const serverRaw = readFileSync(serverAbsPath, "utf8");
+  const serverOldVersion = JSON.parse(serverRaw).version;
+  const serverUpdated = serverRaw.replace(
+    /("version"\s*:\s*")([^"]+)(")/g,
     `$1${newVersion}$3`,
   );
-  if (updated === raw && oldVersion !== newVersion) {
-    console.error(`  ${relPath}: FAILED to locate version field`);
-    process.exit(1);
+  if (serverUpdated === serverRaw && serverOldVersion !== newVersion) {
+    throw new Error(`${SERVER_JSON}: failed to locate version field`);
   }
-  writeFileSync(absPath, updated);
-  console.log(`  ${relPath}: ${oldVersion} -> ${newVersion}`);
+  writeFileSync(serverAbsPath, serverUpdated);
+  console.log(`  ${SERVER_JSON}: ${serverOldVersion} -> ${newVersion}`);
+
+  const result = checkVersionSync(root);
+  if (!result.ok) {
+    throw new Error(
+      `version sync check failed after bump:\n${result.errors.join("\n")}`,
+    );
+  }
 }
 
-console.log(`\nDone. All ${VERSION_FILES.length} manifests set to ${newVersion}.`);
+function main() {
+  const arg = process.argv[2];
+  if (!arg) {
+    console.error("Usage: node scripts/bump_version.mjs <new-version>");
+    console.error("       node scripts/bump_version.mjs --check");
+    console.error("Example: node scripts/bump_version.mjs 0.7.0");
+    process.exit(1);
+  }
+
+  if (arg === "--check") {
+    const result = checkVersionSync();
+    if (!result.ok) {
+      for (const line of result.errors) console.error(line);
+      process.exit(1);
+    }
+    const version = [...result.versions.values()][0];
+    console.log(
+      `All ${result.versions.size} version fields are at ${version}.`,
+    );
+    return;
+  }
+
+  if (!/^\d+\.\d+\.\d+$/.test(arg)) {
+    console.error(`Invalid semver: ${arg}`);
+    process.exit(1);
+  }
+
+  bumpVersion(arg);
+  console.log(
+    `\nDone. All ${VERSION_FILES.length + 1} manifests set to ${arg}.`,
+  );
+}
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : null;
+const modulePath = fileURLToPath(import.meta.url);
+
+if (invokedPath === modulePath) {
+  try {
+    main();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`bump_version failed: ${message}`);
+    process.exit(1);
+  }
+}

--- a/scripts/bump_version.test.mjs
+++ b/scripts/bump_version.test.mjs
@@ -1,0 +1,122 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  REGISTRY_DESCRIPTION_MAX,
+  SERVER_JSON,
+  VERSION_FILES,
+  bumpVersion,
+  checkVersionSync,
+} from './bump_version.mjs';
+
+const REPO_ROOT = resolve(import.meta.dirname, '..');
+
+const tempDirs = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function fixtureRoot({ version = '1.2.3', serverOverrides = {} } = {}) {
+  const root = mkdtempSync(join(tmpdir(), 'oa-bump-version-'));
+  tempDirs.push(root);
+
+  for (const relPath of VERSION_FILES) {
+    const absPath = join(root, relPath);
+    mkdirSync(dirname(absPath), { recursive: true });
+    writeFileSync(absPath, `${JSON.stringify({ name: relPath, version }, null, 2)}\n`);
+  }
+
+  const serverJson = {
+    name: 'io.github.open-agreements/open-agreements',
+    description: 'Test server.',
+    version,
+    packages: [{ identifier: '@open-agreements/contract-templates-mcp', version }],
+    ...serverOverrides,
+  };
+  writeFileSync(join(root, SERVER_JSON), `${JSON.stringify(serverJson, null, 2)}\n`);
+  return root;
+}
+
+describe('checkVersionSync', () => {
+  it('passes on the real repo (all manifests in lockstep)', () => {
+    const result = checkVersionSync(REPO_ROOT);
+    expect(result.errors).toEqual([]);
+    expect(result.ok).toBe(true);
+    // Every tracked manifest plus server.json's top-level and per-package
+    // version fields must be represented.
+    expect(result.versions.size).toBeGreaterThanOrEqual(VERSION_FILES.length + 2);
+  });
+
+  it('passes on an in-sync fixture', () => {
+    const result = checkVersionSync(fixtureRoot());
+    expect(result.ok).toBe(true);
+  });
+
+  it('fails when server.json top-level version drifts', () => {
+    const root = fixtureRoot({ serverOverrides: { version: '0.5.0' } });
+    const result = checkVersionSync(root);
+    expect(result.ok).toBe(false);
+    expect(result.errors.join('\n')).toContain('0.5.0');
+  });
+
+  it('fails when server.json packages[0].version drifts', () => {
+    const root = fixtureRoot({
+      serverOverrides: { packages: [{ identifier: 'x', version: '0.0.1' }] },
+    });
+    const result = checkVersionSync(root);
+    expect(result.ok).toBe(false);
+    expect(result.errors.join('\n')).toContain('packages[0]');
+  });
+
+  it('fails when a package.json version drifts', () => {
+    const root = fixtureRoot();
+    writeFileSync(
+      join(root, 'package.json'),
+      `${JSON.stringify({ name: 'package.json', version: '9.9.9' }, null, 2)}\n`,
+    );
+    const result = checkVersionSync(root);
+    expect(result.ok).toBe(false);
+  });
+
+  it('fails when the registry description cap is exceeded', () => {
+    const root = fixtureRoot({
+      serverOverrides: { description: 'x'.repeat(REGISTRY_DESCRIPTION_MAX + 1) },
+    });
+    const result = checkVersionSync(root);
+    expect(result.ok).toBe(false);
+    expect(result.errors.join('\n')).toContain(`${REGISTRY_DESCRIPTION_MAX}`);
+  });
+
+  it('enforces the registry description cap on the real server.json', () => {
+    const serverJson = JSON.parse(readFileSync(join(REPO_ROOT, SERVER_JSON), 'utf8'));
+    expect(serverJson.description.length).toBeLessThanOrEqual(REGISTRY_DESCRIPTION_MAX);
+  });
+});
+
+describe('bumpVersion', () => {
+  it('bumps every manifest including both server.json version fields', () => {
+    const root = fixtureRoot();
+    bumpVersion('2.0.0', root);
+
+    for (const relPath of VERSION_FILES) {
+      const pkg = JSON.parse(readFileSync(join(root, relPath), 'utf8'));
+      expect(pkg.version, relPath).toBe('2.0.0');
+    }
+    const serverJson = JSON.parse(readFileSync(join(root, SERVER_JSON), 'utf8'));
+    expect(serverJson.version).toBe('2.0.0');
+    expect(serverJson.packages[0].version).toBe('2.0.0');
+  });
+
+  it('throws when the post-bump sync check fails', () => {
+    const root = fixtureRoot({
+      serverOverrides: { description: 'x'.repeat(REGISTRY_DESCRIPTION_MAX + 1) },
+    });
+    expect(() => bumpVersion('2.0.0', root)).toThrow(/description/);
+  });
+});

--- a/server.json
+++ b/server.json
@@ -3,13 +3,13 @@
   "name": "io.github.open-agreements/open-agreements",
   "title": "Open Agreements",
   "description": "Fill standard legal agreement templates (NDAs, SAFEs, NVCA docs, employment) as DOCX files.",
-  "version": "0.5.0",
+  "version": "0.7.7",
   "websiteUrl": "https://openagreements.org",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@open-agreements/contract-templates-mcp",
-      "version": "0.5.0",
+      "version": "0.7.7",
       "transport": { "type": "stdio" },
       "runtimeHint": "npx",
       "environmentVariables": []


### PR DESCRIPTION
Part 1 of 3 for #434 — fix 3 (lockstep + guard), first in the issue's suggested order.

## What

- **`scripts/bump_version.mjs`** now updates `server.json` — both the top-level `version` and every `packages[].version` — alongside the other seven manifests, and gains a `--check` mode that verifies all nine version fields agree and that the `server.json` description fits the MCP registry's 100-char cap. That cap is the 422-at-publish-time failure safe-docx hit in UseJunior/safe-docx#399, *after* npm had already shipped — the worst place to discover it.
- **Release preflight** (`release.yml`) pins the tag to both `server.json` version fields and runs `bump_version.mjs --check`, so a half-bumped commit can never release.
- **`server.json` remediated** from the drifted 0.5.0 to the suite's 0.7.7 (both fields).
- **`scripts/bump_version.test.mjs`**: 9 tests covering drift detection in either server.json field or any package.json, the description cap, both-field bumping — plus a live-repo lockstep assertion, so any future PR that bumps one manifest without the others fails CI immediately.

## Why

`server.json` sat at 0.5.0 while everything else said 0.7.7 — outside both `bump_version.mjs`'s update list and preflight's version-pin step. Whenever MCP registry publishing resumes (fix 2, next PR), it would have published a wrong-versioned entry.

Up next per #434: fix 2 (`publish-mcp-registry` job in `release.yml`), then fix 1 (auto-tag on version-bump merge).