### PR TITLE
chore(license): relicense MIT → Apache-2.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,5 +6,5 @@
     "name": "Open Agreements",
     "email": "steven@usejunior.com"
   },
-  "license": "MIT"
+  "license": "Apache-2.0"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -10,7 +10,7 @@
   "publisher": "Open Agreements",
   "homepage": "https://github.com/open-agreements/open-agreements#readme",
   "repository": "https://github.com/open-agreements/open-agreements",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "logo": "site/assets/openagreements_logo.jpg",
   "keywords": [
     "cursor",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,4 +167,4 @@ integration-tests/          # Integration and end-to-end tests
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the MIT License. Template content retains the license of its source (CC BY 4.0, CC0, or CC BY-ND 4.0).
+By contributing, you agree that your contributions will be licensed under the Apache License 2.0. Template content retains the license of its source (CC BY 4.0, CC0, or CC BY-ND 4.0).

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,201 @@
-MIT License
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2026 UseJunior
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 OM Innovation AI Inc. (UseJunior)
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,12 @@
+OpenAgreements
+Copyright 2026 OM Innovation AI Inc. (UseJunior), a Delaware corporation
+
+This product includes software developed by OM Innovation AI Inc.
+(UseJunior) and the OpenAgreements contributors
+(https://github.com/open-agreements/open-agreements).
+
+Bundled agreement template content under content/templates/ and
+content/external/ is licensed separately by its respective authors
+(e.g. CC BY 4.0, CC0 1.0, CC BY-ND 4.0), as recorded in each
+template's metadata.yaml. This NOTICE and the Apache License, Version
+2.0 apply to the project code, not to that template content.

--- a/README.de.md
+++ b/README.de.md
@@ -4,7 +4,7 @@
 
 [![npm version](https://img.shields.io/npm/v/open-agreements)](https://www.npmjs.com/package/open-agreements)
 [![npm downloads](https://img.shields.io/npm/dm/open-agreements.svg)](https://npmjs.org/package/open-agreements)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![CI](https://github.com/open-agreements/open-agreements/actions/workflows/ci.yml/badge.svg)](https://github.com/open-agreements/open-agreements/actions/workflows/ci.yml)
 [![codecov](https://img.shields.io/codecov/c/github/open-agreements/open-agreements/main)](https://app.codecov.io/gh/open-agreements/open-agreements)
 [![Socket Badge](https://socket.dev/api/badge/npm/package/open-agreements)](https://socket.dev/npm/package/open-agreements)
@@ -410,7 +410,7 @@ Baust du auf OpenAgreements auf? Eröffne einen PR, um dein Projekt aufzunehmen.
 
 ## Lizenz
 
-MIT. Vorlageninhalte werden von ihren jeweiligen Autor:innen lizenziert:
+Der Projektcode ist unter der [Apache License 2.0](LICENSE) lizenziert. Die Apache-Lizenz gilt nur für den Code — mitgelieferte Vorlageninhalte behalten ihre Upstream-Lizenzen, festgelegt von ihren jeweiligen Autor:innen:
 
 - CC BY 4.0 für Common Paper-, Bonterms- und OpenAgreements-erstellte Vorlagen
 - CC BY-ND 4.0 für unverändert vendored Y-Combinator-SAFE-Vorlagen

--- a/README.es.md
+++ b/README.es.md
@@ -4,7 +4,7 @@
 
 [![npm version](https://img.shields.io/npm/v/open-agreements)](https://www.npmjs.com/package/open-agreements)
 [![npm downloads](https://img.shields.io/npm/dm/open-agreements.svg)](https://npmjs.org/package/open-agreements)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![CI](https://github.com/open-agreements/open-agreements/actions/workflows/ci.yml/badge.svg)](https://github.com/open-agreements/open-agreements/actions/workflows/ci.yml)
 [![codecov](https://img.shields.io/codecov/c/github/open-agreements/open-agreements/main)](https://app.codecov.io/gh/open-agreements/open-agreements)
 [![Socket Badge](https://socket.dev/api/badge/npm/package/open-agreements)](https://socket.dev/npm/package/open-agreements)
@@ -412,7 +412,7 @@ Consulta [CONTRIBUTING.md](https://github.com/open-agreements/open-agreements/bl
 
 ## Licencia
 
-MIT. El contenido de las plantillas está licenciado por sus respectivos autores:
+El código del proyecto está licenciado bajo la [Apache License 2.0](LICENSE). La licencia Apache cubre solo el código — el contenido de plantillas incluido conserva sus licencias originales, establecidas por sus respectivos autores:
 
 - CC BY 4.0 para plantillas de Common Paper, Bonterms y de autoría OpenAgreements
 - CC BY-ND 4.0 para plantillas SAFE de Y Combinator vendorizadas sin cambios

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![npm version](https://img.shields.io/npm/v/open-agreements)](https://www.npmjs.com/package/open-agreements)
 [![npm downloads](https://img.shields.io/npm/dm/open-agreements.svg)](https://npmjs.org/package/open-agreements)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![CI](https://github.com/open-agreements/open-agreements/actions/workflows/ci.yml/badge.svg)](https://github.com/open-agreements/open-agreements/actions/workflows/ci.yml)
 [![codecov](https://img.shields.io/codecov/c/github/open-agreements/open-agreements/main)](https://app.codecov.io/gh/open-agreements/open-agreements)
 [![Socket Badge](https://socket.dev/api/badge/npm/package/open-agreements)](https://socket.dev/npm/package/open-agreements)
@@ -497,7 +497,7 @@ Building on OpenAgreements? Open a PR to add your project.
 
 ## License
 
-MIT. Template content is licensed by its respective authors:
+Project code is licensed under [Apache License 2.0](LICENSE). The Apache license covers the code only — bundled template content retains its upstream licenses, set by its respective authors:
 
 - CC BY 4.0 for Common Paper, Bonterms, and OpenAgreements-authored templates
 - CC BY-ND 4.0 for Y Combinator SAFE templates vendored unchanged

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -4,7 +4,7 @@
 
 [![npm version](https://img.shields.io/npm/v/open-agreements)](https://www.npmjs.com/package/open-agreements)
 [![npm downloads](https://img.shields.io/npm/dm/open-agreements.svg)](https://npmjs.org/package/open-agreements)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![CI](https://github.com/open-agreements/open-agreements/actions/workflows/ci.yml/badge.svg)](https://github.com/open-agreements/open-agreements/actions/workflows/ci.yml)
 [![codecov](https://img.shields.io/codecov/c/github/open-agreements/open-agreements/main)](https://app.codecov.io/gh/open-agreements/open-agreements)
 [![Socket Badge](https://socket.dev/api/badge/npm/package/open-agreements)](https://socket.dev/npm/package/open-agreements)
@@ -412,7 +412,7 @@ Está construindo algo sobre o OpenAgreements? Abra um PR para adicionar seu pro
 
 ## Licença
 
-MIT. O conteúdo dos modelos é licenciado por seus respectivos autores:
+O código do projeto está licenciado sob a [Apache License 2.0](LICENSE). A licença Apache cobre apenas o código — o conteúdo dos modelos incluídos mantém suas licenças originais, definidas por seus respectivos autores:
 
 - CC BY 4.0 para modelos da Common Paper, Bonterms e modelos autorais do OpenAgreements
 - CC BY-ND 4.0 para modelos de SAFE do Y Combinator vendorizados sem alterações

--- a/README.template.md
+++ b/README.template.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/open-agreements)](https://www.npmjs.com/package/open-agreements)
 [![npm downloads](https://img.shields.io/npm/dm/open-agreements.svg)](https://npmjs.org/package/open-agreements)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![CI](https://github.com/open-agreements/open-agreements/actions/workflows/ci.yml/badge.svg)](https://github.com/open-agreements/open-agreements/actions/workflows/ci.yml)
 [![codecov](https://img.shields.io/codecov/c/github/open-agreements/open-agreements/main)](https://app.codecov.io/gh/open-agreements/open-agreements)
 [![Socket Badge](https://socket.dev/api/badge/npm/package/open-agreements)](https://socket.dev/npm/package/open-agreements)
@@ -322,7 +322,7 @@ Building on OpenAgreements? Open a PR to add your project.
 
 ## License
 
-MIT. Template content is licensed by its respective authors:
+Project code is licensed under [Apache License 2.0](LICENSE). The Apache license covers the code only — bundled template content retains its upstream licenses, set by its respective authors:
 
 - CC BY 4.0 for Common Paper, Bonterms, and OpenAgreements-authored templates
 - CC BY-ND 4.0 for Y Combinator SAFE templates vendored unchanged

--- a/README.zh.md
+++ b/README.zh.md
@@ -4,7 +4,7 @@
 
 [![npm version](https://img.shields.io/npm/v/open-agreements)](https://www.npmjs.com/package/open-agreements)
 [![npm downloads](https://img.shields.io/npm/dm/open-agreements.svg)](https://npmjs.org/package/open-agreements)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![CI](https://github.com/open-agreements/open-agreements/actions/workflows/ci.yml/badge.svg)](https://github.com/open-agreements/open-agreements/actions/workflows/ci.yml)
 [![codecov](https://img.shields.io/codecov/c/github/open-agreements/open-agreements/main)](https://app.codecov.io/gh/open-agreements/open-agreements)
 [![Socket Badge](https://socket.dev/api/badge/npm/package/open-agreements)](https://socket.dev/npm/package/open-agreements)
@@ -412,7 +412,7 @@ npx -y open-agreements@latest list
 
 ## 许可
 
-MIT。模板内容按各自作者授权：
+项目代码采用 [Apache License 2.0](LICENSE) 许可。Apache 许可证仅涵盖代码——捆绑的模板内容保留其上游许可，由各自的作者授权：
 
 - Common Paper、Bonterms 以及 OpenAgreements 撰写的模板采用 CC BY 4.0
 - Y Combinator SAFE 模板原样 vendor，采用 CC BY-ND 4.0

--- a/docs/licensing.md
+++ b/docs/licensing.md
@@ -11,7 +11,7 @@ section: Reference
 
 ## Tool License
 
-OpenAgreements itself is licensed under the **MIT License**. You can use, modify, and distribute the tool freely.
+OpenAgreements itself is licensed under the **Apache License 2.0**, which includes an express patent grant from each contributor. You can use, modify, and distribute the tool freely. The Apache license covers the project code only — bundled template content retains the upstream licenses described below.
 
 ## Template Licenses
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "bundleDependencies": [
         "@usejunior/docx-core"
       ],
-      "license": "MIT",
+      "license": "Apache-2.0",
       "workspaces": [
         "packages/allure-test-factory",
         "packages/contract-templates-mcp",
@@ -7826,7 +7826,7 @@
     "packages/allure-test-factory": {
       "name": "@usejunior/allure-test-factory",
       "version": "0.1.0",
-      "license": "MIT",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=20"
       },
@@ -7847,7 +7847,7 @@
     "packages/checklist-mcp": {
       "name": "@open-agreements/checklist-mcp",
       "version": "0.7.7",
-      "license": "MIT",
+      "license": "Apache-2.0",
       "dependencies": {
         "open-agreements": ">=0.3.1",
         "zod": "^4.0.0"
@@ -7862,7 +7862,7 @@
     "packages/contract-templates-mcp": {
       "name": "@open-agreements/contract-templates-mcp",
       "version": "0.7.7",
-      "license": "MIT",
+      "license": "Apache-2.0",
       "dependencies": {
         "open-agreements": ">=0.3.1",
         "zod": "^4.0.0"
@@ -7877,7 +7877,7 @@
     "packages/contracts-workspace": {
       "name": "@open-agreements/contracts-workspace",
       "version": "0.1.0",
-      "license": "MIT",
+      "license": "Apache-2.0",
       "dependencies": {
         "commander": "^13.1.0",
         "js-yaml": "^4.1.0",
@@ -7893,7 +7893,7 @@
     "packages/contracts-workspace-mcp": {
       "name": "@open-agreements/contracts-workspace-mcp",
       "version": "0.7.7",
-      "license": "MIT",
+      "license": "Apache-2.0",
       "dependencies": {
         "js-yaml": "^4.1.0",
         "zod": "^4.0.0"
@@ -7908,6 +7908,7 @@
     "packages/signing": {
       "name": "@open-agreements/signing",
       "version": "0.7.7",
+      "license": "Apache-2.0",
       "dependencies": {
         "@google-cloud/firestore": "^8.3.0",
         "@google-cloud/storage": "^7.19.0",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "evidence-collection"
   ],
   "author": "UseJunior <steven@usejunior.com>",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "dependencies": {
     "@usejunior/docx-core": ">=0.7.0",
     "@xmldom/xmldom": "^0.9.9",

--- a/packages/allure-test-factory/package.json
+++ b/packages/allure-test-factory/package.json
@@ -30,5 +30,5 @@
   "engines": {
     "node": ">=20"
   },
-  "license": "MIT"
+  "license": "Apache-2.0"
 }

--- a/packages/checklist-mcp/README.md
+++ b/packages/checklist-mcp/README.md
@@ -33,4 +33,4 @@ Or add to your MCP client config:
 
 ## License
 
-MIT
+Apache-2.0

--- a/packages/checklist-mcp/package.json
+++ b/packages/checklist-mcp/package.json
@@ -32,7 +32,7 @@
     "url": "https://github.com/open-agreements/open-agreements.git",
     "directory": "packages/checklist-mcp"
   },
-  "license": "MIT",
+  "license": "Apache-2.0",
   "dependencies": {
     "open-agreements": ">=0.3.1",
     "zod": "^4.0.0"

--- a/packages/contract-templates-mcp/package.json
+++ b/packages/contract-templates-mcp/package.json
@@ -33,7 +33,7 @@
     "url": "https://github.com/open-agreements/open-agreements.git",
     "directory": "packages/contract-templates-mcp"
   },
-  "license": "MIT",
+  "license": "Apache-2.0",
   "dependencies": {
     "open-agreements": ">=0.3.1",
     "zod": "^4.0.0"

--- a/packages/contracts-workspace-mcp/package.json
+++ b/packages/contracts-workspace-mcp/package.json
@@ -32,7 +32,7 @@
     "url": "https://github.com/open-agreements/open-agreements.git",
     "directory": "packages/contracts-workspace-mcp"
   },
-  "license": "MIT",
+  "license": "Apache-2.0",
   "dependencies": {
     "js-yaml": "^4.1.0",
     "zod": "^4.0.0"

--- a/packages/contracts-workspace/package.json
+++ b/packages/contracts-workspace/package.json
@@ -28,7 +28,7 @@
   "engines": {
     "node": ">=20"
   },
-  "license": "MIT",
+  "license": "Apache-2.0",
   "dependencies": {
     "commander": "^13.1.0",
     "js-yaml": "^4.1.0",

--- a/packages/signing/package.json
+++ b/packages/signing/package.json
@@ -2,6 +2,7 @@
   "name": "@open-agreements/signing",
   "version": "0.7.7",
   "private": true,
+  "license": "Apache-2.0",
   "description": "DocuSign signing adapter for sending filled agreements; pluggable interface for additional providers.",
   "type": "module",
   "main": "./dist/signing/src/index.js",

--- a/server.json
+++ b/server.json
@@ -26,6 +26,6 @@
     "source": "github",
     "id": "open-agreements/open-agreements"
   },
-  "license": "MIT",
+  "license": "Apache-2.0",
   "tags": ["legal", "contracts", "templates", "docx", "nda", "safe", "nvca", "employment"]
 }

--- a/site/.well-known/mcp-server-card
+++ b/site/.well-known/mcp-server-card
@@ -15,6 +15,6 @@
       "url": "https://openagreements.org/api/mcp"
     }
   ],
-  "license": "MIT",
+  "license": "Apache-2.0",
   "tags": ["legal", "contracts", "templates", "docx", "nda", "safe", "nvca", "employment"]
 }

--- a/skills/canonical-markdown-authoring/SKILL.md
+++ b/skills/canonical-markdown-authoring/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   artifacts. Use when the user says "convert this to canonical markdown,"
   "author a new OpenAgreements template," "migrate template to template.md,"
   or "write a canonical-form contract."
-license: MIT
+license: Apache-2.0
 compatibility: >-
   Requires read/write access to an OpenAgreements repo checkout (the canonical
   compiler at scripts/template_renderer/canonical-source.mjs and the

--- a/skills/client-email/SKILL.md
+++ b/skills/client-email/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   Use when composing or revising outbound emails to clients about legal
   work product. Triggers on "draft reply," "email to client," "cover note,"
   "write back to," or any outbound email accompanying a legal deliverable.
-license: MIT
+license: Apache-2.0
 metadata:
   author: open-agreements
   version: "0.1.0"

--- a/skills/cloud-service-agreement/SKILL.md
+++ b/skills/cloud-service-agreement/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   standard forms. Use when user says "SaaS agreement," "cloud contract,"
   "MSA," "order form," "software license," "pilot agreement," or "design
   partner agreement."
-license: MIT
+license: Apache-2.0
 compatibility: >-
   Works with any agent. Remote MCP requires no local dependencies.
   Local CLI requires Node.js >=20.

--- a/skills/data-privacy-agreement/SKILL.md
+++ b/skills/data-privacy-agreement/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   says "DPA," "data processing agreement," "HIPAA BAA," "business associate
   agreement," or "AI addendum." To understand a U.S. state's consumer privacy
   law (CCPA etc.) rather than draft, see data-privacy-law-explainer.
-license: MIT
+license: Apache-2.0
 compatibility: >-
   Works with any agent. Remote MCP requires no local dependencies.
   Local CLI requires Node.js >=20.

--- a/skills/delaware-franchise-tax/SKILL.md
+++ b/skills/delaware-franchise-tax/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   deadline) and LLCs/LPs/GPs (June 1 deadline). Use when user says "Delaware
   franchise tax," "annual report Delaware," "file franchise tax," or "eCorp
   portal."
-license: MIT
+license: Apache-2.0
 metadata:
   author: open-agreements
   version: "0.1.0"

--- a/skills/edit-docx-agreement/SKILL.md
+++ b/skills/edit-docx-agreement/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   edits and tracked-changes outputs. Use when user says "edit this contract,"
   "change a clause," "modify the agreement," "custom edits to the docx," or
   "bespoke changes to the document."
-license: MIT
+license: Apache-2.0
 compatibility: >-
   Works with any agent. Requires a separately configured Safe Docx MCP server for document editing.
   OpenAgreements fill capabilities require the OpenAgreements remote MCP or local CLI.

--- a/skills/employment-contract/SKILL.md
+++ b/skills/employment-contract/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   someone," "new hire paperwork," or "onboarding paperwork." To explain
   non-compete or restrictive-covenant law rather than draft a document, see the
   non-compete-contract-explainer skill.
-license: MIT
+license: Apache-2.0
 compatibility: >-
   Works with any agent. Remote MCP requires no local dependencies.
   Local CLI requires Node.js >=20.

--- a/skills/iso-27001-evidence-collection/SKILL.md
+++ b/skills/iso-27001-evidence-collection/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   timestamped, auditor-ready evidence packages. Use when user says "collect
   audit evidence," "prepare evidence package," "evidence for the auditor,"
   "refresh evidence," or "evidence gap analysis."
-license: MIT
+license: Apache-2.0
 compatibility: >-
   Works with any AI agent. Enhanced with compliance MCP server for automated
   gap detection. Falls back to embedded checklists when no live data available.

--- a/skills/iso-27001-internal-audit/SKILL.md
+++ b/skills/iso-27001-internal-audit/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   recommendations. Uses NIST SP 800-53 (public domain) as canonical reference.
   Use when user says "run internal audit," "ISO 27001 audit," "control
   assessment," "audit findings," or "ISMS assessment."
-license: MIT
+license: Apache-2.0
 compatibility: >-
   Works with any AI agent. Enhanced with compliance MCP server for live
   dashboard data. Falls back to embedded reference files when no live data

--- a/skills/nda/SKILL.md
+++ b/skills/nda/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   agreement. Produces signable DOCX files from Common Paper and Bonterms
   standard forms. Use when user says "NDA," "non-disclosure agreement,"
   "confidentiality agreement," "mutual NDA," or "one-way NDA."
-license: MIT
+license: Apache-2.0
 compatibility: >-
   Works with any agent. Remote MCP requires no local dependencies.
   Local CLI requires Node.js >=20.

--- a/skills/open-agreements/SKILL.md
+++ b/skills/open-agreements/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   Y Combinator templates. Use when the user needs to draft a legal agreement,
   create an NDA, fill a contract template, or generate a SAFE.
   Can also send agreements for electronic signature via DocuSign.
-license: MIT
+license: Apache-2.0
 homepage: https://github.com/open-agreements/open-agreements
 compatibility: >-
   Two execution paths: (1) Remote MCP at openagreements.org (template fill
@@ -128,7 +128,7 @@ Clean up: `rm /tmp/oa-values.json`
 
 ## Source Code and Audit
 
-Open Agreements is fully open source (MIT license). Review the complete source before installing:
+Open Agreements is fully open source (Apache-2.0 license). Review the complete source before installing:
 
 - **GitHub**: https://github.com/open-agreements/open-agreements
 - **npm registry**: https://www.npmjs.com/package/open-agreements

--- a/skills/recipe-quality-audit/SKILL.md
+++ b/skills/recipe-quality-audit/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   structured scorecard per recipe with maturity tier classification. Use when user says
   "audit recipe quality," "check recipe coverage," "recipe scorecard," or "NVCA recipe
   quality."
-license: MIT
+license: Apache-2.0
 compatibility: >-
   Internal skill for the open-agreements development workflow.
   Requires local CLI and repository access.

--- a/skills/safe/SKILL.md
+++ b/skills/safe/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   equity. Produces signable DOCX files. Use when user says "SAFE," "simple
   agreement for future equity," "YC SAFE," "valuation cap," "seed round
   documents," or "fundraising paperwork."
-license: MIT
+license: Apache-2.0
 compatibility: >-
   Works with any agent. Remote MCP requires no local dependencies.
   Local CLI requires Node.js >=20.

--- a/skills/services-agreement/SKILL.md
+++ b/skills/services-agreement/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   signable DOCX files from Common Paper and Bonterms standard forms. Use when
   user says "consulting contract," "contractor agreement," "SOW," "statement
   of work," "services agreement," or "freelancer contract."
-license: MIT
+license: Apache-2.0
 compatibility: >-
   Works with any agent. Remote MCP requires no local dependencies.
   Local CLI requires Node.js >=20.

--- a/skills/soc2-readiness/SKILL.md
+++ b/skills/soc2-readiness/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   domain) as canonical reference with SOC 2 criterion cross-mapping. Use when
   user says "SOC 2 readiness," "SOC 2 preparation," "SOC 2 gap analysis," or
   "prepare for SOC 2 audit."
-license: MIT
+license: Apache-2.0
 compatibility: >-
   Works with any AI agent. Enhanced with compliance MCP server for live
   status data. Falls back to embedded reference material when no live data

--- a/skills/venture-financing/SKILL.md
+++ b/skills/venture-financing/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   templates. Produces signable DOCX files. Use when user says "Series A
   documents," "NVCA," "stock purchase agreement," "investors rights agreement,"
   "voting agreement," or "venture financing docs."
-license: MIT
+license: Apache-2.0
 compatibility: >-
   Works with any agent. Remote MCP requires no local dependencies.
   Local CLI requires Node.js >=20.


### PR DESCRIPTION
Closes #440.

Relicenses project code from MIT to Apache-2.0, in lockstep with UseJunior/safe-docx#416 and open-agreements/docx-platform-tests#13. Primary motivation is patent-risk reduction: Apache-2.0 grants an explicit patent license from every contributor (§3) and terminates it for anyone who initiates patent litigation over the work.

## Checklist from #440

- [x] Replace root `LICENSE` with Apache-2.0 text; added `NOTICE` — copyright **OM Innovation AI Inc. (UseJunior), a Delaware corporation**
- [x] `license` field updated in root `package.json` and all workspace packages (incl. private `@open-agreements/signing`, which had no field), plus `server.json`, `site/.well-known/mcp-server-card`, `.claude-plugin/plugin.json`, `.cursor-plugin/plugin.json`
- [x] README badge swapped (all 5 language variants + `README.template.md`, with `README.md` regenerated) and the License section now states the Apache license covers code only — bundled template content retains upstream licenses (CC BY 4.0 / CC BY-ND 4.0 / proprietary recipe sources per each template's `metadata.yaml`)
- [x] npm tarball: `LICENSE` already in the `files` allowlist; applies from next release

Also updated: `CONTRIBUTING.md` inbound-license clause, `docs/licensing.md` Tool License section, and project-authored skill frontmatter (`license: MIT` → `Apache-2.0`; the two CC-BY-4.0 legal-explainer snapshots untouched).

## Copyright provenance check (per issue mechanics)

Two external contributors exist:
- **#168** (Joey Tsang) — Cooley SAFE consent *template content*, which retains its upstream license regardless of the code license
- **#236** (S Bala Vignesh) — code in `packages/signing` / `api/mcp.ts`

Both were submitted under `CONTRIBUTING.md`'s inbound-license terms (MIT at the time). MIT permits sublicensing and is one-way compatible with Apache-2.0, so the flip is clean; their contributions remain attributed in git history.

## Not changed (intentional)

- Template-content license metadata and tests (`license: 'MIT'` in `metadata.test.ts` / `list.test.ts` is an intentionally *invalid template license* fixture)
- Historical openspec change docs and archives
- `docs/employment-source-policy.md` (describes a third-party source's license)
- `site/trust/system-card.md` regeneration drift surfaced by `trust:check` locally — out of scope, left at committed state

## Verification

`preflight:ci` components run locally: lint, validate, template-previews, preview-freshness, gemini-extension-manifest, check:readme (regenerated, now committed), test suite (1000 passed; the single failure is `packages/signing/tests/gcloud-storage.test.ts` hitting a live-GCS 403 — fails identically on clean main, pre-existing/credential-gated).