### PR TITLE
docs(readme): add brand seal hero, issue quick links, and roadmap pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 <!-- This file is generated from README.template.md by scripts/generate_readme.mjs. Do not edit README.md directly. -->
 
+<p align="center">
+  <img src="https://raw.githubusercontent.com/open-agreements/open-agreements/main/docs/assets/oa-seal.svg" alt="OpenAgreements seal" width="140">
+</p>
+
 # OpenAgreements
 
 [![npm version](https://img.shields.io/npm/v/open-agreements)](https://www.npmjs.com/package/open-agreements)
@@ -18,6 +22,8 @@
 Fill standard legal agreement templates and get signable DOCX files. OpenAgreements includes 40+ templates across NDAs, cloud service agreements, employment docs, contractor agreements, SAFEs, and NVCA financing documents.
 
 Works with Claude Code, Gemini CLI, Cursor, and local MCP or CLI workflows.
+
+[Propose a Form Source](https://github.com/open-agreements/open-agreements/issues/new?template=form-source-proposal.yml) · [Request a Feature](https://github.com/open-agreements/open-agreements/issues/new?template=general-enhancement.yml) · [Report an Issue](https://github.com/open-agreements/open-agreements/issues/new/choose)
 
 ## Who this is for
 
@@ -38,6 +44,7 @@ close to the document.
 - [Documentation](#documentation)
 - [Privacy](#privacy)
 - [See Also](#see-also)
+- [Roadmap](#roadmap)
 - [Contributing](#contributing)
 - [Built With OpenAgreements](#built-with-openagreements)
 - [License](#license)
@@ -475,6 +482,10 @@ Security policy: see [SECURITY.md](https://github.com/open-agreements/open-agree
 ## See Also
 
 - [safe-docx](https://github.com/UseJunior/safe-docx) — surgical editing of existing Word documents with coding agents
+
+## Roadmap
+
+Planned work is tracked in [open issues](https://github.com/open-agreements/open-agreements/issues). Larger changes are designed first as proposals in [`openspec/changes/`](https://github.com/open-agreements/open-agreements/tree/main/openspec/changes).
 
 ## Contributing
 

--- a/README.template.md
+++ b/README.template.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/open-agreements/open-agreements/main/docs/assets/oa-seal.svg" alt="OpenAgreements seal" width="140">
+</p>
+
 # OpenAgreements
 
 [![npm version](https://img.shields.io/npm/v/open-agreements)](https://www.npmjs.com/package/open-agreements)
@@ -16,6 +20,8 @@
 Fill standard legal agreement templates and get signable DOCX files. OpenAgreements includes 40+ templates across NDAs, cloud service agreements, employment docs, contractor agreements, SAFEs, and NVCA financing documents.
 
 Works with Claude Code, Gemini CLI, Cursor, and local MCP or CLI workflows.
+
+[Propose a Form Source](https://github.com/open-agreements/open-agreements/issues/new?template=form-source-proposal.yml) · [Request a Feature](https://github.com/open-agreements/open-agreements/issues/new?template=general-enhancement.yml) · [Report an Issue](https://github.com/open-agreements/open-agreements/issues/new/choose)
 
 ## Who this is for
 
@@ -305,6 +311,10 @@ Security policy: see [SECURITY.md](https://github.com/open-agreements/open-agree
 ## See Also
 
 - [safe-docx](https://github.com/UseJunior/safe-docx) — surgical editing of existing Word documents with coding agents
+
+## Roadmap
+
+Planned work is tracked in [open issues](https://github.com/open-agreements/open-agreements/issues). Larger changes are designed first as proposals in [`openspec/changes/`](https://github.com/open-agreements/open-agreements/tree/main/openspec/changes).
 
 ## Contributing
 

--- a/docs/assets/oa-seal.svg
+++ b/docs/assets/oa-seal.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" role="img" aria-label="OpenAgreements seal" viewBox="0 0 180 180" width="180" height="180">
+  <defs>
+    <style>
+      @font-face {
+        font-family: 'IBM Plex Sans Seal';
+        font-weight: 700;
+        src: url(data:font/woff2;base64,d09GMgABAAAAAAioABEAAAAAEhwAAAhLAAMBRwAAAAAAAAAAAAAAAAAAAAAAAAAAGhYbgz4cNgZgAGwIRgmCcxEQCo9gjjwBNgIkAzgLHgAEIAWCagcgDIQWGywQIxHCxgEAlT0zxF8l8GSodl0kRIQIcTQM046wtv9rrVvDdhshcgPxCo5xBi9E8LXW22927wOxQ+GIhQEKo0d1yofcVYza8kHh48eH3s16M5NAMgFCxSjdDVoxoCJKlfqKC3crZr09N2D1/lSkEMQ2HyulETJEk6Qyl6ppR/8DhH/fXO6NhJ3cu98a3T5zNcwlPHLWqeCCF1Rz+9GaZm9mswWXpCxRlYWLrqtwMfIupZ0iskah0AgCeiT58vW/Mm8yfvs3Un8ix1hpf3ABOgAkBKUgCGjjUUvYaWwPwHJ77bIFsNxfNnM+LE+mrlgECwF4+XhPj2cuWwQJFCBQjKTYKhQECZVIADM0FAUQL9QzINSXqDCrZkEWZ6HUmMIUA5Sor+nShGs3cbQ5boQOshHIqh/iJBRXmQBD0TzWMAJqyV8GnziPRAfa8rViIZ8aFnmVvO3M3cI/Mj8S+0lPm/yCskFqjvgIOwkGciR4EZbBebGejF9JDcNbUkABL9ltg2c1VisuUewO9OqTz5zMaewMNTYv0zx6GRFSXRwEHMNV4wozokwiVJGYSBl+rYMgjP3XD7f8GtGgzdiZYcxJsgRCYgABpE4aAWZQkEABBjAEDBAMgj5mDKXJUaNBky6BGfvYWNhav55/we1EfB6TsW9A5Nc5bFi9WZpNs1LAAu2K5dpLqx2cZIajjAIduRiGaIEulkKXjDCkyASfSvavsgGiBk2B3DNfQvaTkLGHOPXFH2SHrVehgAQA+qqYTAkFNBAQD0MBCyBl5koHxiWwmm05WC2Fy/bAggsqe3Mc7VAMjF5z/akdMMjVlF81OBJVQoFgiglhdoii4WaE3ZSym38oEIMmMHP3TN9wUOWzULUsImi+3uNJ1wX+KyVUF6wCk+/XTNigD9d5JUgyJIZNVJcsDNndjDQXOdhy8tZBv+MJrldPCXh1pMBoZebSQoK9XRGkgHyWkdzDKH/5XalQIAfNodEqj0ghJQhGwpnp81jdgC7ABOiBaAfiAQBKKN8CSEhhVEUeoUUwpEWZYk0qN/NMyRRv7OcBPlmZOI8PKopohEEvu7htdOC7Z0NNbpivouwZ+wLnZ3z3ALwbGVeKL+mEcGKkfDkPBPr7OeWiMqSMKAKfXeL7FEb9plqRhxrBIa1/z5xw/e2FicZNfKnMi69yDiZKgUCpz7nCU43mId7PB0pZTK3PagdekxV1GaU19rtYsiJw14zvLhC0CvrczTVf4CInKvrqvr4I5ObwgHfuwO7sqsaK068d/UyPf+rKvb3sPZef/Md761eXv9zpz8KXPw7X5ort0ugcf+SdHXUH4rbHnajbMaBfJK4Yaegsn53tH8rcNjiYvaNnZHlu06QdXe6u9Y1/1hVXNPV2Dy4Z6O1pslqHGyyOGzfHbAtu6H+K+Wbu+H3rb/kL2UsHIjfd1UjvaLwYObDU1lK7h72eYm67imedOkNpWJrdOZy5fWhokqG8HKiBVad+e0P7UGBOYA5pwKvV+SOtXr82N6XH60vpnlvrex/6Nzhqn2bPmmYZnf3ZyUibxz9+3u7yvqbKuX/sjLpz7djCC5tFvsnHPshRJmyufGL6obFzTvFEd8rvOiUtMs6aO5jr8NcWTRlX2bnae/+MmXsbnYV5MZpz8WP1fL559rQRn6O3vmymNn+xL+9k3pUd0TsqTvPsexyxjnuy0R/YXz+WccSnWp1W1XckY3W2OGcC8AOJgbE3uiRE6gkRKyGwe1KaryaHiVLWhngoWAliEIjKESiRYMiUrub3hMjVcsmeMM70P/FGyK78XCDRJQgViOiCYIjQXACxygYxXkAgWLasb5UmHU1DNkWOqZhaOYTQE2Z1ZU9YCWT6CYxjWzjEmThWmROiwWlwr89EiUZZV0ZjX+Mfmq3MYlBSSVWMPSGkuivy2c8GMiQdC1iEUvl0hC5q53cT8kF4EIPH3CIkZqBgDJZ8aOY4ZhQSWzGLQCSGib1PgPNkW7MklvgQ8//wGKq7nCVaGCXOZVytYTiAEXmJcUr2ZRjVk72JRTKYjM1IdSkSJJ3dKqHUNahAym0Ioa4mdvUDqOtf1ujRRTWFagkVi4Y0jCQIUhoRB2E0gG6ofkxigGh/2UhBEJWgBhp6Mi/DJEVBCgxWH136VpmyMG4ocTcgxHErtxLYTGcrMNLJCwu7uOIkVnZvM6Yk8uMKaRAlEEEYR+BB2VlkUfqfQtohCY8UAdqxRY8XBBTR1PHqEXGyWv6bJLMvgX+eE9/hKdafnUyVfGETCBkFBJSxkQ5q9wQk44AYe+2KN2m+BdJnYtNk+NMLfEVeplcn8fTSNB2Ei693CdypGclRiLq4j0oEdAnQm0VEAG2Q0CEICGg2jCGlDLRgUCph2XKkJCscmUIbHAVODzmKLF5/SB3Nj+ostsRay8w12xwraHw8vIppWtTy0wRpWf/dHJoaCyygKQUuZ9BMCDNpVUudIUeduhSuP9Maml5TLbJcrcUWmCFPDg+PAmWH/8JX0b+FZlMXTYdqPbA/GDnT3DZqEc1Z9xzUZwDZp87GKg2wKAKhoosEa80YXLtKkWwOSVTQsnhNFLfxEkVRmBQtUjlFPDNOAnUpopJPBocYuaWobnXyuSSl8ZhC60sJ/Kp4OcQdrUUlcrhZxEgnUppqvIRcVq9Wnozu7y5QYhXbJDLRUrIW5XLZxB753HTdPTlbMi2lWGWKNoXsR6FBGu3acr6UUZsKHk4JNJ5JekgTVS7jFBdFhBgS/WIIPo/XiVAlAXkD+RJezUfRLL3l1YmLJW0FTCHpNZoVFqqKSHAV5Iv5hcQHSFYJfpH4j9glveEebk70sFHgCwQAAAA=) format('woff2');
+      }
+    </style>
+    <path d="M 35 90 a 55 55 0 0 1 110 0" id="oa-seal-top"/>
+    <path d="M 145 90 a 55 55 0 0 1 -110 0" id="oa-seal-bottom"/>
+  </defs>
+  <g fill="#1457d9" font-family="'IBM Plex Sans Seal', 'IBM Plex Sans', system-ui, sans-serif">
+    <text font-size="11.2" font-weight="700" letter-spacing="1.45">
+      <textPath href="#oa-seal-top" startOffset="50%" text-anchor="middle">OPENAGREEMENTS.ORG •</textPath>
+    </text>
+    <text font-size="11.2" font-weight="700" letter-spacing="1.45">
+      <textPath href="#oa-seal-bottom" startOffset="50%" text-anchor="middle">OPENAGREEMENTS.ORG •</textPath>
+    </text>
+    <text font-size="34" font-weight="700" text-anchor="middle" x="90" y="102">OA</text>
+  </g>
+</svg>

--- a/scripts/generate_readme.mjs
+++ b/scripts/generate_readme.mjs
@@ -67,6 +67,7 @@ const CONTENTS = [
   ["Documentation", "#documentation"],
   ["Privacy", "#privacy"],
   ["See Also", "#see-also"],
+  ["Roadmap", "#roadmap"],
   ["Contributing", "#contributing"],
   ["Built With OpenAgreements", "#built-with-openagreements"],
   ["License", "#license"],


### PR DESCRIPTION
## Summary

- Add `docs/assets/oa-seal.svg` — the openagreements.org brand seal adapted for GitHub rendering: brand blue `#1457d9` hardcoded (`currentColor` resolves to black in `<img>` context) and a 2.2KB subsetted IBM Plex Sans Bold embedded as a data URI so the `textPath` glyphs (including the trailing bullets) never clip on fallback fonts. Wired into the README hero, centered at 140px above the title.
- Surface the existing issue forms under the tagline: Propose a Form Source · Request a Feature · Report an Issue.
- Add a one-paragraph Roadmap section pointing at open issues and `openspec/changes/` (no hand-maintained checklist to rot).
- `README.md` regenerated from `README.template.md`; Roadmap added to the generated TOC.

Note: the seal `<img>` points at `raw.githubusercontent.com/.../main/...`, so it renders as broken in this PR's preview and appears once merged — same pattern as the existing demo GIF.

Translated READMEs (es/zh/pt-br/de) are maintained manually and will pick these sections up on their next refresh pass.