### PR TITLE
fix(recipes): strip orphaned cross-reference fields on [Reserved] substitution (#479)

### DIFF
--- a/src/core/selector.test.ts
+++ b/src/core/selector.test.ts
@@ -74,12 +74,46 @@ function extractText(docxPath: string): string {
   return parts.join('');
 }
 
+/** Read the raw word/document.xml from a DOCX (for structural assertions). */
+function readDocumentXml(docxPath: string): string {
+  const zip = new AdmZip(docxPath);
+  const entry = zip.getEntry('word/document.xml');
+  return entry ? entry.getData().toString('utf-8') : '';
+}
+
 // ---------------------------------------------------------------------------
 // Helper to make paragraph XML with marker prefix
 // ---------------------------------------------------------------------------
 
 function para(text: string): string {
   return `<w:p xmlns:w="${W_NS}"><w:r><w:t xml:space="preserve">${text}</w:t></w:r></w:p>`;
+}
+
+/**
+ * Paragraph containing leading text followed by a complex Word cross-reference
+ * field (fldChar begin/separate/end + instrText) whose cached result is `fieldResult`.
+ * Mirrors the real NVCA "Additional Closings" clause structure from issue #479.
+ */
+function paraWithComplexField(leadingText: string, fieldResult: string): string {
+  return (
+    `<w:p xmlns:w="${W_NS}">` +
+    `<w:r><w:t xml:space="preserve">${leadingText}</w:t></w:r>` +
+    `<w:r><w:fldChar w:fldCharType="begin"/></w:r>` +
+    `<w:r><w:instrText xml:space="preserve"> REF _Ref137575642 \\r \\h  \\* MERGEFORMAT </w:instrText></w:r>` +
+    `<w:r><w:fldChar w:fldCharType="separate"/></w:r>` +
+    `<w:r><w:t>${fieldResult}</w:t></w:r>` +
+    `<w:r><w:fldChar w:fldCharType="end"/></w:r>` +
+    `</w:p>`
+  );
+}
+
+/** Paragraph whose ONLY content is a simple field (<w:fldSimple>). */
+function paraWithSimpleField(fieldResult: string): string {
+  return (
+    `<w:p xmlns:w="${W_NS}">` +
+    `<w:fldSimple w:instr=" REF _Ref137575642 \\h "><w:r><w:t>${fieldResult}</w:t></w:r></w:fldSimple>` +
+    `</w:p>`
+  );
 }
 
 function tableCell(...paragraphs: string[]): string {
@@ -691,5 +725,88 @@ describe('inline selections', () => {
     if (!result.success) {
       expect(result.error.message).toContain('inline');
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Field-construct stripping on replaceWith substitution (issue #479)
+// ---------------------------------------------------------------------------
+
+describe('replaceWith strips orphaned field constructs', () => {
+  const fieldGroup: SelectionsConfig = {
+    groups: [{
+      id: 'additional_closings',
+      type: 'checkbox',
+      standalone: true,
+      markerless: true,
+      options: [{
+        marker: 'Additional Closings',
+        trigger: { field: 'closing_type', equals: 'additional' },
+        replaceWith: '[Reserved]',
+      }],
+    }],
+  };
+
+  it('removes fldChar/instrText when the option is de-selected (the #479 fix)', async () => {
+    const body = `
+      ${para('Section 1.2(a) Initial Closing.')}
+      ${paraWithComplexField('Additional Closings. See ', 'Exhibit A')}
+      ${para('Section 1.2(c) Tranche Closing.')}
+    `;
+    const inputPath = buildTestDocx(body);
+    const outputPath = join(makeTempDir(), 'out.docx');
+
+    await applySelections(inputPath, outputPath, fieldGroup, { closing_type: 'single' });
+
+    const xml = readDocumentXml(outputPath);
+    // No field machinery survives — so nothing re-resolves to "Exhibit A".
+    expect(xml).not.toContain('<w:fldChar');
+    expect(xml).not.toContain('<w:instrText');
+
+    const text = extractText(outputPath);
+    expect(text).toContain('[Reserved]');
+    expect(text).not.toContain('Exhibit A');
+    expect(text).not.toContain('Additional Closings');
+  });
+
+  it('leaves the field intact when the option is selected (control)', async () => {
+    const body = `
+      ${para('Section 1.2(a) Initial Closing.')}
+      ${paraWithComplexField('Additional Closings. See ', 'Exhibit A')}
+      ${para('Section 1.2(c) Tranche Closing.')}
+    `;
+    const inputPath = buildTestDocx(body);
+    const outputPath = join(makeTempDir(), 'out.docx');
+
+    await applySelections(inputPath, outputPath, fieldGroup, { closing_type: 'additional' });
+
+    const xml = readDocumentXml(outputPath);
+    // Kept paragraph: field machinery must remain untouched.
+    expect(xml).toContain('<w:fldChar');
+    expect(xml).toContain('<w:instrText');
+
+    const text = extractText(outputPath);
+    expect(text).toContain('Additional Closings');
+    expect(text).toContain('Exhibit A');
+  });
+
+  it('renders [Reserved] when the paragraph was entirely a simple field', async () => {
+    const body = `
+      ${para('Section 1.2(a) Initial Closing.')}
+      ${paraWithSimpleField('Additional Closings (Exhibit A)')}
+      ${para('Section 1.2(c) Tranche Closing.')}
+    `;
+    const inputPath = buildTestDocx(body);
+    const outputPath = join(makeTempDir(), 'out.docx');
+
+    await applySelections(inputPath, outputPath, fieldGroup, { closing_type: 'single' });
+
+    const xml = readDocumentXml(outputPath);
+    expect(xml).not.toContain('<w:fldSimple');
+
+    const text = extractText(outputPath);
+    // Placeholder is not silently dropped despite there being no <w:t> left after stripping.
+    expect(text).toContain('[Reserved]');
+    expect(text).not.toContain('Exhibit A');
   });
 });

--- a/src/core/selector.ts
+++ b/src/core/selector.ts
@@ -668,6 +668,9 @@ function replaceParagraphText(para: Element, newText: string): void {
     if (doc) {
       const r = doc.createElementNS(W_NS, 'w:r');
       const t = doc.createElementNS(W_NS, 'w:t');
+      // Preserve any leading/trailing whitespace in the placeholder, matching
+      // how authored runs carry xml:space="preserve".
+      t.setAttribute('xml:space', 'preserve');
       t.textContent = newText;
       r.appendChild(t);
       para.appendChild(r);

--- a/src/core/selector.ts
+++ b/src/core/selector.ts
@@ -623,9 +623,57 @@ function processStandaloneGroup(
   return madeChanges;
 }
 
+/**
+ * Remove embedded Word field constructs from a paragraph so no orphaned field
+ * survives a text substitution. Complex fields use runs containing <w:fldChar>
+ * (begin/separate/end) and <w:instrText>; simple fields use <w:fldSimple>.
+ *
+ * Without this, replacing a paragraph's text (e.g. with the "[Reserved]"
+ * placeholder) empties a cross-reference field's cached result run but leaves
+ * the field machinery intact, so Word/LibreOffice re-resolves the reference
+ * (e.g. a `REF` field re-rendering its bookmark target like "Exhibit A").
+ */
+function stripFieldConstructs(para: Element): void {
+  // Snapshot matches into an array before removal — getElementsByTagNameNS
+  // returns a live NodeList that shifts as nodes are removed.
+  const toRemove: Element[] = [];
+
+  // Remove every <w:r> that carries field machinery (fldChar or instrText).
+  const runs = para.getElementsByTagNameNS(W_NS, 'r');
+  for (let i = 0; i < runs.length; i++) {
+    const r = runs[i];
+    if (
+      r.getElementsByTagNameNS(W_NS, 'fldChar').length > 0 ||
+      r.getElementsByTagNameNS(W_NS, 'instrText').length > 0
+    ) {
+      toRemove.push(r);
+    }
+  }
+
+  // Remove any simple fields (<w:fldSimple>) wholesale.
+  const simple = para.getElementsByTagNameNS(W_NS, 'fldSimple');
+  for (let i = 0; i < simple.length; i++) toRemove.push(simple[i]);
+
+  for (const el of toRemove) el.parentNode?.removeChild(el);
+}
+
 /** Replace all <w:t> content in a paragraph with new text. First node gets the text, rest get empty string. */
 function replaceParagraphText(para: Element, newText: string): void {
+  stripFieldConstructs(para);
   const tElements = para.getElementsByTagNameNS(W_NS, 't');
+  // If stripping removed every text node (e.g. the paragraph was entirely a
+  // <w:fldSimple>), synthesize a run so newText is never silently dropped.
+  if (tElements.length === 0) {
+    const doc = para.ownerDocument;
+    if (doc) {
+      const r = doc.createElementNS(W_NS, 'w:r');
+      const t = doc.createElementNS(W_NS, 'w:t');
+      t.textContent = newText;
+      r.appendChild(t);
+      para.appendChild(r);
+    }
+    return;
+  }
   for (let i = 0; i < tElements.length; i++) {
     tElements[i].textContent = i === 0 ? newText : '';
   }


### PR DESCRIPTION
Closes #479.

## Problem
In a filled NVCA SPA, §1.2(b) rendered as **`[Reserved]Exhibit A`** (with "Exhibit A" underlined) instead of just `[Reserved]`. The `[Reserved]` placeholder is intended (the optional "Additional Closings" sub-clause is de-selected when `closing_type ≠ "additional"`); the bug was a leftover cross-reference field.

## Root cause
`replaceParagraphText()` (`src/core/selector.ts`) rewrote a paragraph's `<w:t>` nodes but left embedded Word field machinery (`<w:fldChar>` begin/separate/end, `<w:instrText>`) in place. The de-selected clause contains a `REF _Ref137575642 \r \h \* MERGEFORMAT` cross-reference whose cached result was "Exhibit A". Emptying the cached result run while leaving the field intact caused Word/LibreOffice to re-resolve the bookmark and render "Exhibit A" right after "[Reserved]".

Pre-existing (independent of #472 / the docx-core bump).

## Fix
- Add `stripFieldConstructs()` to remove field-machinery runs and any `<w:fldSimple>` before the text rewrite.
- Add a fallback in `replaceParagraphText()` that synthesizes a `<w:r><w:t>` run when stripping removes every `<w:t>` (a paragraph that was entirely a simple field) — so the placeholder is never silently dropped.

Only the unselected/replace call sites invoke this, so kept paragraphs' fields — including the many legitimate "Exhibit A" references elsewhere in the SPA — are untouched.

### Trade-off (noted from peer review)
The inline-fallback caller (`SafeDocxError` path) already rewrites the whole paragraph destructively. Stripping fields there is corrective — it prevents a latent field-cache *duplication* on field update — but any *other* live cross-reference in such a spliced paragraph is flattened to static text. Acceptable, since that path was already destructive.

## Tests
New `describe('replaceWith strips orphaned field constructs')` in `src/core/selector.test.ts`:
- **de-selected** → no `<w:fldChar>`/`<w:instrText>` survive; renders `[Reserved]`, no "Exhibit A";
- **selected (control)** → field machinery left intact;
- **whole-paragraph `<w:fldSimple>`** → `[Reserved]` still rendered (exercises the empty-`<w:t>` fallback).

## Verification
- `npm run build` clean.
- `vitest run src/core/selector.test.ts` → 24 pass; `nvca-spa-template.test.ts` → 9 pass.
- E2E repro from the issue: `orphaned REF field still present: false` (was `true`).
- Rendered to PDF: §1.2(b) shows `(b) [Reserved]` with no trailing "Exhibit A"; all retained "Exhibit A" references preserved.

Peer-reviewed (Codex + agy, both dynamic — read files, ran build/tests/repro). Both independently caught the empty-`<w:t>` fallback gap, now handled.