### PR TITLE
feat(recipes): migrate NVCA SPA `>`-anchor keys to selector contracts (#476)

### DIFF
--- a/content/recipes/nvca-stock-purchase-agreement/fields/agreement_date_month_day.json
+++ b/content/recipes/nvca-stock-purchase-agreement/fields/agreement_date_month_day.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": 1,
+  "field_id": "agreement_date_month_day",
+  "field_label": "Agreement Date (Month and Day)",
+  "description": "Month-and-day portion of the agreement's execution date in the preamble. Anchored on \"is made as of\" because the 8-underscore blank [________] is not globally unique.",
+  "source_template_version": "10-28-2025",
+  "occurrences": [
+    {
+      "primary": {
+        "kind": "regex",
+        "pattern": "is made as of\\s(\\[________\\])",
+        "group": 1
+      }
+    }
+  ],
+  "postconditions": [
+    "no_unresolved_placeholder",
+    "no_double_dollar"
+  ],
+  "failure_behavior": "warn",
+  "fixtures": [
+    {
+      "occurrence": 0,
+      "anchor": "is made as of [________]",
+      "note": "preamble date blank; regex captures only the [________] span"
+    }
+  ]
+}

--- a/content/recipes/nvca-stock-purchase-agreement/fields/agreement_year_two_digits.json
+++ b/content/recipes/nvca-stock-purchase-agreement/fields/agreement_year_two_digits.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": 1,
+  "field_id": "agreement_year_two_digits",
+  "field_label": "Agreement Year (Two Digits)",
+  "description": "Two-digit year portion of the agreement's execution date in the preamble (\"20[__]\"). Anchored on \", 20\" because the 2-underscore blank [__] recurs throughout the document.",
+  "source_template_version": "10-28-2025",
+  "occurrences": [
+    {
+      "primary": {
+        "kind": "regex",
+        "pattern": ", 20(\\[__\\])",
+        "group": 1
+      }
+    }
+  ],
+  "postconditions": [
+    "no_unresolved_placeholder",
+    "no_double_dollar"
+  ],
+  "failure_behavior": "warn",
+  "fixtures": [
+    {
+      "occurrence": 0,
+      "anchor": ", 20[__]",
+      "note": "preamble year blank; regex captures only the [__] span after \", 20\""
+    }
+  ]
+}

--- a/content/recipes/nvca-stock-purchase-agreement/fields/investor_counsel.json
+++ b/content/recipes/nvca-stock-purchase-agreement/fields/investor_counsel.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": 1,
+  "field_id": "investor_counsel",
+  "field_label": "Investor Counsel (Fees and Expenses)",
+  "description": "The investor counsel named in the fees-and-expenses clause (\"reasonable fees and expenses of [_______], the counsel for ...\"). Anchored on \"expenses of\" because the 7-underscore blank is not unique on its own.",
+  "source_template_version": "10-28-2025",
+  "occurrences": [
+    {
+      "primary": {
+        "kind": "regex",
+        "pattern": "expenses of\\s(\\[_______\\])",
+        "group": 1
+      }
+    }
+  ],
+  "postconditions": [
+    "no_unresolved_placeholder",
+    "no_double_dollar"
+  ],
+  "failure_behavior": "warn",
+  "fixtures": [
+    {
+      "occurrence": 0,
+      "anchor": "expenses of [_______]",
+      "note": "fees-and-expenses clause; regex captures only the [_______] blank after \"expenses of\""
+    }
+  ]
+}

--- a/content/recipes/nvca-stock-purchase-agreement/fields/minimum_shares_initial_closing.json
+++ b/content/recipes/nvca-stock-purchase-agreement/fields/minimum_shares_initial_closing.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": 1,
+  "field_id": "minimum_shares_initial_closing",
+  "field_label": "Minimum Shares at Initial Closing",
+  "description": "Minimum number of Shares that must be sold at the Initial Closing. Appears in two optional condition clauses (Purchasers' and Company's obligations) with different blank widths; each occurrence is captured by its exact underscore count.",
+  "source_template_version": "10-28-2025",
+  "occurrences": [
+    {
+      "primary": {
+        "kind": "regex",
+        "pattern": "A minimum of\\s(\\[_________\\])\\sShares",
+        "group": 1
+      }
+    },
+    {
+      "primary": {
+        "kind": "regex",
+        "pattern": "A minimum of\\s(\\[_______\\])\\sShares",
+        "group": 1
+      }
+    }
+  ],
+  "postconditions": [
+    "no_unresolved_placeholder",
+    "no_double_dollar"
+  ],
+  "failure_behavior": "warn",
+  "fixtures": [
+    {
+      "occurrence": 0,
+      "anchor": "A minimum of [_________] Shares",
+      "note": "Purchasers' conditions clause; 9-underscore blank"
+    },
+    {
+      "occurrence": 1,
+      "anchor": "A minimum of [_______] Shares",
+      "note": "Company's conditions clause; 7-underscore blank"
+    }
+  ]
+}

--- a/content/recipes/nvca-stock-purchase-agreement/fields/optional_plural_suffix.json
+++ b/content/recipes/nvca-stock-purchase-agreement/fields/optional_plural_suffix.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": 1,
+  "field_id": "optional_plural_suffix",
+  "field_label": "Optional Plural Suffix",
+  "description": "The optional \"s\" in the \"Closing[s]; Delivery.\" heading, toggled depending on whether the financing has additional closings. Anchored on \"Closing\" so the [s] blank is captured at exactly that span.",
+  "source_template_version": "10-28-2025",
+  "occurrences": [
+    {
+      "primary": {
+        "kind": "regex",
+        "pattern": "Closing(\\[s\\])",
+        "group": 1
+      }
+    }
+  ],
+  "postconditions": [
+    "no_unresolved_placeholder",
+    "no_double_dollar"
+  ],
+  "failure_behavior": "warn",
+  "fixtures": [
+    {
+      "occurrence": 0,
+      "anchor": "Closing[s]",
+      "note": "section heading; regex captures only the [s] suffix"
+    }
+  ]
+}

--- a/content/recipes/nvca-stock-purchase-agreement/fields/par_value_per_share.json
+++ b/content/recipes/nvca-stock-purchase-agreement/fields/par_value_per_share.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": 1,
+  "field_id": "par_value_per_share",
+  "field_label": "Par Value Per Share",
+  "description": "Par value of the Series preferred stock named in the purchase clause (\"Stock, $[__] par value per share\"). A bare contextual locator on $[__] resolves to zero, so a regex with surrounding context captures the exact 2-underscore blank.",
+  "source_template_version": "10-28-2025",
+  "occurrences": [
+    {
+      "primary": {
+        "kind": "regex",
+        "pattern": "Stock, \\$(\\[__\\])\\spar value",
+        "group": 1
+      }
+    }
+  ],
+  "postconditions": [
+    "no_unresolved_placeholder",
+    "no_double_dollar"
+  ],
+  "failure_behavior": "warn",
+  "fixtures": [
+    {
+      "occurrence": 0,
+      "anchor": "Stock, $[__] par value",
+      "note": "purchase clause; regex captures only the [__] blank between \"Stock, $\" and \"par value\""
+    }
+  ]
+}

--- a/content/recipes/nvca-stock-purchase-agreement/fields/purchase_price_per_share.json
+++ b/content/recipes/nvca-stock-purchase-agreement/fields/purchase_price_per_share.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": 1,
+  "field_id": "purchase_price_per_share",
+  "field_label": "Purchase Price Per Share",
+  "description": "Per-share purchase price in the purchase clause (\"purchase price of $[__] per share\"). A bare contextual locator on $[__] resolves to zero, so a regex with surrounding context captures the exact 2-underscore blank (distinct from the 3-underscore convertible-securities price later in the same paragraph).",
+  "source_template_version": "10-28-2025",
+  "occurrences": [
+    {
+      "primary": {
+        "kind": "regex",
+        "pattern": "purchase price of \\$(\\[__\\])\\sper share",
+        "group": 1
+      }
+    }
+  ],
+  "postconditions": [
+    "no_unresolved_placeholder",
+    "no_double_dollar"
+  ],
+  "failure_behavior": "warn",
+  "fixtures": [
+    {
+      "occurrence": 0,
+      "anchor": "purchase price of $[__] per share",
+      "note": "purchase clause; regex captures only the [__] blank, not the later [___] convertible price"
+    }
+  ]
+}

--- a/content/recipes/nvca-stock-purchase-agreement/fields/series_designation.json
+++ b/content/recipes/nvca-stock-purchase-agreement/fields/series_designation.json
@@ -1,0 +1,160 @@
+{
+  "schema_version": 1,
+  "field_id": "series_designation",
+  "field_label": "Series Designation",
+  "description": "The Series letter/name of the preferred stock (e.g. \"A\"), written into every \"Series [___] Preferred Stock\" reference. The legacy replacements.json filled exactly 12 of the document's 14 series-style blanks (the legacy patcher replaces only the first blank after each context per paragraph), so this field declares exactly those 12 occurrences. Two blanks are deliberately left unmigrated to preserve parity with the legacy output: the third \"[___]\" in the purchase clause and the second \"[___]\" in the capitalization clause. Each occurrence anchors on distinctive preceding context; \\s matches the non-breaking space the source uses between \"Series\" and the blank.",
+  "source_template_version": "10-28-2025",
+  "occurrences": [
+    {
+      "primary": {
+        "kind": "regex",
+        "pattern": "^SERIES\\s(\\[___\\])\\sPREFERRED",
+        "group": 1
+      }
+    },
+    {
+      "primary": {
+        "kind": "regex",
+        "pattern": "THIS SERIES\\s(\\[___\\])\\sPREFERRED",
+        "group": 1
+      }
+    },
+    {
+      "primary": {
+        "kind": "regex",
+        "pattern": "that number of shares of Series\\s(\\[___\\])\\sPreferred",
+        "group": 1
+      }
+    },
+    {
+      "primary": {
+        "kind": "regex",
+        "pattern": "par value per share \\(the “Series\\s(\\[___\\])\\sPreferred",
+        "group": 1
+      }
+    },
+    {
+      "primary": {
+        "kind": "regex",
+        "pattern": "such shares\\)\\] of Series\\s(\\[___\\])\\sPreferred",
+        "group": 1
+      }
+    },
+    {
+      "primary": {
+        "kind": "regex",
+        "pattern": "with respect to the Series\\s(\\[___\\])\\sPreferred",
+        "group": 1
+      }
+    },
+    {
+      "primary": {
+        "kind": "regex",
+        "pattern": "transfer of a Purchaser’s Series\\s(\\[___\\])\\sPreferred",
+        "group": 1
+      }
+    },
+    {
+      "primary": {
+        "kind": "regex",
+        "pattern": "receive such Series\\s(\\[__\\])\\sPreferred",
+        "group": 1
+      }
+    },
+    {
+      "primary": {
+        "kind": "regex",
+        "pattern": "the number of shares of Series\\s(\\[___\\])\\sPreferred",
+        "group": 1
+      }
+    },
+    {
+      "primary": {
+        "kind": "regex",
+        "pattern": "designated Series\\s(\\[___\\])\\sPreferred",
+        "group": 1
+      }
+    },
+    {
+      "primary": {
+        "kind": "regex",
+        "pattern": "executed this Series\\s(\\[___\\])\\sPreferred",
+        "group": 1
+      }
+    },
+    {
+      "primary": {
+        "kind": "regex",
+        "pattern": "Section 2 of the Series\\s(\\[___\\])\\sPreferred",
+        "group": 1
+      }
+    }
+  ],
+  "postconditions": [
+    "no_unresolved_placeholder",
+    "no_double_dollar"
+  ],
+  "failure_behavior": "warn",
+  "fixtures": [
+    {
+      "occurrence": 0,
+      "anchor": "SERIES [___] PREFERRED STOCK PURCHASE AGREEMENT",
+      "note": "title heading (regular space)"
+    },
+    {
+      "occurrence": 1,
+      "anchor": "THIS SERIES [___] PREFERRED",
+      "note": "preamble"
+    },
+    {
+      "occurrence": 2,
+      "anchor": "that number of shares of Series [___] Preferred",
+      "note": "purchase clause, first series blank"
+    },
+    {
+      "occurrence": 3,
+      "anchor": "(the “Series [___] Preferred Stock”)",
+      "note": "purchase clause, defined-term (curly-quote variant)"
+    },
+    {
+      "occurrence": 4,
+      "anchor": "shares)] of Series [___] Preferred",
+      "note": "additional-closings clause"
+    },
+    {
+      "occurrence": 5,
+      "anchor": "with respect to the Series [___] Preferred",
+      "note": "special mandatory conversion"
+    },
+    {
+      "occurrence": 6,
+      "anchor": "transfer of a Purchaser’s Series [___] Preferred",
+      "note": "transfer condition"
+    },
+    {
+      "occurrence": 7,
+      "anchor": "receive such Series [__] Preferred",
+      "note": "transfer condition (2-underscore \"such Series\" variant)"
+    },
+    {
+      "occurrence": 8,
+      "anchor": "the number of shares of Series [___] Preferred",
+      "note": "convertible-securities conversion"
+    },
+    {
+      "occurrence": 9,
+      "anchor": "designated Series [___] Preferred",
+      "note": "capitalization clause, first series blank"
+    },
+    {
+      "occurrence": 10,
+      "anchor": "executed this Series [___] Preferred",
+      "note": "signature recital"
+    },
+    {
+      "occurrence": 11,
+      "anchor": "Section 2 of the Series [___] Preferred",
+      "note": "disclosure schedule recital"
+    }
+  ]
+}

--- a/content/recipes/nvca-stock-purchase-agreement/template-manifest.json
+++ b/content/recipes/nvca-stock-purchase-agreement/template-manifest.json
@@ -6,6 +6,19 @@
   "migrated_keys": [
     "[Insert Company Name]",
     "[Company name]",
-    "[____________]"
+    "[____________]",
+    "SERIES > [___]",
+    "Series > [___]",
+    "such Series > [__]",
+    "“Series > [___]",
+    "\"Series > [___]",
+    "is made as of > [________]",
+    ", 20 > [__]",
+    "Stock, $ > [__]",
+    "purchase price of $ > [__]",
+    "Closing > [s]",
+    "A minimum of > [_________]",
+    "A minimum of > [_______]",
+    "expenses of > [_______]"
   ]
 }

--- a/integration-tests/nvca-spa-template.test.ts
+++ b/integration-tests/nvca-spa-template.test.ts
@@ -65,6 +65,21 @@ interface FieldAssertionPolicy {
 
 const RECIPE_ID = 'nvca-stock-purchase-agreement';
 const RECIPE_DIR = join(import.meta.dirname, '..', 'content', 'recipes', RECIPE_ID);
+
+/**
+ * Context-qualified (`>`-anchor) replacement keys that have been migrated to selector contracts
+ * (`template-manifest.json.migrated_keys`). These resolve against the real document's prose context,
+ * so the flat `Marker N: <key>` synthetic fixture below cannot exercise them — they are covered by the
+ * whole-document parity tests in selector-contracts.test.ts against the real cached source. Literal
+ * migrated keys (e.g. company_name's `[Insert Company Name]`) are NOT excluded: their selectors match
+ * verbatim and still render in the synthetic harness.
+ */
+function loadMigratedContextKeys(): Set<string> {
+  const manifest = JSON.parse(readFileSync(join(RECIPE_DIR, 'template-manifest.json'), 'utf-8')) as {
+    migrated_keys?: string[];
+  };
+  return new Set((manifest.migrated_keys ?? []).filter((key) => key.includes('>')));
+}
 const it = itAllure.withLabels({
   epic: 'NVCA SPA Template',
   feature: 'NVCA SPA Legal QA',
@@ -595,7 +610,11 @@ describe('NVCA SPA Template', () => {
     const { metadata, replacements, cleanConfig } = await allureStep('Load NVCA recipe artifacts', () =>
       loadNvcaRecipeArtifacts()
     );
-    const sourcePlaceholders = Object.keys(replacements).filter((key) => !isNthReplacementKey(key));
+    const migratedContextKeys = loadMigratedContextKeys();
+    const legacyReplacements = Object.fromEntries(
+      Object.entries(replacements).filter(([key]) => !migratedContextKeys.has(key))
+    );
+    const sourcePlaceholders = Object.keys(legacyReplacements).filter((key) => !isNthReplacementKey(key));
     const values = buildScenarioValues(metadata.fields ?? [], {
       company_name: 'Acme Robotics, Inc.',
       investor_name: 'North Star Ventures LLC',
@@ -603,7 +622,7 @@ describe('NVCA SPA Template', () => {
       director_names: 'Jane Founder; Pat Director',
       applicable_purchasers: 'North Star Ventures LLC',
     });
-    const verificationValues = buildVerificationValues(values, sourcePlaceholders, replacements);
+    const verificationValues = buildVerificationValues(values, sourcePlaceholders, legacyReplacements);
 
     const fixture = createSyntheticRecipeFixture(sourcePlaceholders);
     await applyLawyerReviewContext(
@@ -625,7 +644,7 @@ describe('NVCA SPA Template', () => {
 
       const outputText = await allureStep('Extract output text', () => extractAllText(fixture.outputPath));
       const verifyResult = await allureStep('Run recipe verifier against output', () =>
-        verifyOutput(fixture.outputPath, verificationValues, replacements, cleanConfig)
+        verifyOutput(fixture.outputPath, verificationValues, legacyReplacements, cleanConfig)
       );
 
       const fullCorpusMatrixHtml = renderClauseEvidenceMatrixHtml(
@@ -676,9 +695,13 @@ describe('NVCA SPA Template', () => {
     const policyFieldNames = Object.keys(FIELD_ASSERTION_POLICY).sort();
     const fieldsMissingPolicy = metadataFieldNames.filter((fieldName) => !(fieldName in FIELD_ASSERTION_POLICY));
     const policyWithoutField = policyFieldNames.filter((fieldName) => !metadataFieldNames.includes(fieldName));
-    const sourcePlaceholders = Object.keys(replacements).filter((key) => !isNthReplacementKey(key));
+    const migratedContextKeys = loadMigratedContextKeys();
+    const legacyReplacements = Object.fromEntries(
+      Object.entries(replacements).filter(([key]) => !migratedContextKeys.has(key))
+    );
+    const sourcePlaceholders = Object.keys(legacyReplacements).filter((key) => !isNthReplacementKey(key));
     const sourcePlaceholderSet = new Set(sourcePlaceholders);
-    const placeholdersByField = buildPlaceholdersByField(replacements);
+    const placeholdersByField = buildPlaceholdersByField(legacyReplacements);
 
     await applyLawyerReviewContext(
       policyContext,
@@ -702,7 +725,7 @@ describe('NVCA SPA Template', () => {
       director_names: 'Jane Founder; Pat Director',
       applicable_purchasers: 'North Star Ventures LLC',
     });
-    const verificationValues = buildVerificationValues(values, sourcePlaceholders, replacements);
+    const verificationValues = buildVerificationValues(values, sourcePlaceholders, legacyReplacements);
     const fixture = createSyntheticRecipeFixture(sourcePlaceholders);
     await applyLawyerReviewContext(
       policyContext,
@@ -722,7 +745,7 @@ describe('NVCA SPA Template', () => {
 
       const outputText = await allureStep('Extract rendered text', () => extractAllText(fixture.outputPath));
       const verifyResult = await allureStep('Verify output consistency', () =>
-        verifyOutput(fixture.outputPath, verificationValues, replacements, cleanConfig)
+        verifyOutput(fixture.outputPath, verificationValues, legacyReplacements, cleanConfig)
       );
 
       const policyMatrixHtml = renderClauseEvidenceMatrixHtml(

--- a/integration-tests/selector-contracts.test.ts
+++ b/integration-tests/selector-contracts.test.ts
@@ -5,7 +5,8 @@ import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import AdmZip from 'adm-zip';
 import { resolveRecipeDir } from '../src/utils/paths.js';
-import { loadCleanConfig } from '../src/core/metadata.js';
+import { loadCleanConfig, loadRecipeMetadata } from '../src/core/metadata.js';
+import replacements from '../content/recipes/nvca-stock-purchase-agreement/replacements.json' with { type: 'json' };
 import { cleanDocument } from '../src/core/recipe/cleaner.js';
 import { patchDocument } from '../src/core/recipe/patcher.js';
 import {
@@ -80,15 +81,37 @@ describe('loadSelectorContracts', () => {
     }
   });
 
-  it('loads the real nvca company_name manifest + template manifest', () => {
+  it('loads every real nvca SPA field manifest + template manifest', () => {
     const recipeDir = resolveRecipeDir('nvca-stock-purchase-agreement');
-    const { manifests, templateManifest } = loadSelectorContracts(recipeDir, ['company_name']);
-    expect(manifests.map((m) => m.field_id)).toEqual(['company_name']);
-    expect(templateManifest?.migrated_keys).toEqual([
-      '[Insert Company Name]',
-      '[Company name]',
-      '[____________]',
+    const fieldNames = loadRecipeMetadata(recipeDir).fields.map((f) => f.name);
+    const { manifests, templateManifest } = loadSelectorContracts(recipeDir, fieldNames);
+    expect(manifests.map((m) => m.field_id).sort()).toEqual([
+      'agreement_date_month_day',
+      'agreement_year_two_digits',
+      'company_name',
+      'investor_counsel',
+      'minimum_shares_initial_closing',
+      'optional_plural_suffix',
+      'par_value_per_share',
+      'purchase_price_per_share',
+      'series_designation',
     ]);
+    // company_name (3) + the 13 migrated `>` keys = 16
+    expect(templateManifest?.migrated_keys).toHaveLength(16);
+    expect(templateManifest?.migrated_keys).toEqual(
+      expect.arrayContaining([
+        '[Insert Company Name]',
+        'SERIES > [___]',
+        'such Series > [__]',
+        'is made as of > [________]',
+        'A minimum of > [_______]',
+        'expenses of > [_______]',
+      ]),
+    );
+    // every migrated key is a real replacements.json key (no typos / drift)
+    for (const key of templateManifest!.migrated_keys) {
+      expect(replacements, `migrated key ${JSON.stringify(key)} missing from replacements.json`).toHaveProperty([key]);
+    }
   });
 });
 
@@ -133,4 +156,70 @@ describeWithSource('selector contracts against the real NVCA source', () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+});
+
+// Per-field migration parity for the `>`-anchor keys migrated in #476. For each field we assert the
+// STRONGEST possible gate: the whole-document text after selector-patching ONLY that field is byte-for-byte
+// identical to the text after legacy-patching ONLY that field's `>` keys. Equal tag counts are not enough —
+// a selector could place a tag in the wrong span and still match a count, which matters for the 12
+// near-identical `series_designation` blanks. We also confirm every occurrence resolves against the raw
+// source (the drift-canary surface), not just the cleaned doc.
+const MIGRATED_SPAN_COUNTS: Record<string, number> = {
+  series_designation: 12,
+  agreement_date_month_day: 1,
+  agreement_year_two_digits: 1,
+  par_value_per_share: 1,
+  purchase_price_per_share: 1,
+  optional_plural_suffix: 1,
+  minimum_shares_initial_closing: 2,
+  investor_counsel: 1,
+};
+
+describeWithSource('SPA `>`-anchor field migration parity (#476)', () => {
+  const recipeDir = resolveRecipeDir('nvca-stock-purchase-agreement');
+  const fieldNames = loadRecipeMetadata(recipeDir).fields.map((f) => f.name);
+  const { manifests, templateManifest } = loadSelectorContracts(recipeDir, fieldNames);
+  const migratedKeys = new Set(templateManifest?.migrated_keys ?? []);
+  const manifestById = new Map(manifests.map((m) => [m.field_id, m]));
+  // legacy `>` keys grouped by the field_id they target ({field_id} value), restricted to migrated keys.
+  const legacyKeysByField = new Map<string, Record<string, string>>();
+  for (const [key, value] of Object.entries(replacements as Record<string, string>)) {
+    if (!migratedKeys.has(key) || !key.includes('>')) continue;
+    const field = value.replace(/^\{|\}$/g, '');
+    legacyKeysByField.set(field, { ...(legacyKeysByField.get(field) ?? {}), [key]: value });
+  }
+
+  for (const [field, expectedSpans] of Object.entries(MIGRATED_SPAN_COUNTS)) {
+    it(`[${field}] selector patch is byte-identical to legacy \`>\` patch (${expectedSpans} span(s))`, async () => {
+      const manifest = manifestById.get(field)!;
+      const legacyKeys = legacyKeysByField.get(field)!;
+      expect(manifest, `no manifest loaded for ${field}`).toBeDefined();
+      expect(Object.keys(legacyKeys).length, `no migrated legacy keys for ${field}`).toBeGreaterThan(0);
+
+      // Drift surface: every occurrence must resolve against the raw source.
+      const rawRes = await resolveSelectorContracts(cachedSourcePath(), [manifest]);
+      expect(rawRes.fields[0].unresolved, `${field} unresolved against raw source`).toBe(false);
+
+      const dir = mkdtempSync(join(tmpdir(), `selector-parity-${field}-`));
+      try {
+        const cleaned = join(dir, 'cleaned.docx');
+        await cleanDocument(cachedSourcePath(), cleaned, loadCleanConfig(recipeDir));
+
+        const legacy = join(dir, 'legacy.docx');
+        await patchDocument(cleaned, legacy, legacyKeys);
+
+        const selector = join(dir, 'selector.docx');
+        await applySelectorContracts(cleaned, selector, [manifest]);
+
+        const legacyText = textOf(legacy);
+        const selectorText = textOf(selector);
+        const tag = new RegExp(`\\{${field}\\}`, 'g');
+        expect((legacyText.match(tag) ?? []).length).toBe(expectedSpans);
+        // The strong gate: identical whole-document text ⇒ selector hit the exact legacy spans.
+        expect(selectorText).toBe(legacyText);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+  }
 });


### PR DESCRIPTION
Closes #476.

Rolls the deterministic selector-contract migration (engine + `company_name` PoC from #472) across the remaining `>`-anchor `replacements.json` keys in `nvca-stock-purchase-agreement`: **13 legacy context keys → 8 field manifests (20 spans)**. Each field's keys are added to `template-manifest.json.migrated_keys` only after proving **byte-for-byte parity** with the legacy `>`-patched output against the real cached source. CoI (81 keys) is the planned follow-up PR, per the issue's "SPA first" sequencing.

## Fields migrated (`content/recipes/nvca-stock-purchase-agreement/fields/`)

| field | spans | locator |
|---|---|---|
| `series_designation` | 12 | per-span `regex` + capture group, extended context |
| `agreement_date_month_day` | 1 | `regex` `is made as of\s(\[________\])` |
| `agreement_year_two_digits` | 1 | `regex` `, 20(\[__\])` |
| `par_value_per_share` | 1 | `regex` `Stock, \$(\[__\])\spar value` |
| `purchase_price_per_share` | 1 | `regex` `purchase price of \$(\[__\])\sper share` |
| `optional_plural_suffix` | 1 | `regex` `Closing(\[s\])` |
| `minimum_shares_initial_closing` | 2 | `regex` per underscore count |
| `investor_counsel` | 1 | `regex` `expenses of\s(\[_______\])` |

## Design notes

- **`regex`+capture-group, not `contextual`.** safe-docx `contextual` matches *every* target in *every* context-node (no "after context" constraint) and resolves to **zero** for `Stock, $[__]` / `purchase price of $[__]`. A capture-group regex is the faithful analogue of legacy first-after-context and rewrites only the blank. `\s` is used around blanks because the source uses a **non-breaking space** between "Series" and the bracket.
- **`series_designation` declares exactly the 12 spans legacy fills** (the patcher fills only the first blank after each context per paragraph), deliberately leaving the para-8 3rd and para-66 2nd `[___]` blanks to preserve parity.
- **Postconditions** are `no_unresolved_placeholder` + `no_double_dollar`. `all_occurrences_identical` is omitted for these fields because their migrated-key search texts are generic bracket blanks (`[___]`, `[__]`, `[s]`, …) that legitimately recur elsewhere, so it would always false-positive. Single-value consistency is instead guaranteed by the drift canary (exact single-span resolution) + the whole-document parity tests.

## Tests

- **`selector-contracts.test.ts`** — load test now covers all 9 SPA manifests + 16 migrated keys; adds table-driven per-field parity asserting **whole-document text equality** (`selectorText === legacyText`) — the strong gate that pins the exact span, not just tag counts.
- **`nvca-spa-template.test.ts`** — the synthetic full-corpus/policy harnesses exclude context-qualified (`>`) migrated keys, which can't be exercised by flat synthetic markers (they're covered by the real-source parity tests); literal migrated keys like `company_name` still render in synthetic.

## Verification

- `tsc --noEmit` clean; 105 selector/recipe unit tests + 30 targeted + 33 broader recipe integration tests pass.
- `source_drift_canary` → `ok: true`, no unresolved selector fields / assertion failures.
- Real-source fill renders all 8 fields correctly (Series A, March 14 2026, $0.0001, $2.50, Cooley LLP, 1,000,000); **zero new verification warnings vs `main`**; LibreOffice render clean.
- `data/templates-snapshot.json` unaffected (keys off `metadata.yaml`, untouched).

**Content + tests only — no engine changes.**

This plan was peer-reviewed (Codex + agy/Gemini) before implementation.