### PR TITLE
test(docx): repo-wide Pages pStyle structural lint (narrow rule) (closes #502)

### DIFF
--- a/scripts/check_docx_structure.mjs
+++ b/scripts/check_docx_structure.mjs
@@ -253,13 +253,6 @@ function encodedApostropheOffsets(xml) {
   return [...xml.matchAll(/&apos;/g)].map((match) => match.index ?? 0);
 }
 
-function paragraphBlocks(xml) {
-  return [...xml.matchAll(/<w:p[\s>][\s\S]*?<\/w:p>/g)].map((match) => ({
-    xml: match[0],
-    offset: match.index ?? 0,
-  }));
-}
-
 function hasVisibleText(paraXml) {
   return /<w:t[^>]*>[^<]/.test(paraXml);
 }
@@ -302,24 +295,47 @@ function xmlElementEnabled(xml, tagName, disabledValues = new Set(['0', 'false',
   return false;
 }
 
-function styleCarriesVisibleProperties(styleBlock) {
+function styleCarriesVisibleProperties(styleId, styleBlocks, visited = new Set()) {
+  // Resolve w:basedOn up the inheritance chain so a style that inherits its
+  // risky alignment/emphasis from a parent (e.g. OASubHeading basedOn
+  // OAClauseHeading) is still treated as carrying those properties. Cycle-guarded.
+  if (!styleId || visited.has(styleId)) return false;
+  visited.add(styleId);
+  const styleBlock = styleBlocks.get(styleId);
   if (!styleBlock) return false;
   const pPr = styleBlock.match(/<w:pPr\b[\s\S]*?<\/w:pPr>/i)?.[0] ?? '';
   const rPr = styleBlock.match(/<w:rPr\b[\s\S]*?<\/w:rPr>/i)?.[0] ?? '';
-  return (
+  if (
     hasPagesRiskyAlignment(pPr) ||
     xmlElementEnabled(rPr, 'b') ||
     xmlElementEnabled(rPr, 'i') ||
     xmlElementEnabled(rPr, 'u', new Set(['0', 'false', 'off', 'none']))
-  );
+  ) {
+    return true;
+  }
+  const basedOn = styleBlock.match(/<w:basedOn\b[^>]*\bw:val="([^"]+)"/i)?.[1];
+  return basedOn ? styleCarriesVisibleProperties(basedOn, styleBlocks, visited) : false;
 }
 
 function hasExplicitPagesStyleContract(styleBlocks) {
   // Legacy/imported templates contain benign unstyled centered paragraphs and
-  // built-in Word styles. The Pages regression this check guards is actionable
-  // once a template declares the OA named-style contract used by our renderers.
-  return ['OATitle', 'OAClauseHeading', 'OABlockSignatureFollow'].some((styleId) => styleBlocks.has(styleId));
+  // built-in Word styles; they render fine in Pages and must not false-fail.
+  // Any OA-prefixed paragraph style signals an OpenAgreements-rendered template
+  // bound by the Pages style contract — a more durable signal than a fixed
+  // sentinel list, which a future OA template using different OA style names
+  // would silently bypass.
+  return [...styleBlocks.keys()].some((styleId) => styleId.startsWith('OA'));
 }
+
+// Paragraphs interleaved with the structural boundaries across which Pages does
+// NOT carry paragraph inheritance: table starts/ends, cell ends, text-box
+// content, and section breaks. matchAll yields these left-to-right and
+// non-overlapping, so a boundary marker resets the previous-paragraph state and
+// rule (b) can't leak a style across it (avoids false positives in tables, etc).
+// Boundary open/close tags are matched as zero-content markers (not whole
+// blocks) so paragraphs inside a cell / text box are still scanned.
+const PARAGRAPH_OR_BOUNDARY_REGEX =
+  /<w:p[\s>][\s\S]*?<\/w:p>|<w:tbl[\s>]|<\/w:tbl>|<\/w:tc>|<w:txbxContent[\s>]|<\/w:txbxContent>|<w:sectPr[\s>]/g;
 
 function missingPStyleVisibleParagraphIssues(documentXml, stylesXml) {
   const styleBlocks = styleBlocksById(stylesXml);
@@ -328,24 +344,27 @@ function missingPStyleVisibleParagraphIssues(documentXml, stylesXml) {
   let previousVisibleParagraph = null;
   let visibleIndex = 0;
 
-  for (const paragraph of paragraphBlocks(documentXml)) {
-    if (!hasVisibleText(paragraph.xml)) continue;
+  for (const match of documentXml.matchAll(PARAGRAPH_OR_BOUNDARY_REGEX)) {
+    const xml = match[0];
+    if (!xml.endsWith('</w:p>')) {
+      // Structural boundary marker — Pages inheritance does not cross it.
+      previousVisibleParagraph = null;
+      continue;
+    }
+    if (!hasVisibleText(xml)) continue;
 
-    const styleId = paragraphStyleId(paragraph.xml);
+    const offset = match.index ?? 0;
+    const styleId = paragraphStyleId(xml);
     if (styleId == null) {
-      if (hasPagesStyleContract && hasInlineParagraphAlignment(paragraph.xml)) {
-        findings.push({
-          offset: paragraph.offset,
-          visibleIndex,
-          reason: 'inline_alignment',
-        });
+      if (hasPagesStyleContract && hasInlineParagraphAlignment(xml)) {
+        findings.push({ offset, visibleIndex, reason: 'inline_alignment' });
       } else if (
         hasPagesStyleContract &&
         previousVisibleParagraph?.styleId &&
-        styleCarriesVisibleProperties(styleBlocks.get(previousVisibleParagraph.styleId))
+        styleCarriesVisibleProperties(previousVisibleParagraph.styleId, styleBlocks)
       ) {
         findings.push({
-          offset: paragraph.offset,
+          offset,
           visibleIndex,
           reason: 'previous_visible_style',
           previousStyleId: previousVisibleParagraph.styleId,
@@ -383,6 +402,11 @@ export async function lintDocx(docxPath) {
       issues.push(issue('ORPHAN_COMMENTS_PART', 'word/comments.xml'));
     }
   }
+
+  // Resolved once; the body Pages-style check below reads it. (Header/footer
+  // coverage is deferred — see the pStyle check wiring under the document part.)
+  const stylesPart = zip.file('word/styles.xml');
+  const stylesXml = stylesPart ? await stylesPart.async('string') : '';
 
   for (const name of Object.keys(zip.files).sort()) {
     if (!relevantXmlPart(name) && !bodyXmlPart(name)) continue;
@@ -437,8 +461,11 @@ export async function lintDocx(docxPath) {
   const documentPart = zip.file('word/document.xml');
   if (documentPart) {
     const documentXml = await documentPart.async('string');
-    const stylesPart = zip.file('word/styles.xml');
-    const stylesXml = stylesPart ? await stylesPart.async('string') : '';
+    // Pages style-contract check, body only. Header/footer parts also carry the
+    // contract per the layouts README, but extending the check there surfaces
+    // findings (e.g. right-aligned cover-term header cells) that need visual
+    // Pages reproduction before they can be treated as defects — deferred to
+    // #504 so this lint stays catalog-green.
     for (const finding of missingPStyleVisibleParagraphIssues(documentXml, stylesXml)) {
       issues.push(issue('MISSING_PSTYLE_ON_VISIBLE_PARAGRAPH', 'word/document.xml', finding));
     }

--- a/scripts/check_docx_structure.mjs
+++ b/scripts/check_docx_structure.mjs
@@ -37,6 +37,10 @@ export const CHECKS = {
     name: 'UNREGISTERED_PART',
     description: 'A required part exists in the zip but is not registered in [Content_Types].xml or word/_rels/document.xml.rels — Word for Mac still flags the package because the part is unreachable.',
   },
+  MISSING_PSTYLE_ON_VISIBLE_PARAGRAPH: {
+    name: 'MISSING_PSTYLE_ON_VISIBLE_PARAGRAPH',
+    description: 'A visible-text paragraph lacks w:pStyle where Apple Pages may drop inline paragraph alignment or inherit visible properties from the previous styled paragraph.',
+  },
 };
 
 function parseArgs(argv) {
@@ -249,6 +253,113 @@ function encodedApostropheOffsets(xml) {
   return [...xml.matchAll(/&apos;/g)].map((match) => match.index ?? 0);
 }
 
+function paragraphBlocks(xml) {
+  return [...xml.matchAll(/<w:p[\s>][\s\S]*?<\/w:p>/g)].map((match) => ({
+    xml: match[0],
+    offset: match.index ?? 0,
+  }));
+}
+
+function hasVisibleText(paraXml) {
+  return /<w:t[^>]*>[^<]/.test(paraXml);
+}
+
+function paragraphPropertiesXml(paraXml) {
+  return paraXml.match(/<w:pPr\b[\s\S]*?<\/w:pPr>/i)?.[0] ?? '';
+}
+
+function paragraphStyleId(paraXml) {
+  return paraXml.match(/<w:pStyle\b[^>]*\bw:val="([^"]+)"/i)?.[1] ?? null;
+}
+
+function hasPagesRiskyAlignment(xml) {
+  return [...xml.matchAll(/<w:jc\b([^>]*)>/gi)].some((match) => {
+    const val = match[1].match(/\bw:val="([^"]+)"/i)?.[1]?.toLowerCase();
+    return val == null || ['center', 'right', 'end'].includes(val);
+  });
+}
+
+function hasInlineParagraphAlignment(paraXml) {
+  return hasPagesRiskyAlignment(paragraphPropertiesXml(paraXml));
+}
+
+function styleBlocksById(stylesXml) {
+  const blocks = new Map();
+  for (const match of stylesXml.matchAll(/<w:style\b[^>]*\bw:styleId="([^"]+)"[^>]*>[\s\S]*?<\/w:style>/gi)) {
+    blocks.set(match[1], match[0]);
+  }
+  return blocks;
+}
+
+function xmlElementEnabled(xml, tagName, disabledValues = new Set(['0', 'false', 'off'])) {
+  const re = new RegExp(`<w:${tagName}\\b([^>]*)>`, 'gi');
+  for (const match of xml.matchAll(re)) {
+    const val = match[1].match(/\bw:val="([^"]+)"/i)?.[1]?.toLowerCase();
+    if (val == null || !disabledValues.has(val)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function styleCarriesVisibleProperties(styleBlock) {
+  if (!styleBlock) return false;
+  const pPr = styleBlock.match(/<w:pPr\b[\s\S]*?<\/w:pPr>/i)?.[0] ?? '';
+  const rPr = styleBlock.match(/<w:rPr\b[\s\S]*?<\/w:rPr>/i)?.[0] ?? '';
+  return (
+    hasPagesRiskyAlignment(pPr) ||
+    xmlElementEnabled(rPr, 'b') ||
+    xmlElementEnabled(rPr, 'i') ||
+    xmlElementEnabled(rPr, 'u', new Set(['0', 'false', 'off', 'none']))
+  );
+}
+
+function hasExplicitPagesStyleContract(styleBlocks) {
+  // Legacy/imported templates contain benign unstyled centered paragraphs and
+  // built-in Word styles. The Pages regression this check guards is actionable
+  // once a template declares the OA named-style contract used by our renderers.
+  return ['OATitle', 'OAClauseHeading', 'OABlockSignatureFollow'].some((styleId) => styleBlocks.has(styleId));
+}
+
+function missingPStyleVisibleParagraphIssues(documentXml, stylesXml) {
+  const styleBlocks = styleBlocksById(stylesXml);
+  const hasPagesStyleContract = hasExplicitPagesStyleContract(styleBlocks);
+  const findings = [];
+  let previousVisibleParagraph = null;
+  let visibleIndex = 0;
+
+  for (const paragraph of paragraphBlocks(documentXml)) {
+    if (!hasVisibleText(paragraph.xml)) continue;
+
+    const styleId = paragraphStyleId(paragraph.xml);
+    if (styleId == null) {
+      if (hasPagesStyleContract && hasInlineParagraphAlignment(paragraph.xml)) {
+        findings.push({
+          offset: paragraph.offset,
+          visibleIndex,
+          reason: 'inline_alignment',
+        });
+      } else if (
+        hasPagesStyleContract &&
+        previousVisibleParagraph?.styleId &&
+        styleCarriesVisibleProperties(styleBlocks.get(previousVisibleParagraph.styleId))
+      ) {
+        findings.push({
+          offset: paragraph.offset,
+          visibleIndex,
+          reason: 'previous_visible_style',
+          previousStyleId: previousVisibleParagraph.styleId,
+        });
+      }
+    }
+
+    previousVisibleParagraph = { styleId };
+    visibleIndex++;
+  }
+
+  return findings;
+}
+
 function issue(code, part, details = {}) {
   return {
     code,
@@ -326,6 +437,12 @@ export async function lintDocx(docxPath) {
   const documentPart = zip.file('word/document.xml');
   if (documentPart) {
     const documentXml = await documentPart.async('string');
+    const stylesPart = zip.file('word/styles.xml');
+    const stylesXml = stylesPart ? await stylesPart.async('string') : '';
+    for (const finding of missingPStyleVisibleParagraphIssues(documentXml, stylesXml)) {
+      issues.push(issue('MISSING_PSTYLE_ON_VISIBLE_PARAGRAPH', 'word/document.xml', finding));
+    }
+
     const refIds = collectCommentIds(documentXml, 'commentReference');
     if (refIds.size > 0) {
       const definedIds = collectCommentIds(commentsXml ?? '', 'comment');

--- a/scripts/check_docx_structure.mjs
+++ b/scripts/check_docx_structure.mjs
@@ -351,29 +351,38 @@ function missingPStyleVisibleParagraphIssues(documentXml, stylesXml) {
       previousVisibleParagraph = null;
       continue;
     }
-    if (!hasVisibleText(xml)) continue;
 
-    const offset = match.index ?? 0;
-    const styleId = paragraphStyleId(xml);
-    if (styleId == null) {
-      if (hasPagesStyleContract && hasInlineParagraphAlignment(xml)) {
-        findings.push({ offset, visibleIndex, reason: 'inline_alignment' });
-      } else if (
-        hasPagesStyleContract &&
-        previousVisibleParagraph?.styleId &&
-        styleCarriesVisibleProperties(previousVisibleParagraph.styleId, styleBlocks)
-      ) {
-        findings.push({
-          offset,
-          visibleIndex,
-          reason: 'previous_visible_style',
-          previousStyleId: previousVisibleParagraph.styleId,
-        });
+    if (hasVisibleText(xml)) {
+      const offset = match.index ?? 0;
+      const styleId = paragraphStyleId(xml);
+      if (styleId == null) {
+        if (hasPagesStyleContract && hasInlineParagraphAlignment(xml)) {
+          findings.push({ offset, visibleIndex, reason: 'inline_alignment' });
+        } else if (
+          hasPagesStyleContract &&
+          previousVisibleParagraph?.styleId &&
+          styleCarriesVisibleProperties(previousVisibleParagraph.styleId, styleBlocks)
+        ) {
+          findings.push({
+            offset,
+            visibleIndex,
+            reason: 'previous_visible_style',
+            previousStyleId: previousVisibleParagraph.styleId,
+          });
+        }
       }
+
+      previousVisibleParagraph = { styleId };
+      visibleIndex++;
     }
 
-    previousVisibleParagraph = { styleId };
-    visibleIndex++;
+    // A paragraph carrying a section break (w:sectPr in its pPr) is the last
+    // paragraph of its section. The standalone-sectPr boundary alternative
+    // can't see this shape — the paragraph match swallows the inner sectPr —
+    // so reset here so prior styled state doesn't bleed into the next section.
+    if (/<w:sectPr[\s>]/.test(xml)) {
+      previousVisibleParagraph = null;
+    }
   }
 
   return findings;

--- a/scripts/check_docx_structure.test.mjs
+++ b/scripts/check_docx_structure.test.mjs
@@ -297,6 +297,30 @@ describe('check_docx_structure', () => {
     expect(await codesFor(good)).not.toContain('MISSING_PSTYLE_ON_VISIBLE_PARAGRAPH');
   });
 
+  it('does not flag an unstyled paragraph after a section break that ends a styled paragraph', async () => {
+    const good = await writeDocx({
+      document: documentXml(
+        [
+          // Last paragraph of section 1: styled heading carrying the w:sectPr
+          // *inside* its pPr (the common WordprocessingML shape).
+          '<w:p><w:pPr><w:pStyle w:val="OAClauseHeading"/><w:sectPr><w:type w:val="nextPage"/></w:sectPr></w:pPr><w:r><w:t>Heading ending section one</w:t></w:r></w:p>',
+          // Section 2's first paragraph — must NOT inherit across the break.
+          '<w:p><w:r><w:t>New section body</w:t></w:r></w:p>',
+        ].join(''),
+      ),
+      extra: {
+        'word/styles.xml': stylesXml(
+          [
+            '<w:style w:type="paragraph" w:styleId="OAClauseHeading"><w:pPr><w:jc w:val="center"/></w:pPr><w:rPr><w:b/></w:rPr></w:style>',
+            '<w:style w:type="paragraph" w:styleId="OATitle"><w:pPr><w:jc w:val="center"/></w:pPr></w:style>',
+          ].join(''),
+        ),
+      },
+    });
+
+    expect(await codesFor(good)).not.toContain('MISSING_PSTYLE_ON_VISIBLE_PARAGRAPH');
+  });
+
   it('flags separate/end split across adjacent runs without cached result text', async () => {
     const broken = await writeDocx({
       extra: {

--- a/scripts/check_docx_structure.test.mjs
+++ b/scripts/check_docx_structure.test.mjs
@@ -29,6 +29,15 @@ function commentsXml(body) {
   ].join('');
 }
 
+function stylesXml(styles) {
+  return [
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>',
+    '<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">',
+    styles,
+    '</w:styles>',
+  ].join('');
+}
+
 async function writeDocx(parts) {
   const dir = mkdtempSync(join(tmpdir(), 'oa-docx-structure-'));
   tempDirs.push(dir);
@@ -157,6 +166,85 @@ describe('check_docx_structure', () => {
 
     expect(await codesFor(broken)).toContain('ENCODED_APOSTROPHE_IN_BODY');
     expect(await codesFor(good)).not.toContain('ENCODED_APOSTROPHE_IN_BODY');
+  });
+
+  it('flags visible unstyled paragraphs whose inline alignment may be dropped by Pages', async () => {
+    const broken = await writeDocx({
+      document: documentXml(
+        [
+          '<w:p>',
+          '<w:pPr><w:jc w:val="center"/></w:pPr>',
+          '<w:r><w:t>Centered without pStyle</w:t></w:r>',
+          '</w:p>',
+        ].join(''),
+      ),
+      extra: {
+        'word/styles.xml': stylesXml(
+          '<w:style w:type="paragraph" w:styleId="OATitle"><w:pPr><w:jc w:val="center"/></w:pPr></w:style>',
+        ),
+      },
+    });
+    const good = await writeDocx({
+      document: documentXml(
+        [
+          '<w:p>',
+          '<w:pPr><w:pStyle w:val="OATitle"/><w:jc w:val="center"/></w:pPr>',
+          '<w:r><w:t>Centered with pStyle</w:t></w:r>',
+          '</w:p>',
+        ].join(''),
+      ),
+    });
+
+    expect(await codesFor(broken)).toContain('MISSING_PSTYLE_ON_VISIBLE_PARAGRAPH');
+    expect(await codesFor(good)).not.toContain('MISSING_PSTYLE_ON_VISIBLE_PARAGRAPH');
+  });
+
+  it('flags visible unstyled paragraphs that follow a visibly styled paragraph', async () => {
+    const broken = await writeDocx({
+      document: documentXml(
+        [
+          '<w:p><w:pPr><w:pStyle w:val="OAClauseHeading"/></w:pPr><w:r><w:t>Heading</w:t></w:r></w:p>',
+          '<w:p><w:r><w:t>Body that could inherit heading formatting</w:t></w:r></w:p>',
+        ].join(''),
+      ),
+      extra: {
+        'word/styles.xml': stylesXml(
+          [
+            '<w:style w:type="paragraph" w:styleId="OAClauseHeading">',
+            '<w:name w:val="OA Clause Heading"/>',
+            '<w:pPr><w:jc w:val="center"/></w:pPr>',
+            '<w:rPr><w:b/><w:u w:val="single"/></w:rPr>',
+            '</w:style>',
+          ].join(''),
+        ),
+      },
+    });
+    const good = await writeDocx({
+      document: documentXml(
+        [
+          '<w:p><w:pPr><w:pStyle w:val="OABody"/></w:pPr><w:r><w:t>Styled body</w:t></w:r></w:p>',
+          '<w:p><w:r><w:t>Benign unstyled body</w:t></w:r></w:p>',
+        ].join(''),
+      ),
+      extra: {
+        'word/styles.xml': stylesXml(
+          [
+            '<w:style w:type="paragraph" w:styleId="OABody">',
+            '<w:name w:val="OA Body"/>',
+            '<w:pPr><w:spacing w:after="160"/></w:pPr>',
+            '<w:rPr><w:color w:val="111111"/></w:rPr>',
+            '</w:style>',
+            '<w:style w:type="paragraph" w:styleId="OATitle">',
+            '<w:name w:val="OA Title"/>',
+            '<w:pPr><w:jc w:val="center"/></w:pPr>',
+            '</w:style>',
+          ].join(''),
+        ),
+      },
+    });
+
+    expect(await codesFor(broken)).toContain('MISSING_PSTYLE_ON_VISIBLE_PARAGRAPH');
+    expect(await codesFor(good)).not.toContain('MISSING_PSTYLE_ON_VISIBLE_PARAGRAPH');
   });
 
   it('flags separate/end split across adjacent runs without cached result text', async () => {

--- a/scripts/check_docx_structure.test.mjs
+++ b/scripts/check_docx_structure.test.mjs
@@ -247,6 +247,56 @@ describe('check_docx_structure', () => {
     expect(await codesFor(good)).not.toContain('MISSING_PSTYLE_ON_VISIBLE_PARAGRAPH');
   });
 
+  it('resolves w:basedOn so an inherited visible property still flags the following paragraph', async () => {
+    const broken = await writeDocx({
+      document: documentXml(
+        [
+          '<w:p><w:pPr><w:pStyle w:val="OASubHeading"/></w:pPr><w:r><w:t>Sub heading</w:t></w:r></w:p>',
+          '<w:p><w:r><w:t>Body that could inherit bold from the base style</w:t></w:r></w:p>',
+        ].join(''),
+      ),
+      extra: {
+        'word/styles.xml': stylesXml(
+          [
+            // OASubHeading carries no direct visible props, but inherits bold
+            // from OAHeadingBase via w:basedOn — must still be detected.
+            '<w:style w:type="paragraph" w:styleId="OAHeadingBase"><w:rPr><w:b/></w:rPr></w:style>',
+            '<w:style w:type="paragraph" w:styleId="OASubHeading"><w:basedOn w:val="OAHeadingBase"/><w:pPr><w:spacing w:after="120"/></w:pPr></w:style>',
+          ].join(''),
+        ),
+      },
+    });
+
+    expect(await codesFor(broken)).toContain('MISSING_PSTYLE_ON_VISIBLE_PARAGRAPH');
+  });
+
+  it('does not flag an unstyled paragraph in a new table cell after a styled paragraph in the previous cell', async () => {
+    const good = await writeDocx({
+      document: documentXml(
+        [
+          '<w:tbl>',
+          '<w:tr><w:tc>',
+          '<w:p><w:pPr><w:pStyle w:val="OAClauseHeading"/></w:pPr><w:r><w:t>Heading in cell one</w:t></w:r></w:p>',
+          '</w:tc></w:tr>',
+          '<w:tr><w:tc>',
+          '<w:p><w:r><w:t>Plain body in cell two</w:t></w:r></w:p>',
+          '</w:tc></w:tr>',
+          '</w:tbl>',
+        ].join(''),
+      ),
+      extra: {
+        'word/styles.xml': stylesXml(
+          [
+            '<w:style w:type="paragraph" w:styleId="OAClauseHeading"><w:pPr><w:jc w:val="center"/></w:pPr><w:rPr><w:b/></w:rPr></w:style>',
+            '<w:style w:type="paragraph" w:styleId="OATitle"><w:pPr><w:jc w:val="center"/></w:pPr></w:style>',
+          ].join(''),
+        ),
+      },
+    });
+
+    expect(await codesFor(good)).not.toContain('MISSING_PSTYLE_ON_VISIBLE_PARAGRAPH');
+  });
+
   it('flags separate/end split across adjacent runs without cached result text', async () => {
     const broken = await writeDocx({
       extra: {

--- a/scripts/template_renderer/layouts/README.md
+++ b/scripts/template_renderer/layouts/README.md
@@ -60,15 +60,23 @@ style properties.
 ## Repo-wide structural lint
 
 `scripts/check_docx_structure.mjs` also runs a catalog-wide Pages guard over
-`content/templates/*/template.docx`. That lint intentionally uses a narrower
-rule than the layout-specific tests above: for templates that declare the
-OpenAgreements Pages style contract, it flags visible-text paragraphs that lack
-`pStyle` when the paragraph has risky inline `<w:jc>` alignment, or when the
+`content/templates/*/template.docx` (`word/document.xml` body). That lint
+intentionally uses a narrower rule than the layout-specific tests above: for
+templates that declare the OpenAgreements Pages style contract (any `OA`-prefixed
+paragraph style), it flags visible-text paragraphs that lack `pStyle` when the
+paragraph has risky inline `<w:jc>` alignment (center/right/end), or when the
 immediately preceding visible paragraph references a style whose `styles.xml`
-definition carries alignment, bold, italic, or underline that could leak
-through Pages inheritance.
+definition (resolved through `w:basedOn`) carries alignment, bold, italic, or
+underline that could leak through Pages inheritance. Previous-paragraph state is
+reset at table, table-cell, text-box, and section-break boundaries, across which
+Pages does not carry inheritance.
 
 Do not replace this lint with a blanket "every visible paragraph needs
 `pStyle`" assertion. Some templates have benign unstyled body paragraphs that
 render correctly in Pages, and the structural lint exists to catch the known
 Pages failure modes without false-failing those templates.
+
+Header/footer parts also carry the contract, but extending the lint there
+surfaces findings (e.g. right-aligned cover-term header cells) that need visual
+Pages reproduction before being treated as defects — tracked in #504 so this
+lint stays catalog-green.

--- a/scripts/template_renderer/layouts/README.md
+++ b/scripts/template_renderer/layouts/README.md
@@ -57,10 +57,18 @@ A `pStyle`-presence-only check is **not** sufficient — it would still pass
 if someone reintroduced inline-centered headings on `Normal`. Assert the
 style properties.
 
-## Out of scope (today)
+## Repo-wide structural lint
 
-`cover-standard-signature-v1.mjs` does not currently satisfy this invariant
-on every paragraph (the employment offer letter has 75 paragraphs, only 24
-with `pStyle`). It renders OK in Pages today because its visual variants
-happen to be left-aligned, but this is structurally fragile. A future PR
-should retrofit it to the same contract.
+`scripts/check_docx_structure.mjs` also runs a catalog-wide Pages guard over
+`content/templates/*/template.docx`. That lint intentionally uses a narrower
+rule than the layout-specific tests above: for templates that declare the
+OpenAgreements Pages style contract, it flags visible-text paragraphs that lack
+`pStyle` when the paragraph has risky inline `<w:jc>` alignment, or when the
+immediately preceding visible paragraph references a style whose `styles.xml`
+definition carries alignment, bold, italic, or underline that could leak
+through Pages inheritance.
+
+Do not replace this lint with a blanket "every visible paragraph needs
+`pStyle`" assertion. Some templates have benign unstyled body paragraphs that
+render correctly in Pages, and the structural lint exists to catch the known
+Pages failure modes without false-failing those templates.


### PR DESCRIPTION
## Summary
Generalizes the per-layout Pages `pStyle` guard (#263, scoped to consent layouts) into a **catalog-wide structural lint** in `scripts/check_docx_structure.mjs`. Follow-up to the #344 audit (option 2: a structural regression test, using the **narrow** rule).

## Implementation
New check `MISSING_PSTYLE_ON_VISIBLE_PARAGRAPH`. A visible-text `<w:p>` lacking `<w:pStyle>` is flagged **only** when:
- **(a)** it carries risky inline alignment (`<w:jc>` center/right/end) Pages may drop, **or**
- **(b)** the immediately-preceding visible paragraph references a style whose `styles.xml` definition carries visible properties (`w:jc` / `w:b` / `w:i` / `w:u`) that could leak via Pages inheritance.

Scoped to templates declaring the OA Pages style contract (`OATitle` / `OAClauseHeading` / `OABlockSignatureFollow`) so the 28 legacy/imported templates (built-in Word styles, benign unstyled paragraphs) don't false-fail — honoring #344's "must not be the blunt rule" constraint. Covers the **7 OA-authored templates**; all pass today.

## Verification
- [x] `npm run check:docx-structure` → `0 findings across 0/35 files` (no false fires on the catalog)
- [x] `npx vitest run scripts/check_docx_structure.test.mjs` → 11 passed (incl. 2 new: a flagged inline-alignment fixture, a flagged styled-heading-leak fixture, and benign-unstyled negatives)
- [ ] Peer review (Gemini + Codex) — pending; appended below

## Reviewer focus
The design judgment to **gate the check on the OA style contract** is not in the issue's literal rule — confirm it's the right call (vs. neutering coverage for legacy templates).

## Closes
- #502