### PR TITLE
fix(ci): auto-tag-release — don't let persisted GITHUB_TOKEN override the release-bot token

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -36,6 +36,12 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          # Do NOT persist the GITHUB_TOKEN as an http.extraheader: it would
+          # override the release-bot App token on the tag push below (git applies
+          # the persisted Authorization header in preference to the push URL's
+          # credential), so the push would authenticate as github-actions[bot]
+          # — read-only here — and 403. The App token must be the only credential.
+          persist-credentials: false
 
       - name: Detect a merged version bump without a tag
         id: detect


### PR DESCRIPTION
## Problem
v0.8.0 (#473) merged to main but never got tagged/published: the `Auto-tag release` run failed at the tag push with `Permission ... denied to github-actions[bot]` (403).

## Root cause
Not the App or secrets — those are correct (`open-agreements-release-bot` is installed with `contents: write`, and the token step mints a valid token). The `actions/checkout@v5` step ran with the default `persist-credentials: true`, which writes the workflow `GITHUB_TOKEN` into git config as `http.https://github.com/.extraheader`. On the tag push, git applies that persisted `Authorization` header in preference to the App-token credential in the push URL, so the push authenticates as `github-actions[bot]` — read-only under this workflow's top-level `permissions: contents: read` — and 403s.

## Fix
Set `persist-credentials: false` on the checkout so the release-bot App token is the only credential on the push. Restores the safe-docx pattern this workflow was ported from.

## Note
This fixes **future** version-bump merges. v0.8.0 itself already merged, so its tag still needs to be created once by hand (auto-tag only fires on the version-change merge, which has passed).