### PR TITLE
chore(corpus): Rename content/legal/ -> content/practice-guides/ to match URL taxonomy (#1082)

### DIFF
--- a/legal-practice-library/non-compete/au/log.md
+++ b/legal-practice-library/non-compete/au/log.md
@@ -1,5 +1,8 @@
 # Au Update Log
 
+## 2026-06-26
+* **Update**: Rename content/legal/ -> content/practice-guides/ to match URL taxonomy (#1082) ([7fb9b1a](https://github.com/UseJunior/legal-explainer/commit/7fb9b1a59b1be5495d248f7d0fff7a1a9bc6f126))
+
 ## 2026-06-15
 * **Update**: feat(ia): country-first jurisdiction paths + /practice-guides & /surveys roots (closes #790) (#800) ([01b7b50](https://github.com/UseJunior/legal-explainer/commit/01b7b5028fe5cdd75b5ff4652151f0c9b19d0545))
 

--- a/legal-practice-library/non-compete/log.md
+++ b/legal-practice-library/non-compete/log.md
@@ -1,5 +1,8 @@
 # Non Compete Update Log
 
+## 2026-06-26
+* **Update**: Rename content/legal/ -> content/practice-guides/ to match URL taxonomy (#1082) ([7fb9b1a](https://github.com/UseJunior/legal-explainer/commit/7fb9b1a59b1be5495d248f7d0fff7a1a9bc6f126))
+
 ## 2026-06-22
 * **Update**: refactor(ia): rename worldwide survey URL /international → /worldwide with 301s (#976) (#977) ([8356032](https://github.com/UseJunior/legal-explainer/commit/8356032f8745b0bbaeaa9373bd97d19e87e959e5))
 

--- a/legal-practice-library/non-compete/us/log.md
+++ b/legal-practice-library/non-compete/us/log.md
@@ -1,6 +1,7 @@
 # Us Update Log
 
 ## 2026-06-26
+* **Update**: Rename content/legal/ -> content/practice-guides/ to match URL taxonomy (#1082) ([7fb9b1a](https://github.com/UseJunior/legal-explainer/commit/7fb9b1a59b1be5495d248f7d0fff7a1a9bc6f126))
 * **Update**: Update South Dakota non-compete note for HB 1180 (eff. July 1, 2026) (#1084) ([9a4eb72](https://github.com/UseJunior/legal-explainer/commit/9a4eb72213fd3640c99e12cdaf1d21d962c0fe51))
 * **Update**: Add Brown v. Best post-hire-consideration Q&A to Wyoming non-compete page (#1081) ([a00f292](https://github.com/UseJunior/legal-explainer/commit/a00f292cc5fb7d0a534712301ce8b4a2ed0f4334))
 

--- a/legal-practice-library/privacy-policy/disclose-rights-catalog/log.md
+++ b/legal-practice-library/privacy-policy/disclose-rights-catalog/log.md
@@ -1,6 +1,7 @@
 # Disclose Rights Catalog Update Log
 
 ## 2026-06-26
+* **Update**: Rename content/legal/ -> content/practice-guides/ to match URL taxonomy (#1082) ([7fb9b1a](https://github.com/UseJunior/legal-explainer/commit/7fb9b1a59b1be5495d248f7d0fff7a1a9bc6f126))
 * **Update**: feat(privacy-corpus): codify the rescue pipeline + lift the corpus tail (30 of 36 holdouts) (#1069) ([dc18933](https://github.com/UseJunior/legal-explainer/commit/dc189330dfec271bca7ab4fdf96eba7aacca4cd6))
 * **Update**: feat(privacy-corpus): propagate 3M email correction to published content (#1059) (#1076) ([e554d23](https://github.com/UseJunior/legal-explainer/commit/e554d23c5ad83772974162f854d5fe46d898caba))
 * **Update**: feat(privacy-corpus): add EchoStar — 492 → 493 policies (496/500 URLs) (#1055) ([fef5546](https://github.com/UseJunior/legal-explainer/commit/fef554671f164d24aeeea46e7e2ada4d3cc88cd4))

--- a/legal-practice-library/privacy-policy/identify-business/log.md
+++ b/legal-practice-library/privacy-policy/identify-business/log.md
@@ -1,6 +1,7 @@
 # Identify Business Update Log
 
 ## 2026-06-26
+* **Update**: Rename content/legal/ -> content/practice-guides/ to match URL taxonomy (#1082) ([7fb9b1a](https://github.com/UseJunior/legal-explainer/commit/7fb9b1a59b1be5495d248f7d0fff7a1a9bc6f126))
 * **Update**: feat(privacy-corpus): codify the rescue pipeline + lift the corpus tail (30 of 36 holdouts) (#1069) ([dc18933](https://github.com/UseJunior/legal-explainer/commit/dc189330dfec271bca7ab4fdf96eba7aacca4cd6))
 * **Update**: feat(privacy-corpus): propagate 3M email correction to published content (#1059) (#1076) ([e554d23](https://github.com/UseJunior/legal-explainer/commit/e554d23c5ad83772974162f854d5fe46d898caba))
 * **Update**: feat(privacy-corpus): add EchoStar — 492 → 493 policies (496/500 URLs) (#1055) ([fef5546](https://github.com/UseJunior/legal-explainer/commit/fef554671f164d24aeeea46e7e2ada4d3cc88cd4))

--- a/legal-practice-library/privacy/us/log.md
+++ b/legal-practice-library/privacy/us/log.md
@@ -1,5 +1,8 @@
 # Us Update Log
 
+## 2026-06-26
+* **Update**: Rename content/legal/ -> content/practice-guides/ to match URL taxonomy (#1082) ([7fb9b1a](https://github.com/UseJunior/legal-explainer/commit/7fb9b1a59b1be5495d248f7d0fff7a1a9bc6f126))
+
 ## 2026-06-18
 * **Update**: fix(content): close citation/coverage gaps in privacy notes (16 states) [#838] (#850) ([446acad](https://github.com/UseJunior/legal-explainer/commit/446acadc6ce8f536bdae05ea39e34c3852359bad))
 * **Update**: fix(content): re-ingest deferred sources for NJ/IN privacy + WARN/token-economics topics [#852] (#864) ([ff690fe](https://github.com/UseJunior/legal-explainer/commit/ff690fe5c5d0548cd61a77353a93c1758ffe5541))

--- a/skills/legal-explainers/data-privacy-law-explainer/manifest.json
+++ b/skills/legal-explainers/data-privacy-law-explainer/manifest.json
@@ -1,7 +1,7 @@
 {
   "topic": "privacy",
   "snapshotAsOf": "2026-06-26",
-  "sourceCommit": "a00f292cc5fb7d0a534712301ce8b4a2ed0f4334",
+  "sourceCommit": "7fb9b1a59b1be5495d248f7d0fff7a1a9bc6f126",
   "canonicalBase": "https://openagreements.org/practice-guides/privacy",
   "license": "CC BY 4.0",
   "jurisdictions": [

--- a/skills/legal-explainers/non-compete-contract-explainer/manifest.json
+++ b/skills/legal-explainers/non-compete-contract-explainer/manifest.json
@@ -1,7 +1,7 @@
 {
   "topic": "non-compete",
   "snapshotAsOf": "2026-06-26",
-  "sourceCommit": "a00f292cc5fb7d0a534712301ce8b4a2ed0f4334",
+  "sourceCommit": "7fb9b1a59b1be5495d248f7d0fff7a1a9bc6f126",
   "canonicalBase": "https://openagreements.org/practice-guides/non-compete",
   "license": "CC BY 4.0",
   "jurisdictions": [


### PR DESCRIPTION
Automated corpus projection from UseJunior/legal-explainer@7fb9b1a59b1be5495d248f7d0fff7a1a9bc6f126.