### PR TITLE
Exempt upstream-authored DOCX from the named-pStyle structure check

### DIFF
--- a/scripts/check_docx_structure.mjs
+++ b/scripts/check_docx_structure.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
-import { relative, resolve, sep } from 'node:path';
+import { dirname, join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import JSZip from 'jszip';
@@ -475,8 +475,17 @@ export async function lintDocx(docxPath) {
     // findings (e.g. right-aligned cover-term header cells) that need visual
     // Pages reproduction before they can be treated as defects — deferred to
     // #504 so this lint stays catalog-green.
-    for (const finding of missingPStyleVisibleParagraphIssues(documentXml, stylesXml)) {
-      issues.push(issue('MISSING_PSTYLE_ON_VISIBLE_PARAGRAPH', 'word/document.xml', finding));
+    //
+    // Upstream-authored templates (synced from a canonical Markdoc source, marked
+    // by a sibling `template.mdoc`) ship a humanized DOCX rendered upstream; OA's
+    // named-pStyle convention does not apply to them and their render fidelity is
+    // owned by the upstream author. The package-integrity checks above (theme /
+    // webSettings / part registration — Word-readability) still run for every DOCX.
+    const isUpstreamAuthored = existsSync(join(dirname(docxPath), 'template.mdoc'));
+    if (!isUpstreamAuthored) {
+      for (const finding of missingPStyleVisibleParagraphIssues(documentXml, stylesXml)) {
+        issues.push(issue('MISSING_PSTYLE_ON_VISIBLE_PARAGRAPH', 'word/document.xml', finding));
+      }
     }
 
     const refIds = collectCommentIds(documentXml, 'commentReference');


### PR DESCRIPTION
## Summary
Follow-up to #542. The `template-preview-gate` job also runs `check:docx-structure`, which I missed exempting: it flags `MISSING_PSTYLE_ON_VISIBLE_PARAGRAPH` on the 5 upstream-authored agreements because their humanized DOCX (rendered upstream) doesn't follow OA's named-pStyle Pages-compatibility convention.

## Change
`scripts/check_docx_structure.mjs` skips **only** the `MISSING_PSTYLE` convention check for a template dir that has a sibling `template.mdoc` (the upstream-authored marker). The package-integrity checks (theme / webSettings / part registration — Word-readability) still run for **every** DOCX, mirroring the unsafe-tag scan decision in #542.

## Verification
- `check:docx-structure`: native main passes (0 findings); verified against an applied upstream sync the 5 are now exempt (0 findings).
- `scripts/check_docx_structure.test.mjs`: 14 passed.
- Full suite: 1034 passed.