### PR TITLE
chore: neutral wording in template-pipeline code comments

### DIFF
--- a/.github/workflows/llm-based-quality-gate.yml
+++ b/.github/workflows/llm-based-quality-gate.yml
@@ -435,9 +435,9 @@ jobs:
             const overall = warns > 0 ? '⚠️ WARN' : (passes > 0 ? '✅ PASS' : '❓ NO RESULTS');
             const labels = JSON.parse(process.env.PR_LABELS || '[]');
             const labelOverride = labels.includes('llm-gate/override');
-            // Automated SSOT-mirror sync PRs (deterministic branch `update/templates-*`
-            // opened by the GitHub App bot) carry generated, pre-reviewed content
-            // (LE projection tests + the OA acceptance gates). Their large binary
+            // Automated template-update PRs (deterministic branch `update/templates-*`
+            // opened by the maintenance bot) carry generated, pre-reviewed content
+            // (validated upstream + by the acceptance gates below). Their large binary
             // DOCX diffs deterministically break the per-item LLM call, and code
             // review of generated output adds no signal — so they are auto-overridden.
             // Requires BOTH the deterministic branch prefix AND a bot author so a
@@ -449,7 +449,7 @@ jobs:
             const overrideActive = labelOverride || isSyncBotPR;
 
             const overrideReason = isSyncBotPR && !labelOverride
-              ? 'automated sync PR (`update/templates-*`, bot-authored)'
+              ? 'automated template-update PR (`update/templates-*`, bot-authored)'
               : '`llm-gate/override` label is set';
             const overrideBanner = overrideActive
               ? `\n\n> ⚠️ **Override active** — ${overrideReason}; this gate\'s WARN findings are non-blocking on this PR.\n`

--- a/src/core/metadata.ts
+++ b/src/core/metadata.ts
@@ -79,7 +79,7 @@ export const FieldDefinitionSchema: z.ZodType<FieldDefinition> = z.lazy(() =>
     description: z.string(),
     display_label: z.string().optional(),
     // Accept YAML-native scalar defaults (`default: false`, `default: 5`) by
-    // coercing to their string form before validation. Upstream-authored
+    // coercing to their string form before validation. Generated template
     // metadata serializes booleans/numbers natively; downstream code already
     // treats `default` as a string (e.g. JSON.parse(field.default), the
     // `=== 'false'` checks), and String(false) === 'false' is value-preserving.

--- a/src/core/validation/template.ts
+++ b/src/core/validation/template.ts
@@ -163,10 +163,10 @@ export function validateTemplate(templateDir: string, templateId: string): Templ
     };
   }
 
-  // Upstream-authored templates (synced from the canonical Markdoc source, marked
-  // by a `template.mdoc` in the dir) ship a fully-rendered, humanized DOCX rather
-  // than an OA fill-token document — so the `{field}` placeholder-coverage / FOR /
-  // multiselect scans below do not apply. Their metadata has already been validated
+  // Templates that ship a fully-rendered, humanized DOCX (marked by a
+  // `template.mdoc` in the dir) rather than an OA fill-token document — so the
+  // `{field}` placeholder-coverage / FOR / multiselect scans below do not apply.
+  // Their metadata has already been validated
   // above by loadMetadata, and the license check runs separately. BUT the unsafe-tag
   // security scan is defense-in-depth and runs for EVERY committed DOCX regardless
   // of authorship (a DOCX must never carry docx-templates control/code tags).


### PR DESCRIPTION
Rewords a few internal code comments (and one user-facing override label) so the automated template-update mechanism is described in neutral terms — 'generated', 'template-update PR' — rather than naming the upstream authoring pipeline. Comments/label only; no behavior change.

Files: `src/core/metadata.ts`, `src/core/validation/template.ts`, `.github/workflows/llm-based-quality-gate.yml`.