### PR TITLE
Rename public "practice notes" → "practice guides" (#1245)

### DIFF
--- a/.github/ISSUE_TEMPLATE/practice-guide-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/practice-guide-feedback.yml
@@ -1,15 +1,15 @@
-name: Practice note feedback
-description: Share feedback on a published practice-note page — a correction, a suggestion, a question, or anything we could improve. All feedback is welcome and helps us get it right.
-title: "Practice note feedback: "
+name: Practice guide feedback
+description: Share feedback on a published practice-guide page — a correction, a suggestion, a question, or anything we could improve. All feedback is welcome and helps us get it right.
+title: "Practice guide feedback: "
 labels:
-  - area/practice-notes
+  - area/practice-guides
 body:
   - type: markdown
     attributes:
       value: |
         Triage notes:
         - Set issue Type to `Bug` for factual errors or broken citations; `Feature` for stale-law updates requiring a content rewrite.
-        - Maintainers assign `area/practice-notes`, `priority/*`, and `status/*` labels during triage.
+        - Maintainers assign `area/practice-guides`, `priority/*`, and `status/*` labels during triage.
         - Keep Assignees, Projects, and Milestone empty unless ownership / scheduling is explicit.
 
   - type: input

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 Open, primary-source-backed U.S. legal content **and** standard agreement templates — built for legal teams of any size and the agents helping them.
 
-- **Legal Practice Library** — jurisdiction-by-jurisdiction practice notes (non-compete & restrictive covenants, consumer data privacy, AI employment law), every claim cited to primary law.
+- **Legal Practice Library** — jurisdiction-by-jurisdiction practice guides (non-compete & restrictive covenants, consumer data privacy, AI employment law), every claim cited to primary law.
 - **Templates** — 40+ fillable forms across NDAs, cloud service agreements, employment docs, SAFEs, and NVCA financing documents.
 - **Checklists** — clause-by-clause reviewer checklists.
 - **Law Surveys** — 50-state and international comparison tables.
@@ -33,7 +33,7 @@ Everything ships as plain markdown in this repo and as machine-readable twins on
 ## Who this is for
 
 OpenAgreements is for legal teams of any size and the agents helping them. The
-practice notes, surveys, and checklists answer jurisdiction-specific questions
+practice guides, surveys, and checklists answer jurisdiction-specific questions
 with citations to primary law; the templates start from standard forms teams
 already recognize — Common Paper, Bonterms, NVCA model documents, and YC SAFE
 templates — keeping source, license, and validation context close to the
@@ -60,7 +60,7 @@ document. It does not provide legal advice; consult an attorney.
 
 ## Legal Practice Library
 
-Primary-source-backed legal practice notes, projected from openagreements.org as plain markdown under [`legal-practice-library/`](https://github.com/open-agreements/open-agreements/tree/main/legal-practice-library). Each note cites primary law and links to its canonical page (with machine-readable twins — see [For AI Agents](#for-ai-agents)).
+Primary-source-backed legal practice guides, projected from openagreements.org as plain markdown under [`legal-practice-library/`](https://github.com/open-agreements/open-agreements/tree/main/legal-practice-library). Each guide cites primary law and links to its canonical page (with machine-readable twins — see [For AI Agents](#for-ai-agents)).
 
 | Topic | What it covers | Coverage | Browse | Live |
 |-------|----------------|----------|--------|------|
@@ -194,7 +194,7 @@ Side-by-side comparison tables across jurisdictions. The web pages also publish 
 
 ## For AI Agents
 
-Every practice note, survey, and checklist is plain markdown in
+Every practice guide, survey, and checklist is plain markdown in
 [`legal-practice-library/`](https://github.com/open-agreements/open-agreements/tree/main/legal-practice-library) — clone or fetch it directly. The pages also publish machine-readable twins on openagreements.org, which vary by content type:
 
 | Content | Markdown | JSON | Other |
@@ -327,7 +327,7 @@ open-agreements/
     templates/            # Fillable DOCX templates with {tag} placeholders
     external/             # YC SAFE templates vendored unchanged
     recipes/              # Recipe instructions for non-redistributable sources
-  legal-practice-library/ # Practice notes, surveys, and checklists (markdown)
+  legal-practice-library/ # Practice guides, surveys, and checklists (markdown)
   skills/                 # Agent skill definitions
   server.json             # MCP server manifest
   gemini-extension.json   # Gemini CLI extension config

--- a/README.template.md
+++ b/README.template.md
@@ -19,7 +19,7 @@
 
 Open, primary-source-backed U.S. legal content **and** standard agreement templates — built for legal teams of any size and the agents helping them.
 
-- **Legal Practice Library** — jurisdiction-by-jurisdiction practice notes (non-compete & restrictive covenants, consumer data privacy, AI employment law), every claim cited to primary law.
+- **Legal Practice Library** — jurisdiction-by-jurisdiction practice guides (non-compete & restrictive covenants, consumer data privacy, AI employment law), every claim cited to primary law.
 - **Templates** — 40+ fillable forms across NDAs, cloud service agreements, employment docs, SAFEs, and NVCA financing documents.
 - **Checklists** — clause-by-clause reviewer checklists.
 - **Law Surveys** — 50-state and international comparison tables.
@@ -31,7 +31,7 @@ Everything ships as plain markdown in this repo and as machine-readable twins on
 ## Who this is for
 
 OpenAgreements is for legal teams of any size and the agents helping them. The
-practice notes, surveys, and checklists answer jurisdiction-specific questions
+practice guides, surveys, and checklists answer jurisdiction-specific questions
 with citations to primary law; the templates start from standard forms teams
 already recognize — Common Paper, Bonterms, NVCA model documents, and YC SAFE
 templates — keeping source, license, and validation context close to the
@@ -66,7 +66,7 @@ agent or the CLI, see [Template Filling via MCP](#template-filling-via-mcp).
 
 ## For AI Agents
 
-Every practice note, survey, and checklist is plain markdown in
+Every practice guide, survey, and checklist is plain markdown in
 [`legal-practice-library/`](https://github.com/open-agreements/open-agreements/tree/main/legal-practice-library) — clone or fetch it directly. The pages also publish machine-readable twins on openagreements.org, which vary by content type:
 
 | Content | Markdown | JSON | Other |
@@ -151,7 +151,7 @@ open-agreements/
     templates/            # Fillable DOCX templates with {tag} placeholders
     external/             # YC SAFE templates vendored unchanged
     recipes/              # Recipe instructions for non-redistributable sources
-  legal-practice-library/ # Practice notes, surveys, and checklists (markdown)
+  legal-practice-library/ # Practice guides, surveys, and checklists (markdown)
   skills/                 # Agent skill definitions
   server.json             # MCP server manifest
   gemini-extension.json   # Gemini CLI extension config

--- a/scripts/generate_readme.mjs
+++ b/scripts/generate_readme.mjs
@@ -129,7 +129,7 @@ function renderLegalPracticeLibrary() {
   const library = buildLibrary({ rootDir: root });
   const lines = [];
   lines.push(
-    `Primary-source-backed legal practice notes, projected from openagreements.org as plain markdown under [\`legal-practice-library/\`](${githubTreeUrl("legal-practice-library")}). Each note cites primary law and links to its canonical page (with machine-readable twins — see [For AI Agents](#for-ai-agents)).`,
+    `Primary-source-backed legal practice guides, projected from openagreements.org as plain markdown under [\`legal-practice-library/\`](${githubTreeUrl("legal-practice-library")}). Each guide cites primary law and links to its canonical page (with machine-readable twins — see [For AI Agents](#for-ai-agents)).`,
   );
   lines.push("");
   lines.push(

--- a/scripts/lib/library-data.mjs
+++ b/scripts/lib/library-data.mjs
@@ -91,20 +91,24 @@ export const CHECKLIST_SECTIONS = [
 export const SURVEYS_DIR = "surveys";
 export const CASE_EXCERPTS_DIR = "case-excerpts";
 
-// State-law guides carry `STATE_TYPE`; non-U.S.-state jurisdiction guides (e.g.
-// Australian states) carry `NOTE_TYPE` and signal "+ international". The pillar
-// ("Law Topic") and other types are neither, so they don't trigger it.
+// State-law guides carry a `STATE_TYPES` value; non-U.S.-state jurisdiction
+// guides (e.g. Australian states) carry a `NOTE_TYPES` value and signal
+// "+ international". The pillar ("Law Topic") and other types are neither, so
+// they don't trigger it.
 //
-// These two strings are NOT reader copy — they are the bundle's machine-readable
-// `type` controlled vocabulary, written verbatim into the projected
-// `legal-practice-library/**` frontmatter by legal-explainer's
-// scripts/render-okf-bundle.ts and matched exactly below (`type === STATE_TYPE`).
-// They are deliberately left as "Practice Note" under the "practice notes →
-// practice guides" rename (#1245): renaming them here without re-projecting the
-// bot-managed bundle would zero out the counts. The reader-facing label lives in
-// the website hero and this README's prose, and has been renamed there.
-const STATE_TYPE = "State Law Practice Note";
-const NOTE_TYPE = "Practice Note";
+// These are the bundle's machine-readable `type` controlled vocabulary, written
+// verbatim into the projected `legal-practice-library/**` frontmatter by
+// legal-explainer's scripts/render-okf-bundle.ts and matched below by SET
+// membership. The vocabulary was renamed "… Practice Note" → "… Practice Guide"
+// under #1245, but the bundle is bot-projected from legal-explainer on its own
+// cadence, so during the transition the committed frontmatter may carry EITHER
+// the legacy or the new value. Matching both keeps the README counts correct
+// regardless of when re-projection lands — array order is irrelevant.
+//
+// CLEANUP FOLLOW-UP: once the bot has re-projected the bundle to the new
+// vocabulary everywhere, drop the legacy "… Practice Note" entries below.
+const STATE_TYPES = ["State Law Practice Guide", "State Law Practice Note"];
+const NOTE_TYPES = ["Practice Guide", "Practice Note"];
 
 function parseFrontmatter(raw) {
   const match = raw.match(/^---\n([\s\S]*?)\n---/);
@@ -145,9 +149,9 @@ function tallyTypes(rootDir, dirs) {
     for (const file of conceptFiles(resolve(rootDir, LIBRARY_DIR, dir))) {
       total += 1;
       const { type } = parseFrontmatter(readFileSync(file, "utf-8"));
-      if (type === STATE_TYPE) {
+      if (STATE_TYPES.includes(type)) {
         stateCount += 1;
-      } else if (type === NOTE_TYPE) {
+      } else if (NOTE_TYPES.includes(type)) {
         internationalCount += 1;
       }
     }

--- a/scripts/lib/library-data.mjs
+++ b/scripts/lib/library-data.mjs
@@ -91,9 +91,18 @@ export const CHECKLIST_SECTIONS = [
 export const SURVEYS_DIR = "surveys";
 export const CASE_EXCERPTS_DIR = "case-excerpts";
 
-// State-law notes carry `STATE_TYPE`; non-U.S.-state jurisdiction notes (e.g.
+// State-law guides carry `STATE_TYPE`; non-U.S.-state jurisdiction guides (e.g.
 // Australian states) carry `NOTE_TYPE` and signal "+ international". The pillar
 // ("Law Topic") and other types are neither, so they don't trigger it.
+//
+// These two strings are NOT reader copy — they are the bundle's machine-readable
+// `type` controlled vocabulary, written verbatim into the projected
+// `legal-practice-library/**` frontmatter by legal-explainer's
+// scripts/render-okf-bundle.ts and matched exactly below (`type === STATE_TYPE`).
+// They are deliberately left as "Practice Note" under the "practice notes →
+// practice guides" rename (#1245): renaming them here without re-projecting the
+// bot-managed bundle would zero out the counts. The reader-facing label lives in
+// the website hero and this README's prose, and has been renamed there.
 const STATE_TYPE = "State Law Practice Note";
 const NOTE_TYPE = "Practice Note";
 


### PR DESCRIPTION
Public-facing terminology change on the OpenAgreements repo surface. **Pairs with `UseJunior/legal-explainer#1245` / PR UseJunior/legal-explainer#1260** (the website + projection source) — the two PRs **must land together** (cross-repo feedback-link coupling below).

## Changed (reader copy / generated copy / issue template)
- **README sources** (edited at source, not hand-edited output): `README.template.md` prose + `scripts/generate_readme.mjs` Legal Practice Library blurb → "practice guides" / "Each guide". `README.md` regenerated via `npm run generate:readme` (build dist first so the template list isn't stale); `check:readme` is clean. Counts unchanged.
- **Issue template** renamed `practice-note-feedback.yml` → `practice-guide-feedback.yml` with updated `name`/`description`/`title`, and label `area/practice-notes` → `area/practice-guides`.

## Cross-repo coupling (must land together)
legal-explainer `lib/site-constants.ts` builds the public **Errata + feedback** links from this template's filename (`practice-guide-feedback.yml`) and the `area/practice-guides` label. PR #1260 updates those links to the new names. If only one repo merges, the feedback link 404s / the errata filter returns nothing. Also note: the GitHub **label** `area/practice-notes` should be renamed to `area/practice-guides` in repo settings (renaming via GitHub preserves it on existing issues).

## Intentionally KEPT as a structural identifier (commented at the definition)
`scripts/lib/library-data.mjs` `STATE_TYPE` / `NOTE_TYPE` (`"State Law Practice Note"` / `"Practice Note"`) are the bundle's machine-readable `type` **controlled vocabulary**, written verbatim into the bot-projected `legal-practice-library/**` frontmatter by legal-explainer's `render-okf-bundle.ts` and matched exactly (`type === STATE_TYPE`). Renaming them here **without re-projecting the bot-managed bundle would zero out the README counts** (silent correctness bug, not just a gate failure). They stay until a coordinated taxonomy migration. **This is a deliberate deviation** from the original ask to rename these two constants — flagged for your call.

## NOT hand-edited (bot-projected / generated)
`legal-practice-library/**`, `skills/**/NOTICE`, `data/templates-snapshot.json` — these re-project from legal-explainer.

## Gates
```
$ npm run build            → exit 0 (tsc)
$ npm run generate:readme  → README.md regenerated
$ npm run check:readme     → exit 0 (drift gate clean)
$ npm run preflight:ci     → lint, validate, check:template-previews,
                             check:preview-freshness, check:gemini-extension-manifest,
                             check:readme, test:run (1026 passed | 6 skipped) ALL PASS;
                             ONLY `trust:check` fails.
```
**`trust:check` failure is PRE-EXISTING and unrelated to this PR.** It regenerates `site/trust/system-card.md` with line-number shifts for `integration-tests/readme-generation.test.ts` (a file this PR does not touch). I reproduced the identical failure on a pristine `origin/main` working tree (stash + `npm run trust:check` → same 4-line diff). Left out of this PR to keep it focused; recommend a separate `npm run trust:check` regeneration commit on main.

Draft — do not merge / mark ready (per coordinator: README is generated content; note the `llm-gate/override` convention applies; coordinator will mark ready + label + pair with #1260).