### PR TITLE
chore: finish #1245 reader rename — README count unit + case-excerpt copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ Primary-source-backed legal practice guides, projected from openagreements.org a
 |-------|----------------|----------|--------|------|
 | Non-Compete & Restrictive Covenants | Enforceability, blue-pencil reformation, tolling, choice of law, and FTC-rule status. | 56 U.S. states + international | [Markdown](https://github.com/open-agreements/open-agreements/tree/main/legal-practice-library/non-compete) | [Web](https://openagreements.org/practice-guides/non-compete) |
 | Consumer Data Privacy | CCPA/CPRA and every comprehensive state privacy act — who's covered, consumer rights, opt-outs, and who enforces. | 51 U.S. states | [Markdown](https://github.com/open-agreements/open-agreements/tree/main/legal-practice-library/privacy) | [Web](https://openagreements.org/practice-guides/privacy/us) |
-| AI Vendors | Zero-data-retention, data residency, and the terms that matter in AI vendor contracts. | 9 notes | [Markdown](https://github.com/open-agreements/open-agreements/tree/main/legal-practice-library/ai-vendors) | [Web](https://openagreements.org/practice-guides/ai-vendors) |
-| AI & the Workforce | AI in hiring and adverse-action, workforce AI policies, and outside-counsel transitions. | 20 notes | [Markdown](https://github.com/open-agreements/open-agreements/tree/main/legal-practice-library) | [Web](https://openagreements.org/practice-guides) |
-| Privacy-Policy Requirement Phrasings | Preferred phrasings for what a U.S. consumer privacy policy must disclose. | 8 notes | [Markdown](https://github.com/open-agreements/open-agreements/tree/main/legal-practice-library/privacy-policy) | [Web](https://openagreements.org/practice-guides/privacy/us) |
+| AI Vendors | Zero-data-retention, data residency, and the terms that matter in AI vendor contracts. | 9 practice guides | [Markdown](https://github.com/open-agreements/open-agreements/tree/main/legal-practice-library/ai-vendors) | [Web](https://openagreements.org/practice-guides/ai-vendors) |
+| AI & the Workforce | AI in hiring and adverse-action, workforce AI policies, and outside-counsel transitions. | 20 practice guides | [Markdown](https://github.com/open-agreements/open-agreements/tree/main/legal-practice-library) | [Web](https://openagreements.org/practice-guides) |
+| Privacy-Policy Requirement Phrasings | Preferred phrasings for what a U.S. consumer privacy policy must disclose. | 8 practice guides | [Markdown](https://github.com/open-agreements/open-agreements/tree/main/legal-practice-library/privacy-policy) | [Web](https://openagreements.org/practice-guides/privacy/us) |
 
-Backed by 516 verbatim [case excerpts](https://github.com/open-agreements/open-agreements/tree/main/legal-practice-library/case-excerpts) — the passages our notes rely on, each linked to the full opinion on CourtListener. Supporting evidence, not a case database.
+Backed by 516 verbatim [case excerpts](https://github.com/open-agreements/open-agreements/tree/main/legal-practice-library/case-excerpts) — the passages our practice guides rely on, each linked to the full opinion on CourtListener. Supporting evidence, not a case database.
 
 ## Available Templates
 

--- a/scripts/generate_readme.mjs
+++ b/scripts/generate_readme.mjs
@@ -146,7 +146,7 @@ function renderLegalPracticeLibrary() {
   );
   lines.push("");
   lines.push(
-    `Backed by ${library.caseExcerptCount} verbatim [case excerpts](${githubTreeUrl("legal-practice-library/case-excerpts")}) — the passages our notes rely on, each linked to the full opinion on CourtListener. Supporting evidence, not a case database.`,
+    `Backed by ${library.caseExcerptCount} verbatim [case excerpts](${githubTreeUrl("legal-practice-library/case-excerpts")}) — the passages our practice guides rely on, each linked to the full opinion on CourtListener. Supporting evidence, not a case database.`,
   );
   return lines.join("\n").trim();
 }

--- a/scripts/lib/library-data.mjs
+++ b/scripts/lib/library-data.mjs
@@ -20,7 +20,7 @@ const RESERVED_FILES = new Set(["index.md", "log.md"]);
 // they cannot drift from what the corpus bot syncs. Rows are ordered by measured
 // demand (Vercel log drain, 30d): non-compete >> privacy > AI. `kind`:
 // "jurisdictional" renders a "N states (+ international)" coverage label;
-// "topic" renders a plain note count. A section may span multiple `dirs` (the
+// "topic" renders a plain practice-guide count. A section may span multiple `dirs` (the
 // collapsed AI & Workforce row); its Browse link then points at the library root.
 export const PRACTICE_GUIDE_SECTIONS = [
   {
@@ -165,7 +165,7 @@ function coverageLabel(kind, { total, stateCount, internationalCount }) {
       ? `${stateCount} U.S. states + international`
       : `${stateCount} U.S. states`;
   }
-  return `${total} note${total === 1 ? "" : "s"}`;
+  return `${total} practice guide${total === 1 ? "" : "s"}`;
 }
 
 /**


### PR DESCRIPTION
Follow-up to #561 (#1245). Post-merge smoke caught two reader-facing "note" residuals that live in the README **generation sources** — not `README.template.md` (which earlier greps covered), which is why they slipped through.

## Fixes
1. `scripts/lib/library-data.mjs:168` — topic coverage unit `${total} note(s)` → `${total} practice guide(s)` (renders the AI Vendors / AI & Workforce / Phrasings Coverage cells). Line-23 comment updated to match.
2. `scripts/generate_readme.mjs:149` — case-excerpts copy "the passages our **notes** rely on" → "our **practice guides** rely on".

`README.md` regenerated.

## Before → after (Coverage column)
| Row | Before | After |
|---|---|---|
| Non-Compete & Restrictive Covenants | 56 U.S. states + international | 56 U.S. states + international (unchanged) |
| Consumer Data Privacy | 51 U.S. states | 51 U.S. states (unchanged) |
| AI Vendors | 9 notes | **9 practice guides** |
| AI & the Workforce | 20 notes | **20 practice guides** |
| Privacy-Policy Requirement Phrasings | 8 notes | **8 practice guides** |

Case-excerpts line: "…516 verbatim case excerpts — the passages our **practice guides** rely on…" (count 516 unchanged). `git diff README.md` = exactly these 4 lines; all other counts/prose byte-identical.

## Gates
- `npm run build` → exit 0 · `npm run generate:readme` → regenerated · `npm run check:readme` → **exit 0** (drift gate clean).

## Extra grep of the GENERATED README for residual reader-facing "note/notes"
Two hits, both reviewed and **correctly left**:
- README.md:243 — `client-email` skill description "cover notes for contract deliverables… cover note" — correct domain language (email cover notes), not a practice-note reference.
- `library-data.mjs:110-111` `NOTE_TYPES`/legacy `"Practice Note"` strings — the intentional **dual-match** machine values (transition cover until the bot re-projects the bundle to the new `type` vocabulary), already documented in-source. Kept.

No other in-scope reader residual remains.

Generated-content PR — `llm-gate/override` convention applies. Left **DRAFT** for you to mark ready + label + smoke.