### PR TITLE
feat(fill): dual-artifact templates — fill from template.fill.docx + validate its token coverage

### DIFF
--- a/integration-tests/fill-variant.test.ts
+++ b/integration-tests/fill-variant.test.ts
@@ -1,0 +1,270 @@
+import { afterEach, describe, expect, vi } from 'vitest';
+import { join } from 'node:path';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import AdmZip from 'adm-zip';
+import { validateTemplate } from '../src/core/validation/template.js';
+import { itAllure } from './helpers/allure-test.js';
+
+// Dual-artifact templates (#1378 / legal-explainer projection): `template.docx`
+// is the humanized [bracket]-prose human download, `template.fill.docx` is the
+// machine-fillable {token} document. The engine must fill from the variant and
+// validation must scan the variant for token coverage.
+
+const it = itAllure.epic('Filling & Rendering');
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  vi.unmock('../src/core/metadata.js');
+  vi.unmock('../src/core/selector.js');
+  vi.unmock('../src/core/unified-pipeline.js');
+  vi.unmock('../src/core/fill-utils.js');
+  vi.restoreAllMocks();
+  vi.resetModules();
+});
+
+const CONTENT_TYPES_XML =
+  '<?xml version="1.0" encoding="UTF-8"?>' +
+  '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">' +
+  '<Default Extension="xml" ContentType="application/xml"/>' +
+  '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+  '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+  '</Types>';
+
+const RELS_XML =
+  '<?xml version="1.0" encoding="UTF-8"?>' +
+  '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+  '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>' +
+  '</Relationships>';
+
+const WORD_RELS_XML =
+  '<?xml version="1.0" encoding="UTF-8"?>' +
+  '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"/>';
+
+const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+function buildDocx(documentText: string): Buffer {
+  const zip = new AdmZip();
+  const xml =
+    '<?xml version="1.0" encoding="UTF-8"?>' +
+    `<w:document xmlns:w="${W_NS}"><w:body><w:p><w:r><w:t>${documentText}</w:t></w:r></w:p></w:body></w:document>`;
+  zip.addFile('[Content_Types].xml', Buffer.from(CONTENT_TYPES_XML, 'utf-8'));
+  zip.addFile('_rels/.rels', Buffer.from(RELS_XML, 'utf-8'));
+  zip.addFile('word/_rels/document.xml.rels', Buffer.from(WORD_RELS_XML, 'utf-8'));
+  zip.addFile('word/document.xml', Buffer.from(xml, 'utf-8'));
+  return zip.toBuffer();
+}
+
+function createDualArtifactFixture(opts: {
+  humanDocText: string;
+  fillDocText?: string;
+  fieldsYaml: string;
+  priorityFields?: string[];
+  withMdocTwin?: boolean;
+  withReplacements?: boolean;
+}): string {
+  const dir = mkdtempSync(join(tmpdir(), 'oa-fill-variant-'));
+  tempDirs.push(dir);
+  const priorityFields = opts.priorityFields ?? [];
+  const priorityFieldsLines =
+    priorityFields.length === 0
+      ? ['priority_fields: []']
+      : ['priority_fields:', ...priorityFields.map((field) => `  - ${field}`)];
+  writeFileSync(
+    join(dir, 'metadata.yaml'),
+    [
+      'name: Fixture Template',
+      'source_url: https://example.com/template.docx',
+      'version: "1.0"',
+      'license: CC-BY-4.0',
+      'allow_derivatives: true',
+      'attribution_text: Example Attribution',
+      'fields:',
+      opts.fieldsYaml,
+      ...priorityFieldsLines,
+      '',
+    ].join('\n'),
+    'utf-8'
+  );
+  writeFileSync(join(dir, 'template.docx'), buildDocx(opts.humanDocText));
+  if (opts.fillDocText !== undefined) {
+    writeFileSync(join(dir, 'template.fill.docx'), buildDocx(opts.fillDocText));
+  }
+  if (opts.withMdocTwin ?? true) {
+    writeFileSync(join(dir, 'template.mdoc'), '# Fixture Template\n', 'utf-8');
+  }
+  if (opts.withReplacements) {
+    writeFileSync(join(dir, 'replacements.json'), JSON.stringify({ '[X]': '{x}' }), 'utf-8');
+  }
+  return dir;
+}
+
+const COMPANY_FIELD_YAML = [
+  '  - name: company_name',
+  '    type: string',
+  '    description: Company legal name',
+].join('\n');
+
+describe('validateTemplate with template.fill.docx', () => {
+  it('scans the fill variant for token coverage and passes when covered', () => {
+    const dir = createDualArtifactFixture({
+      humanDocText: 'By and between [Company legal name] and the undersigned.',
+      fillDocText: 'By and between {company_name} and the undersigned.',
+      fieldsYaml: COMPANY_FIELD_YAML,
+      priorityFields: ['company_name'],
+    });
+    const result = validateTemplate(dir, 'fixture');
+    expect(result.errors).toEqual([]);
+    expect(result.valid).toBe(true);
+  });
+
+  it('errors when a priority field is missing from the fill variant, naming template.fill.docx', () => {
+    const dir = createDualArtifactFixture({
+      humanDocText: 'By and between [Company legal name] and the undersigned.',
+      fillDocText: 'No tokens here at all.',
+      fieldsYaml: COMPANY_FIELD_YAML,
+      priorityFields: ['company_name'],
+    });
+    const result = validateTemplate(dir, 'fixture');
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('template.fill.docx') && e.includes('company_name'))).toBe(true);
+  });
+
+  it('errors when template.docx itself carries fill tokens alongside a fill variant', () => {
+    const dir = createDualArtifactFixture({
+      humanDocText: 'Leaked token {company_name} in the human doc.',
+      fillDocText: 'By and between {company_name}.',
+      fieldsYaml: COMPANY_FIELD_YAML,
+    });
+    const result = validateTemplate(dir, 'fixture');
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('token-free'))).toBe(true);
+  });
+
+  it('rejects the fill variant + replacements.json combination', () => {
+    const dir = createDualArtifactFixture({
+      humanDocText: 'Humanized prose.',
+      fillDocText: '{company_name}',
+      fieldsYaml: COMPANY_FIELD_YAML,
+      withReplacements: true,
+    });
+    const result = validateTemplate(dir, 'fixture');
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('replacements.json'))).toBe(true);
+  });
+
+  it('runs the unsafe-tag scan against the fill variant', () => {
+    const dir = createDualArtifactFixture({
+      humanDocText: 'Humanized prose.',
+      fillDocText: 'Unsafe {= 1 + 1} expression and {company_name}.',
+      fieldsYaml: COMPANY_FIELD_YAML,
+    });
+    const result = validateTemplate(dir, 'fixture');
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('Unsafe template tag'))).toBe(true);
+  });
+
+  it('runs the unsafe-tag scan against the human doc too', () => {
+    const dir = createDualArtifactFixture({
+      humanDocText: 'Unsafe {#if x} tag in the human doc.',
+      fillDocText: '{company_name}',
+      fieldsYaml: COMPANY_FIELD_YAML,
+    });
+    const result = validateTemplate(dir, 'fixture');
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('Unsafe template tag'))).toBe(true);
+  });
+
+  it('preserves the humanized-skip for mdoc templates without a fill variant', () => {
+    const dir = createDualArtifactFixture({
+      humanDocText: 'By and between [Company legal name] and the undersigned.',
+      fieldsYaml: COMPANY_FIELD_YAML,
+      priorityFields: ['company_name'],
+    });
+    const result = validateTemplate(dir, 'fixture');
+    expect(result.errors).toEqual([]);
+    expect(result.valid).toBe(true);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('validates FOR loops and item refs in the fill variant', () => {
+    const dir = createDualArtifactFixture({
+      humanDocText: 'Humanized signer list.',
+      fillDocText: '{FOR item IN board_members} Print Name: {$item.name} {END-FOR item}',
+      fieldsYaml: [
+        '  - name: board_members',
+        '    type: array',
+        '    description: Board members',
+        '    items:',
+        '      - name: name',
+        '        type: string',
+        '        description: Director name',
+      ].join('\n'),
+    });
+    const result = validateTemplate(dir, 'fixture');
+    expect(result.errors).toEqual([]);
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe('fillTemplate input selection', () => {
+  async function loadEngineWithPipelineSpy(): Promise<{
+    fillTemplate: (args: { templateDir: string; values: Record<string, unknown>; outputPath: string }) => Promise<unknown>;
+    runFillPipeline: ReturnType<typeof vi.fn>;
+  }> {
+    vi.resetModules();
+    const runFillPipeline = vi.fn(async (args: { inputPath: string; outputPath: string }) => ({
+      outputPath: args.outputPath,
+      fieldsUsed: [],
+      providedFieldsUsed: [],
+      fillCommandCount: 0,
+      warnings: [],
+    }));
+    vi.doMock('../src/core/metadata.js', () => ({
+      loadMetadata: vi.fn(() => ({
+        name: 'Fixture Template',
+        fields: [{ name: 'company_name', type: 'string', description: 'Company' }],
+        priority_fields: [] as string[],
+      })),
+      loadCleanConfig: vi.fn(() => ({})),
+    }));
+    vi.doMock('../src/core/selector.js', () => ({
+      loadSelectionsConfig: vi.fn(() => ({ groups: [] })),
+    }));
+    vi.doMock('../src/core/unified-pipeline.js', () => ({ runFillPipeline }));
+    vi.doMock('../src/core/fill-utils.js', () => ({
+      BLANK_PLACEHOLDER: '__BLANK__',
+      verifyTemplateFill: vi.fn(() => ({ passed: true, checks: [] })),
+    }));
+    const module = await import('../src/core/engine.js');
+    return { fillTemplate: module.fillTemplate, runFillPipeline };
+  }
+
+  it('fills from template.fill.docx when it exists', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'oa-fill-variant-engine-'));
+    tempDirs.push(dir);
+    writeFileSync(join(dir, 'template.docx'), buildDocx('Humanized prose.'));
+    writeFileSync(join(dir, 'template.fill.docx'), buildDocx('{company_name}'));
+
+    const { fillTemplate, runFillPipeline } = await loadEngineWithPipelineSpy();
+    await fillTemplate({ templateDir: dir, values: {}, outputPath: join(dir, 'out.docx') });
+
+    expect(runFillPipeline).toHaveBeenCalledTimes(1);
+    expect(runFillPipeline.mock.calls[0][0].inputPath).toBe(join(dir, 'template.fill.docx'));
+  });
+
+  it('falls back to template.docx when no fill variant exists', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'oa-fill-variant-engine-'));
+    tempDirs.push(dir);
+    writeFileSync(join(dir, 'template.docx'), buildDocx('{company_name}'));
+
+    const { fillTemplate, runFillPipeline } = await loadEngineWithPipelineSpy();
+    await fillTemplate({ templateDir: dir, values: {}, outputPath: join(dir, 'out.docx') });
+
+    expect(runFillPipeline).toHaveBeenCalledTimes(1);
+    expect(runFillPipeline.mock.calls[0][0].inputPath).toBe(join(dir, 'template.docx'));
+  });
+});

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "build:checklist-mcp": "tsc -p packages/checklist-mcp/tsconfig.json",
     "dev": "tsc --watch",
     "check:template-previews": "node scripts/check_template_previews.mjs",
-    "check:docx-structure": "node scripts/check_docx_structure.mjs 'templates/*/*/template.docx'",
+    "check:docx-structure": "node scripts/check_docx_structure.mjs",
     "check:preview-freshness": "node scripts/check_preview_freshness.mjs",
     "check:source-drift": "npm run build && node scripts/source_drift_canary.mjs",
     "check:allure-labels": "node scripts/validate_allure_test_labels.mjs",

--- a/scripts/check_docx_structure.mjs
+++ b/scripts/check_docx_structure.mjs
@@ -6,7 +6,10 @@ import { fileURLToPath } from 'node:url';
 
 import JSZip from 'jszip';
 
-const DEFAULT_PATTERN = 'templates/*/*/template.docx';
+const DEFAULT_PATTERNS = [
+  'templates/*/*/template.docx',
+  'templates/*/*/template.fill.docx',
+];
 
 export const CHECKS = {
   ORPHAN_COMMENTS_PART: {
@@ -79,7 +82,7 @@ function parseArgs(argv) {
   }
 
   if (parsed.patterns.length === 0) {
-    parsed.patterns.push(DEFAULT_PATTERN);
+    parsed.patterns.push(...DEFAULT_PATTERNS);
   }
 
   return parsed;
@@ -92,7 +95,7 @@ function printHelp() {
       '',
       'Runs lightweight OOXML structural checks for Word unreadable-content failure modes.',
       '',
-      'Defaults to: templates/*/*/template.docx',
+      'Defaults to: templates/*/*/template.docx + templates/*/*/template.fill.docx',
       '',
       'Options:',
       '      --format=json   Emit machine-readable JSON output',

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -289,8 +289,14 @@ export async function fillTemplate(options: FillOptions): Promise<FillResult> {
     console.warn(`Warning: unknown field(s) not in metadata: ${unknownKeys.join(', ')}`);
   }
 
+  // Dual-artifact templates (LE-projected) ship a humanized `template.docx`
+  // for human download plus a machine-fillable `template.fill.docx` carrying
+  // the {field} tokens — fill from the fill variant when it exists.
+  const fillVariantPath = join(templateDir, 'template.fill.docx');
+  const templatePath = existsSync(fillVariantPath)
+    ? fillVariantPath
+    : join(templateDir, 'template.docx');
   // Build cleanPatch if replacements.json or clean.json exists
-  const templatePath = join(templateDir, 'template.docx');
   const replacementsPath = join(templateDir, 'replacements.json');
   const cleanJsonPath = join(templateDir, 'clean.json');
   const hasReplacements = existsSync(replacementsPath);

--- a/src/core/validation/template.ts
+++ b/src/core/validation/template.ts
@@ -186,13 +186,47 @@ export function validateTemplate(templateDir: string, templateId: string): Templ
   const docxTextForTokenScan = extractDocxText(templatePath);
   const docxHasFillTokens = /\{(?:IF |FOR |END|\$|\w+\})/.test(docxTextForTokenScan);
   const hasMdocTwin = existsSync(join(templateDir, 'template.mdoc'));
-  if (!docxHasFillTokens && hasMdocTwin) {
+
+  // Dual-artifact layout (LE-projected, #1378): `template.docx` is the
+  // humanized human download and `template.fill.docx` carries the machine-fill
+  // tokens. When the fill variant exists, the token-coverage/FOR/multiselect
+  // scans below run against IT, the human doc must itself be token-free, and
+  // the unsafe-tag security scan covers BOTH documents (the fill variant is
+  // scanned in the main branch below).
+  const fillVariantPath = join(templateDir, 'template.fill.docx');
+  const hasFillVariant = existsSync(fillVariantPath);
+  if (hasFillVariant) {
+    if (docxHasFillTokens) {
+      errors.push(
+        'template.docx must be token-free when template.fill.docx is present ' +
+        '(dual-artifact layout: humanized human doc + machine-fill variant); ' +
+        'found fill tokens in template.docx'
+      );
+    }
+    if (existsSync(join(templateDir, 'replacements.json'))) {
+      errors.push(
+        'template.fill.docx cannot be combined with replacements.json — the ' +
+        'declarative-replacements pipeline patches template.docx and would never ' +
+        'see the fill variant'
+      );
+      return { templateId, valid: false, errors, warnings };
+    }
+    const humanRawXml = extractRawDocumentXml(templatePath);
+    if (humanRawXml) {
+      scanForUnsafeTemplateTags(humanRawXml, errors);
+    }
+  } else if (!docxHasFillTokens && hasMdocTwin) {
     const rawXml = extractRawDocumentXml(templatePath);
     if (rawXml) {
       scanForUnsafeTemplateTags(rawXml, errors);
     }
     return { templateId, valid: errors.length === 0, errors, warnings };
   }
+
+  // The document the fill engine actually consumes — all token scans below
+  // target this path, and error/warning messages name it.
+  const scanPath = hasFillVariant ? fillVariantPath : templatePath;
+  const scanName = hasFillVariant ? 'template.fill.docx' : 'template.docx';
 
   const metadataFieldNames = new Set(metadata.fields.map((f) => f.name));
   const priorityFieldNames = new Set(metadata.priority_fields);
@@ -349,7 +383,7 @@ export function validateTemplate(templateDir: string, templateId: string): Templ
     );
   } else {
     // Original behavior: scan DOCX text directly for {tags}
-    const text = extractDocxText(templatePath);
+    const text = hasFillVariant ? extractDocxText(scanPath) : docxTextForTokenScan;
     const placeholderRegex = /\{(\w+)\}/g;
     const foundTags = new Set<string>();
     let match;
@@ -416,7 +450,7 @@ export function validateTemplate(templateDir: string, templateId: string): Templ
 
     // Security: scan for docx-templates control/code tags that should not exist
     // in open-source templates. Only simple {identifier} tags are allowed.
-    const rawXml = extractRawDocumentXml(templatePath);
+    const rawXml = extractRawDocumentXml(scanPath);
     if (rawXml) {
       scanForUnsafeTemplateTags(rawXml, errors);
     }
@@ -438,11 +472,11 @@ export function validateTemplate(templateDir: string, templateId: string): Templ
       if (!inDocx) {
         if (priorityFieldNames.has(fieldName)) {
           errors.push(
-            `Priority field "${fieldName}" defined in metadata but not found as {${fieldName}} in template.docx`
+            `Priority field "${fieldName}" defined in metadata but not found as {${fieldName}} in ${scanName}`
           );
         } else {
           warnings.push(
-            `Optional field "${fieldName}" defined in metadata but not found as {${fieldName}} in template.docx`
+            `Optional field "${fieldName}" defined in metadata but not found as {${fieldName}} in ${scanName}`
           );
         }
       }
@@ -454,7 +488,7 @@ export function validateTemplate(templateDir: string, templateId: string): Templ
       if (controlTokens.has(tag)) continue;
       if (!metadataFieldNames.has(tag)) {
         warnings.push(
-          `Placeholder {${tag}} found in template.docx but not defined in metadata fields`
+          `Placeholder {${tag}} found in ${scanName} but not defined in metadata fields`
         );
       }
     }


### PR DESCRIPTION
## Upstream context

legal-explainer #1378: every LE-projected template will ship BOTH a humanized `template.docx` (human download, [bracket] prose) and a machine-fillable `template.fill.docx` ({token} document). This PR makes the OA engine and validation dual-artifact aware. **Inert until the LE projection ships the new artifact** — no behavior change for any existing template.

## Changes

- `fillTemplate` (engine.ts): fills from `template.fill.docx` when present, else `template.docx` (unchanged today).
- `validateTemplate` (validation/template.ts): when the fill variant exists —
  - the {field}/{IF}/{FOR}/{$item.x} token-coverage scans run against the **fill variant** (messages name `template.fill.docx`),
  - the human `template.docx` must itself be **token-free** (dual-artifact contract),
  - the unsafe-tag security scan runs against **both** documents,
  - `replacements.json` + fill variant is rejected (the declarative pipeline patches template.docx and would never see the variant).
  - The mdoc-twin humanized skip is preserved for templates without a fill variant.
- `check_docx_structure.mjs`: default glob also covers `templates/*/*/template.fill.docx` (aggregate empty-check unaffected).

## Tests

New `integration-tests/fill-variant.test.ts` (10 tests): engine input selection both ways; validation coverage pass/fail against the variant; token-free human-doc enforcement; replacements rejection; unsafe-tag scan on both docs; humanized-skip preservation; FOR/item-ref validation in the variant.

Full suite: 1016 passed, 6 skipped.

https://claude.ai/code/session_01CeTTafjv6F51UoQvseYp5W