### PR TITLE
fix(ci): drop deleted site/ dir from semgrep scan targets

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -25,7 +25,7 @@ jobs:
             --metrics=off \
             --sarif \
             --output semgrep.sarif \
-            src packages scripts bin site
+            src packages scripts bin
 
       - name: Upload Semgrep SARIF
         uses: github/codeql-action/upload-sarif@v3


### PR DESCRIPTION
Closes #583.

## What

Removes `site` from the hardcoded semgrep scan-target list in `.github/workflows/semgrep.yml`. The remaining targets (`src packages scripts bin`) all exist.

## Why

The eleventy site was deleted in the 2026-07-01 root cleanup, but the semgrep workflow (shared by CI via `workflow_call` and the weekly schedule) still passed `site` as a target. Semgrep fatals with exit 2 on a nonexistent target path, so every CI run on main since 2026-07-01 has failed on the `semgrep / semgrep` job — including the weekly scheduled run on 2026-07-06.

## Verification

The semgrep job on this PR's CI run is the real test — it runs the exact command in the exact container.

https://claude.ai/code/session_01WCTp1Mo7hDgAXkKgtEdo7f