### PR TITLE
test(list): maxBuffer for list --json envelope checks at post-sync catalog scale

### DIFF
--- a/integration-tests/list.test.ts
+++ b/integration-tests/list.test.ts
@@ -31,6 +31,8 @@ describe('list --json envelope', () => {
       cwd: ROOT,
       encoding: 'utf-8',
       timeout: 10_000,
+      // The ~100-template catalog exceeds execSync's 1 MiB default (ENOBUFS).
+      maxBuffer: 16 * 1024 * 1024,
     });
     parsed = JSON.parse(output) as ListResponse;
   } catch (err) {
@@ -117,6 +119,7 @@ describe('list options', () => {
           cwd: ROOT,
           encoding: 'utf-8',
           timeout: 10_000,
+          maxBuffer: 16 * 1024 * 1024,
           env: {
             ...process.env,
             OPEN_AGREEMENTS_CONTENT_ROOTS: root,


### PR DESCRIPTION
Last ENOBUFS straggler blocking the templates sync (#568): `list.test.ts`'s module-scope `list --json` / `--json-strict` calls sit right at execSync's 1 MiB default at the ~100-template catalog size — under it on local hardware, over it on CI. Same class and fix as #585's sweep (this site passed locally then, so it escaped).

https://claude.ai/code/session_01CeTTafjv6F51UoQvseYp5W