### PR TITLE
fix(fill): render unfilled signature-block fields as clean rules, not highlighted underscore stubs

### DIFF
--- a/integration-tests/fill-pipeline.test.ts
+++ b/integration-tests/fill-pipeline.test.ts
@@ -1481,6 +1481,46 @@ describe('Parametric smoke test — signatory fields across all templates', () =
   }, seconds(60));
 });
 
+describe('Unfilled signature-block fields — no highlighted stub on ruled lines (issue #588)', () => {
+  // The restrictive-covenant family has employer_signatory_name/title fields but
+  // NO *_signatory_type field, so the deriveSignatoryFields path never runs. The
+  // signature "rule" is the table cell's bottom border; an unfilled signatory
+  // token must render empty, not as a highlighted _______ stub on top of the rule.
+  const RC_DIR = templateDirFor('openagreements-restrictive-covenant-wyoming');
+
+  it('omitted signatory fields render as clean rules (no blank-underscore stub)', async () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      // dummyAllValues fills every metadata field EXCEPT signatory fields, so the
+      // signatory fields are the only ones that would blank-default.
+      const xml = await fillAndExtractXml(RC_DIR, dummyAllValues(RC_DIR));
+      expect(xml).not.toContain(BLANK_PLACEHOLDER);
+      // Signature rows themselves survive (labels + ruled cells still present)
+      expect(xml).toContain('Signatory Name');
+      expect(xml).toContain('>Title<');
+    } finally {
+      spy.mockRestore();
+    }
+  }, seconds(30));
+
+  it('provided signatory fields still render with highlight stripped', async () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const values = {
+        ...dummyAllValues(RC_DIR),
+        employer_signatory_name: 'Alice Johnson',
+        employer_signatory_title: 'CEO',
+      };
+      const xml = await fillAndExtractXml(RC_DIR, values);
+      expect(xml).toContain('Alice Johnson');
+      // The filled signatory runs must not keep their authoring highlight
+      expect(xml).not.toMatch(/<w:highlight[^>]*>(?:(?!<\/w:r>).)*Alice Johnson/s);
+    } finally {
+      spy.mockRestore();
+    }
+  }, seconds(30));
+});
+
 describe('confirmation cover notice + clause renumbering', () => {
   const confirmFields = [
     { name: 'covered', type: 'boolean', default: 'false' },

--- a/integration-tests/fill-pipeline.test.ts
+++ b/integration-tests/fill-pipeline.test.ts
@@ -1513,8 +1513,10 @@ describe('Unfilled signature-block fields — no highlighted stub on ruled lines
       };
       const xml = await fillAndExtractXml(RC_DIR, values);
       expect(xml).toContain('Alice Johnson');
+      expect(xml).toContain('CEO');
       // The filled signatory runs must not keep their authoring highlight
       expect(xml).not.toMatch(/<w:highlight[^>]*>(?:(?!<\/w:r>).)*Alice Johnson/s);
+      expect(xml).not.toMatch(/<w:highlight[^>]*>(?:(?!<\/w:r>).)*CEO/s);
     } finally {
       spy.mockRestore();
     }

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -132,6 +132,18 @@ function computeDisplayFields(data: Record<string, unknown>, fieldNames: Set<str
     }
   }
 
+  // ── Unfilled signature-block fields ──
+  // Signatory tokens sit on ruled signature lines, so an unfilled one must
+  // render as a clean rule — not a highlighted blank-underscore stub on top
+  // of the rule (open-agreements#588). deriveSignatoryFields already blanks
+  // these when the template declares a *_signatory_type field; this covers
+  // templates without one (e.g. the restrictive-covenant family).
+  for (const key of fieldNames) {
+    if (/(^|_)signatory_(name|title|email|company)$/.test(key) && isBlankPlaceholder(data[key])) {
+      data[key] = '';
+    }
+  }
+
   // ── Bonterms signatory defaults + computed fields ──
   for (const n of [1, 2]) {
     const p = `party_${n}`;


### PR DESCRIPTION
![Fixed signature page — single clean rules on Signatory Name/Title, no highlighted stub](https://raw.githubusercontent.com/UseJunior/ci-screenshots/main/pr-590/premerge-wyoming-signature-page-1.png)

*Pre-merge fill of the real Wyoming RC template with `employer_signatory_name`/`employer_signatory_title` omitted — compare the double-underline stub in the issue screenshot.*

## What

Fixes #588 — when a fill omits signature-block fields (`employer_signatory_name` / `employer_signatory_title`), the output DOCX showed a yellow-highlighted underscore stub sitting on top of the full-width ruled signature line: a "double underline". After this fix, an unfilled signatory field renders as a single clean rule, exactly like the untemplated Signature/Date rows.

## Root cause

- `prepareFillData(useBlankPlaceholder: true)` defaults every unprovided field to the `'_______'` blank placeholder.
- `stripFilledHighlighting` in `fillDocx` strips `<w:highlight>` only from runs whose fields are **filled**, so a blank-defaulted token keeps its yellow authoring highlight.
- The signature "rule" is the table cell's **bottom border** — so the highlighted underscore stub lands on top of an existing rule.
- The engine already normalizes blank signatory fields to `''` (`deriveSignatoryFields`), but only for templates that declare a `*_signatory_type` field. The restrictive-covenant family declares none, so the normalization never ran.

## Fix

`computeDisplayFields` (`src/core/engine.ts`) now blanks any field matching `/(^|_)signatory_(name|title|email|company)$/` whose value is still the blank placeholder, regardless of whether a signatory-type field exists. The blank-underscore visual cue is unchanged for body fields; only signature-line fields are affected.

Safety checks done:

- No template uses a signatory-named field in an `{IF ...}` condition, so the `''` normalization changes no conditional rendering.
- The regex does not match computed display keys (`party_1_signatory_name_and_title`) or non-signatory fields.
- Full suite green: 1001 passed.

## Tests

New describe block in `integration-tests/fill-pipeline.test.ts` filling the real `openagreements-restrictive-covenant-wyoming` template end-to-end via `fillTemplate` (uses `template.fill.docx`, same as the production MCP path):

- omitted signatory fields → output XML contains zero `_______` and the signature rows survive (red-checked: fails without the engine fix);
- provided signatory fields still render with the authoring highlight stripped.

## Verification

Filled the real Wyoming template with signatory fields omitted; the rendered signature page shows single clean rules on Signatory Name / Title (screenshot above), with zero blank placeholders in the document XML.
