### PR TITLE
feat(issue-forms): "Challenge a specific claim" issue-form (#1357)

### DIFF
--- a/.github/ISSUE_TEMPLATE/challenge.yml
+++ b/.github/ISSUE_TEMPLATE/challenge.yml
@@ -1,0 +1,76 @@
+name: Challenge a specific claim
+description: Challenge one row, source, or comparison on a published page — a missing exception, a wrong or weak source, a stale law, or a benchmark that looks off. This is the "prove me wrong" path; every challenge is anchored to the exact version it targets.
+title: "Challenge: "
+labels:
+  - challenge
+body:
+  - type: markdown
+    attributes:
+      value: |
+        You almost certainly reached this form from a **"Challenge this / Suggest a source / Report stale law"** link on a specific row. If so, the **Anchor** field at the bottom is already filled in — please don't edit it; it records the exact provision and version your challenge targets.
+
+        Triage notes (maintainers):
+        - Adjudicate by closing with one of: `challenge/accepted`, `challenge/partially-accepted`, `challenge/duplicate`, `challenge/superseded`, or close as *not planned* for rejected.
+        - `scripts/challenge/sync-ledger.ts` (in `legal-explainer`) folds outcomes into the committed `challenges/<topic>.json` ledger.
+
+  - type: dropdown
+    id: challenge_type
+    attributes:
+      label: Type of challenge
+      description: What kind of problem is this? (If you followed a per-row link, this is already implied by the Anchor — pick the closest match anyway.)
+      options:
+        - Missing exception or carve-out
+        - Wrong, weak, or missing source
+        - The law has changed (stale)
+        - Benchmark comparison looks wrong
+        - Wrong for this jurisdiction
+    validations:
+      required: true
+
+  - type: input
+    id: page_url
+    attributes:
+      label: Page URL
+      placeholder: https://openagreements.org/surveys/invention-assignment/us/form-conformance
+    validations:
+      required: true
+
+  - type: textarea
+    id: whats_wrong
+    attributes:
+      label: What's wrong
+      description: Tell us what's incorrect, missing, or out of date — in your own words.
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggested_correction
+    attributes:
+      label: Suggested correction (whole replacement text)
+      description: Optional. If you can, paste the corrected wording for the whole row/provision (not a diff).
+    validations:
+      required: false
+
+  - type: input
+    id: cited_source
+    attributes:
+      label: Source / authority
+      description: Optional but strongly preferred — the primary law (statute, case, regulation) or other source that backs your challenge.
+      placeholder: e.g. Cal. Lab. Code § 2870; Smith v. Jones, 123 F.3d 456 (9th Cir. 2025)
+    validations:
+      required: false
+
+  - type: textarea
+    id: anchor
+    attributes:
+      label: Anchor (do not edit)
+      description: Machine-readable anchor identifying the exact provision and version. Auto-filled by the per-row link — please leave it unchanged.
+      value: |
+        kind:
+        target_id:
+        page:
+        section_id:
+        base_content_hash:
+        challenge_type:
+    validations:
+      required: false


### PR DESCRIPTION
## The reader-facing raw store for the "make quality falsifiable" loop

Companion to legal-explainer #1356/#1357 (epic #1344).

Per-row **"Challenge this / Suggest a source / Report stale law"** affordances on openagreements.org open a prefilled instance of this issue-form, anchored to the exact provision + content-hash the reader saw (the "Anchor (do not edit)" field). GitHub is the append-only, never-lost store; a sync script (`challenge:sync`, in legal-explainer) folds outcomes into the committed `challenges/<topic>.json` ledger.

- `.github/ISSUE_TEMPLATE/challenge.yml` — challenge_type, page_url, what's wrong, suggested correction (whole replacement), source/authority, and the machine anchor. Labeled `challenge`.

Peer-reviewed (codex): field ids/labels confirmed to line up with the legal-explainer emit helper (`challenge-link.ts`) and the issue parser (`parse-issue.ts`).

> Note: create the `challenge` label in this repo so the form's `labels:` applies cleanly.

https://claude.ai/code/session_01S1fpZAr88kKJU4hrG61kGg