### PR TITLE
refactor(fill): suppress blank placeholder on ruled lines structurally, not by field-name regex

### DIFF
--- a/integration-tests/fill-pipeline.test.ts
+++ b/integration-tests/fill-pipeline.test.ts
@@ -1481,11 +1481,52 @@ describe('Parametric smoke test — signatory fields across all templates', () =
   }, seconds(60));
 });
 
-describe('Unfilled signature-block fields — no highlighted stub on ruled lines (issue #588)', () => {
-  // The restrictive-covenant family has employer_signatory_name/title fields but
-  // NO *_signatory_type field, so the deriveSignatoryFields path never runs. The
-  // signature "rule" is the table cell's bottom border; an unfilled signatory
-  // token must render empty, not as a highlighted _______ stub on top of the rule.
+describe('Blank placeholder on an already-ruled line (issue #588)', () => {
+  // The fix is structural, not field-name-based: an unfilled field whose blank
+  // placeholder ('_______') sits on a line that already carries a bottom-border
+  // rule must render as a single clean rule, not stack underscores on top of the
+  // border ("double underline"). The signature block is the motivating case, but
+  // the rule keys off the OOXML border, not off which field is a "signatory".
+
+  const CELL_BORDER =
+    '<w:tcBorders><w:bottom w:val="single" w:sz="6" w:space="0" w:color="000000"/></w:tcBorders>';
+  const CELL_NO_BORDER =
+    '<w:tcBorders><w:bottom w:val="none" w:sz="0" w:space="0" w:color="auto"/></w:tcBorders>';
+
+  /** A one-cell table row: a highlighted {token} in a cell that may/may not be ruled. */
+  function ruledRow(token: string, borders: string): string {
+    return (
+      `<w:tr><w:tc><w:tcPr><w:tcW w:w="4320" w:type="dxa"/>${borders}</w:tcPr>` +
+      '<w:p><w:r><w:rPr><w:highlight w:val="yellow"/></w:rPr>' +
+      `<w:t xml:space="preserve">{${token}}</w:t></w:r></w:p></w:tc></w:tr>`
+    );
+  }
+
+  it('clears the blank placeholder on a ruled line but keeps it on an un-ruled line', async () => {
+    const documentXml =
+      '<?xml version="1.0" encoding="UTF-8"?>' +
+      '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>' +
+      `<w:tbl>${ruledRow('on_rule', CELL_BORDER)}${ruledRow('no_rule', CELL_NO_BORDER)}</w:tbl>` +
+      '</w:body></w:document>';
+
+    // Both fields unfilled → both default to the blank placeholder.
+    const filled = await fillDocx({
+      templateBuffer: buildDocxBuffer(documentXml),
+      data: { on_rule: BLANK_PLACEHOLDER, no_rule: BLANK_PLACEHOLDER },
+      stripParagraphPatterns: [],
+    });
+    const xml = new AdmZip(Buffer.from(filled)).getEntry('word/document.xml')!.getData().toString('utf-8');
+
+    // The ruled cell keeps exactly one underline (its border), no underscores.
+    const ruledCell = xml.slice(xml.indexOf('w:val="single"'), xml.indexOf('w:val="none"'));
+    expect(ruledCell).not.toContain(BLANK_PLACEHOLDER);
+    expect(ruledCell).not.toContain('<w:highlight'); // stray highlight dropped too
+    // The un-ruled cell keeps its placeholder underscores (the intended cue).
+    expect(xml.slice(xml.indexOf('w:val="none"'))).toContain(BLANK_PLACEHOLDER);
+  });
+
+  // The restrictive-covenant family has employer_signatory_name/title fields on
+  // ruled cells and NO *_signatory_type field — the real-world motivating case.
   const RC_DIR = templateDirFor('openagreements-restrictive-covenant-wyoming');
 
   it('omitted signatory fields render as clean rules (no blank-underscore stub)', async () => {

--- a/integration-tests/fill-pipeline.test.ts
+++ b/integration-tests/fill-pipeline.test.ts
@@ -1525,6 +1525,33 @@ describe('Blank placeholder on an already-ruled line (issue #588)', () => {
     expect(xml.slice(xml.indexOf('w:val="none"'))).toContain(BLANK_PLACEHOLDER);
   });
 
+  it('only clears the cell\'s last paragraph — a placeholder above the rule survives', async () => {
+    // A bottom-bordered cell with two paragraphs: the border underlines only the
+    // LAST line, so a placeholder in the FIRST paragraph is not on the rule.
+    const documentXml =
+      '<?xml version="1.0" encoding="UTF-8"?>' +
+      '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>' +
+      '<w:tbl><w:tr><w:tc>' +
+      `<w:tcPr><w:tcW w:w="4320" w:type="dxa"/>${CELL_BORDER}</w:tcPr>` +
+      '<w:p><w:r><w:t xml:space="preserve">{early}</w:t></w:r></w:p>' +
+      '<w:p><w:r><w:t xml:space="preserve">{late}</w:t></w:r></w:p>' +
+      '</w:tc></w:tr></w:tbl>' +
+      '</w:body></w:document>';
+
+    const filled = await fillDocx({
+      templateBuffer: buildDocxBuffer(documentXml),
+      data: { early: BLANK_PLACEHOLDER, late: BLANK_PLACEHOLDER },
+      stripParagraphPatterns: [],
+    });
+    const xml = new AdmZip(Buffer.from(filled)).getEntry('word/document.xml')!.getData().toString('utf-8');
+
+    // Exactly one placeholder survives — the one above the rule (first paragraph).
+    expect((xml.match(new RegExp(BLANK_PLACEHOLDER, 'g')) ?? []).length).toBe(1);
+    const paras = xml.match(/<w:p>[\s\S]*?<\/w:p>/g) ?? [];
+    expect(paras[0]).toContain(BLANK_PLACEHOLDER); // above the rule: kept
+    expect(paras[paras.length - 1]).not.toContain(BLANK_PLACEHOLDER); // on the rule: cleared
+  });
+
   // The restrictive-covenant family has employer_signatory_name/title fields on
   // ruled cells and NO *_signatory_type field — the real-world motivating case.
   const RC_DIR = templateDirFor('openagreements-restrictive-covenant-wyoming');

--- a/integration-tests/fill-pipeline.test.ts
+++ b/integration-tests/fill-pipeline.test.ts
@@ -1552,6 +1552,29 @@ describe('Blank placeholder on an already-ruled line (issue #588)', () => {
     expect(paras[paras.length - 1]).not.toContain(BLANK_PLACEHOLDER); // on the rule: cleared
   });
 
+  it('preserves a trailing-whitespace anchor when clearing the placeholder (#109)', async () => {
+    // The placeholder run carries a trailing space that a signing field-selector
+    // might anchor on. Clearing must drop the underscores but keep the space.
+    const documentXml =
+      '<?xml version="1.0" encoding="UTF-8"?>' +
+      '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>' +
+      '<w:tbl><w:tr><w:tc>' +
+      `<w:tcPr><w:tcW w:w="4320" w:type="dxa"/>${CELL_BORDER}</w:tcPr>` +
+      '<w:p><w:r><w:t xml:space="preserve">{anchored} </w:t></w:r></w:p>' +
+      '</w:tc></w:tr></w:tbl>' +
+      '</w:body></w:document>';
+
+    const filled = await fillDocx({
+      templateBuffer: buildDocxBuffer(documentXml),
+      data: { anchored: BLANK_PLACEHOLDER },
+      stripParagraphPatterns: [],
+    });
+    const xml = new AdmZip(Buffer.from(filled)).getEntry('word/document.xml')!.getData().toString('utf-8');
+
+    expect(xml).not.toContain(BLANK_PLACEHOLDER); // underscores gone
+    expect(xml).toMatch(/<w:t[^>]*>\s+<\/w:t>/); // the trailing space survives
+  });
+
   // The restrictive-covenant family has employer_signatory_name/title fields on
   // ruled cells and NO *_signatory_type field — the real-world motivating case.
   const RC_DIR = templateDirFor('openagreements-restrictive-covenant-wyoming');

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -132,18 +132,6 @@ function computeDisplayFields(data: Record<string, unknown>, fieldNames: Set<str
     }
   }
 
-  // ── Unfilled signature-block fields ──
-  // Signatory tokens sit on ruled signature lines, so an unfilled one must
-  // render as a clean rule — not a highlighted blank-underscore stub on top
-  // of the rule (open-agreements#588). deriveSignatoryFields already blanks
-  // these when the template declares a *_signatory_type field; this covers
-  // templates without one (e.g. the restrictive-covenant family).
-  for (const key of fieldNames) {
-    if (/(^|_)signatory_(name|title|email|company)$/.test(key) && isBlankPlaceholder(data[key])) {
-      data[key] = '';
-    }
-  }
-
   // ── Bonterms signatory defaults + computed fields ──
   for (const n of [1, 2]) {
     const p = `party_${n}`;

--- a/src/core/fill-pipeline.ts
+++ b/src/core/fill-pipeline.ts
@@ -554,13 +554,131 @@ function stripEmptyTableRows(docxBuffer: Buffer): Buffer {
 }
 
 /**
+ * True if `borders` (a `<w:tcBorders>` or `<w:pBdr>` element) declares a visible
+ * bottom border — i.e. the line is already "ruled". A `<w:bottom>` with val
+ * `none`/`nil` (or absent) is not a rule.
+ */
+function hasVisibleBottomBorder(borders: Element | null): boolean {
+  if (!borders) return false;
+  const bottoms = borders.getElementsByTagNameNS(W_NS, 'bottom');
+  for (let i = 0; i < bottoms.length; i++) {
+    if (bottoms[i].parentNode !== borders) continue; // direct child only
+    const val = bottoms[i].getAttribute('w:val');
+    if (val && val !== 'none' && val !== 'nil') return true;
+  }
+  return false;
+}
+
+/** First matching `<w:NAME>` element that is a direct child of `parent`, or null. */
+function directChild(parent: Element | null, name: string): Element | null {
+  if (!parent) return null;
+  for (let i = 0; i < parent.childNodes.length; i++) {
+    const child = parent.childNodes[i] as Element;
+    if (child?.nodeType === 1 && child.localName === name && child.namespaceURI === W_NS) {
+      return child;
+    }
+  }
+  return null;
+}
+
+/**
+ * True when `run` sits on a line that already carries a bottom-border rule —
+ * either its enclosing table cell (`<w:tc>/<w:tcPr>/<w:tcBorders>/<w:bottom>`)
+ * or its paragraph (`<w:p>/<w:pPr>/<w:pBdr>/<w:bottom>`). Purely structural: it
+ * asks what the OOXML draws, never what the field means.
+ */
+function sitsOnRuledLine(run: Element): boolean {
+  let cell: Element | null = null;
+  let para: Element | null = null;
+  let node: Node | null = run.parentNode;
+  while (node) {
+    if (node.nodeType === 1) {
+      const el = node as Element;
+      if (el.namespaceURI === W_NS) {
+        if (!para && el.localName === 'p') para = el;
+        if (!cell && el.localName === 'tc') cell = el;
+      }
+    }
+    node = node.parentNode;
+  }
+  const cellBorders = directChild(directChild(cell, 'tcPr'), 'tcBorders');
+  const paraBorders = directChild(directChild(para, 'pPr'), 'pBdr');
+  return hasVisibleBottomBorder(cellBorders) || hasVisibleBottomBorder(paraBorders);
+}
+
+/**
+ * Suppress the blank-fill placeholder ('_______') on runs that already sit on a
+ * ruled line. The placeholder exists to draw a "write a value here" line where
+ * the template provides none; on a line that is already ruled (a signature
+ * block, an underlined field) it just stacks a second underline on top of the
+ * existing rule. This clears the redundant underscores — leaving the rule as the
+ * clean blank line — and drops any authoring highlight left on the run.
+ *
+ * Structural by design: it keys off the OOXML border, not off field names, so it
+ * needs no knowledge of which fields are "signatures". A blank placeholder on an
+ * un-ruled line is left untouched (its underscores are the intended cue).
+ */
+function stripBlankPlaceholderOnRuledLines(docxBuffer: Buffer): Buffer {
+  const zip = new AdmZip(docxBuffer);
+  const parser = new DOMParser();
+  const serializer = new XMLSerializer();
+  const parts = enumerateTextParts(zip);
+  const partNames = getGeneralTextPartNames(parts);
+
+  let modified = false;
+
+  for (const partName of partNames) {
+    const entry = zip.getEntry(partName);
+    if (!entry) continue;
+
+    const doc: Document = parser.parseFromString(entry.getData().toString('utf-8'), 'text/xml');
+    const runs = doc.getElementsByTagNameNS(W_NS, 'r');
+    let changed = false;
+
+    for (let i = 0; i < runs.length; i++) {
+      const run = runs[i];
+      // Only a run whose entire text IS the blank placeholder — not underscores
+      // embedded in real prose.
+      if (extractRunText(run).trim() !== BLANK_PLACEHOLDER) continue;
+      if (!sitsOnRuledLine(run)) continue;
+
+      // Clear the underscores (keep the run/paragraph so the rule survives).
+      const tEls = run.getElementsByTagNameNS(W_NS, 't');
+      for (let t = 0; t < tEls.length; t++) tEls[t].textContent = '';
+
+      // Drop any leftover authoring highlight on the now-empty run.
+      const rPr = run.getElementsByTagNameNS(W_NS, 'rPr');
+      if (rPr.length > 0) {
+        const highlights = rPr[0].getElementsByTagNameNS(W_NS, 'highlight');
+        for (let h = highlights.length - 1; h >= 0; h--) {
+          highlights[h].parentNode?.removeChild(highlights[h]);
+        }
+      }
+      changed = true;
+    }
+
+    if (changed) {
+      modified = true;
+      zip.updateFile(partName, Buffer.from(serializer.serializeToString(doc), 'utf-8'));
+    }
+  }
+
+  if (!modified) return docxBuffer;
+
+  const outZip = new AdmZip();
+  copyEntriesSkippingDirs(zip, outZip);
+  return outZip.toBuffer();
+}
+
+/**
  * Fill a DOCX template with prepared data:
  * 1. Strip drafting note paragraphs (configurable, on by default)
  * 2. Strip highlighting from runs with filled fields (unfilled keep their highlight)
  * 3. Sanitize currency values by scanning the template buffer for ${field} patterns
  * 4. Call docx-templates createReport() with standard delimiters
  * 5. Remove structurally empty table rows left by conditional rendering
- * 6. Return the filled buffer
+ * 6. Suppress the blank-fill placeholder on lines that already carry a rule
+ * 7. Return the filled buffer
  */
 export async function fillDocx(options: FillDocxOptions): Promise<Uint8Array> {
   const {
@@ -605,8 +723,12 @@ export async function fillDocx(options: FillDocxOptions): Promise<Uint8Array> {
 
   // Step 5: Remove malformed empty table rows from conditional rendering
   const cleaned = stripEmptyTableRows(filledBuffer);
-  // Step 6: Renumber clause headings so fully-omitted clauses leave no gap
-  return renumberClauseHeadings(cleaned);
+  // Step 6: Drop the blank placeholder where the line is already ruled, so an
+  // unfilled field on a signature/underlined line shows a single clean rule
+  // instead of stacking underscores on top of the existing border.
+  const deruled = stripBlankPlaceholderOnRuledLines(cleaned);
+  // Step 7: Renumber clause headings so fully-omitted clauses leave no gap
+  return renumberClauseHeadings(deruled);
 }
 
 /** The OAClauseHeading style marks the numbered standard-terms clause headings. */

--- a/src/core/fill-pipeline.ts
+++ b/src/core/fill-pipeline.ts
@@ -581,11 +581,28 @@ function directChild(parent: Element | null, name: string): Element | null {
   return null;
 }
 
+/** Last `<w:p>` that is a direct child of `cell` — the line its bottom border underlines. */
+function lastDirectParagraph(cell: Element): Element | null {
+  let last: Element | null = null;
+  for (let i = 0; i < cell.childNodes.length; i++) {
+    const child = cell.childNodes[i] as Element;
+    if (child?.nodeType === 1 && child.localName === 'p' && child.namespaceURI === W_NS) {
+      last = child;
+    }
+  }
+  return last;
+}
+
 /**
- * True when `run` sits on a line that already carries a bottom-border rule —
- * either its enclosing table cell (`<w:tc>/<w:tcPr>/<w:tcBorders>/<w:bottom>`)
- * or its paragraph (`<w:p>/<w:pPr>/<w:pBdr>/<w:bottom>`). Purely structural: it
- * asks what the OOXML draws, never what the field means.
+ * True when `run` sits on a line that already carries a bottom-border rule:
+ * - its paragraph has its own bottom border (`<w:p>/<w:pPr>/<w:pBdr>/<w:bottom>`), or
+ * - it is in the LAST paragraph of a table cell whose bottom border is visible
+ *   (`<w:tc>/<w:tcPr>/<w:tcBorders>/<w:bottom>`).
+ *
+ * The last-paragraph guard matters: a cell's bottom border only underlines the
+ * cell's final line, so a placeholder in an earlier paragraph of a multi-line
+ * cell is NOT on the rule and must be left alone. Purely structural — it asks
+ * what the OOXML draws, never what the field means.
  */
 function sitsOnRuledLine(run: Element): boolean {
   let cell: Element | null = null;
@@ -601,9 +618,15 @@ function sitsOnRuledLine(run: Element): boolean {
     }
     node = node.parentNode;
   }
-  const cellBorders = directChild(directChild(cell, 'tcPr'), 'tcBorders');
+
   const paraBorders = directChild(directChild(para, 'pPr'), 'pBdr');
-  return hasVisibleBottomBorder(cellBorders) || hasVisibleBottomBorder(paraBorders);
+  if (hasVisibleBottomBorder(paraBorders)) return true;
+
+  const cellBorders = directChild(directChild(cell, 'tcPr'), 'tcBorders');
+  if (hasVisibleBottomBorder(cellBorders) && cell && para === lastDirectParagraph(cell)) {
+    return true;
+  }
+  return false;
 }
 
 /**

--- a/src/core/fill-pipeline.ts
+++ b/src/core/fill-pipeline.ts
@@ -665,9 +665,13 @@ function stripBlankPlaceholderOnRuledLines(docxBuffer: Buffer): Buffer {
       if (extractRunText(run).trim() !== BLANK_PLACEHOLDER) continue;
       if (!sitsOnRuledLine(run)) continue;
 
-      // Clear the underscores (keep the run/paragraph so the rule survives).
+      // Remove only the placeholder underscores, preserving any surrounding
+      // whitespace — a trailing space can be a signing-anchor callers rely on
+      // (#109) — and keeping the run/paragraph so the rule itself survives.
       const tEls = run.getElementsByTagNameNS(W_NS, 't');
-      for (let t = 0; t < tEls.length; t++) tEls[t].textContent = '';
+      for (let t = 0; t < tEls.length; t++) {
+        tEls[t].textContent = (tEls[t].textContent ?? '').replace(BLANK_PLACEHOLDER, '');
+      }
 
       // Drop any leftover authoring highlight on the now-empty run.
       const rPr = run.getElementsByTagNameNS(W_NS, 'rPr');


### PR DESCRIPTION
![Wyoming signature page — single clean rules on Signatory Name/Title, via the structural pass](https://raw.githubusercontent.com/UseJunior/ci-screenshots/main/pr-597/premerge-wyoming-signature-page-1.png)

*Real Wyoming RC fill with signatory fields omitted — single clean rules, produced by the structural border-check (no field-name regex).*

## What

Re-does the #588 / #590 signature-line "double underline" fix with a **structural** rule instead of a field-name regex.

#590 fixed the symptom by blanking any field whose name matched `/(^|_)signatory_(name|title|email|company)$/`. That was brittle: it made a **formatting** outcome depend on **guessing the semantic role** of a field from its name. This replaces it with the actual rule — *don't stack the blank-fill placeholder on a line that already has a rule* — keyed off the OOXML border, not the field name.

## Root cause (unchanged from #590, re-confirmed)

For unfilled fields, the fill pipeline substitutes the blank placeholder `_______` (a "write a value here" line). The signature cell already has a `<w:bottom>` border — the rule. Underscores on top of the border = the double line. Filled values (e.g. "Jane Doe") render on a **single** clean rule, so the template is correct; the double-underline is purely a fill-time artifact of the placeholder colliding with an existing rule.

## Fix

- **`src/core/fill-pipeline.ts`** — new post-fill pass `stripBlankPlaceholderOnRuledLines`: any run whose text is exactly the blank placeholder **and** which sits in a table cell (`<w:tcBorders><w:bottom>`) or paragraph (`<w:pBdr><w:bottom>`) with a visible bottom border gets its underscores cleared (the rule stays as the clean blank line) and any stray authoring highlight dropped. Purely structural — no field names, no notion of "signature".
- **`src/core/engine.ts`** — removes the `/(^|_)signatory_.../` regex block added in #590.

A blank placeholder on an **un-ruled** line is left untouched — its underscores are the intended "fill me in" cue.

## Layering

The change lives entirely in open-agreements' fill pipeline (the templating engine). `@usejunior/docx-core` is untouched and remains a pure OOXML layer with no agreement/templating knowledge.

## Tests

`integration-tests/fill-pipeline.test.ts`:
- **New structural test** (synthetic two-cell table): a blank placeholder in a bottom-bordered cell is cleared (0 underscores, 0 highlight); the same placeholder in a border-less cell is preserved. This is what proves the fix is structural, not a blanket strip.
- The real-template Wyoming tests from #590 stay (omitted → clean rules; provided → highlight stripped) and still pass. Red-checked: both fail without the new pass once the regex is removed.
