### PR TITLE
ci: fix catalog-size test ceiling and changed-files env overflow (#603)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,27 +75,34 @@ jobs:
       - name: Install dependencies (retry)
         uses: ./.github/actions/npm-ci-retry
 
+      # The changed-file list rides in a file, not an env var: sync PRs can
+      # touch 1,400+ files (~164 KB of JSON), which overflows the 128 KiB
+      # per-string execve limit and kills the step with "Argument list too
+      # long" before the check runs (open-agreements#603).
       - name: Collect changed files
-        id: diff
         uses: actions/github-script@v7
         with:
-          result-encoding: string
           script: |
+            const fs = require('fs');
+            const path = require('path');
             const files = await github.paginate(github.rest.pulls.listFiles, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.payload.pull_request.number,
               per_page: 100,
             });
-            return JSON.stringify(files.map((f) => ({
-              status: f.status,
-              path: f.filename,
-              previousPath: f.previous_filename ?? null,
-            })));
+            fs.writeFileSync(
+              path.join(process.env.RUNNER_TEMP, 'oa-changed-files.json'),
+              JSON.stringify(files.map((f) => ({
+                status: f.status,
+                path: f.filename,
+                previousPath: f.previous_filename ?? null,
+              })))
+            );
 
       - name: Validate preview freshness
         env:
-          OA_CHANGED_FILES: ${{ steps.diff.outputs.result }}
+          OA_CHANGED_FILES_PATH: ${{ runner.temp }}/oa-changed-files.json
           OA_GATE_REQUIRE_INPUT: "1"
           OA_PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
         run: npm run check:preview-freshness

--- a/packages/contract-templates-mcp/tests/tools.test.ts
+++ b/packages/contract-templates-mcp/tests/tools.test.ts
@@ -40,6 +40,23 @@ function getPayload(result: Awaited<ReturnType<typeof callTool>>): Record<string
   return (result.structuredContent ?? {}) as Record<string, unknown>;
 }
 
+// The catalog outgrew a single max-size page (open-agreements#603), so the
+// full-catalog fetch must itself paginate rather than assume limit=100 covers
+// everything.
+async function fetchFullCatalog(): Promise<Array<{ template_id: string }>> {
+  const all: Array<{ template_id: string }> = [];
+  let cursor: string | undefined;
+  do {
+    const args: Record<string, unknown> = { limit: 100 };
+    if (cursor !== undefined) args.cursor = cursor;
+    const r = await callTool('list_templates', args);
+    const data = getPayload(r).data as Record<string, unknown>;
+    all.push(...(data.templates as Array<{ template_id: string }>));
+    cursor = (data.next_cursor as string | null) ?? undefined;
+  } while (cursor !== undefined);
+  return all;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function mockModules(overrides: Record<string, unknown> = {}): any {
   return {
@@ -121,16 +138,18 @@ describe('contract-templates-mcp tools', () => {
   // template's metadata — linear catalog growth costs quadratic test time, so
   // an explicit timeout replaces the 5s default (~100 templates post-sync).
   it('paginates the catalog using cursor + limit roundtrip with no duplicates', async () => {
-    const allResult = await callTool('list_templates', { limit: 100 });
-    const allTemplates = ((getPayload(allResult).data as Record<string, unknown>).templates) as Array<{ template_id: string }>;
+    const allTemplates = await fetchFullCatalog();
     expect(allTemplates.length).toBeGreaterThan(2); // need enough to page through
 
     const limit = 2;
+    // +2 slack: bound derived from the catalog, not hardcoded, so growth past
+    // any fixed ceiling can't turn a legitimate next_cursor into a failure.
+    const maxPages = Math.ceil(allTemplates.length / limit) + 2;
     const seen: string[] = [];
     let cursor: string | undefined;
     let totalCount: number | null = null;
     let lastNextCursor: string | null | undefined;
-    for (let i = 0; i < 50; i += 1) {
+    for (let i = 0; i < maxPages; i += 1) {
       const args: Record<string, unknown> = { limit };
       if (cursor !== undefined) args.cursor = cursor;
       const r = await callTool('list_templates', args);
@@ -152,9 +171,10 @@ describe('contract-templates-mcp tools', () => {
 
   it('maintains lexicographic continuity across page boundaries', async () => {
     const limit = 2;
+    const maxPages = Math.ceil((await fetchFullCatalog()).length / limit) + 2;
     const pages: Array<Array<{ template_id: string }>> = [];
     let cursor: string | undefined;
-    for (let i = 0; i < 50; i += 1) {
+    for (let i = 0; i < maxPages; i += 1) {
       const args: Record<string, unknown> = { limit };
       if (cursor !== undefined) args.cursor = cursor;
       const r = await callTool('list_templates', args);

--- a/scripts/check_preview_freshness.mjs
+++ b/scripts/check_preview_freshness.mjs
@@ -497,7 +497,13 @@ function sha256File(filePath) {
 
 function readChangedFilesFromInput(env) {
   const requireInput = env.OA_GATE_REQUIRE_INPUT === "1";
-  const fromEnv = env.OA_CHANGED_FILES;
+  // File transport first: large PRs (1,400+ changed files) overflow the
+  // 128 KiB per-string execve limit if the JSON rides in an env var
+  // ("Argument list too long"), so CI writes it to a file and passes the path.
+  const fromEnv =
+    env.OA_CHANGED_FILES_PATH !== undefined
+      ? readFileSync(env.OA_CHANGED_FILES_PATH, "utf8")
+      : env.OA_CHANGED_FILES;
 
   if (fromEnv !== undefined) {
     const trimmed = String(fromEnv).trim();
@@ -549,7 +555,7 @@ function readChangedFilesFromInput(env) {
 }
 
 function isLocalWorktreeDirty(env) {
-  if (env.OA_CHANGED_FILES !== undefined) return false; // CI mode
+  if (env.OA_CHANGED_FILES !== undefined || env.OA_CHANGED_FILES_PATH !== undefined) return false; // CI mode
   const status = spawnSync("git", ["status", "--porcelain"], {
     cwd: REPO_ROOT,
     encoding: "utf8",
@@ -653,7 +659,7 @@ export async function main(env) {
 
   if (input.mode === "ci-missing") {
     console.error(
-      "FAIL preview-freshness gate: OA_CHANGED_FILES env is required when OA_GATE_REQUIRE_INPUT=1. " +
+      "FAIL preview-freshness gate: OA_CHANGED_FILES (or OA_CHANGED_FILES_PATH) env is required when OA_GATE_REQUIRE_INPUT=1. " +
         "Check that the CI workflow populates it from actions/github-script."
     );
     process.exit(1);


### PR DESCRIPTION
Fixes #603. Both defects block the automated update PRs (#570, #601) from going green.

## Changes

1. **`packages/contract-templates-mcp/tests/tools.test.ts`** — the full-catalog fetch now paginates until `next_cursor === null` instead of assuming a single `limit: 100` page covers the catalog, and both pagination walks derive their iteration bound from the fetched catalog size (`Math.ceil(n / limit) + 2`) instead of a hardcoded 50. The catalog is at 102 templates; the old ceiling made the terminal-page assertion fail on any catalog-changing PR.

2. **`.github/workflows/ci.yml` + `scripts/check_preview_freshness.mjs`** — the preview-freshness gate's changed-file list now travels via `$RUNNER_TEMP/oa-changed-files.json` + `OA_CHANGED_FILES_PATH` instead of an env var. On #570 the list is 1,471 files (~164 KB of JSON), which exceeds the 128 KiB per-string `execve` limit and killed the step with `Argument list too long` before the check ran. The env-var transport (`OA_CHANGED_FILES`) remains supported for local/other callers.

## Verification (local)

- `npx vitest run packages/contract-templates-mcp/tests/tools.test.ts` — 30/30 pass
- `npx vitest run integration-tests/check-preview-freshness.test.ts` — 52/52 pass
- Gate exercised with a synthetic 1,500-file list (177,781 bytes, above the 131,072-byte env limit) via `OA_CHANGED_FILES_PATH`: runs and passes; small-list `OA_CHANGED_FILES` env transport unchanged; missing-input failure message updated to name both variables.

Test/CI-only; no runtime behavior changes.