### PR TITLE
fix(fill): cover NVCA charter company_name caption and opening recital (#607)

### DIFF
--- a/integration-tests/selector-contracts.test.ts
+++ b/integration-tests/selector-contracts.test.ts
@@ -294,7 +294,14 @@ describeWithCoiSource('CoI `>`-anchor field migration parity', () => {
     legacyKeysByField.set(field, { ...(legacyKeysByField.get(field) ?? {}), [key]: value });
   }
 
-  for (const manifest of manifests) {
+  // `company_name` is deliberately excluded from the byte-identity gate and covered by its own
+  // dedicated test below (#607). Its caption (`INCORPORATIONOF > [_________]`) and opening-recital
+  // (`[____________], a corporation > [____________]`) legacy `>` keys are dead duplicates — the
+  // legacy `replaceFirstAfterContext` never fires them (the caption context has no space before the
+  // blank; the recital context IS the target blank) — so legacy fills only the two body occurrences.
+  // The selector correctly fills all four, which is exactly the bug #607 fixes, so the two paths are
+  // intentionally NOT byte-identical for this field.
+  for (const manifest of manifests.filter((m) => m.field_id !== 'company_name')) {
     const field = manifest.field_id;
     const expectedSpans = manifest.occurrences.length;
     it(`[${field}] selector patch is byte-identical to legacy patch (${expectedSpans} span(s))`, async () => {
@@ -328,4 +335,56 @@ describeWithCoiSource('CoI `>`-anchor field migration parity', () => {
       }
     });
   }
+});
+
+// ---------------------------------------------------------------------------
+// CoI `company_name` — all four occurrences (#607).
+//
+// The pre-#607 selector declared only the two body occurrences ("name of this corporation is
+// [_______________]"). The caption ("CERTIFICATE OF INCORPORATIONOF[_________]") and opening recital
+// ("[____________], a corporation ...") were owned by migrated `>` keys that the legacy patcher never
+// fills (dead duplicates — see the note on the parity loop above), so they fell through BOTH paths and
+// rendered as raw `[_________]` / `[____________]` placeholders. This asserts the selector now fills every
+// company-name occurrence represented by the migrated keys: caption + opening recital + both body spans.
+// ---------------------------------------------------------------------------
+describeWithCoiSource('CoI company_name covers all four occurrences (#607)', () => {
+  const fieldSelectorDir = resolveFieldSelectorDir(COI);
+  const fieldNames = loadFieldSelectorMetadata(fieldSelectorDir).fields.map((f) => f.name);
+  const { manifests } = loadSelectorContracts(fieldSelectorDir, fieldNames);
+  const manifest = manifests.find((m) => m.field_id === 'company_name')!;
+
+  it('[company_name] fills the caption, opening recital, and both body occurrences', async () => {
+    expect(manifest, 'company_name manifest not loaded').toBeDefined();
+    expect(manifest.occurrences).toHaveLength(4);
+
+    // Drift surface: all four occurrences resolve uniquely against the raw source.
+    const raw = await resolveSelectorContracts(cachedSourcePathFor(COI), [manifest]);
+    expect(raw.fields[0].unresolved, 'company_name unresolved against raw source').toBe(false);
+    expect(raw.fields[0].assertionFailures, 'company_name assertion failures').toHaveLength(0);
+    expect(raw.fields[0].occurrences.map((o) => o.resolution.unresolved)).toEqual([false, false, false, false]);
+
+    const dir = mkdtempSync(join(tmpdir(), 'coi-company-name-607-'));
+    try {
+      const cleaned = join(dir, 'cleaned.docx');
+      await cleanDocument(cachedSourcePathFor(COI), cleaned, loadCleanConfig(fieldSelectorDir));
+
+      const selector = join(dir, 'selector.docx');
+      await applySelectorContracts(cleaned, selector, [manifest]);
+
+      const text = textOf(selector);
+      // Exactly four company_name tags — caption + recital + two body.
+      expect((text.match(/\{company_name\}/g) ?? []).length).toBe(4);
+      // Caption: "...CERTIFICATE OF INCORPORATIONOF{company_name}" (was [_________]).
+      expect(text).toContain('INCORPORATIONOF{company_name}');
+      // Opening recital: "{company_name}, a corporation" (was [____________]).
+      expect(text).toContain('{company_name}, a corporation');
+      // Both body occurrences still filled.
+      expect((text.match(/name of this corporation is \{company_name\}/g) ?? []).length).toBe(2);
+      // The caption and recital source placeholders are gone.
+      expect(text.includes('[_________]'), 'caption placeholder still present').toBe(false);
+      expect(text.includes('[____________]'), 'recital placeholder still present').toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/templates/nvca-free-non-redistributable/nvca-certificate-of-incorporation/fields/company_name.json
+++ b/templates/nvca-free-non-redistributable/nvca-certificate-of-incorporation/fields/company_name.json
@@ -8,6 +8,20 @@
     {
       "primary": {
         "kind": "regex",
+        "pattern": "INCORPORATION\\s*OF\\s*(\\[_________\\])",
+        "group": 1
+      }
+    },
+    {
+      "primary": {
+        "kind": "regex",
+        "pattern": "(\\[____________\\]),\\s+a\\s+corporation",
+        "group": 1
+      }
+    },
+    {
+      "primary": {
+        "kind": "regex",
         "pattern": "the\\s+name\\s+of\\s+this\\s+corporation\\s+is\\s+(\\[_______________\\])",
         "group": 1
       }


### PR DESCRIPTION
## Summary

Filling `nvca-certificate-of-incorporation` with `company_name` filled the two body occurrences but left the caption (`[_________]`) and opening-recital (`[____________]`) placeholders unfilled.

**Root cause:** `fields/company_name.json` declared only the two body occurrences. The caption (`INCORPORATIONOF > [_________]`) and opening recital (`[____________], a corporation > [____________]`) are owned by migrated `>` replacement keys, but those keys are dead duplicates that the legacy `replaceFirstAfterContext` patcher never fires (the caption context has no blank-adjacent space; the recital context *is* the target blank). Because migrated keys are excluded from the legacy path, the caption and recital fell through **both** paths.

## Change

- `fields/company_name.json`: add two occurrence locators (regex + capture group) for the caption and the opening recital. Each resolves to exactly one span against the source.
  - Caption: `INCORPORATION\s*OF\s*(\[_________\])`
  - Recital: `(\[____________\]),\s+a\s+corporation`
- `integration-tests/selector-contracts.test.ts`: add a dedicated assertion covering all four occurrences (caption + opening recital + both body), and exclude `company_name` from the byte-identity parity loop — the selector now intentionally fills more than the broken legacy path.

## Verification

Ran the exact repro:

```sh
node bin/open-agreements.js fill nvca-certificate-of-incorporation \
  --set 'company_name=Meridian Inc.' effective_date=2026-07-15 \
  --output /tmp/charter-607.docx
```

- Caption in `word/document.xml`: `...CERTIFICATE OF INCORPORATIONOFMeridian Inc.` (was `[_________]`)
- Opening recital: `...State of Delaware)Meridian Inc., a corporation organized` (was `[____________]`)
- Four `Meridian Inc.` occurrences total; `[_________]` and `[____________]` no longer present.
- Verifier no longer reports the caption/recital placeholders as leftovers. (`A Preferred Stock` remains — series-designation territory, out of scope. `effective_date` untouched — owned by #608.)

Full local gate green: `build`, `lint`, `validate`, `vitest` (1012 passed).

Closes #607