### PR TITLE
fix(verify): eliminate context-token and source-baseline fill false positives (#609)

### DIFF
--- a/src/core/external/index.ts
+++ b/src/core/external/index.ts
@@ -48,7 +48,9 @@ export async function runExternalFill(options: ExternalFillOptions): Promise<Ext
     fields: metadata.fields,
     priorityFieldNames: metadata.priority_fields,
     cleanPatch: { cleanConfig, replacements },
-    verify: (p) => verifyOutput(p, values, replacements, cleanConfig),
+    // Forward the cleaned source so formatting anomalies and context-key
+    // placeholders are baselined against it (consistent with runFieldSelector).
+    verify: (p, cleanedSourcePath) => verifyOutput(p, values, replacements, cleanConfig, cleanedSourcePath),
     keepIntermediate,
   });
 

--- a/src/core/field-selector/index.ts
+++ b/src/core/field-selector/index.ts
@@ -142,11 +142,13 @@ export async function runFieldSelector(options: FieldSelectorRunOptions): Promis
         });
       }
       : undefined,
-    verify: async (p) => {
+    verify: async (p, cleanedSourcePath) => {
       // Verifier receives the FULL replacements key set (incl. migrated keys) so
       // a selector occurrence that failed to fill is still caught as a leftover
       // source placeholder — coverage is preserved after migration.
-      const base = await verifyOutput(p, verificationValues, replacements, cleanConfig);
+      // cleanedSourcePath baselines pre-existing formatting anomalies so only
+      // fill-introduced ones are reported.
+      const base = await verifyOutput(p, verificationValues, replacements, cleanConfig, cleanedSourcePath);
       if (selectorManifests.length === 0) return base;
       const fieldValues: Record<string, string> = {};
       for (const manifest of selectorManifests) {

--- a/src/core/field-selector/patcher.ts
+++ b/src/core/field-selector/patcher.ts
@@ -18,7 +18,7 @@ const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
  * Uses the same canonical quote set as verifier's normalizeText().
  * This is a 1-to-1 character mapping so charMap positions remain valid.
  */
-function normalizeQuotes(text: string): string {
+export function normalizeQuotes(text: string): string {
   return text
     .replace(/[\u2018\u2019\u2039\u203A]/g, "'")
     .replace(/[\u201C\u201D\u201A\u201E\u00AB\u00BB]/g, '"');

--- a/src/core/field-selector/verifier.test.ts
+++ b/src/core/field-selector/verifier.test.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import AdmZip from 'adm-zip';
-import { verifyOutput, normalizeText } from './verifier.js';
+import { verifyOutput, normalizeText, findLeftoverPlaceholders } from './verifier.js';
 import {
   allureJsonAttachment,
   allureParameter,
@@ -33,6 +33,48 @@ function buildDocx(documentXml: string, additionalParts?: Record<string, string>
   const docxPath = join(tempDir, 'test.docx');
   zip.writeZip(docxPath);
   return docxPath;
+}
+
+function escapeXml(text: string): string {
+  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+/** Build a DOCX whose body is one plain-text paragraph per supplied string. */
+function buildTextDocx(paragraphs: string[]): string {
+  const body = paragraphs
+    .map((t) => `<w:p><w:r><w:t xml:space="preserve">${escapeXml(t)}</w:t></w:r></w:p>`)
+    .join('');
+  return buildDocx(
+    '<?xml version="1.0" encoding="UTF-8"?>' +
+      `<w:document xmlns:w="${W_NS}"><w:body>${body}</w:body></w:document>`
+  );
+}
+
+/**
+ * Build a DOCX with `count` formatting anomalies: each is a single-character
+ * underlined run immediately followed by a non-underlined run (the pattern
+ * countFormattingAnomalies() flags).
+ */
+function buildAnomalyDocx(count: number): string {
+  const paras: string[] = [];
+  for (let i = 0; i < count; i++) {
+    paras.push(
+      '<w:p>' +
+        '<w:r><w:rPr><w:u w:val="single"/></w:rPr><w:t>A</w:t></w:r>' +
+        '<w:r><w:t>bc</w:t></w:r>' +
+        '</w:p>'
+    );
+  }
+  return buildDocx(
+    '<?xml version="1.0" encoding="UTF-8"?>' +
+      `<w:document xmlns:w="${W_NS}"><w:body>${paras.join('')}</w:body></w:document>`
+  );
+}
+
+function cleanupDocx(...docxPaths: string[]): void {
+  for (const p of docxPaths) {
+    rmSync(p.replace('/test.docx', ''), { recursive: true, force: true });
+  }
 }
 
 async function runVerificationWithTrace(
@@ -233,5 +275,154 @@ describe('verifyOutput', () => {
     });
 
     rmSync(docxPath.replace('/test.docx', ''), { recursive: true, force: true });
+  });
+
+  it('reports zero new formatting anomalies when source and output have the same count', async () => {
+    // Issue #609: runFieldSelector previously verified without the cleaned source,
+    // so pre-existing source anomalies were all reported as fill-introduced.
+    const sourcePath = buildAnomalyDocx(3);
+    const outputPath = buildAnomalyDocx(3);
+
+    await allureParameter('case', 'formatting-anomaly-baseline');
+    const result = await verifyOutput(outputPath, {}, {}, undefined, sourcePath);
+
+    const anomalyCheck = result.checks.find((c) => c.name === 'No formatting anomalies');
+    await allureStep('Assert equal anomaly counts report zero new', () => {
+      expect(anomalyCheck?.passed).toBe(true);
+    });
+
+    cleanupDocx(sourcePath, outputPath);
+  });
+
+  it('still reports anomalies the fill introduced above the source baseline', async () => {
+    const sourcePath = buildAnomalyDocx(1);
+    const outputPath = buildAnomalyDocx(3);
+
+    await allureParameter('case', 'formatting-anomaly-introduced');
+    const result = await verifyOutput(outputPath, {}, {}, undefined, sourcePath);
+
+    const anomalyCheck = result.checks.find((c) => c.name === 'No formatting anomalies');
+    await allureStep('Assert fill-introduced anomalies are still reported', () => {
+      expect(anomalyCheck?.passed).toBe(false);
+      expect(anomalyCheck?.details).toContain('2 new');
+    });
+
+    cleanupDocx(sourcePath, outputPath);
+  });
+});
+
+describe('findLeftoverPlaceholders', () => {
+  it('passes a mapped "Closing > [s]" fill even when an unrelated "Management Rights Letter[s]" remains', async () => {
+    // Issue #609 case 1: the [s] in an unrelated source option must not be read
+    // as a failed "Closing > [s]" replacement.
+    const docxPath = buildTextDocx([
+      'Closings; Delivery.',
+      'Management Rights Letter[s] shall be delivered to each Investor.',
+    ]);
+
+    await allureParameter('case', 'unrelated-token-same-as-mapped');
+    const leftovers = findLeftoverPlaceholders(docxPath, { 'Closing > [s]': '{optional_plural_suffix}' });
+    await allureJsonAttachment('leftovers.json', leftovers);
+
+    await allureStep('Assert no leftover reported', () => {
+      expect(leftovers).toEqual([]);
+    });
+
+    cleanupDocx(docxPath);
+  });
+
+  it('does not fail the mapped-key check for a placeholder in a different paragraph/context', async () => {
+    // Issue #609 case 2: a [___] with no "Series" context of its own is not a
+    // failed "Series > [___]" replacement.
+    const docxPath = buildTextDocx([
+      'Series A Preferred Stock is issued under this Agreement.',
+      'The counsel-expense cap is [___].',
+    ]);
+
+    await allureParameter('case', 'different-context-placeholder');
+    const leftovers = findLeftoverPlaceholders(docxPath, { 'Series > [___]': '{series_designation}' });
+
+    await allureStep('Assert no leftover reported', () => {
+      expect(leftovers).toEqual([]);
+    });
+
+    cleanupDocx(docxPath);
+  });
+
+  it('still reports a genuinely unfilled placeholder at the mapped location', async () => {
+    // Landmine: true-positive detection must survive — a real leftover at the
+    // qualified location is still caught.
+    const docxPath = buildTextDocx(['THIS SERIES [___] PREFERRED STOCK']);
+
+    await allureParameter('case', 'true-positive-at-mapped-location');
+    const leftovers = findLeftoverPlaceholders(docxPath, { 'SERIES > [___]': '{series_designation}' });
+
+    await allureStep('Assert unfilled placeholder is reported', () => {
+      expect(leftovers).toContain('SERIES > [___]');
+    });
+
+    cleanupDocx(docxPath);
+  });
+
+  it('reports a context key the fill never touched (source count == output count)', async () => {
+    // #607-shaped true positive: the caption placeholder is unchanged from the
+    // cleaned source, so the mapping was entirely unhandled. The count baseline
+    // catches it even when the context is unmatchable via paragraph text.
+    const sourcePath = buildTextDocx(['CERTIFICATE OF INCORPORATION OF [_________]']);
+    const outputPath = buildTextDocx(['CERTIFICATE OF INCORPORATION OF [_________]']);
+
+    await allureParameter('case', 'baseline-total-miss');
+    const leftovers = findLeftoverPlaceholders(
+      outputPath,
+      { 'INCORPORATIONOF > [_________]': '{company_name}' },
+      sourcePath
+    );
+
+    await allureStep('Assert unhandled mapping is reported', () => {
+      expect(leftovers).toContain('INCORPORATIONOF > [_________]');
+    });
+
+    cleanupDocx(sourcePath, outputPath);
+  });
+
+  it('does not report deliberately-retained occurrences once some were filled (count dropped)', async () => {
+    // Issue #609: series_designation fills its declared occurrences and retains
+    // two by design. With the source baseline, a partial reduction is treated as
+    // intentional retention, not a failed replacement.
+    const sourcePath = buildTextDocx([
+      'that number of shares of Series [___] Preferred',
+      '(the "Series [___] Preferred Stock")',
+      'designated Series [___] Preferred Stock (retained)',
+    ]);
+    const outputPath = buildTextDocx([
+      'that number of shares of Series A Preferred',
+      '(the "Series A Preferred Stock")',
+      'designated Series [___] Preferred Stock (retained)',
+    ]);
+
+    await allureParameter('case', 'baseline-retained-occurrence');
+    const leftovers = findLeftoverPlaceholders(
+      outputPath,
+      { 'Series > [___]': '{series_designation}' },
+      sourcePath
+    );
+
+    await allureStep('Assert retained occurrence is not reported', () => {
+      expect(leftovers).toEqual([]);
+    });
+
+    cleanupDocx(sourcePath, outputPath);
+  });
+
+  it('reports a simple key that survives anywhere in the document', async () => {
+    const docxPath = buildTextDocx(['Header', 'Leftover [Company Name] remains here.']);
+
+    const leftovers = findLeftoverPlaceholders(docxPath, { '[Company Name]': '{company_name}' });
+
+    await allureStep('Assert simple key leftover is reported', () => {
+      expect(leftovers).toContain('[Company Name]');
+    });
+
+    cleanupDocx(docxPath);
   });
 });

--- a/src/core/field-selector/verifier.ts
+++ b/src/core/field-selector/verifier.ts
@@ -240,6 +240,18 @@ function hasQualifiedLeftover(
  * Find leftover source placeholders from the replacement map that survive in the
  * filled output.
  *
+ * Known limitation (deliberate tradeoff): the count baseline treats ANY
+ * reduction of a context key's token as success, so it cannot distinguish an
+ * occurrence a selector deliberately retains (e.g. the two documented `[___]` in
+ * series_designation) from an unexpected extra occurrence of the same token that
+ * failed to fill — the two are textually identical. Fully distinguishing them
+ * would require machine-readable retained-occurrence metadata in the field
+ * contract (fields/<id>.json), which is out of scope here. Two existing
+ * mechanisms cover the realistic paths this check cannot: (a) an unexpected
+ * extra token means the source changed, which the source_sha256 pin / source
+ * drift canary flags before fill; (b) a DECLARED selector occurrence that fails
+ * to resolve surfaces an `unresolved` selector warning.
+ *
  * Two key shapes are handled differently, matching how the patcher targets them:
  *
  *  - Simple keys ("[Company Name]") replace every occurrence, so any surviving

--- a/src/core/field-selector/verifier.ts
+++ b/src/core/field-selector/verifier.ts
@@ -1,9 +1,12 @@
 import AdmZip from 'adm-zip';
 import { DOMParser } from '@xmldom/xmldom';
+import type { Element } from '@xmldom/xmldom';
+import { getParagraphText } from '@usejunior/docx-core';
 import type { VerifyResult, VerifyCheck } from './types.js';
 import type { CleanConfig } from '../metadata.js';
 import { enumerateTextParts, getGeneralTextPartNames } from './ooxml-parts.js';
-import { extractSearchText } from './replacement-keys.js';
+import { parseReplacementKey } from './replacement-keys.js';
+import { getTableRowContext, normalizeQuotes } from './patcher.js';
 import type { ReplacementValue } from './replacement-keys.js';
 
 const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
@@ -71,10 +74,13 @@ export async function verifyOutput(
     details: unrenderedTags.length > 0 ? `Found: ${unrenderedTags.join(', ')}` : undefined,
   });
 
-  // Check 3: No leftover [bracketed placeholders] from replacement map
-  // Use extractSearchText() to handle qualified keys (context) properly
-  const searchTexts = [...new Set(Object.keys(replacements).map(extractSearchText))];
-  const leftoverBrackets = searchTexts.filter((text) => rawFullText.includes(text));
+  // Check 3: No leftover [bracketed placeholders] from replacement map.
+  // Context-qualified keys ("context > placeholder") are verified at their
+  // qualified location — mirroring the patcher's deterministic anchoring — so an
+  // intentional occurrence of the same bare token in an unrelated context is not
+  // reported as a failed mapped replacement. Simple keys keep whole-document
+  // search (a bare placeholder should not survive anywhere).
+  const leftoverBrackets = findLeftoverPlaceholders(outputPath, replacements, cleanedSourcePath);
   checks.push({
     name: 'Leftover source placeholders',
     passed: leftoverBrackets.length === 0,
@@ -152,6 +158,170 @@ export async function verifyOutput(
     passed: checks.every((c) => c.passed),
     checks,
   };
+}
+
+/** A paragraph's normalized text plus its table-row label context (if any). */
+interface ParagraphInfo {
+  text: string;
+  rowContext: string | null;
+}
+
+/**
+ * Extract each paragraph's normalized text and table-row label context from a
+ * DOCX, using the same normalization (quotes only) the patcher matches on.
+ */
+function extractParagraphInfos(docxPath: string): ParagraphInfo[] {
+  const zip = new AdmZip(docxPath);
+  const parser = new DOMParser();
+  const partNames = getGeneralTextPartNames(enumerateTextParts(zip));
+  const infos: ParagraphInfo[] = [];
+  for (const partName of partNames) {
+    const entry = zip.getEntry(partName);
+    if (!entry) continue;
+    const doc = parser.parseFromString(entry.getData().toString('utf-8'), 'text/xml');
+    const paras = doc.getElementsByTagNameNS(W_NS, 'p');
+    for (let i = 0; i < paras.length; i++) {
+      const para = paras[i] as unknown as Element;
+      const paraText = getParagraphText(para as unknown as globalThis.Element);
+      if (!paraText) continue;
+      const rowContext = getTableRowContext(para);
+      infos.push({
+        text: normalizeQuotes(paraText),
+        rowContext: rowContext !== null ? normalizeQuotes(rowContext) : null,
+      });
+    }
+  }
+  return infos;
+}
+
+/** Count non-overlapping occurrences of `needle` in `haystack`. */
+function countOccurrences(haystack: string, needle: string): number {
+  if (needle.length === 0) return 0;
+  let count = 0;
+  let from = 0;
+  let pos: number;
+  while ((pos = haystack.indexOf(needle, from)) !== -1) {
+    count++;
+    from = pos + needle.length;
+  }
+  return count;
+}
+
+/**
+ * Whether a context key has an unfilled placeholder at its qualified location,
+ * mirroring how the patcher targets them:
+ *  - Table-row context: a `searchText` survives in a paragraph whose row label
+ *    cell contains the context.
+ *  - Paragraph context: a `searchText` appears AFTER the first occurrence of the
+ *    context in the paragraph (the patcher fills the first placeholder after the
+ *    context).
+ *
+ * Used only when no source baseline is available (see findLeftoverPlaceholders).
+ */
+function hasQualifiedLeftover(
+  paragraphs: ParagraphInfo[],
+  context: string,
+  searchText: string,
+): boolean {
+  if (searchText.length === 0) return false;
+  for (const { text, rowContext } of paragraphs) {
+    if (rowContext !== null) {
+      if (rowContext.includes(context) && text.includes(searchText)) return true;
+    } else {
+      const ctxPos = text.indexOf(context);
+      if (ctxPos === -1) continue;
+      if (text.indexOf(searchText, ctxPos + context.length) !== -1) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Find leftover source placeholders from the replacement map that survive in the
+ * filled output.
+ *
+ * Two key shapes are handled differently, matching how the patcher targets them:
+ *
+ *  - Simple keys ("[Company Name]") replace every occurrence, so any surviving
+ *    occurrence anywhere in the document is reported.
+ *
+ *  - Context-qualified keys ("context > placeholder") target one placeholder per
+ *    context, so a bare token may legitimately remain elsewhere (an unrelated
+ *    context) or be deliberately retained (a selector field that fills only its
+ *    declared occurrences). These are handled by comparing the placeholder's
+ *    count against the cleaned source:
+ *      - With a source baseline, a context key is reported only when the fill
+ *        reduced NOTHING (output count >= source count) — i.e. the mapping was
+ *        entirely unhandled (a genuine defect, e.g. a caption the patcher/
+ *        selector never touched), as opposed to a partial reduction that leaves
+ *        deliberately-retained or selector-verified occurrences behind. This is
+ *        the same deterministic baseline-against-source technique used for
+ *        formatting anomalies. Counting is done on the flattened text (the same
+ *        text the patcher's replacements ultimately land in) so a context that
+ *        is unmatchable due to intra-paragraph line breaks — the #607 caption —
+ *        is still caught.
+ *      - Without a baseline, the key is reported only if an unfilled placeholder
+ *        survives at its qualified location — so an intentional occurrence of the
+ *        same token in an unrelated context (e.g. "[s]" in "Management Rights
+ *        Letter[s]" while the mapped "Closing > [s]" was filled) is not reported.
+ *
+ * Returns the offending key labels (simple keys as their search text; context
+ * keys as their full "context > placeholder" label).
+ */
+export function findLeftoverPlaceholders(
+  docxPath: string,
+  replacements: Record<string, ReplacementValue>,
+  cleanedSourcePath?: string,
+): string[] {
+  const simpleSearchTexts = new Set<string>();
+  const contextKeys: { context: string; searchText: string; label: string }[] = [];
+  for (const key of Object.keys(replacements)) {
+    const parsed = parseReplacementKey(key, '');
+    if (parsed.type === 'context') {
+      contextKeys.push({
+        // Match the patcher's quote normalization so the checks anchor on
+        // exactly what the patcher would have targeted.
+        context: normalizeQuotes(parsed.context),
+        searchText: normalizeQuotes(parsed.searchText),
+        label: key,
+      });
+    } else {
+      simpleSearchTexts.add(parsed.searchText);
+    }
+  }
+
+  const leftovers = new Set<string>();
+  const outputFullText = normalizeQuotes(extractAllText(docxPath));
+
+  // Simple keys: whole-document search (any surviving occurrence is a leftover).
+  for (const text of simpleSearchTexts) {
+    if (outputFullText.includes(normalizeQuotes(text))) leftovers.add(text);
+  }
+
+  // Context keys: count baseline against the cleaned source, else qualified location.
+  if (contextKeys.length > 0) {
+    if (cleanedSourcePath) {
+      const sourceFullText = normalizeQuotes(extractAllText(cleanedSourcePath));
+      for (const ck of contextKeys) {
+        const srcCount = countOccurrences(sourceFullText, ck.searchText);
+        if (srcCount === 0) continue; // key does not apply to this document
+        const outCount = countOccurrences(outputFullText, ck.searchText);
+        // Nothing filled for this placeholder → the mapping was entirely
+        // unhandled. A partial reduction leaves only intentionally-retained /
+        // selector-verified occurrences behind, which are not reported.
+        if (outCount >= srcCount) leftovers.add(ck.label);
+      }
+    } else {
+      const outputParagraphs = extractParagraphInfos(docxPath);
+      for (const ck of contextKeys) {
+        if (hasQualifiedLeftover(outputParagraphs, ck.context, ck.searchText)) {
+          leftovers.add(ck.label);
+        }
+      }
+    }
+  }
+
+  return [...leftovers];
 }
 
 /**

--- a/src/core/unified-pipeline.ts
+++ b/src/core/unified-pipeline.ts
@@ -59,8 +59,11 @@ export interface PipelineOptions {
   // fillDocx options
   fixSmartQuotes?: boolean;             // default: false
 
-  // Verification callback — each path passes its own verifier
-  verify: (outputPath: string) => VerifyResult | Promise<VerifyResult>;
+  // Verification callback — each path passes its own verifier. The second
+  // argument is the cleaned-but-unfilled source (present only when cleanPatch is
+  // configured); verifiers use it to baseline pre-existing source anomalies so
+  // only fill-introduced ones are reported.
+  verify: (outputPath: string, cleanedSourcePath?: string) => VerifyResult | Promise<VerifyResult>;
   postProcess?: (outputPath: string) => void | Promise<void>;
 
   // Debugging
@@ -173,9 +176,13 @@ export async function runFillPipeline(options: PipelineOptions): Promise<Pipelin
 
     // Step 3: Clean → Patch (if configured)
     let currentPath = sourcePath;
+    // Cleaned-but-unfilled source, threaded to verify() as the formatting-anomaly
+    // baseline so pre-existing source anomalies are not reported as fill defects.
+    let cleanedSourcePath: string | undefined;
     if (cleanPatch) {
       const cleanedPath = join(tempDir, 'cleaned.docx');
       await cleanDocument(sourcePath, cleanedPath, cleanPatch.cleanConfig);
+      cleanedSourcePath = cleanedPath;
 
       // Selector-contract patch (deterministic locators) runs between clean and
       // the legacy patch. It rewrites resolved occurrences to {field_id} tags;
@@ -300,7 +307,7 @@ export async function runFillPipeline(options: PipelineOptions): Promise<Pipelin
     }
 
     // Step 8: Verify — failures surface to callers via warnings (soft; no throw)
-    const verifyResult = await verify(outputPath);
+    const verifyResult = await verify(outputPath, cleanedSourcePath);
     if (!verifyResult.passed) {
       const failedChecks = verifyResult.checks.filter((c) => !c.passed);
       const failures = failedChecks


### PR DESCRIPTION
## Summary

Fixes two classes of false-positive fill defects the `nvca-stock-purchase-agreement` verifier reports (issue #609).

### 1. Placeholder false positives
`findLeftoverPlaceholders` (was an inline check in `verifier.ts`) previously stripped the context from context-qualified keys (`Closing > [s]`, `is made as of > [________]`) and grepped the bare token **anywhere** in the document. An intentional occurrence in an unrelated context was reported as a failed mapped replacement:
- `[s]` in the source option `Management Rights Letter[s]` (mapped `Closing > [s]` was filled)
- a counsel-expense `[________]` (mapped agreement date was filled)
- a capitalization `[_________]` (mapped minimum-shares was filled)
- the two deliberately retained `[___]` documented in `fields/series_designation.json`

Now context keys are verified with a **deterministic count baseline against the cleaned source** — the same baseline-against-source technique already used for formatting anomalies:
- **Simple keys** (`[Company Name]`) replace every occurrence, so any survivor anywhere is still reported (unchanged).
- **Context keys** target one placeholder per context. With the cleaned source they are reported only when the fill reduced the token's count to **nothing** (`output >= source`). A total miss is caught; a partial reduction leaves deliberately-retained / selector-verified occurrences behind and is not reported. Counting runs on the flattened text, so a context that is unmatchable via paragraph text (intra-paragraph line breaks) is still caught. Without a baseline, a context key is reported only when an unfilled placeholder survives at its qualified location.

### 2. Formatting-baseline false positive
`runFieldSelector()` called `verifyOutput()` without the cleaned source, so all pre-existing source anomalies were reported as new (source 3, output 3 → "3 new"). The cleaned-but-unfilled source is now threaded through the pipeline `verify` callback and passed to `verifyOutput` as the anomaly baseline, so only fill-introduced anomalies are reported.

## True-positive detection preserved (landmine)
The charter caption/recital true positive (#607) is a **migrated context key** whose token count does not drop (nothing fills it) — the count baseline still reports it. Verified empirically:
- **SPA** fill (with source): **zero** leftover/anomaly warnings.
- **Charter** fill (with source): still flags `INCORPORATIONOF > [_________]` (caption) and `[____________], a corporation > [____________]` (recital), and no longer emits a pre-existing `A Preferred Stock` false positive.

## Deliberately-updated assumptions
No existing test asserted the old global-grep behavior for context keys (the one existing leftover test uses a **simple** key and is unchanged). The synthetic-fixture SPA integration test and the real-source selector-contracts test both still pass.

## Tests
- The issue's three suggested cases (mapped `Closing > [s]` passes despite unrelated `Management Rights Letter[s]`; a placeholder in a different context does not fail the mapped-key check; equal source/output anomaly counts report zero new).
- A **true-positive control**: a real leftover at the mapped location is still caught.
- A #607-shaped total-miss (source count == output count → reported).
- A deliberately-retained occurrence (count dropped → not reported).
- Formatting: introduced anomalies above the source baseline are still reported.

## Notes
- Exports `patcher.normalizeQuotes` for reuse by the verifier's context matching.
- Does not touch `src/core/fill-pipeline.ts` or any `templates/` content.

Full local gate green: `build`, `lint`, `validate`, and `vitest` (1020 passed / 6 skipped, GCS test excluded).

Closes #609