### PR TITLE
fix(templates): unpublish dead ROFR optional_blank_value + cover MRL body slots

### DIFF
--- a/concerto/nvca-management-rights-letter.cto
+++ b/concerto/nvca-management-rights-letter.cto
@@ -12,6 +12,8 @@ import org.accordproject.contract.Contract from https://models.accordproject.org
 
 asset NvcaManagementRightsLetter extends Contract {
   o String company_name_upper
+  o String letter_date
+  o String purchased_shares
   o String investor_name
   o String investor_name_upper
   o String city

--- a/concerto/nvca-rofr-co-sale-agreement.cto
+++ b/concerto/nvca-rofr-co-sale-agreement.cto
@@ -17,7 +17,6 @@ asset NvcaRofrCoSaleAgreement extends Contract {
   o String key_holder_name
   o String company_counsel
   o String counsel_cc default=""
-  o String optional_blank_value default=""
   o String amended_restated_upper default=""
   o String amended_restated default=""
   o String judicial_district default="District of Delaware"

--- a/data/templates-snapshot.json
+++ b/data/templates-snapshot.json
@@ -11316,7 +11316,25 @@
           "type": "string",
           "required": true,
           "section": null,
-          "description": "Company name in uppercase",
+          "description": "Company name in uppercase. Fills both the uppercase signature-block slot ([COMPANY]) and the body's \"Preferred Stock of ______ (the \"Company\")\" blank, so the supplied value appears verbatim in both places — NVCA convention uppercases the signature block, so supply the name in uppercase.",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "letter_date",
+          "type": "date",
+          "required": true,
+          "section": null,
+          "description": "Date of the letter (fills the \"______, 20__\" dateline). Accepts ISO YYYY-MM-DD (rendered as e.g. \"July 15, 2026\") or a display-ready date string, which replaces the entire dateline including the pre-printed \"20\" — do not supply a partial date expecting the \"20__\" year stub to remain.",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "purchased_shares",
+          "type": "string",
+          "required": true,
+          "section": null,
+          "description": "Number of shares of preferred stock purchased by the investor (e.g. 1,000,000)",
           "default": null,
           "default_value_rationale": null
         },
@@ -11451,15 +11469,6 @@
           "required": false,
           "section": null,
           "description": "Additional counsel to CC on notices, or empty string if none",
-          "default": "",
-          "default_value_rationale": null
-        },
-        {
-          "name": "optional_blank_value",
-          "type": "string",
-          "required": false,
-          "section": null,
-          "description": "Empty-value replacement used to clear optional bracketed drafting text and formatting artifacts",
           "default": "",
           "default_value_rationale": null
         },

--- a/integration-tests/field-selector-validation.test.ts
+++ b/integration-tests/field-selector-validation.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, expect } from 'vitest';
 import { validateFieldSelector } from '../src/core/validation/field-selector.js';
 import { validateFieldSelectorMetadata } from '../src/core/metadata.js';
@@ -60,6 +62,62 @@ describe('validateFieldSelectorMetadata', () => {
     await allureJsonAttachment('field-selector-metadata-validation-result.json', result);
     await allureStep('Assert scaffold metadata validation passes', () => {
       expect(result.valid).toBe(true);
+    });
+  });
+});
+
+// Issue #620: template-hygiene coverage assertions for the NVCA family audit.
+// These pin the deterministic slot bindings added for the management rights
+// letter and the removal of the dead ROFR field, without requiring a network
+// fetch of the (non-redistributable) source document.
+describe('issue #620 slot coverage', () => {
+  it('nvca-management-rights-letter maps the body company, letter-date, and purchased-shares slots', async () => {
+    const dir = resolveFieldSelectorDir('nvca-management-rights-letter');
+    await allureParameter('field_selector_id', 'nvca-management-rights-letter');
+    const replacements = JSON.parse(
+      readFileSync(join(dir, 'replacements.json'), 'utf-8')
+    ) as Record<string, string>;
+
+    await allureStep('Assert body slots are bound to fields', () => {
+      // Body company slot (21 underscores) fills from the same field as the
+      // uppercase signature-block slot.
+      expect(replacements['[_____________________]']).toBe('{company_name_upper}');
+      // Dateline: the full "______, 20__" shape (including the pre-printed
+      // "20") is replaced by a single formatted date (type: date → ISO input
+      // renders as e.g. "July 15, 2026").
+      expect(replacements['[______], 20[__]']).toBe('{letter_date}');
+      // Purchased shares slot (8 underscores).
+      expect(replacements['[________]']).toBe('{purchased_shares}');
+    });
+
+    await allureStep('Assert the series blank stays unmapped (deferred to issue #618)', () => {
+      // "Series [_]" is deliberately NOT covered here: the ancillary
+      // series/par-value issue (#618) owns that field family. This assertion
+      // documents that the remaining body blank is intentional, not missed.
+      expect(Object.keys(replacements)).not.toContain('[_]');
+      expect(
+        Object.values(replacements).some((v) => v.includes('series'))
+      ).toBe(false);
+    });
+
+    await allureStep('Assert letter_date is a date-typed metadata field', () => {
+      const metadata = readFileSync(join(dir, 'metadata.yaml'), 'utf-8');
+      expect(metadata).toMatch(/- name: letter_date\n\s+type: date/);
+      expect(metadata).toMatch(/- name: purchased_shares\n\s+type: string/);
+    });
+  });
+
+  it('nvca-rofr-co-sale-agreement no longer publishes the dead optional_blank_value field', async () => {
+    const dir = resolveFieldSelectorDir('nvca-rofr-co-sale-agreement');
+    await allureParameter('field_selector_id', 'nvca-rofr-co-sale-agreement');
+    const metadata = readFileSync(join(dir, 'metadata.yaml'), 'utf-8');
+    const replacements = readFileSync(join(dir, 'replacements.json'), 'utf-8');
+
+    await allureStep('Assert optional_blank_value is unpublished', () => {
+      // A sentinel fill confirmed the field never reached the document: no
+      // replacements key, selector, or binding referenced it (issue #620).
+      expect(metadata).not.toContain('optional_blank_value');
+      expect(replacements).not.toContain('optional_blank_value');
     });
   });
 });

--- a/integration-tests/fixtures/rofr-co-sale-agreement-series-c.json
+++ b/integration-tests/fixtures/rofr-co-sale-agreement-series-c.json
@@ -4,7 +4,6 @@
   "key_holder_name": "Maya Imani",
   "company_counsel": "Wilson Sonsini Goodrich & Rosati, P.C., 650 Page Mill Road, Palo Alto, CA 94304",
   "counsel_cc": "Cooley LLP, 3175 Hanover Street, Palo Alto, CA 94304",
-  "optional_blank_value": "",
   "amended_restated_upper": "AMENDED AND RESTATED",
   "amended_restated": "Amended and Restated",
   "judicial_district": "Northern District of California",

--- a/src/core/field-selector/index.test.ts
+++ b/src/core/field-selector/index.test.ts
@@ -339,4 +339,97 @@ describe('runFieldSelector', () => {
       },
     ]);
   });
+
+  // Issue #620 regression: the verifier must compare `type: date` fields
+  // against the FORMATTED date the fill actually writes (prepareFillData
+  // renders ISO "2026-03-15" as "March 15, 2026"), not the raw ISO input.
+  // Before the fix, every ISO-supplied date field produced a spurious
+  // 'verify: ... Missing: <field>="<iso>"' warning.
+  itFilling('ISO date input verifies against the formatted document date (no spurious Missing warning)', async () => {
+    const fieldSelectorDir = createFieldSelectorFixture();
+    // Mirror the MRL dateline shape: a date-typed field bound to the full
+    // "[______], 20[__]" slot.
+    writeFileSync(
+      join(fieldSelectorDir, 'metadata.yaml'),
+      [
+        'name: Fixture Date FieldSelector',
+        'source_url: https://example.com/source.docx',
+        'source_version: "1.0"',
+        'license_note: Example fieldSelector license',
+        'fields:',
+        '  - name: letter_date',
+        '    type: date',
+        '    description: Date of the letter',
+        'priority_fields:',
+        '  - letter_date',
+        '',
+      ].join('\n'),
+      'utf-8'
+    );
+    writeFileSync(
+      join(fieldSelectorDir, 'replacements.json'),
+      JSON.stringify({ '[______], 20[__]': '{letter_date}' }, null, 2),
+      'utf-8'
+    );
+
+    const { mkdtempSync: mkTemp } = await import('node:fs');
+    const { tmpdir: osTmp } = await import('node:os');
+    const AdmZip = (await import('adm-zip')).default;
+    const workDir = mkTemp(join(osTmp(), 'oa-issue-620-date-'));
+    tempDirs.push(workDir);
+    const inputPath = join(workDir, 'input.docx');
+    const outputPath = join(workDir, 'output.docx');
+    const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+    const zip = new AdmZip();
+    zip.addFile(
+      'word/document.xml',
+      Buffer.from(
+        '<?xml version="1.0" encoding="UTF-8"?>' +
+          `<w:document xmlns:w="${W_NS}"><w:body>` +
+          '<w:p><w:r><w:t xml:space="preserve">[______], 20[__]</w:t></w:r></w:p>' +
+          '</w:body></w:document>',
+        'utf-8'
+      )
+    );
+    zip.addFile(
+      '[Content_Types].xml',
+      Buffer.from(
+        '<?xml version="1.0" encoding="UTF-8"?>' +
+          '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">' +
+          '<Default Extension="xml" ContentType="application/xml"/>' +
+          '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+          '</Types>',
+        'utf-8'
+      )
+    );
+    zip.writeZip(inputPath);
+
+    // Earlier tests in this file register module mocks for the fill pipeline
+    // and downloader; this test must run the REAL pipeline end-to-end.
+    vi.doUnmock('../unified-pipeline.js');
+    vi.doUnmock('./downloader.js');
+    vi.doMock('../../utils/paths.js', () => ({
+      resolveFieldSelectorDir: () => fieldSelectorDir,
+    }));
+    const { runFieldSelector } = await import('./index.js');
+
+    const result = await runFieldSelector({
+      fieldSelectorId: 'fixture-date-fieldSelector',
+      inputPath,
+      outputPath,
+      values: { letter_date: '2026-03-15' },
+    });
+
+    await allureJsonAttachment('iso-date-verification-result.json', result);
+
+    const outZip = new AdmZip(result.outputPath);
+    const outXml = outZip.getEntry('word/document.xml')?.getData().toString('utf-8') ?? '';
+    // The formatted date is written, the ISO input is not.
+    expect(outXml).toContain('March 15, 2026');
+    expect(outXml).not.toContain('2026-03-15');
+    // And the verifier no longer reports the field as missing.
+    const missingWarnings = result.warnings.filter((w) => w.includes('Missing') && w.includes('letter_date'));
+    expect(missingWarnings).toEqual([]);
+  });
 });
+

--- a/src/core/field-selector/index.ts
+++ b/src/core/field-selector/index.ts
@@ -16,6 +16,7 @@ import {
 } from './computed.js';
 import { normalizeBracketArtifacts } from './bracket-normalizer.js';
 import { runFillPipeline } from '../unified-pipeline.js';
+import { formatDocumentDate } from '../fill-pipeline.js';
 import type { FieldSelectorRunOptions, FieldSelectorRunResult } from './types.js';
 import type { ComputedValueMap } from './computed.js';
 
@@ -106,7 +107,11 @@ export async function runFieldSelector(options: FieldSelectorRunOptions): Promis
     }
     const value = effectiveValues[field.name];
     if (typeof value === 'string') {
-      verificationValues[field.name] = value;
+      // Mirror prepareFillData's date handling: `type: date` fields render ISO
+      // input as a document date ("2026-07-15" → "July 15, 2026"), so verify
+      // against the formatted value actually written to the output — otherwise
+      // every ISO-supplied date field reports a spurious "Missing" warning.
+      verificationValues[field.name] = field.type === 'date' ? formatDocumentDate(value) : value;
     }
   }
   const computedArtifact = computedEvaluation && computedProfile

--- a/templates/nvca-free-non-redistributable/nvca-management-rights-letter/metadata.yaml
+++ b/templates/nvca-free-non-redistributable/nvca-management-rights-letter/metadata.yaml
@@ -13,7 +13,19 @@ artifact_type: field-selector
 fields:
   - name: company_name_upper
     type: string
-    description: Company name in uppercase
+    description: >-
+      Company name in uppercase. Fills both the uppercase signature-block slot ([COMPANY]) and the body's
+      "Preferred Stock of ______ (the "Company")" blank, so the supplied value appears verbatim in both places —
+      NVCA convention uppercases the signature block, so supply the name in uppercase.
+  - name: letter_date
+    type: date
+    description: >-
+      Date of the letter (fills the "______, 20__" dateline). Accepts ISO YYYY-MM-DD (rendered as e.g.
+      "July 15, 2026") or a display-ready date string, which replaces the entire dateline including the
+      pre-printed "20" — do not supply a partial date expecting the "20__" year stub to remain.
+  - name: purchased_shares
+    type: string
+    description: Number of shares of preferred stock purchased by the investor (e.g. 1,000,000)
   - name: investor_name
     type: string
     description: Full name of the investor
@@ -42,6 +54,8 @@ fields:
     default: Signature Page Follows
 priority_fields:
   - company_name_upper
+  - letter_date
+  - purchased_shares
   - investor_name
   - investor_name_upper
   - city

--- a/templates/nvca-free-non-redistributable/nvca-management-rights-letter/replacements.json
+++ b/templates/nvca-free-non-redistributable/nvca-management-rights-letter/replacements.json
@@ -1,5 +1,8 @@
 {
   "[COMPANY]": "{company_name_upper}",
+  "[_____________________]": "{company_name_upper}",
+  "[______], 20[__]": "{letter_date}",
+  "[________]": "{purchased_shares}",
   "[Investor Name]": "{investor_name}",
   "[INVESTOR]": "{investor_name_upper}",
   "[City]": "{city}",

--- a/templates/nvca-free-non-redistributable/nvca-rofr-co-sale-agreement/metadata.yaml
+++ b/templates/nvca-free-non-redistributable/nvca-rofr-co-sale-agreement/metadata.yaml
@@ -29,10 +29,6 @@ fields:
     type: string
     description: Additional counsel to CC on notices, or empty string if none
     default: ''
-  - name: optional_blank_value
-    type: string
-    description: Empty-value replacement used to clear optional bracketed drafting text and formatting artifacts
-    default: ''
   - name: amended_restated_upper
     type: string
     description: Uppercase prefix if amending a prior agreement (e.g. AMENDED AND RESTATED) or empty string


### PR DESCRIPTION
Closes #620

Two template-hygiene fixes from the NVCA family audit, plus one small verifier fix they surfaced.

## 1. ROFR: unpublish dead `optional_blank_value`

No replacements key, selector, or binding references it. Sentinel fill before the change (`--set optional_blank_value="XX-SENTINEL-OBV-XX"` on top of the series-c fixture):

```
Fields used: company_name, investor_name, key_holder_name, company_counsel, counsel_cc, amended_restated_upper, amended_restated, judicial_district, state_lower, business_description, signature_page_marker, effective_date, specify_percentage, rofr_response_days, key_holders_label
$ grep -c "XX-SENTINEL-OBV-XX" word/document.xml
0
```

The sentinel never reaches the document and the field is absent from "Fields used" — unpublished per the issue's expected outcome. Also removed from the series-c fixture.

## 2. MRL: cover the body slots

The example letter is the operative post-clean output. Slot inventory of the source body (all unique, plain ASCII underscores, each occurring exactly once — no NBSP in any slot):

| Slot (exact literal) | Disposition |
|---|---|
| `[_____________________]` (body company, 21 underscores) | → `{company_name_upper}` (existing field; same value fills signature block + body, documented in the field description) |
| `[______], 20[__]` (dateline, single run) | → `{letter_date}`, **`type: date`** — ISO input renders via the #612 formatter; the replacement consumes the entire dateline including the pre-printed "20", documented in the field description |
| `[________]` (purchased shares) | → `{purchased_shares}` (string) |
| `Series [_]` | **intentionally unmapped** — owned by #618 (series/par-value family); pinned by test so it reads as deliberate, not missed |

No replacement key is a substring of another slot's literal, and the patcher applies simple keys longest-first, so bindings are collision-free and deterministic.

**Observed before-fill output (baseline):**

```
7  '[______], 20[__]'
13 '...purchase of [________] shares of Series [_] Preferred Stock of [_____________________] (the "Company")...'
```

**Observed after-fill output** (`letter_date=2026-03-15`, `purchased_shares=1,234,567`, `company_name_upper=SENTINEL-COMPANY-UPPER`):

```
7  'March 15, 2026'
13 'This letter will confirm our agreement that pursuant to and effective as of your purchase of 1,234,567 shares of Series [_] Preferred Stock of SENTINEL-COMPANY-UPPER (the "Company"), Sentinel Investor LP (the "Investor") shall be entitled to the foll…'
remaining blanks: Counter({'[_]': 1})
ISO leak: False
```

Only remaining blank is the #618-owned series slot.

## 3. Verifier: format date fields before comparing

The first after-fill logged `Warning: verify: … Missing: letter_date="2026-03-15"`: #612 taught `prepareFillData` to format ISO dates but the field-selector verifier still compared the raw ISO string. `verificationValues` now mirrors `formatDocumentDate` for `type: date` fields (fixes the same spurious warning for the COI date fields). Warning confirmed gone on re-fill.

## Tests / snapshot

- New `issue #620 slot coverage` block in `integration-tests/field-selector-validation.test.ts`: pins the three MRL bindings, pins `Series [_]` as deferred-to-#618, asserts ROFR no longer publishes `optional_blank_value`. Offline — no fetch of the non-redistributable source.
- `data/templates-snapshot.json` regenerated (`node scripts/export-templates-snapshot.mjs`).
- Full local gate green: build, lint, validate, vitest (1038 passed, gcloud-storage excluded locally as usual).
