### PR TITLE
feat(cli): add template show command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,9 +97,9 @@ graduation checklist, not two orthogonal signals. A template is `stable` (i.e. `
    settled. The `0.x` renumber is cosmetic and does **not** reset this counter; prior settled history
    still counts.
 
-`stability` is surfaced on the template-detail page, the CLI (`oa list` — a Stability column in the
-table and a `stability` key in `--json`), and MCP output (`get_template` and `list_templates`). Until
-a template is `stable`/`1.0` it shows `experimental` or `beta`.
+`stability` is surfaced on the template-detail page, the CLI (`open-agreements list` and
+`open-agreements template show`), and MCP output (`get_template` and `list_templates`). Until a
+template is `stable`/`1.0` it shows `experimental` or `beta`.
 
 ### Changelog and archived versions
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -16,10 +16,16 @@ This page is the canonical command reference. Run `open-agreements <command>
 open-agreements list
 open-agreements list --json
 open-agreements list --json-strict
+open-agreements template show <template>
+open-agreements template show <template> --json
 ```
 
 `--json` includes field definitions for automation. `--json-strict` also exits
 non-zero if any catalog metadata fails to load.
+
+`template show` narrows the same canonical catalog record to one agreement. Its
+human-readable output highlights stability, provenance, distribution, and
+priority fields; `--json` returns the exact item shape used by `list --json`.
 
 ## Fill a standard form
 

--- a/integration-tests/template-show.test.ts
+++ b/integration-tests/template-show.test.ts
@@ -1,0 +1,69 @@
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+import { describe, expect } from 'vitest';
+import { itAllure } from './helpers/allure-test.js';
+
+const ROOT = new URL('..', import.meta.url).pathname;
+const BIN = join(ROOT, 'bin/open-agreements.js');
+const it = itAllure.epic('Discovery & Metadata');
+
+interface CatalogItem {
+  name: string;
+  artifact_type?: string;
+  stability?: string | null;
+  fields: unknown[];
+  [key: string]: unknown;
+}
+
+interface ShowResponse {
+  schema_version: number;
+  cli_version: string;
+  item: CatalogItem;
+}
+
+function runCli(args: string[]): string {
+  return execFileSync('node', [BIN, ...args], {
+    cwd: ROOT,
+    encoding: 'utf-8',
+    timeout: 10_000,
+    maxBuffer: 16 * 1024 * 1024,
+  });
+}
+
+describe('template show', () => {
+  it('prints stability and priority fields for a template', () => {
+    const output = runCli(['template', 'show', 'openagreements-board-consent-safe']);
+
+    expect(output).toContain('ID: openagreements-board-consent-safe');
+    expect(output).toContain('Stability: experimental');
+    expect(output).toMatch(/Fields \(\d+ priority \/ \d+ total\):/);
+  });
+
+  it('returns exactly the matching list catalog item with --json', () => {
+    const shown = JSON.parse(
+      runCli(['template', 'show', 'openagreements-board-consent-safe', '--json']),
+    ) as ShowResponse;
+    const listed = JSON.parse(runCli(['list', '--json'])) as { items: CatalogItem[] };
+
+    expect(shown.schema_version).toBe(1);
+    expect(shown.cli_version).toMatch(/^\d+\.\d+\.\d+/);
+    expect(shown.item).toEqual(
+      listed.items.find((item) => item.name === 'openagreements-board-consent-safe'),
+    );
+  });
+
+  it('inspects field-selectors through the same command', () => {
+    const shown = JSON.parse(
+      runCli(['template', 'show', 'nvca-stock-purchase-agreement', '--json']),
+    ) as ShowResponse;
+
+    expect(shown.item.artifact_type).toBe('field-selector');
+    expect(shown.item.fields.length).toBeGreaterThan(0);
+  });
+
+  it('fails clearly for an unknown agreement ID', () => {
+    expect(() => runCli(['template', 'show', 'not-a-real-template'])).toThrow(
+      /Unknown agreement "not-a-real-template"/,
+    );
+  });
+});

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5,6 +5,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import { runFill } from '../commands/fill.js';
 import { runValidate } from '../commands/validate.js';
 import { runList } from '../commands/list.js';
+import { runTemplateShow } from '../commands/template.js';
 import { runFieldSelectorCommand, runFieldSelectorClean, runFieldSelectorPatch } from '../commands/field-selector.js';
 import { runScan } from '../commands/scan.js';
 import {
@@ -102,6 +103,21 @@ export function createProgram(): Command {
     .action((opts: { json?: boolean; jsonStrict?: boolean }) => {
       runList({ json: opts.json, jsonStrict: opts.jsonStrict });
     });
+
+  // --- Template discovery command ---
+
+  const templateCmd = new Command('template');
+  templateCmd.description('Inspect agreement metadata and fillable fields');
+
+  templateCmd
+    .command('show <template>')
+    .description('Show one template, external form, or field-selector')
+    .option('--json', 'Output the canonical machine-readable catalog item')
+    .action((template: string, opts: { json?: boolean }) => {
+      runTemplateShow(template, { json: opts.json });
+    });
+
+  program.addCommand(templateCmd);
 
   // --- Field-selector command ---
 

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -12,9 +12,18 @@ export interface ListOptions {
   jsonStrict?: boolean;
 }
 
-interface ListItem {
+export interface AgreementListItem {
   name: string;
   [key: string]: unknown;
+}
+
+export interface AgreementCatalog {
+  items: AgreementListItem[];
+  errors: string[];
+}
+
+export function getCliVersion(): string {
+  return pkg.version as string;
 }
 
 export function runList(opts: ListOptions = {}): void {
@@ -26,7 +35,30 @@ export function runList(opts: ListOptions = {}): void {
 }
 
 function runListJson(opts: ListOptions): void {
-  const results: ListItem[] = [];
+  const { items, errors } = loadAgreementCatalog();
+
+  if (opts.jsonStrict && errors.length > 0) {
+    for (const msg of errors) {
+      console.error(`error: ${msg}`);
+    }
+    process.exit(1);
+  }
+
+  const envelope = {
+    schema_version: 1,
+    cli_version: getCliVersion(),
+    items,
+  };
+  console.log(JSON.stringify(envelope, null, 2));
+}
+
+/**
+ * Load the complete agreement catalog once for every detailed discovery
+ * surface. `list --json` and `template show` deliberately share this function
+ * so their field, provenance, stability, and distribution shapes cannot drift.
+ */
+export function loadAgreementCatalog(): AgreementCatalog {
+  const results: AgreementListItem[] = [];
   const errors: string[] = [];
   // Templates
   for (const entry of listTemplateEntries()) {
@@ -92,7 +124,7 @@ function runListJson(opts: ListOptions): void {
       const dir = entry.dir;
       try {
         const meta = loadFieldSelectorMetadata(dir);
-        const item: ListItem = {
+        const item: AgreementListItem = {
           name: id,
           tier: 'field-selector' as const,
           display_name: meta.name,
@@ -118,20 +150,7 @@ function runListJson(opts: ListOptions): void {
     }
 
   results.sort((a, b) => a.name.localeCompare(b.name));
-
-  if (opts.jsonStrict && errors.length > 0) {
-    for (const msg of errors) {
-      console.error(`error: ${msg}`);
-    }
-    process.exit(1);
-  }
-
-  const envelope = {
-    schema_version: 1,
-    cli_version: pkg.version,
-    items: results,
-  };
-  console.log(JSON.stringify(envelope, null, 2));
+  return { items: results, errors };
 }
 
 function listAgreementsWithOptions(_opts: ListOptions): void {

--- a/src/commands/template.ts
+++ b/src/commands/template.ts
@@ -1,0 +1,113 @@
+import { getCliVersion, loadAgreementCatalog, type AgreementListItem } from './list.js';
+import type { TemplateListField } from '../core/template-listing.js';
+
+export interface TemplateShowOptions {
+  json?: boolean;
+}
+
+export function runTemplateShow(templateId: string, opts: TemplateShowOptions = {}): void {
+  const { items, errors } = loadAgreementCatalog();
+  const item = items.find((candidate) => candidate.name === templateId);
+
+  if (!item) {
+    const loadError = errors.find((message) => message.startsWith(`template ${templateId}:`)
+      || message.startsWith(`external ${templateId}:`)
+      || message.startsWith(`field-selector ${templateId}:`));
+    if (loadError) {
+      throw new Error(`Could not load agreement "${templateId}": ${loadError}`);
+    }
+    throw new Error(
+      `Unknown agreement "${templateId}". Run "open-agreements list" to see available IDs.`,
+    );
+  }
+
+  if (opts.json) {
+    console.log(JSON.stringify({
+      schema_version: 1,
+      cli_version: getCliVersion(),
+      item,
+    }, null, 2));
+    return;
+  }
+
+  printHumanReadable(item);
+}
+
+function printHumanReadable(item: AgreementListItem): void {
+  const fields = Array.isArray(item.fields) ? item.fields as TemplateListField[] : [];
+  const priorityCount = fields.filter((field) => field.required).length;
+  const title = stringValue(item.display_name) ?? item.name;
+
+  console.log(`\n${title}`);
+  printProperty('ID', item.name);
+  printProperty('Kind', stringValue(item.artifact_type) ?? stringValue(item.tier));
+  printProperty('Category', stringValue(item.category));
+  printProperty('Stability', stringValue(item.stability));
+  printProperty('Distribution', stringValue(item.distribution));
+  printProperty('License', stringValue(item.license) ?? stringValue(item.license_note));
+  printProperty('Source', stringValue(item.source));
+  printProperty('Source version', stringValue(item.source_version));
+  printProperty('Source URL', stringValue(item.source_url));
+  printProperty('Derived from', stringValue(item.derived_from));
+  printProperty('Description', stringValue(item.description));
+
+  const credits = normalizeCredits(item.credits);
+  if (credits.length > 0) {
+    console.log('Credits:');
+    for (const credit of credits) {
+      console.log(`  - ${credit.name}${credit.role ? ` — ${credit.role}` : ''}`);
+    }
+  }
+
+  console.log(`Fields (${priorityCount} priority / ${fields.length} total):`);
+  if (fields.length === 0) {
+    console.log('  None');
+  } else {
+    for (const field of fields) {
+      printField(field, 1);
+    }
+  }
+  console.log('');
+}
+
+function printField(field: TemplateListField, depth: number): void {
+  const indent = '  '.repeat(depth);
+  const label = field.display_label && field.display_label !== field.name
+    ? `${field.display_label} (${field.name})`
+    : field.name;
+  const required = field.required ? ', priority' : '';
+  console.log(`${indent}- ${label} [${field.type}${required}]`);
+  if (field.description) console.log(`${indent}  ${field.description}`);
+  if (field.default !== null) console.log(`${indent}  Default: ${field.default}`);
+  if (field.options && field.options.length > 0) {
+    console.log(`${indent}  Options: ${field.options.join(', ')}`);
+  }
+  for (const child of field.items ?? []) {
+    printField(child, depth + 1);
+  }
+}
+
+function printProperty(label: string, value: string | undefined): void {
+  if (value !== undefined && value.length > 0) {
+    console.log(`${label}: ${value}`);
+  }
+}
+
+function stringValue(value: unknown): string | undefined {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  return undefined;
+}
+
+function normalizeCredits(value: unknown): Array<{ name: string; role?: string }> {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((credit) => {
+    if (!credit || typeof credit !== 'object' || Array.isArray(credit)) return [];
+    const record = credit as Record<string, unknown>;
+    if (typeof record.name !== 'string') return [];
+    return [{
+      name: record.name,
+      ...(typeof record.role === 'string' ? { role: record.role } : {}),
+    }];
+  });
+}


### PR DESCRIPTION
## Summary

- add open-agreements template show for templates, external forms, and field-selectors
- reuse the exact list --json catalog loader as the SSOT for metadata shape
- provide human-readable and machine-readable output
- document the command and protect it with integration tests

## Validation

- npm run preflight:ci
- 1,045 tests passed; 6 skipped
- manual human and JSON command smoke tests

Closes #243