### PR TITLE
chore(catalog): reconcile generated template snapshot

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Validate all templates
         run: node bin/open-agreements.js validate
 
+      - name: Check committed template snapshot
+        run: npm run check:templates-snapshot
+
       - name: Check no CC BY-ND derivatives
         run: |
           # Determine base ref for diff

--- a/data/templates-snapshot.json
+++ b/data/templates-snapshot.json
@@ -10658,7 +10658,7 @@
           "required": false,
           "section": null,
           "description": "Series designation for preferred stock (e.g., A, B, C)",
-          "default": "A",
+          "default": "",
           "default_value_rationale": null
         },
         {
@@ -12583,8 +12583,8 @@
           "required": false,
           "section": "Inventions",
           "description": "Carveout statement for independently developed inventions",
-          "default": "Inventions Employee develops entirely on personal time without using company equipment, supplies, facilities, or trade secret information are excluded, except for inventions that either (a) relate to company business or its actual or demonstrably anticipated research or development, or (b) result from work performed for the company. No exclusion covers a patentable invention or trade secret developed during the course and scope of employment that relates directly to the work performed.",
-          "default_value_rationale": "Nevada's NRS 600.500 makes the employer the sole owner, absent an express written agreement, of any patentable invention or trade secret developed in the course and scope of employment that relates directly to the work. The final sentence keeps every exclusion outside that statutory grant, so the form never gives away ownership the statute already vests in the employer."
+          "default": "Inventions Employee develops entirely on personal time without using company equipment, supplies, facilities, or trade secret information are excluded, except for inventions that either (a) relate to company business or its actual or demonstrably anticipated research or development, or (b) result from work performed for the company. No exclusion covers any Employment-Scope IP.",
+          "default_value_rationale": "Nevada's NRS 600.500 makes the employer the sole owner, absent an express written agreement, of any patentable invention or trade secret developed in the course and scope of employment that relates directly to the work. The Employment-Scope IP defined term carries that statutory scope, and the final sentence keeps every exclusion outside it, so the form never gives away ownership the statute already vests in the employer."
         },
         {
           "name": "return_of_materials_timing",
@@ -25746,6 +25746,284 @@
           "display_label": "Employee Is a Physician",
           "default": null,
           "default_value_rationale": null
+        }
+      ]
+    },
+    {
+      "name": "openagreements-restrictive-covenant-puerto-rico",
+      "tier": "internal",
+      "display_name": "Employee Restrictive Covenant (Puerto Rico)",
+      "category": "non-compete",
+      "description": "Puerto Rico-specific employee restrictive covenant agreement with modular covenant structure. Reflects the twelve-month maximum and reasonableness requirements described in Arthur Young & Co. v. Vega, 136 D.P.R. 157 (1994). Drafted as a starting point for review by licensed Puerto Rico counsel.",
+      "license": "CC-BY-4.0",
+      "source_url": "https://github.com/open-agreements/open-agreements/tree/main/templates/openagreements-restrictive-covenant-master",
+      "source": "OpenAgreements",
+      "attribution_text": "Authored by OpenAgreements contributors. Puerto Rico-specific analysis informed by publicly available commentary on Arthur Young & Co. v. Vega, 136 D.P.R. 157 (1994). Licensed under CC BY 4.0.",
+      "allow_derivatives": true,
+      "distribution": "bundled",
+      "artifact_type": "template",
+      "stability": "experimental",
+      "credits": [],
+      "fields": [
+        {
+          "name": "employer_name",
+          "type": "string",
+          "required": true,
+          "section": "Parties",
+          "description": "Legal name of the employer",
+          "display_label": "Employer",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "employer_signatory_name",
+          "type": "string",
+          "required": false,
+          "section": "Parties",
+          "description": "Full name of the authorized signatory signing for the employer",
+          "display_label": "Employer Signatory Name",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "employer_signatory_title",
+          "type": "string",
+          "required": false,
+          "section": "Parties",
+          "description": "Title of the authorized signatory signing for the employer",
+          "display_label": "Employer Signatory Title",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "employee_name",
+          "type": "string",
+          "required": true,
+          "section": "Parties",
+          "description": "Full legal name of the employee",
+          "display_label": "Employee",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "employee_title",
+          "type": "string",
+          "required": false,
+          "section": "Parties",
+          "description": "Employee job title or position (optional)",
+          "display_label": "Employee Title / Position",
+          "default": "",
+          "default_value_rationale": null
+        },
+        {
+          "name": "effective_date",
+          "type": "date",
+          "required": false,
+          "section": "Timing",
+          "description": "Effective date of this agreement",
+          "display_label": "Effective Date",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "governing_law",
+          "type": "string",
+          "required": false,
+          "section": "Legal",
+          "description": "Governing law state",
+          "display_label": "Governing Law",
+          "default": "Puerto Rico",
+          "default_value_rationale": null
+        },
+        {
+          "name": "confidentiality_trade_secret_duration",
+          "type": "string",
+          "required": false,
+          "section": "Confidentiality",
+          "description": "Duration of confidentiality obligations for trade secrets",
+          "display_label": "Trade Secrets Duration",
+          "default": "Perpetual",
+          "default_value_rationale": null
+        },
+        {
+          "name": "confidentiality_other_duration",
+          "type": "string",
+          "required": false,
+          "section": "Confidentiality",
+          "description": "Duration of confidentiality obligations for non-trade-secret information",
+          "display_label": "Other Confidential Information Duration",
+          "default": "24 months",
+          "default_value_rationale": "24 months is common for non-trade-secret confidentiality obligations in employment agreements."
+        },
+        {
+          "name": "employee_nonsolicit_included",
+          "type": "boolean",
+          "required": false,
+          "section": "Employee Non-Solicitation",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "display_label": "Employee No-Hire Included",
+          "default": "true",
+          "default_value_rationale": null
+        },
+        {
+          "name": "employee_nonsolicit_duration",
+          "type": "string",
+          "required": false,
+          "section": "Employee Non-Solicitation",
+          "description": "Duration of employee non-solicitation restriction",
+          "display_label": "Employee Non-Solicitation Duration",
+          "default": "12 months",
+          "default_value_rationale": "24 months matches the modal employee non-solicit term observed in benchmarked, publicly-filed employee agreements; 12 months is the common lighter alternative. Puerto Rico judges the covenant on common-law reasonableness, so counsel should size the term to the employer's actual protectable interest."
+        },
+        {
+          "name": "covered_employee_period",
+          "type": "string",
+          "required": false,
+          "section": "Employee Non-Solicitation",
+          "description": "Lookback period for determining which employees are covered by the non-solicitation restriction.",
+          "display_label": "Covered Employee Period",
+          "default": "12 months",
+          "default_value_rationale": "12 months is the most common lookback period for employee non-solicitation scope."
+        },
+        {
+          "name": "customer_nonsolicit_included",
+          "type": "boolean",
+          "required": false,
+          "section": "Customer Non-Solicitation",
+          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "display_label": "Customer Non-Solicitation Included",
+          "default": "true",
+          "default_value_rationale": null
+        },
+        {
+          "name": "customer_nonsolicit_duration",
+          "type": "string",
+          "required": false,
+          "section": "Customer Non-Solicitation",
+          "description": "Duration of customer/partner non-solicitation restriction",
+          "display_label": "Customer Non-Solicitation Duration",
+          "default": "12 months",
+          "default_value_rationale": "12 months is the most common customer non-solicit term in benchmarked, publicly-filed employee agreements, edging out 24 months by only a narrow margin — a conservative pick counsel should size to the customer relationships actually protected."
+        },
+        {
+          "name": "covered_customer_period",
+          "type": "string",
+          "required": false,
+          "section": "Customer Non-Solicitation",
+          "description": "Lookback period for determining which customers are covered by the non-solicitation and non-dealing restrictions.",
+          "display_label": "Covered Customer Period",
+          "default": "12 months",
+          "default_value_rationale": "12 months is the most common lookback period for customer non-solicitation scope."
+        },
+        {
+          "name": "noncompete_included",
+          "type": "boolean",
+          "required": false,
+          "section": "Non-Competition",
+          "description": "Whether the non-competition covenant is included. Under Alabama law an employee may agree to a geographically limited non-compete; this template recites the employee-exception basis, ties the covenant to a listed protectable interest, and biases the duration into the two-year presumptively reasonable window.",
+          "display_label": "Non-Competition Included",
+          "default": "true",
+          "default_value_rationale": "Conservative default. Non-competes are the most heavily scrutinized covenant; include only after confirming the restraint fits Alabama's employee exception for a specified geographic area, a competing business, and an existing employment relationship; protects a listed interest; stays within the two-year presumption; will be signed by all parties, including the employer; and does not restrain a member of a recognized profession from practicing that profession. The party seeking enforcement bears the burden of proof on every element."
+        },
+        {
+          "name": "noncompete_duration",
+          "type": "string",
+          "required": false,
+          "section": "Non-Competition",
+          "description": "Duration of non-competition restriction",
+          "display_label": "Non-Competition Duration",
+          "default": "12 months",
+          "default_value_rationale": "Twelve months is the jurisdiction-specific maximum post-employment term; any additional term is excessive."
+        },
+        {
+          "name": "territory",
+          "type": "string",
+          "required": false,
+          "section": "Non-Competition",
+          "description": "Geographic scope of the non-competition restriction",
+          "display_label": "Restricted Territory",
+          "default": "the geographic area in which Employee provided services",
+          "default_value_rationale": "Tied to the employee's actual service area. Narrower scope improves enforceability under Puerto Rico's strict scrutiny."
+        },
+        {
+          "name": "competitive_business_definition",
+          "type": "string",
+          "required": false,
+          "section": "Non-Competition",
+          "description": "Description of the business activities that constitute competition with the employer.",
+          "display_label": "Competitive Business",
+          "default": null,
+          "default_value_rationale": null
+        },
+        {
+          "name": "specified_competitors",
+          "type": "string",
+          "required": false,
+          "section": "Non-Competition",
+          "description": "Optional named list of specific competitors. Narrowing the restriction to named competitors strengthens enforceability.",
+          "display_label": "Specified Competitors",
+          "default": "",
+          "default_value_rationale": null
+        },
+        {
+          "name": "nondealing_included",
+          "type": "boolean",
+          "required": false,
+          "section": "No Business with Covered Customers",
+          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "display_label": "No Business with Covered Customers Included",
+          "default": "false",
+          "default_value_rationale": null
+        },
+        {
+          "name": "nondealing_duration",
+          "type": "string",
+          "required": false,
+          "section": "No Business with Covered Customers",
+          "description": "Duration of the no-business-with-covered-customers restriction",
+          "display_label": "No Business with Covered Customers Duration",
+          "default": "12 months",
+          "default_value_rationale": null
+        },
+        {
+          "name": "passive_public_holdings_threshold",
+          "type": "string",
+          "required": false,
+          "section": "Definitions",
+          "description": "Maximum ownership percentage of publicly traded securities permitted under the Passive Public Holdings carveout.",
+          "display_label": "Passive Public Holdings Threshold",
+          "default": "five percent",
+          "default_value_rationale": "Five percent of any class of publicly traded securities is the modal passive-investment carve-out threshold observed in benchmarked, publicly-filed employee agreements that include the carve-out (lower 1-3 percent thresholds are the common tighter alternatives)."
+        },
+        {
+          "name": "noninvestment_included",
+          "type": "boolean",
+          "required": false,
+          "section": "Non-Investment",
+          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "display_label": "Non-Investment Included",
+          "default": "false",
+          "default_value_rationale": null
+        },
+        {
+          "name": "noninvestment_duration",
+          "type": "string",
+          "required": false,
+          "section": "Non-Investment",
+          "description": "Duration of non-investment restriction",
+          "display_label": "Non-Investment Duration",
+          "default": "12 months",
+          "default_value_rationale": null
+        },
+        {
+          "name": "nondisparagement_duration",
+          "type": "string",
+          "required": false,
+          "section": "Non-Disparagement",
+          "description": "Duration of non-disparagement obligation (measured from termination)",
+          "display_label": "Non-Disparagement Duration",
+          "default": "24 months",
+          "default_value_rationale": "24 months is common for employment non-disparagement provisions."
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "generate:templates": "node scripts/generate_templates.mjs && npm run check:docx-structure",
     "generate:employment-templates:libreoffice": "node scripts/generate_employment_templates_libreoffice.mjs",
     "generate:readme": "node scripts/generate_readme.mjs",
+    "generate:templates-snapshot": "node scripts/export-templates-snapshot.mjs",
     "generate:template-previews": "npm run build && node scripts/generate_template_previews.mjs",
     "render:docx-pages": "node scripts/render_docx_pages.mjs",
     "test": "npm run build && vitest",
@@ -91,10 +92,11 @@
     "report:allure:open": "allure open ./allure-report",
     "allure:deploy": "node scripts/deploy_allure_report.mjs",
     "check:readme": "npm run generate:readme && git diff --exit-code -- README.md docs/reference/catalog.md",
+    "check:templates-snapshot": "node scripts/export-templates-snapshot.mjs --check",
     "check:docs": "node scripts/check_docs.mjs",
     "generate:llms": "node scripts/generate_llms_txt.mjs",
     "check:llms": "npm run generate:llms && git diff --exit-code -- llms.txt llms-full.txt",
-    "preflight:ci": "npm run lint && npm run validate && npm run check:template-previews && npm run check:preview-freshness && npm run check:gemini-extension-manifest && npm run check:readme && npm run check:docs && npm run check:llms && npm run test:run"
+    "preflight:ci": "npm run lint && npm run validate && npm run check:templates-snapshot && npm run check:template-previews && npm run check:preview-freshness && npm run check:gemini-extension-manifest && npm run check:readme && npm run check:docs && npm run check:llms && npm run test:run"
   },
   "keywords": [
     "legal",


### PR DESCRIPTION
## Outcome

Regenerates `data/templates-snapshot.json` from the current CLI catalog and makes freshness a required validation check, so the committed downstream artifact cannot silently drift from template metadata again.

## Reconciled drift

- NVCA certificate `series_designation` default projected in #638
- Nevada invention-assignment carveout wording projected in #625
- Puerto Rico restrictive-covenant catalog entry projected in #625

The Puerto Rico source currently contains five Alabama-specific field descriptions. Because Legal Explainer is the template SSOT, this PR does not patch generated downstream bytes independently; the canonical correction is tracked in https://github.com/UseJunior/legal-explainer/issues/1927 and should arrive through projection after legal review.

## Enforcement

- adds `generate:templates-snapshot` as the canonical regeneration command
- adds `check:templates-snapshot` as the canonical freshness command
- runs the freshness check in `preflight:ci`
- runs it in the required Validate Templates workflow

## Verification

- `npm run build`
- `npm run check:templates-snapshot`
- `npm run validate`
- `npm run lint`
- full Vitest suite: 291/291 suites; 1,058 passed, 6 skipped, 0 failed
- regenerated catalog contains 114 unique items and one Puerto Rico entry