### PR TITLE
fix(release): bundle @usejunior/docx-core into scoped @open-agreements/open-agreements (closes #642)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,15 @@ jobs:
               exit 1
             fi
           done
+          npm pack --dry-run --json | node -e '
+            const data = JSON.parse(require("fs").readFileSync(0, "utf8"));
+            const bundled = data[0].bundled || [];
+            if (!bundled.includes("@usejunior/docx-core")) {
+              console.error("FAIL: @usejunior/docx-core not in unscoped bundled list:", bundled);
+              process.exit(1);
+            }
+            console.log("OK: unscoped open-agreements bundles @usejunior/docx-core");
+          '
           (cd packages/contracts-workspace-mcp && npm pack --dry-run)
           (cd packages/contract-templates-mcp && npm pack --dry-run)
           (cd packages/checklist-mcp && npm pack --dry-run)
@@ -128,6 +137,15 @@ jobs:
           trap cleanup_scoped_dir EXIT
           node scripts/prepare_scoped_open_agreements_package.mjs --out-dir "$SCOPED_DIR"
           (cd "$SCOPED_DIR" && npm pack --dry-run)
+          (cd "$SCOPED_DIR" && npm pack --dry-run --json) | node -e '
+            const data = JSON.parse(require("fs").readFileSync(0, "utf8"));
+            const bundled = data[0].bundled || [];
+            if (!bundled.includes("@usejunior/docx-core")) {
+              console.error("FAIL: @usejunior/docx-core not in scoped bundled list:", bundled);
+              process.exit(1);
+            }
+            console.log("OK: scoped @open-agreements/open-agreements bundles @usejunior/docx-core");
+          '
           trap - EXIT
           cleanup_scoped_dir
 
@@ -200,6 +218,15 @@ jobs:
           if npm view "open-agreements@$VERSION" version >/dev/null 2>&1; then
             echo "open-agreements@$VERSION already published — skipping."
           else
+            npm pack --dry-run --json | node -e '
+              const data = JSON.parse(require("fs").readFileSync(0, "utf8"));
+              const bundled = data[0].bundled || [];
+              if (!bundled.includes("@usejunior/docx-core")) {
+                console.error("FAIL: @usejunior/docx-core not in unscoped bundled list:", bundled);
+                process.exit(1);
+              }
+              console.log("OK: unscoped open-agreements bundles @usejunior/docx-core");
+            '
             npm publish --provenance --access public
           fi
 
@@ -213,6 +240,15 @@ jobs:
             }
             trap cleanup_scoped_dir EXIT
             node scripts/prepare_scoped_open_agreements_package.mjs --out-dir "$SCOPED_DIR"
+            (cd "$SCOPED_DIR" && npm pack --dry-run --json) | node -e '
+              const data = JSON.parse(require("fs").readFileSync(0, "utf8"));
+              const bundled = data[0].bundled || [];
+              if (!bundled.includes("@usejunior/docx-core")) {
+                console.error("FAIL: @usejunior/docx-core not in scoped bundled list:", bundled);
+                process.exit(1);
+              }
+              console.log("OK: scoped @open-agreements/open-agreements bundles @usejunior/docx-core");
+            '
             echo "Publishing @open-agreements/open-agreements from $SCOPED_DIR"
             (cd "$SCOPED_DIR" && npm publish --provenance --access public)
             trap - EXIT
@@ -414,4 +450,3 @@ jobs:
             echo "### Template snapshot: ${TAG_REF}"
             echo "- Tarball: \`${TARBALL}\` (${SIZE_BYTES} bytes)"
           } >> "$GITHUB_STEP_SUMMARY"
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,6 +109,7 @@ jobs:
         run: npm run check:isolated-runtime
 
       - name: Verify package contents
+        shell: bash
         run: |
           PACK_OUTPUT="$(npm pack --dry-run 2>&1)"
           echo "$PACK_OUTPUT"
@@ -208,6 +209,7 @@ jobs:
           npm run build:checklist-mcp
 
       - name: Publish to npm (trusted publishing + provenance)
+        shell: bash
         run: |
           TAG_REF="${RELEASE_TAG:-$GITHUB_REF_NAME}"
           VERSION="${TAG_REF#v}"

--- a/scripts/prepare_scoped_open_agreements_package.mjs
+++ b/scripts/prepare_scoped_open_agreements_package.mjs
@@ -1,9 +1,11 @@
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
 const ROOT_PACKAGE_PATH = path.resolve("package.json");
 const SCOPED_PACKAGE_NAME = "@open-agreements/open-agreements";
+const NPM_COMMAND = process.platform === "win32" ? "npm.cmd" : "npm";
 
 function parseOutDir(argv) {
   for (let i = 0; i < argv.length; i += 1) {
@@ -36,6 +38,48 @@ function copyPublishFiles(files, outDir) {
   }
 }
 
+function getRootBundledPackages() {
+  const npmCacheDir = fs.mkdtempSync(path.join(os.tmpdir(), "open-agreements-npm-pack-"));
+
+  try {
+    const packOutput = execFileSync(
+      NPM_COMMAND,
+      ["pack", "--dry-run", "--json", "--ignore-scripts", "--offline", "--cache", npmCacheDir],
+      {
+        cwd: path.dirname(ROOT_PACKAGE_PATH),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          NO_UPDATE_NOTIFIER: "1",
+          npm_config_update_notifier: "false"
+        },
+        maxBuffer: 50 * 1024 * 1024
+      }
+    );
+    const packMetadata = JSON.parse(packOutput);
+    const bundledPackages = packMetadata[0]?.bundled;
+    if (!Array.isArray(bundledPackages)) {
+      throw new Error("Root npm pack metadata must contain a bundled array.");
+    }
+    return bundledPackages;
+  } finally {
+    fs.rmSync(npmCacheDir, { recursive: true, force: true });
+  }
+}
+
+function copyBundledPackages(packageNames, outDir) {
+  for (const packageName of packageNames) {
+    const sourcePath = path.resolve("node_modules", packageName);
+    if (!fs.existsSync(sourcePath)) {
+      throw new Error(`Missing bundled package in root node_modules: ${packageName}`);
+    }
+
+    const destinationPath = path.join(outDir, "node_modules", packageName);
+    fs.mkdirSync(path.dirname(destinationPath), { recursive: true });
+    fs.cpSync(sourcePath, destinationPath, { recursive: true });
+  }
+}
+
 const outDir = parseOutDir(process.argv.slice(2));
 const packageJsonRaw = fs.readFileSync(ROOT_PACKAGE_PATH, "utf8");
 const rootPackageJson = JSON.parse(packageJsonRaw);
@@ -59,5 +103,6 @@ if (scopedPackageJson.scripts && typeof scopedPackageJson.scripts === "object") 
 
 fs.mkdirSync(outDir, { recursive: true });
 copyPublishFiles(rootPackageJson.files, outDir);
+copyBundledPackages(getRootBundledPackages(), outDir);
 fs.writeFileSync(path.join(outDir, "package.json"), `${JSON.stringify(scopedPackageJson, null, 2)}\n`);
 process.stdout.write(`${outDir}\n`);

--- a/scripts/prepare_scoped_open_agreements_package.test.mjs
+++ b/scripts/prepare_scoped_open_agreements_package.test.mjs
@@ -58,6 +58,6 @@ describe('prepare_scoped_open_agreements_package', () => {
       expect(actual).toContain('@usejunior/docx-core');
       expect([...actual].sort()).toEqual([...expected].sort());
     },
-    30_000,
+    60_000,
   );
 });

--- a/scripts/prepare_scoped_open_agreements_package.test.mjs
+++ b/scripts/prepare_scoped_open_agreements_package.test.mjs
@@ -1,0 +1,63 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(import.meta.dirname, '..');
+const PREPARE_SCRIPT = join(REPO_ROOT, 'scripts', 'prepare_scoped_open_agreements_package.mjs');
+const NPM_COMMAND = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+
+const tempDirs = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function tempDir(prefix) {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function bundledPackages(packageDir) {
+  const npmCacheDir = tempDir('oa-scoped-pack-cache-');
+  const output = execFileSync(
+    NPM_COMMAND,
+    ['pack', '--dry-run', '--json', '--ignore-scripts', '--offline', '--cache', npmCacheDir],
+    {
+      cwd: packageDir,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        NO_UPDATE_NOTIFIER: '1',
+        npm_config_update_notifier: 'false',
+      },
+      maxBuffer: 50 * 1024 * 1024,
+    },
+  );
+  return JSON.parse(output)[0]?.bundled ?? [];
+}
+
+describe('prepare_scoped_open_agreements_package', () => {
+  it(
+    'stages the same bundled dependency tree as the root package',
+    () => {
+      const expected = bundledPackages(REPO_ROOT);
+      const outDir = tempDir('oa-scoped-package-');
+
+      execFileSync(process.execPath, [PREPARE_SCRIPT, '--out-dir', outDir], {
+        cwd: REPO_ROOT,
+        encoding: 'utf8',
+      });
+
+      const actual = bundledPackages(outDir);
+      expect(actual).toContain('@usejunior/docx-core');
+      expect([...actual].sort()).toEqual([...expected].sort());
+    },
+    30_000,
+  );
+});


### PR DESCRIPTION
## Summary
The scoped npm package `@open-agreements/open-agreements` declared `bundleDependencies: ["@usejunior/docx-core"]` but shipped **no bundled files** — its tarball's `bundled` list was empty. The unscoped twin `open-agreements` bundled correctly. Consumers of the scoped package got an unmet/deduped-invalid `@usejunior/docx-core` instead of the intended bundled copy.

## Root cause
`scripts/prepare_scoped_open_agreements_package.mjs` built the scoped variant into a temp out-dir by copying only `package.json`'s `files` array — never `node_modules`. `release.yml` then packed/published from that dir; with no `node_modules`, `bundleDependencies` bundled nothing. The unscoped package works only because it packs from the repo root where `node_modules` is populated.

## Implementation
- **`prepare_scoped_open_agreements_package.mjs`**: reads the authoritative bundled set from the repo root (`npm pack --dry-run --json`) and copies each package into the out-dir's `node_modules`, so the scoped tarball reproduces the root's full bundle (docx-core + its transitive tree: jszip, pako, @xmldom/xmldom, …). Offline — no network; works in CI where root `node_modules` is already installed.
- **`release.yml`**: guard after every `prepare → npm pack` site (scoped **and** unscoped, in both the verify-contents preflight and the publish step) that fails the job if `@usejunior/docx-core` is absent from the `bundled` list — so this can't silently regress on either name.
- **`scripts/prepare_scoped_open_agreements_package.test.mjs`**: vitest regression asserting the scoped out-dir bundles the same tree as the root.

## Verification
- [x] Repro fixed: `prepare → npm pack --dry-run --json` scoped `bundled` = 15 packages incl. `@usejunior/docx-core` (matches root exactly)
- [x] New vitest test passes
- [x] actionlint clean (only a pre-existing SC2129 style note in an untouched `$GITHUB_STEP_SUMMARY` block)
- [x] Scope: only the 3 files above; no app source touched (release tooling only)
- [ ] Peer review (agy + Codex) — pending; appended below

## Closes
- #642