### PR TITLE
chore(projection): sync jurisdiction metadata fixes

### DIFF
--- a/data/templates-snapshot.json
+++ b/data/templates-snapshot.json
@@ -14938,7 +14938,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -14968,7 +14968,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -15058,7 +15058,7 @@
           "type": "boolean",
           "required": false,
           "section": "No Business with Covered Customers",
-          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "description": "Whether the no-business-with-covered-customers covenant is included.",
           "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
@@ -15088,7 +15088,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -15236,7 +15236,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -15266,7 +15266,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -15346,7 +15346,7 @@
           "type": "boolean",
           "required": false,
           "section": "No Business with Covered Customers",
-          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "description": "Whether the no-business-with-covered-customers covenant is included.",
           "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
@@ -15376,7 +15376,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -15406,7 +15406,7 @@
           "type": "boolean",
           "required": false,
           "section": "Physician",
-          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.",
+          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.",
           "display_label": "Employee Is a Physician",
           "default": null,
           "default_value_rationale": null
@@ -15524,7 +15524,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -15554,7 +15554,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -15634,7 +15634,7 @@
           "type": "boolean",
           "required": false,
           "section": "No Business with Covered Customers",
-          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "description": "Whether the no-business-with-covered-customers covenant is included.",
           "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
@@ -15664,7 +15664,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -15694,7 +15694,7 @@
           "type": "boolean",
           "required": false,
           "section": "Physician",
-          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.",
+          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.",
           "display_label": "Employee Is a Physician",
           "default": null,
           "default_value_rationale": null
@@ -15812,7 +15812,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -15842,7 +15842,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -15922,7 +15922,7 @@
           "type": "boolean",
           "required": false,
           "section": "No Business with Covered Customers",
-          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "description": "Whether the no-business-with-covered-customers covenant is included.",
           "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
@@ -15952,7 +15952,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -15982,7 +15982,7 @@
           "type": "boolean",
           "required": false,
           "section": "Physician",
-          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.",
+          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.",
           "display_label": "Employee Is a Physician",
           "default": null,
           "default_value_rationale": null
@@ -16248,7 +16248,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -16278,7 +16278,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -16358,7 +16358,7 @@
           "type": "boolean",
           "required": false,
           "section": "No Business with Covered Customers",
-          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "description": "Whether the no-business-with-covered-customers covenant is included.",
           "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
@@ -16388,7 +16388,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -16536,7 +16536,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -16566,7 +16566,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -16646,7 +16646,7 @@
           "type": "boolean",
           "required": false,
           "section": "No Business with Covered Customers",
-          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "description": "Whether the no-business-with-covered-customers covenant is included.",
           "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
@@ -16676,7 +16676,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -16814,7 +16814,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -16844,7 +16844,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -16924,7 +16924,7 @@
           "type": "boolean",
           "required": false,
           "section": "No Business with Covered Customers",
-          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "description": "Whether the no-business-with-covered-customers covenant is included.",
           "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
@@ -16954,7 +16954,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -16984,7 +16984,7 @@
           "type": "boolean",
           "required": false,
           "section": "Physician",
-          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.",
+          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.",
           "display_label": "Employee Is a Physician",
           "default": null,
           "default_value_rationale": null
@@ -17122,7 +17122,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -17152,7 +17152,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -17380,7 +17380,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -17410,7 +17410,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -17490,7 +17490,7 @@
           "type": "boolean",
           "required": false,
           "section": "No Business with Covered Customers",
-          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "description": "Whether the no-business-with-covered-customers covenant is included.",
           "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
@@ -17520,7 +17520,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -17550,7 +17550,7 @@
           "type": "boolean",
           "required": false,
           "section": "Physician",
-          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.",
+          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.",
           "display_label": "Employee Is a Physician",
           "default": null,
           "default_value_rationale": null
@@ -17688,7 +17688,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -17718,7 +17718,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -17798,7 +17798,7 @@
           "type": "boolean",
           "required": false,
           "section": "No Business with Covered Customers",
-          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "description": "Whether the no-business-with-covered-customers covenant is included.",
           "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
@@ -17828,7 +17828,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -17858,7 +17858,7 @@
           "type": "boolean",
           "required": false,
           "section": "Physician",
-          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.",
+          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.",
           "display_label": "Employee Is a Physician",
           "default": null,
           "default_value_rationale": null
@@ -17986,7 +17986,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -18016,7 +18016,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -18086,7 +18086,7 @@
           "type": "string",
           "required": false,
           "section": "Non-Competition",
-          "description": "Optional named list of specific competitors. Alabama rewards specificity: the protectable-interest list speaks in terms of specific customers and concrete relationships, and a covenant drawn to named threats is easier to defend as protecting a listed interest than one leaning on an open-ended competitive-business definition.",
+          "description": "Optional named list of specific competitors.",
           "display_label": "Specified Competitors",
           "default": "",
           "default_value_rationale": null
@@ -18096,7 +18096,7 @@
           "type": "boolean",
           "required": false,
           "section": "No Business with Covered Customers",
-          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "description": "Whether the no-business-with-covered-customers covenant is included.",
           "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
@@ -18126,7 +18126,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -18156,7 +18156,7 @@
           "type": "boolean",
           "required": false,
           "section": "Physician",
-          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.",
+          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.",
           "display_label": "Employee Is a Physician",
           "default": null,
           "default_value_rationale": null
@@ -18274,7 +18274,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -18304,7 +18304,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -18394,7 +18394,7 @@
           "type": "boolean",
           "required": false,
           "section": "No Business with Covered Customers",
-          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "description": "Whether the no-business-with-covered-customers covenant is included.",
           "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
@@ -18424,7 +18424,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -18572,7 +18572,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -18602,7 +18602,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -18692,7 +18692,7 @@
           "type": "boolean",
           "required": false,
           "section": "No Business with Covered Customers",
-          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "description": "Whether the no-business-with-covered-customers covenant is included.",
           "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
@@ -18722,7 +18722,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -18860,7 +18860,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -18890,7 +18890,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -18970,7 +18970,7 @@
           "type": "boolean",
           "required": false,
           "section": "No Business with Covered Customers",
-          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "description": "Whether the no-business-with-covered-customers covenant is included.",
           "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
@@ -19000,7 +19000,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -19030,7 +19030,7 @@
           "type": "boolean",
           "required": false,
           "section": "Physician",
-          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.",
+          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.",
           "display_label": "Employee Is a Physician",
           "default": null,
           "default_value_rationale": null
@@ -19158,7 +19158,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -19188,7 +19188,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -19268,7 +19268,7 @@
           "type": "boolean",
           "required": false,
           "section": "No Business with Covered Customers",
-          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "description": "Whether the no-business-with-covered-customers covenant is included.",
           "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
@@ -19298,7 +19298,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -19328,7 +19328,7 @@
           "type": "boolean",
           "required": false,
           "section": "Physician",
-          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.",
+          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.",
           "display_label": "Employee Is a Physician",
           "default": null,
           "default_value_rationale": null
@@ -19446,7 +19446,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -19476,7 +19476,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -19556,7 +19556,7 @@
           "type": "boolean",
           "required": false,
           "section": "No Business with Covered Customers",
-          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "description": "Whether the no-business-with-covered-customers covenant is included.",
           "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
@@ -19586,7 +19586,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -19616,7 +19616,7 @@
           "type": "boolean",
           "required": false,
           "section": "Physician",
-          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.",
+          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.",
           "display_label": "Employee Is a Physician",
           "default": null,
           "default_value_rationale": null
@@ -19754,7 +19754,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -19784,7 +19784,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -19864,7 +19864,7 @@
           "type": "boolean",
           "required": false,
           "section": "No Business with Covered Customers",
-          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "description": "Whether the no-business-with-covered-customers covenant is included.",
           "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
@@ -19894,7 +19894,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -19924,7 +19924,7 @@
           "type": "boolean",
           "required": false,
           "section": "Physician",
-          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.",
+          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.",
           "display_label": "Employee Is a Physician",
           "default": null,
           "default_value_rationale": null
@@ -20042,7 +20042,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -20072,7 +20072,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -20112,10 +20112,10 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Competition",
-          "description": "Whether the non-competition covenant is included. Under Alabama law an employee may agree to a geographically limited non-compete; this template recites the employee-exception basis, ties the covenant to a listed protectable interest, and biases the duration into the two-year presumptively reasonable window.",
+          "description": "Whether the non-competition covenant is included.",
           "display_label": "Non-Competition Included",
           "default": "false",
-          "default_value_rationale": "Conservative default. Non-competes are the most heavily scrutinized covenant; include only after confirming the restraint fits Alabama's employee exception for a specified geographic area, a competing business, and an existing employment relationship; protects a listed interest; stays within the two-year presumption; will be signed by all parties, including the employer; and does not restrain a member of a recognized profession from practicing that profession. The party seeking enforcement bears the burden of proof on every element."
+          "default_value_rationale": "Conservative default. Non-competes are the most heavily scrutinized covenant; include only after confirming enforceability under the agreement's governing law and tailoring the restraint to a legitimate protectable interest."
         },
         {
           "name": "noncompete_duration",
@@ -20152,7 +20152,7 @@
           "type": "boolean",
           "required": false,
           "section": "Physician",
-          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.",
+          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.",
           "display_label": "Employee Is a Physician",
           "default": null,
           "default_value_rationale": null
@@ -20172,7 +20172,7 @@
           "type": "boolean",
           "required": false,
           "section": "No Business with Covered Customers",
-          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "description": "Whether the no-business-with-covered-customers covenant is included.",
           "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
@@ -20202,7 +20202,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -20390,7 +20390,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -20420,7 +20420,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -20500,7 +20500,7 @@
           "type": "boolean",
           "required": false,
           "section": "No Business with Covered Customers",
-          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "description": "Whether the no-business-with-covered-customers covenant is included.",
           "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
@@ -20530,7 +20530,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -20678,7 +20678,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -20708,7 +20708,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -20788,7 +20788,7 @@
           "type": "boolean",
           "required": false,
           "section": "No Business with Covered Customers",
-          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "description": "Whether the no-business-with-covered-customers covenant is included.",
           "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
@@ -20818,7 +20818,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -20966,7 +20966,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -20996,7 +20996,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -21086,7 +21086,7 @@
           "type": "boolean",
           "required": false,
           "section": "No Business with Covered Customers",
-          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "description": "Whether the no-business-with-covered-customers covenant is included.",
           "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
@@ -21116,7 +21116,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -21146,7 +21146,7 @@
           "type": "boolean",
           "required": false,
           "section": "Physician",
-          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.",
+          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.",
           "display_label": "Employee Is a Physician",
           "default": null,
           "default_value_rationale": null
@@ -21264,7 +21264,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -21294,7 +21294,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -21384,7 +21384,7 @@
           "type": "boolean",
           "required": false,
           "section": "No Business with Covered Customers",
-          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "description": "Whether the no-business-with-covered-customers covenant is included.",
           "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
@@ -21414,7 +21414,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -21444,7 +21444,7 @@
           "type": "boolean",
           "required": false,
           "section": "Physician",
-          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.",
+          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.",
           "display_label": "Employee Is a Physician",
           "default": null,
           "default_value_rationale": null
@@ -21730,7 +21730,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -21760,7 +21760,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -21840,7 +21840,7 @@
           "type": "boolean",
           "required": false,
           "section": "No Business with Covered Customers",
-          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "description": "Whether the no-business-with-covered-customers covenant is included.",
           "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
@@ -21870,7 +21870,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -21900,7 +21900,7 @@
           "type": "boolean",
           "required": false,
           "section": "Physician",
-          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.",
+          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.",
           "display_label": "Employee Is a Physician",
           "default": null,
           "default_value_rationale": null
@@ -22028,7 +22028,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -22058,7 +22058,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -22138,7 +22138,7 @@
           "type": "boolean",
           "required": false,
           "section": "No Business with Covered Customers",
-          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "description": "Whether the no-business-with-covered-customers covenant is included.",
           "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
@@ -22168,7 +22168,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -22198,7 +22198,7 @@
           "type": "boolean",
           "required": false,
           "section": "Physician",
-          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.",
+          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.",
           "display_label": "Employee Is a Physician",
           "default": null,
           "default_value_rationale": null
@@ -22326,7 +22326,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -22356,7 +22356,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -22436,7 +22436,7 @@
           "type": "boolean",
           "required": false,
           "section": "No Business with Covered Customers",
-          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "description": "Whether the no-business-with-covered-customers covenant is included.",
           "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
@@ -22466,7 +22466,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -22614,7 +22614,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -22644,7 +22644,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -22714,7 +22714,7 @@
           "type": "boolean",
           "required": false,
           "section": "No Business with Covered Customers",
-          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "description": "Whether the no-business-with-covered-customers covenant is included.",
           "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
@@ -22744,7 +22744,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -22774,7 +22774,7 @@
           "type": "boolean",
           "required": false,
           "section": "Physician",
-          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.",
+          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.",
           "display_label": "Employee Is a Physician",
           "default": null,
           "default_value_rationale": null
@@ -22892,7 +22892,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -22922,7 +22922,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -23012,7 +23012,7 @@
           "type": "boolean",
           "required": false,
           "section": "No Business with Covered Customers",
-          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "description": "Whether the no-business-with-covered-customers covenant is included.",
           "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
@@ -23042,7 +23042,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -23180,7 +23180,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -23210,7 +23210,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -23300,7 +23300,7 @@
           "type": "boolean",
           "required": false,
           "section": "No Business with Covered Customers",
-          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "description": "Whether the no-business-with-covered-customers covenant is included.",
           "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
@@ -23330,7 +23330,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -23468,7 +23468,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -23498,7 +23498,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -23578,7 +23578,7 @@
           "type": "boolean",
           "required": false,
           "section": "No Business with Covered Customers",
-          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "description": "Whether the no-business-with-covered-customers covenant is included.",
           "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
@@ -23608,7 +23608,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -23638,7 +23638,7 @@
           "type": "boolean",
           "required": false,
           "section": "Physician",
-          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.",
+          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.",
           "display_label": "Employee Is a Physician",
           "default": null,
           "default_value_rationale": null
@@ -23786,7 +23786,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -23816,7 +23816,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -23896,7 +23896,7 @@
           "type": "boolean",
           "required": false,
           "section": "No Business with Covered Customers",
-          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "description": "Whether the no-business-with-covered-customers covenant is included.",
           "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
@@ -23926,7 +23926,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -24074,7 +24074,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -24104,7 +24104,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -24184,7 +24184,7 @@
           "type": "boolean",
           "required": false,
           "section": "No Business with Covered Customers",
-          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "description": "Whether the no-business-with-covered-customers covenant is included.",
           "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
@@ -24214,7 +24214,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -24244,7 +24244,7 @@
           "type": "boolean",
           "required": false,
           "section": "Physician",
-          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.",
+          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.",
           "display_label": "Employee Is a Physician",
           "default": null,
           "default_value_rationale": null
@@ -24372,7 +24372,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -24402,7 +24402,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -24482,7 +24482,7 @@
           "type": "boolean",
           "required": false,
           "section": "No Business with Covered Customers",
-          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "description": "Whether the no-business-with-covered-customers covenant is included.",
           "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
@@ -24512,7 +24512,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -24542,7 +24542,7 @@
           "type": "boolean",
           "required": false,
           "section": "Physician",
-          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.",
+          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.",
           "display_label": "Employee Is a Physician",
           "default": null,
           "default_value_rationale": null
@@ -24808,7 +24808,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -24838,7 +24838,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -24918,7 +24918,7 @@
           "type": "boolean",
           "required": false,
           "section": "No Business with Covered Customers",
-          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "description": "Whether the no-business-with-covered-customers covenant is included.",
           "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
@@ -24948,7 +24948,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -24978,7 +24978,7 @@
           "type": "boolean",
           "required": false,
           "section": "Physician",
-          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.",
+          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.",
           "display_label": "Employee Is a Physician",
           "default": null,
           "default_value_rationale": null
@@ -25264,7 +25264,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -25294,7 +25294,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -25384,7 +25384,7 @@
           "type": "boolean",
           "required": false,
           "section": "No Business with Covered Customers",
-          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "description": "Whether the no-business-with-covered-customers covenant is included.",
           "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
@@ -25414,7 +25414,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -25572,7 +25572,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -25602,7 +25602,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -25682,7 +25682,7 @@
           "type": "boolean",
           "required": false,
           "section": "No Business with Covered Customers",
-          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "description": "Whether the no-business-with-covered-customers covenant is included.",
           "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
@@ -25712,7 +25712,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -25742,7 +25742,7 @@
           "type": "boolean",
           "required": false,
           "section": "Physician",
-          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.",
+          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.",
           "display_label": "Employee Is a Physician",
           "default": null,
           "default_value_rationale": null
@@ -25860,7 +25860,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -25890,7 +25890,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -25920,10 +25920,10 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Competition",
-          "description": "Whether the non-competition covenant is included. Under Alabama law an employee may agree to a geographically limited non-compete; this template recites the employee-exception basis, ties the covenant to a listed protectable interest, and biases the duration into the two-year presumptively reasonable window.",
+          "description": "Whether the non-competition covenant is included.",
           "display_label": "Non-Competition Included",
           "default": "true",
-          "default_value_rationale": "Conservative default. Non-competes are the most heavily scrutinized covenant; include only after confirming the restraint fits Alabama's employee exception for a specified geographic area, a competing business, and an existing employment relationship; protects a listed interest; stays within the two-year presumption; will be signed by all parties, including the employer; and does not restrain a member of a recognized profession from practicing that profession. The party seeking enforcement bears the burden of proof on every element."
+          "default_value_rationale": "Conservative default. Non-competes are the most heavily scrutinized covenant; include only after confirming enforceability under the agreement's governing law and tailoring the restraint to a legitimate protectable interest."
         },
         {
           "name": "noncompete_duration",
@@ -25970,7 +25970,7 @@
           "type": "boolean",
           "required": false,
           "section": "No Business with Covered Customers",
-          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "description": "Whether the no-business-with-covered-customers covenant is included.",
           "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
@@ -26000,7 +26000,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -26138,7 +26138,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -26168,7 +26168,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -26248,7 +26248,7 @@
           "type": "boolean",
           "required": false,
           "section": "No Business with Covered Customers",
-          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "description": "Whether the no-business-with-covered-customers covenant is included.",
           "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
@@ -26278,7 +26278,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -26446,7 +26446,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -26476,7 +26476,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -26506,10 +26506,10 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Competition",
-          "description": "Whether the non-competition covenant is included. Under Alabama law an employee may agree to a geographically limited non-compete; this template recites the employee-exception basis, ties the covenant to a listed protectable interest, and biases the duration into the two-year presumptively reasonable window.",
+          "description": "Whether the non-competition covenant is included.",
           "display_label": "Non-Competition Included",
           "default": "true",
-          "default_value_rationale": "Conservative default. Non-competes are the most heavily scrutinized covenant; include only after confirming the restraint fits Alabama's employee exception for a specified geographic area, a competing business, and an existing employment relationship; protects a listed interest; stays within the two-year presumption; will be signed by all parties, including the employer; and does not restrain a member of a recognized profession from practicing that profession. The party seeking enforcement bears the burden of proof on every element."
+          "default_value_rationale": "Conservative default. Non-competes are the most heavily scrutinized covenant; include only after confirming enforceability under the agreement's governing law and tailoring the restraint to a legitimate protectable interest."
         },
         {
           "name": "noncompete_duration",
@@ -26576,7 +26576,7 @@
           "type": "boolean",
           "required": false,
           "section": "No Business with Covered Customers",
-          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "description": "Whether the no-business-with-covered-customers covenant is included.",
           "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
@@ -26606,7 +26606,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -26774,7 +26774,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -26864,7 +26864,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -27012,7 +27012,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -27042,7 +27042,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -27122,7 +27122,7 @@
           "type": "boolean",
           "required": false,
           "section": "No Business with Covered Customers",
-          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "description": "Whether the no-business-with-covered-customers covenant is included.",
           "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
@@ -27152,7 +27152,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -27182,7 +27182,7 @@
           "type": "boolean",
           "required": false,
           "section": "Physician",
-          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.",
+          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.",
           "display_label": "Employee Is a Physician",
           "default": null,
           "default_value_rationale": null
@@ -27300,7 +27300,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -27330,7 +27330,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -27410,7 +27410,7 @@
           "type": "boolean",
           "required": false,
           "section": "No Business with Covered Customers",
-          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "description": "Whether the no-business-with-covered-customers covenant is included.",
           "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
@@ -27440,7 +27440,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -27470,7 +27470,7 @@
           "type": "boolean",
           "required": false,
           "section": "Physician",
-          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.",
+          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.",
           "display_label": "Employee Is a Physician",
           "default": null,
           "default_value_rationale": null
@@ -27588,7 +27588,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -27618,7 +27618,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -27826,7 +27826,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -27856,7 +27856,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -27936,7 +27936,7 @@
           "type": "boolean",
           "required": false,
           "section": "No Business with Covered Customers",
-          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "description": "Whether the no-business-with-covered-customers covenant is included.",
           "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
@@ -27966,7 +27966,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -27996,7 +27996,7 @@
           "type": "boolean",
           "required": false,
           "section": "Physician",
-          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.",
+          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.",
           "display_label": "Employee Is a Physician",
           "default": null,
           "default_value_rationale": null
@@ -28164,7 +28164,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -28244,7 +28244,7 @@
           "type": "boolean",
           "required": false,
           "section": "No Business with Covered Customers",
-          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "description": "Whether the no-business-with-covered-customers covenant is included.",
           "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
@@ -28274,7 +28274,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -28412,7 +28412,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -28442,7 +28442,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -28532,7 +28532,7 @@
           "type": "boolean",
           "required": false,
           "section": "No Business with Covered Customers",
-          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "description": "Whether the no-business-with-covered-customers covenant is included.",
           "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
@@ -28562,7 +28562,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -28710,7 +28710,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -28740,7 +28740,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -28820,7 +28820,7 @@
           "type": "boolean",
           "required": false,
           "section": "No Business with Covered Customers",
-          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "description": "Whether the no-business-with-covered-customers covenant is included.",
           "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
@@ -28850,7 +28850,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -28890,7 +28890,7 @@
           "type": "boolean",
           "required": false,
           "section": "Physician",
-          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.",
+          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.",
           "display_label": "Employee Is a Physician",
           "default": null,
           "default_value_rationale": null
@@ -29008,7 +29008,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -29038,7 +29038,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -29118,7 +29118,7 @@
           "type": "boolean",
           "required": false,
           "section": "No Business with Covered Customers",
-          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "description": "Whether the no-business-with-covered-customers covenant is included.",
           "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
@@ -29148,7 +29148,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -29286,7 +29286,7 @@
           "type": "boolean",
           "required": false,
           "section": "Employee Non-Solicitation",
-          "description": "Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.",
+          "description": "Whether the employee no-hire / non-solicitation covenant is included.",
           "display_label": "Employee No-Hire Included",
           "default": "true",
           "default_value_rationale": null
@@ -29316,7 +29316,7 @@
           "type": "boolean",
           "required": false,
           "section": "Customer Non-Solicitation",
-          "description": "Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.",
+          "description": "Whether the current-customer non-solicitation covenant is included.",
           "display_label": "Customer Non-Solicitation Included",
           "default": "true",
           "default_value_rationale": null
@@ -29396,7 +29396,7 @@
           "type": "boolean",
           "required": false,
           "section": "No Business with Covered Customers",
-          "description": "Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.",
+          "description": "Whether the no-business-with-covered-customers covenant is included.",
           "display_label": "No Business with Covered Customers Included",
           "default": "false",
           "default_value_rationale": null
@@ -29426,7 +29426,7 @@
           "type": "boolean",
           "required": false,
           "section": "Non-Investment",
-          "description": "Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.",
+          "description": "Whether the non-investment covenant is included.",
           "display_label": "Non-Investment Included",
           "default": "false",
           "default_value_rationale": null
@@ -29456,7 +29456,7 @@
           "type": "boolean",
           "required": false,
           "section": "Physician",
-          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.",
+          "description": "Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.",
           "display_label": "Employee Is a Physician",
           "default": null,
           "default_value_rationale": null

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-alabama/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-alabama/metadata.yaml
@@ -62,7 +62,7 @@ fields:
     default_value_rationale: 24 months is common for non-trade-secret confidentiality obligations in employment agreements. A finite term keeps the ordinary-confidentiality obligation from reading as an indefinite restraint on using general experience; job skills alone are not a protectable interest.
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -85,7 +85,7 @@ fields:
     default_value_rationale: 12 months is the most common lookback period for employee no-hire scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -154,7 +154,7 @@ fields:
     rationale_source: editorial
   - name: nondealing_included
     type: boolean
-    description: Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -179,7 +179,7 @@ fields:
     default_value_rationale: Five percent of any class of publicly traded securities is the modal passive-investment carve-out threshold observed in benchmarked, publicly-filed employee agreements that include the carve-out (lower 1-3 percent thresholds are the common tighter alternatives). In a state whose law voids restraints except as it specifically provides, a clause forbidding ordinary public shares is gratuitous overbreadth serving no listed interest.
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-alabama/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-alabama/template.mdoc
@@ -112,11 +112,7 @@ fields:
       experience; job skills alone are not a protectable interest.
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -147,10 +143,7 @@ fields:
     default_value_rationale: 12 months is the most common lookback period for employee no-hire scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -273,12 +266,7 @@ fields:
     rationale_source: editorial
   - name: nondealing_included
     type: boolean
-    description: >-
-      Whether the no-business-with-covered-customers covenant is included. A
-      non-dealing covenant has no named Alabama category of its own, so it must
-      be drafted to fit inside the current-customer non-solicit exception or it
-      is exposed to Alabama's void rule for restraints outside the listed
-      categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -317,11 +305,7 @@ fields:
       listed interest.
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-alaska/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-alaska/metadata.yaml
@@ -67,7 +67,7 @@ fields:
     default_value_rationale: 24 months is common for non-trade-secret confidentiality obligations in employment agreements. Alaska sets no statutory term; counsel should size it to the actual sensitivity of the information.
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -90,7 +90,7 @@ fields:
     default_value_rationale: 12 months is the most common lookback period for employee non-solicitation scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -147,7 +147,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -169,7 +169,7 @@ fields:
     default_value_rationale: Five percent of any class of publicly traded securities is the modal passive-investment carve-out threshold observed in benchmarked, publicly-filed employee agreements that include the carve-out (lower 1-3 percent thresholds are the common tighter alternatives).
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -189,7 +189,7 @@ fields:
     default_value_rationale: 24 months is common for employment non-disparagement provisions.
   - name: worker_is_physician
     type: boolean
-    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.
+    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-alaska/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-alaska/template.mdoc
@@ -118,11 +118,7 @@ fields:
       it to the actual sensitivity of the information.
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -155,10 +151,7 @@ fields:
       scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -255,12 +248,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: >-
-      Whether the no-business-with-covered-customers covenant is included. A
-      non-dealing covenant has no named Alabama category of its own, so it must
-      be drafted to fit inside the current-customer non-solicit exception or it
-      is exposed to Alabama's void rule for restraints outside the listed
-      categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -288,11 +276,7 @@ fields:
       percent thresholds are the common tighter alternatives).
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -314,9 +298,7 @@ fields:
     type: boolean
     description: >-
       Whether Employee is a physician. Set this explicitly from Employee's
-      licensed role to include physician-specific terms. For Indiana, the
-      applicable provisions vary by execution date and employer type, and may
-      require a release buyout term or exclude the non-compete entirely.
+      licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-arizona/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-arizona/metadata.yaml
@@ -61,7 +61,7 @@ fields:
     default_value_rationale: Arizona sets no statutory cap, but an unlimited confidentiality covenant reaching non-secret information has been held unenforceable as the equivalent of a geographically unrestricted non-compete, so ordinary confidential information carries a finite term. 24 months is a common, conservative duration for non-trade-secret confidentiality obligations that counsel should size to the information actually protected.
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -84,7 +84,7 @@ fields:
     default_value_rationale: 12 months is the most common lookback period for employee non-solicitation scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -141,7 +141,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -163,7 +163,7 @@ fields:
     default_value_rationale: Five percent of any class of publicly traded securities is the modal passive-investment carve-out threshold observed in benchmarked, publicly-filed employee agreements that include the carve-out (lower 1-3 percent thresholds are the common tighter alternatives).
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -183,7 +183,7 @@ fields:
     default_value_rationale: 24 months is common for employment non-disparagement provisions.
   - name: worker_is_physician
     type: boolean
-    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.
+    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-arizona/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-arizona/template.mdoc
@@ -108,11 +108,7 @@ fields:
       that counsel should size to the information actually protected.
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -146,10 +142,7 @@ fields:
       scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -251,12 +244,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: >-
-      Whether the no-business-with-covered-customers covenant is included. A
-      non-dealing covenant has no named Alabama category of its own, so it must
-      be drafted to fit inside the current-customer non-solicit exception or it
-      is exposed to Alabama's void rule for restraints outside the listed
-      categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -284,11 +272,7 @@ fields:
       percent thresholds are the common tighter alternatives).
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -310,9 +294,7 @@ fields:
     type: boolean
     description: >-
       Whether Employee is a physician. Set this explicitly from Employee's
-      licensed role to include physician-specific terms. For Indiana, the
-      applicable provisions vary by execution date and employer type, and may
-      require a release buyout term or exclude the non-compete entirely.
+      licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-arkansas/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-arkansas/metadata.yaml
@@ -61,7 +61,7 @@ fields:
     default_value_rationale: 24 months is common for non-trade-secret confidentiality obligations in employment agreements. Arkansas keeps confidentiality agreements on a different track from covenants about competition or competitive work, so a finite term on non-secret information is a common-law reasonableness choice.
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -84,7 +84,7 @@ fields:
     default_value_rationale: 12 months is the most common lookback period for employee non-solicitation scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -147,7 +147,7 @@ fields:
     default_value_rationale: Empty by default because named-competitor limits are deal-specific. When supplied, naming a specific competitor group can strengthen tailoring by limiting the restraint to entities connected to the employer's business.
   - name: nondealing_included
     type: boolean
-    description: Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -172,7 +172,7 @@ fields:
     default_value_rationale: Five percent of any class of publicly traded securities is the modal passive-investment carve-out threshold observed in benchmarked, publicly-filed employee agreements that include the carve-out (lower 1-3 percent thresholds are the common tighter alternatives). A clause that forbids ordinary public shares restrains conduct that threatens no protectable interest, exactly the excess width an Arkansas court would trim.
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -195,7 +195,7 @@ fields:
     default_value_rationale: 24 months is common for employment non-disparagement provisions.
   - name: worker_is_physician
     type: boolean
-    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.
+    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-arkansas/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-arkansas/template.mdoc
@@ -102,11 +102,7 @@ fields:
       choice.
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -140,10 +136,7 @@ fields:
       scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -251,12 +244,7 @@ fields:
       limiting the restraint to entities connected to the employer's business.
   - name: nondealing_included
     type: boolean
-    description: >-
-      Whether the no-business-with-covered-customers covenant is included. A
-      non-dealing covenant has no named Alabama category of its own, so it must
-      be drafted to fit inside the current-customer non-solicit exception or it
-      is exposed to Alabama's void rule for restraints outside the listed
-      categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -294,11 +282,7 @@ fields:
       trim.
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -327,9 +311,7 @@ fields:
     type: boolean
     description: >-
       Whether Employee is a physician. Set this explicitly from Employee's
-      licensed role to include physician-specific terms. For Indiana, the
-      applicable provisions vary by execution date and employer type, and may
-      require a release buyout term or exclude the non-compete entirely.
+      licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-colorado/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-colorado/metadata.yaml
@@ -88,7 +88,7 @@ fields:
     rationale_source: editorial
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -111,7 +111,7 @@ fields:
     default_value_rationale: 12 months is the most common lookback period for employee non-solicitation scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -172,7 +172,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -194,7 +194,7 @@ fields:
     default_value_rationale: Five percent of any class of publicly traded securities is the modal passive-investment carve-out threshold observed in benchmarked, publicly-filed employee agreements that include the carve-out (lower 1-3 percent thresholds are the common tighter alternatives).
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-colorado/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-colorado/template.mdoc
@@ -162,11 +162,7 @@ fields:
     rationale_source: editorial
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -199,10 +195,7 @@ fields:
       scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -308,12 +301,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: >-
-      Whether the no-business-with-covered-customers covenant is included. A
-      non-dealing covenant has no named Alabama category of its own, so it must
-      be drafted to fit inside the current-customer non-solicit exception or it
-      is exposed to Alabama's void rule for restraints outside the listed
-      categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -341,11 +329,7 @@ fields:
       percent thresholds are the common tighter alternatives).
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-connecticut/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-connecticut/metadata.yaml
@@ -62,7 +62,7 @@ fields:
     default_value_rationale: 24 months is common for non-trade-secret confidentiality obligations in employment agreements. Connecticut's reasonableness test supports protecting confidential information for a reasonable period of time, not forever, so a finite term keeps the non-secret obligation within that reasonableness lens.
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -85,7 +85,7 @@ fields:
     default_value_rationale: 12 months is the most common lookback period for employee non-solicitation scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -145,7 +145,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -167,7 +167,7 @@ fields:
     default_value_rationale: Five percent of any class of publicly traded securities is the modal passive-investment carve-out threshold observed in benchmarked, publicly-filed employee agreements that include the carve-out (lower 1-3 percent thresholds are the common tighter alternatives). A clause that technically forbids holding index funds or ordinary public shares adds harshness the employer cannot justify under the fair-protection factor of the reasonableness test.
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-connecticut/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-connecticut/template.mdoc
@@ -127,11 +127,7 @@ fields:
       reasonableness lens.
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -164,10 +160,7 @@ fields:
       scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -281,12 +274,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: >-
-      Whether the no-business-with-covered-customers covenant is included. A
-      non-dealing covenant has no named Alabama category of its own, so it must
-      be drafted to fit inside the current-customer non-solicit exception or it
-      is exposed to Alabama's void rule for restraints outside the listed
-      categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -317,11 +305,7 @@ fields:
       the reasonableness test.
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-delaware/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-delaware/metadata.yaml
@@ -60,7 +60,7 @@ fields:
     default_value_rationale: 24 months is common for non-trade-secret confidentiality obligations in employment agreements.
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -83,7 +83,7 @@ fields:
     default_value_rationale: 12 months is the most common lookback period for employee non-solicitation scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -140,7 +140,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -162,7 +162,7 @@ fields:
     default_value_rationale: Five percent of any class of publicly traded securities is the modal passive-investment carve-out threshold observed in benchmarked, publicly-filed employee agreements that include the carve-out (lower 1-3 percent thresholds are the common tighter alternatives).
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -182,7 +182,7 @@ fields:
     default_value_rationale: 24 months is common for employment non-disparagement provisions.
   - name: worker_is_physician
     type: boolean
-    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.
+    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-delaware/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-delaware/template.mdoc
@@ -103,11 +103,7 @@ fields:
       employment agreements.
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -140,10 +136,7 @@ fields:
       scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -244,12 +237,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: >-
-      Whether the no-business-with-covered-customers covenant is included. A
-      non-dealing covenant has no named Alabama category of its own, so it must
-      be drafted to fit inside the current-customer non-solicit exception or it
-      is exposed to Alabama's void rule for restraints outside the listed
-      categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -277,11 +265,7 @@ fields:
       percent thresholds are the common tighter alternatives).
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -303,9 +287,7 @@ fields:
     type: boolean
     description: >-
       Whether Employee is a physician. Set this explicitly from Employee's
-      licensed role to include physician-specific terms. For Indiana, the
-      applicable provisions vary by execution date and employer type, and may
-      require a release buyout term or exclude the non-compete entirely.
+      licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-district-of-columbia/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-district-of-columbia/metadata.yaml
@@ -78,7 +78,7 @@ fields:
     rationale_source: editorial
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -101,7 +101,7 @@ fields:
     default_value_rationale: 12 months is the most common lookback period for employee non-solicitation scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-district-of-columbia/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-district-of-columbia/template.mdoc
@@ -168,11 +168,7 @@ fields:
     rationale_source: editorial
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -205,10 +201,7 @@ fields:
       scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-florida/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-florida/metadata.yaml
@@ -84,7 +84,7 @@ fields:
     section: Confidentiality
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -107,7 +107,7 @@ fields:
     section: Employee Non-Solicitation
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -166,7 +166,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -188,7 +188,7 @@ fields:
     section: Definitions
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -208,7 +208,7 @@ fields:
     section: Non-Disparagement
   - name: worker_is_physician
     type: boolean
-    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.
+    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-florida/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-florida/template.mdoc
@@ -282,11 +282,7 @@ fields:
     section: Confidentiality
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -318,10 +314,7 @@ fields:
     section: Employee Non-Solicitation
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -411,12 +404,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: >-
-      Whether the no-business-with-covered-customers covenant is included. A
-      non-dealing covenant has no named Alabama category of its own, so it must
-      be drafted to fit inside the current-customer non-solicit exception or it
-      is exposed to Alabama's void rule for restraints outside the listed
-      categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -444,11 +432,7 @@ fields:
     section: Definitions
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -482,9 +466,7 @@ fields:
     type: boolean
     description: >-
       Whether Employee is a physician. Set this explicitly from Employee's
-      licensed role to include physician-specific terms. For Indiana, the
-      applicable provisions vary by execution date and employer type, and may
-      require a release buyout term or exclude the non-compete entirely.
+      licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-georgia/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-georgia/metadata.yaml
@@ -80,7 +80,7 @@ fields:
     requirement_id: REQ-labor-and-employment-law.restrictive-covenant-agreement.georgia.allow-confidentiality-to-run-while-information-remains-protected
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -104,7 +104,7 @@ fields:
     rationale_source: editorial
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -168,7 +168,7 @@ fields:
     rationale_source: editorial
   - name: nondealing_included
     type: boolean
-    description: Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -190,7 +190,7 @@ fields:
     default_value_rationale: Five percent of any class of publicly traded securities is the modal passive-investment carve-out threshold observed in benchmarked, publicly-filed employee agreements that include the carve-out (lower 1-3 percent thresholds are the common tighter alternatives) and keeps ordinary public shares and index funds out of the scope of prohibited activities the Act weighs for reasonableness.
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -210,7 +210,7 @@ fields:
     default_value_rationale: 24 months is common for employment non-disparagement provisions.
   - name: worker_is_physician
     type: boolean
-    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.
+    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-georgia/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-georgia/template.mdoc
@@ -148,11 +148,7 @@ fields:
       REQ-labor-and-employment-law.restrictive-covenant-agreement.georgia.allow-confidentiality-to-run-while-information-remains-protected
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -186,10 +182,7 @@ fields:
     rationale_source: editorial
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -294,12 +287,7 @@ fields:
     rationale_source: editorial
   - name: nondealing_included
     type: boolean
-    description: >-
-      Whether the no-business-with-covered-customers covenant is included. A
-      non-dealing covenant has no named Alabama category of its own, so it must
-      be drafted to fit inside the current-customer non-solicit exception or it
-      is exposed to Alabama's void rule for restraints outside the listed
-      categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -329,11 +317,7 @@ fields:
       the Act weighs for reasonableness.
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -355,9 +339,7 @@ fields:
     type: boolean
     description: >-
       Whether Employee is a physician. Set this explicitly from Employee's
-      licensed role to include physician-specific terms. For Indiana, the
-      applicable provisions vary by execution date and employer type, and may
-      require a release buyout term or exclude the non-compete entirely.
+      licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-hawaii/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-hawaii/metadata.yaml
@@ -69,7 +69,7 @@ fields:
     default_value_rationale: Conservative default. Coverage keys to the EMPLOYER'S revenue mix, not the worker's job title; confirm whether the employing entity derives the majority of its gross income from software or information technology development before including any non-compete or employee non-solicit.
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -93,7 +93,7 @@ fields:
     default_value_rationale: 12 months is a common lookback period. It keeps the covered class tethered to colleagues the departing worker actually worked with, which supports the legitimate ancillary purpose the covenant needs under Hawaii law.
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -145,14 +145,14 @@ fields:
     section: Non-Competition
   - name: specified_competitors
     type: string
-    description: 'Optional named list of specific competitors. Alabama rewards specificity: the protectable-interest list speaks in terms of specific customers and concrete relationships, and a covenant drawn to named threats is easier to defend as protecting a listed interest than one leaning on an open-ended competitive-business definition.'
+    description: Optional named list of specific competitors.
     display_label: Specified Competitors
     default: ''
     section: Non-Competition
     rationale_source: editorial
   - name: nondealing_included
     type: boolean
-    description: Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -175,7 +175,7 @@ fields:
     default_value_rationale: Five percent of any class of publicly traded securities is the modal passive-investment carve-out threshold observed in benchmarked, publicly-filed employee agreements that include the carve-out (lower 1-3 percent thresholds are the common tighter alternatives), and a carve-out avoids adding undue hardship — one of the three Traeger grounds of unreasonableness — with no protected interest behind it.
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -196,7 +196,7 @@ fields:
     default_value_rationale: 24 months is common for employment non-disparagement provisions.
   - name: worker_is_physician
     type: boolean
-    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.
+    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-hawaii/template-annotated.md
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-hawaii/template-annotated.md
@@ -56,7 +56,7 @@ Competitive Business
 : [Description of the business activities that constitute competition with the employer.]
 
 Specified Competitors
-: [Optional named list of specific competitors. Alabama rewards specificity: the protectable-interest list speaks in terms of specific customers and concrete relationships, and a covenant drawn to named threats is easier to defend as protecting a listed interest than one leaning on an open-ended competitive-business definition.]
+: [Optional named list of specific competitors.]
 
 No Business with Covered Customers
 

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-hawaii/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-hawaii/template.mdoc
@@ -122,11 +122,7 @@ fields:
       development before including any non-compete or employee non-solicit.
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -162,10 +158,7 @@ fields:
       the legitimate ancillary purpose the covenant needs under Hawaii law.
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -254,24 +247,14 @@ fields:
     section: Non-Competition
   - name: specified_competitors
     type: string
-    description: >-
-      Optional named list of specific competitors. Alabama rewards specificity:
-      the protectable-interest list speaks in terms of specific customers and
-      concrete relationships, and a covenant drawn to named threats is easier to
-      defend as protecting a listed interest than one leaning on an open-ended
-      competitive-business definition.
+    description: Optional named list of specific competitors.
     display_label: Specified Competitors
     default: ''
     section: Non-Competition
     rationale_source: editorial
   - name: nondealing_included
     type: boolean
-    description: >-
-      Whether the no-business-with-covered-customers covenant is included. A
-      non-dealing covenant has no named Alabama category of its own, so it must
-      be drafted to fit inside the current-customer non-solicit exception or it
-      is exposed to Alabama's void rule for restraints outside the listed
-      categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -305,11 +288,7 @@ fields:
       unreasonableness — with no protected interest behind it.
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -335,9 +314,7 @@ fields:
     type: boolean
     description: >-
       Whether Employee is a physician. Set this explicitly from Employee's
-      licensed role to include physician-specific terms. For Indiana, the
-      applicable provisions vary by execution date and employer type, and may
-      require a release buyout term or exclude the non-compete entirely.
+      licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-idaho/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-idaho/metadata.yaml
@@ -60,7 +60,7 @@ fields:
     default_value_rationale: 24 months is common for non-trade-secret confidentiality obligations in employment agreements. Keeping ordinary confidential information on a finite, separate track from the perpetual trade-secret obligation avoids a perpetual lid on non-secret information that an Idaho court could treat as a disguised restraint.
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -83,7 +83,7 @@ fields:
     default_value_rationale: 12 months is the most common lookback period for employee non-solicitation scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -154,7 +154,7 @@ fields:
     default_value_rationale: Idaho admits no circumstance in which a direct-competition restriction exceeds eighteen months absent consideration beyond employment, while continued at-will employment is sufficient inside the window. Counsel should replace this with the specific negotiated benefit whenever the term exceeds eighteen months.
   - name: nondealing_included
     type: boolean
-    description: Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -177,7 +177,7 @@ fields:
     default_value_rationale: Five percent of any class of publicly traded securities is the modal passive-investment carve-out threshold observed in benchmarked, publicly-filed employee agreements that include the carve-out (lower 1-3 percent thresholds are the common tighter alternatives), and it helps keep the covenant from restraining more than reasonably necessary.
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-idaho/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-idaho/template.mdoc
@@ -99,11 +99,7 @@ fields:
       a disguised restraint.
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -135,10 +131,7 @@ fields:
       scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -270,12 +263,7 @@ fields:
       exceeds eighteen months.
   - name: nondealing_included
     type: boolean
-    description: >-
-      Whether the no-business-with-covered-customers covenant is included. A
-      non-dealing covenant has no named Alabama category of its own, so it must
-      be drafted to fit inside the current-customer non-solicit exception or it
-      is exposed to Alabama's void rule for restraints outside the listed
-      categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -308,11 +296,7 @@ fields:
       the covenant from restraining more than reasonably necessary.
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-illinois/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-illinois/metadata.yaml
@@ -60,7 +60,7 @@ fields:
     default_value_rationale: 24 months is common for non-trade-secret confidentiality obligations in employment agreements.
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -83,7 +83,7 @@ fields:
     default_value_rationale: 12 months is the most common lookback period for employee non-solicitation scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -151,7 +151,7 @@ fields:
     default_value_rationale: The default recites the access-to-confidential-information and compensation that the agreement itself provides and expressly ties them to the covenants, addressing Illinois' express-delineation requirement. Counsel should replace it with the specific negotiated benefit, or rely on the two-year continued-employment benchmark, as appropriate.
   - name: nondealing_included
     type: boolean
-    description: Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -173,7 +173,7 @@ fields:
     default_value_rationale: Five percent of any class of publicly traded securities is the modal passive-investment carve-out threshold observed in benchmarked, publicly-filed employee agreements that include the carve-out (lower 1-3 percent thresholds are the common tighter alternatives).
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-illinois/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-illinois/template.mdoc
@@ -93,11 +93,7 @@ fields:
       employment agreements.
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -129,10 +125,7 @@ fields:
       scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -256,12 +249,7 @@ fields:
       the two-year continued-employment benchmark, as appropriate.
   - name: nondealing_included
     type: boolean
-    description: >-
-      Whether the no-business-with-covered-customers covenant is included. A
-      non-dealing covenant has no named Alabama category of its own, so it must
-      be drafted to fit inside the current-customer non-solicit exception or it
-      is exposed to Alabama's void rule for restraints outside the listed
-      categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -289,11 +277,7 @@ fields:
       percent thresholds are the common tighter alternatives).
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-indiana/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-indiana/metadata.yaml
@@ -60,7 +60,7 @@ fields:
     default_value_rationale: 24 months is common for non-trade-secret confidentiality obligations in employment agreements. A perpetual lid on non-secret information is the kind of unreasonable reach an Indiana court will not enforce, and because the eraser blue pencil cannot rewrite an overbroad term, the finite other-confidential track is kept severable from the perpetual trade-secret track.
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -83,7 +83,7 @@ fields:
     default_value_rationale: '12 months is the most common lookback period for employee non-solicitation scope. In Indiana this look-back is load-bearing: Heraeus voided an employee non-solicitation covenant that reached all of the company''s employees, and the eraser rule means a court cannot rewrite an all-employees class into a narrower one.'
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -140,7 +140,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -162,7 +162,7 @@ fields:
     default_value_rationale: Five percent of any class of publicly traded securities is the modal passive-investment carve-out threshold observed in benchmarked, publicly-filed employee agreements that include the carve-out (lower 1-3 percent thresholds are the common tighter alternatives). A clause that technically forbids holding index funds or ordinary public shares is gratuitous overbreadth an Indiana court will not soften by rewriting.
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -182,7 +182,7 @@ fields:
     default_value_rationale: 24 months is common for employment non-disparagement provisions.
   - name: worker_is_physician
     type: boolean
-    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.
+    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
   - name: physician_buyout_price

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-indiana/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-indiana/template.mdoc
@@ -116,11 +116,7 @@ fields:
       track.
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -156,10 +152,7 @@ fields:
       all-employees class into a narrower one.
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -259,12 +252,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: >-
-      Whether the no-business-with-covered-customers covenant is included. A
-      non-dealing covenant has no named Alabama category of its own, so it must
-      be drafted to fit inside the current-customer non-solicit exception or it
-      is exposed to Alabama's void rule for restraints outside the listed
-      categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -294,11 +282,7 @@ fields:
       gratuitous overbreadth an Indiana court will not soften by rewriting.
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -320,9 +304,7 @@ fields:
     type: boolean
     description: >-
       Whether Employee is a physician. Set this explicitly from Employee's
-      licensed role to include physician-specific terms. For Indiana, the
-      applicable provisions vary by execution date and employer type, and may
-      require a release buyout term or exclude the non-compete entirely.
+      licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
   - name: physician_buyout_price

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-iowa/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-iowa/metadata.yaml
@@ -60,7 +60,7 @@ fields:
     default_value_rationale: 24 months is common for non-trade-secret confidentiality obligations in employment agreements.
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -83,7 +83,7 @@ fields:
     default_value_rationale: 12 months is the most common lookback period for employee non-solicitation scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -140,7 +140,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -162,7 +162,7 @@ fields:
     default_value_rationale: Five percent of any class of publicly traded securities is the modal passive-investment carve-out threshold observed in benchmarked, publicly-filed employee agreements that include the carve-out (lower 1-3 percent thresholds are the common tighter alternatives).
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -182,7 +182,7 @@ fields:
     default_value_rationale: 24 months is common for employment non-disparagement provisions.
   - name: worker_is_physician
     type: boolean
-    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.
+    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-iowa/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-iowa/template.mdoc
@@ -104,11 +104,7 @@ fields:
       employment agreements.
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -141,10 +137,7 @@ fields:
       scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -245,12 +238,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: >-
-      Whether the no-business-with-covered-customers covenant is included. A
-      non-dealing covenant has no named Alabama category of its own, so it must
-      be drafted to fit inside the current-customer non-solicit exception or it
-      is exposed to Alabama's void rule for restraints outside the listed
-      categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -278,11 +266,7 @@ fields:
       percent thresholds are the common tighter alternatives).
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -304,9 +288,7 @@ fields:
     type: boolean
     description: >-
       Whether Employee is a physician. Set this explicitly from Employee's
-      licensed role to include physician-specific terms. For Indiana, the
-      applicable provisions vary by execution date and employer type, and may
-      require a release buyout term or exclude the non-compete entirely.
+      licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-kansas/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-kansas/metadata.yaml
@@ -60,7 +60,7 @@ fields:
     default_value_rationale: 24 months is common for non-trade-secret confidentiality obligations in employment agreements. Kansas protects non-trade-secret information by contract alone (K.S.A. 60-3326(b)(1)), and a contract term is enforced only as far as it is reasonable, so a finite period is easier to defend than a perpetual lid on ordinary confidential information.
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -83,7 +83,7 @@ fields:
     default_value_rationale: 12 months is the most common lookback period for employee non-solicitation scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -144,7 +144,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -167,7 +167,7 @@ fields:
     default_value_rationale: Five percent of any class of publicly traded securities is the modal passive-investment carve-out threshold observed in benchmarked, publicly-filed employee agreements that include the carve-out (lower 1-3 percent thresholds are the common tighter alternatives).
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -187,7 +187,7 @@ fields:
     default_value_rationale: 24 months is common for employment non-disparagement provisions.
   - name: worker_is_physician
     type: boolean
-    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.
+    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-kansas/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-kansas/template.mdoc
@@ -108,11 +108,7 @@ fields:
       than a perpetual lid on ordinary confidential information.
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -146,10 +142,7 @@ fields:
       scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -258,12 +251,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: >-
-      Whether the no-business-with-covered-customers covenant is included. A
-      non-dealing covenant has no named Alabama category of its own, so it must
-      be drafted to fit inside the current-customer non-solicit exception or it
-      is exposed to Alabama's void rule for restraints outside the listed
-      categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -298,11 +286,7 @@ fields:
       percent thresholds are the common tighter alternatives).
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -324,9 +308,7 @@ fields:
     type: boolean
     description: >-
       Whether Employee is a physician. Set this explicitly from Employee's
-      licensed role to include physician-specific terms. For Indiana, the
-      applicable provisions vary by execution date and employer type, and may
-      require a release buyout term or exclude the non-compete entirely.
+      licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-kentucky/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-kentucky/metadata.yaml
@@ -75,7 +75,7 @@ fields:
     default_value_rationale: 24 months is common for non-trade-secret confidentiality obligations in employment agreements.
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -98,7 +98,7 @@ fields:
     default_value_rationale: 12 months is the most common lookback period for employee non-solicitation scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -159,7 +159,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -181,7 +181,7 @@ fields:
     default_value_rationale: Five percent of any class of publicly traded securities is the modal passive-investment carve-out threshold observed in benchmarked, publicly-filed employee agreements that include the carve-out (lower 1-3 percent thresholds are the common tighter alternatives).
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -201,7 +201,7 @@ fields:
     default_value_rationale: 24 months is common for employment non-disparagement provisions.
   - name: worker_is_physician
     type: boolean
-    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.
+    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-kentucky/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-kentucky/template.mdoc
@@ -131,11 +131,7 @@ fields:
       employment agreements.
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -168,10 +164,7 @@ fields:
       scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -278,12 +271,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: >-
-      Whether the no-business-with-covered-customers covenant is included. A
-      non-dealing covenant has no named Alabama category of its own, so it must
-      be drafted to fit inside the current-customer non-solicit exception or it
-      is exposed to Alabama's void rule for restraints outside the listed
-      categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -311,11 +299,7 @@ fields:
       percent thresholds are the common tighter alternatives).
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -337,9 +321,7 @@ fields:
     type: boolean
     description: >-
       Whether Employee is a physician. Set this explicitly from Employee's
-      licensed role to include physician-specific terms. For Indiana, the
-      applicable provisions vary by execution date and employer type, and may
-      require a release buyout term or exclude the non-compete entirely.
+      licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-louisiana/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-louisiana/metadata.yaml
@@ -62,7 +62,7 @@ fields:
     default_value_rationale: 24 months is common for non-trade-secret confidentiality obligations in employment agreements. In Louisiana a confidentiality lid so broad that honoring it would keep the worker from working in the field risks reading as a restraint on a lawful profession under La. R.S. 23:921(A)(1), so a finite term is preferable to everything-forever.
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -85,7 +85,7 @@ fields:
     default_value_rationale: 12 months is the most common lookback period for employee non-solicitation scope, and a class kept to colleagues the departing worker actually worked with supports the Farris reasonableness requirement.
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -116,10 +116,10 @@ fields:
     default_value_rationale: Left for counsel to enumerate. A mileage radius or a catch-all reaching anywhere the employer operates does not satisfy the statute, and because Louisiana courts sever rather than rewrite, an overbroad territory is struck, not trimmed to fit.
   - name: noncompete_included
     type: boolean
-    description: Whether the non-competition covenant is included. Under Alabama law an employee may agree to a geographically limited non-compete; this template recites the employee-exception basis, ties the covenant to a listed protectable interest, and biases the duration into the two-year presumptively reasonable window.
+    description: Whether the non-competition covenant is included.
     display_label: Non-Competition Included
     section: Non-Competition
-    default_value_rationale: Conservative default. Non-competes are the most heavily scrutinized covenant; include only after confirming the restraint fits Alabama's employee exception for a specified geographic area, a competing business, and an existing employment relationship; protects a listed interest; stays within the two-year presumption; will be signed by all parties, including the employer; and does not restrain a member of a recognized profession from practicing that profession. The party seeking enforcement bears the burden of proof on every element.
+    default_value_rationale: Conservative default. Non-competes are the most heavily scrutinized covenant; include only after confirming enforceability under the agreement's governing law and tailoring the restraint to a legitimate protectable interest.
     rationale_source: editorial
     default: false
   - name: noncompete_duration
@@ -144,7 +144,7 @@ fields:
     section: Non-Competition
   - name: worker_is_physician
     type: boolean
-    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.
+    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
   - name: worker_is_real_estate_licensee
@@ -155,7 +155,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -178,7 +178,7 @@ fields:
     default_value_rationale: Five percent of any class of publicly traded securities is the modal passive-investment carve-out threshold observed in benchmarked, publicly-filed employee agreements that include the carve-out (lower 1-3 percent thresholds are the common tighter alternatives). A clause forbidding ordinary public shares would restrain more than the statutory exception describes.
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-louisiana/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-louisiana/template.mdoc
@@ -113,11 +113,7 @@ fields:
       finite term is preferable to everything-forever.
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -153,10 +149,7 @@ fields:
       with supports the Farris reasonableness requirement.
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -209,23 +202,14 @@ fields:
       struck, not trimmed to fit.
   - name: noncompete_included
     type: boolean
-    description: >-
-      Whether the non-competition covenant is included. Under Alabama law an
-      employee may agree to a geographically limited non-compete; this template
-      recites the employee-exception basis, ties the covenant to a listed
-      protectable interest, and biases the duration into the two-year
-      presumptively reasonable window.
+    description: Whether the non-competition covenant is included.
     display_label: Non-Competition Included
     section: Non-Competition
     default_value_rationale: >-
       Conservative default. Non-competes are the most heavily scrutinized
-      covenant; include only after confirming the restraint fits Alabama's
-      employee exception for a specified geographic area, a competing business,
-      and an existing employment relationship; protects a listed interest; stays
-      within the two-year presumption; will be signed by all parties, including
-      the employer; and does not restrain a member of a recognized profession
-      from practicing that profession. The party seeking enforcement bears the
-      burden of proof on every element.
+      covenant; include only after confirming enforceability under the
+      agreement's governing law and tailoring the restraint to a legitimate
+      protectable interest.
     rationale_source: editorial
     default: false
   - name: noncompete_duration
@@ -266,9 +250,7 @@ fields:
     type: boolean
     description: >-
       Whether Employee is a physician. Set this explicitly from Employee's
-      licensed role to include physician-specific terms. For Indiana, the
-      applicable provisions vary by execution date and employer type, and may
-      require a release buyout term or exclude the non-compete entirely.
+      licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
   - name: worker_is_real_estate_licensee
@@ -283,12 +265,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: >-
-      Whether the no-business-with-covered-customers covenant is included. A
-      non-dealing covenant has no named Alabama category of its own, so it must
-      be drafted to fit inside the current-customer non-solicit exception or it
-      is exposed to Alabama's void rule for restraints outside the listed
-      categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -322,11 +299,7 @@ fields:
       exception describes.
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-maine/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-maine/metadata.yaml
@@ -103,7 +103,7 @@ fields:
     default_value_rationale: 24 months is common for non-trade-secret confidentiality obligations in employment agreements. Maine enforces confidentiality covenants that protect specialized proprietary work while leaving general skill and knowledge free, so a finite term keeps the non-secret obligation within that line.
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -126,7 +126,7 @@ fields:
     default_value_rationale: 12 months is the most common lookback period for employee non-solicitation scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -187,7 +187,7 @@ fields:
     rationale_source: editorial
   - name: nondealing_included
     type: boolean
-    description: Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -209,7 +209,7 @@ fields:
     default_value_rationale: Five percent of any class of publicly traded securities is the modal passive-investment carve-out threshold observed in benchmarked, publicly-filed employee agreements that include the carve-out (lower 1-3 percent thresholds are the common tighter alternatives).
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-maine/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-maine/template.mdoc
@@ -194,11 +194,7 @@ fields:
       that line.
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -231,10 +227,7 @@ fields:
       scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -343,12 +336,7 @@ fields:
     rationale_source: editorial
   - name: nondealing_included
     type: boolean
-    description: >-
-      Whether the no-business-with-covered-customers covenant is included. A
-      non-dealing covenant has no named Alabama category of its own, so it must
-      be drafted to fit inside the current-customer non-solicit exception or it
-      is exposed to Alabama's void rule for restraints outside the listed
-      categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -376,11 +364,7 @@ fields:
       percent thresholds are the common tighter alternatives).
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-maryland/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-maryland/metadata.yaml
@@ -65,7 +65,7 @@ fields:
     default_value_rationale: 24 months is common for non-trade-secret confidentiality obligations in employment agreements. A finite term keeps the non-secret obligation sized to the interest behind it, since a perpetual lid on non-secret information reads as overbreadth under the Becker reasonableness test.
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -88,7 +88,7 @@ fields:
     default_value_rationale: 12 months is the most common lookback period for employee non-solicitation scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -147,7 +147,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -169,7 +169,7 @@ fields:
     default_value_rationale: Five percent of any class of publicly traded securities is the modal passive-investment carve-out threshold observed in benchmarked, publicly-filed employee agreements that include the carve-out (lower 1-3 percent thresholds are the common tighter alternatives), and a clause forbidding ordinary index funds and public shares is gratuitous overbreadth that hands the employee an argument for free.
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-maryland/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-maryland/template.mdoc
@@ -125,11 +125,7 @@ fields:
       reads as overbreadth under the Becker reasonableness test.
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -162,10 +158,7 @@ fields:
       scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -270,12 +263,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: >-
-      Whether the no-business-with-covered-customers covenant is included. A
-      non-dealing covenant has no named Alabama category of its own, so it must
-      be drafted to fit inside the current-customer non-solicit exception or it
-      is exposed to Alabama's void rule for restraints outside the listed
-      categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -305,11 +293,7 @@ fields:
       overbreadth that hands the employee an argument for free.
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-massachusetts/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-massachusetts/metadata.yaml
@@ -60,7 +60,7 @@ fields:
     default_value_rationale: 24 months is common for non-trade-secret confidentiality obligations in employment agreements.
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -83,7 +83,7 @@ fields:
     default_value_rationale: 12 months is the most common lookback period for employee non-solicitation scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -152,7 +152,7 @@ fields:
     default_value_rationale: The 50%-of-base-salary garden leave clause is the only consideration the Noncompetition Agreement Act defines, so it is the conservative default. Counsel should confirm the amount and may substitute other mutually-agreed upon consideration sized against this benchmark; the enforceability of a smaller fixed sum is unsettled.
   - name: nondealing_included
     type: boolean
-    description: Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -174,7 +174,7 @@ fields:
     default_value_rationale: Five percent of any class of publicly traded securities is the modal passive-investment carve-out threshold observed in benchmarked, publicly-filed employee agreements that include the carve-out (lower 1-3 percent thresholds are the common tighter alternatives).
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -194,7 +194,7 @@ fields:
     default_value_rationale: 24 months is common for employment non-disparagement provisions.
   - name: worker_is_physician
     type: boolean
-    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.
+    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-massachusetts/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-massachusetts/template.mdoc
@@ -120,11 +120,7 @@ fields:
       employment agreements.
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -157,10 +153,7 @@ fields:
       scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -281,12 +274,7 @@ fields:
       smaller fixed sum is unsettled.
   - name: nondealing_included
     type: boolean
-    description: >-
-      Whether the no-business-with-covered-customers covenant is included. A
-      non-dealing covenant has no named Alabama category of its own, so it must
-      be drafted to fit inside the current-customer non-solicit exception or it
-      is exposed to Alabama's void rule for restraints outside the listed
-      categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -314,11 +302,7 @@ fields:
       percent thresholds are the common tighter alternatives).
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -371,9 +355,7 @@ fields:
     type: boolean
     description: >-
       Whether Employee is a physician. Set this explicitly from Employee's
-      licensed role to include physician-specific terms. For Indiana, the
-      applicable provisions vary by execution date and employer type, and may
-      require a release buyout term or exclude the non-compete entirely.
+      licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-michigan/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-michigan/metadata.yaml
@@ -61,7 +61,7 @@ fields:
     default_value_rationale: 24 months is common for non-trade-secret confidentiality obligations in employment agreements. Michigan enforces confidentiality-based restraints only to the extent they provide reasonable protection for the employer's confidential information, so a finite term for non-secret information is the defensible posture.
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -84,7 +84,7 @@ fields:
     default_value_rationale: 12 months is the most common lookback period for employee non-solicitation scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -153,7 +153,7 @@ fields:
     default_value_rationale: The default recites continued at-will employment plus the compensation and confidential-information access the agreement itself provides. Continued employment is sufficient only where the worker is genuinely at will; counsel should replace it with a specific negotiated benefit (a raise, bonus, promotion, or new confidential access) whenever the worker has just-cause protection or an employment contract.
   - name: nondealing_included
     type: boolean
-    description: Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -175,7 +175,7 @@ fields:
     default_value_rationale: Five percent of any class of publicly traded securities is the modal passive-investment carve-out threshold observed in benchmarked, publicly-filed employee agreements that include the carve-out (lower 1-3 percent thresholds are the common tighter alternatives).
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -195,7 +195,7 @@ fields:
     default_value_rationale: 24 months is common for employment non-disparagement provisions.
   - name: worker_is_physician
     type: boolean
-    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.
+    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-michigan/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-michigan/template.mdoc
@@ -104,11 +104,7 @@ fields:
       the defensible posture.
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -142,10 +138,7 @@ fields:
       scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -277,12 +270,7 @@ fields:
       just-cause protection or an employment contract.
   - name: nondealing_included
     type: boolean
-    description: >-
-      Whether the no-business-with-covered-customers covenant is included. A
-      non-dealing covenant has no named Alabama category of its own, so it must
-      be drafted to fit inside the current-customer non-solicit exception or it
-      is exposed to Alabama's void rule for restraints outside the listed
-      categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -310,11 +298,7 @@ fields:
       percent thresholds are the common tighter alternatives).
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -336,9 +320,7 @@ fields:
     type: boolean
     description: >-
       Whether Employee is a physician. Set this explicitly from Employee's
-      licensed role to include physician-specific terms. For Indiana, the
-      applicable provisions vary by execution date and employer type, and may
-      require a release buyout term or exclude the non-compete entirely.
+      licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-mississippi/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-mississippi/metadata.yaml
@@ -60,7 +60,7 @@ fields:
     default_value_rationale: 24 months is common for non-trade-secret confidentiality obligations in employment agreements. Mississippi weighs a perpetual lid on ordinary business information against the employee's freedom to work, so a finite term is safer than an indefinite one.
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -83,7 +83,7 @@ fields:
     default_value_rationale: 12 months is the most common lookback period for employee non-solicitation scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -140,7 +140,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -162,7 +162,7 @@ fields:
     default_value_rationale: Five percent of any class of publicly traded securities is the modal passive-investment carve-out threshold observed in benchmarked, publicly-filed employee agreements that include the carve-out (lower 1-3 percent thresholds are the common tighter alternatives).
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -182,7 +182,7 @@ fields:
     default_value_rationale: 24 months is common for employment non-disparagement provisions.
   - name: worker_is_physician
     type: boolean
-    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.
+    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-mississippi/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-mississippi/template.mdoc
@@ -115,11 +115,7 @@ fields:
       term is safer than an indefinite one.
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -153,10 +149,7 @@ fields:
       scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -261,12 +254,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: >-
-      Whether the no-business-with-covered-customers covenant is included. A
-      non-dealing covenant has no named Alabama category of its own, so it must
-      be drafted to fit inside the current-customer non-solicit exception or it
-      is exposed to Alabama's void rule for restraints outside the listed
-      categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -294,11 +282,7 @@ fields:
       percent thresholds are the common tighter alternatives).
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -320,9 +304,7 @@ fields:
     type: boolean
     description: >-
       Whether Employee is a physician. Set this explicitly from Employee's
-      licensed role to include physician-specific terms. For Indiana, the
-      applicable provisions vary by execution date and employer type, and may
-      require a release buyout term or exclude the non-compete entirely.
+      licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-missouri/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-missouri/metadata.yaml
@@ -69,7 +69,7 @@ fields:
     default_value_rationale: 24 months is common for non-trade-secret confidentiality obligations in employment agreements.
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -92,7 +92,7 @@ fields:
     default_value_rationale: 12 months is the most common lookback period for employee non-solicitation scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -151,7 +151,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -173,7 +173,7 @@ fields:
     default_value_rationale: Five percent of any class of publicly traded securities is the modal passive-investment carve-out threshold observed in benchmarked, publicly-filed employee agreements that include the carve-out (lower 1-3 percent thresholds are the common tighter alternatives).
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -193,7 +193,7 @@ fields:
     default_value_rationale: 24 months is common for employment non-disparagement provisions.
   - name: worker_is_physician
     type: boolean
-    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.
+    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-missouri/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-missouri/template.mdoc
@@ -128,11 +128,7 @@ fields:
       employment agreements.
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -165,10 +161,7 @@ fields:
       scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -272,12 +265,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: >-
-      Whether the no-business-with-covered-customers covenant is included. A
-      non-dealing covenant has no named Alabama category of its own, so it must
-      be drafted to fit inside the current-customer non-solicit exception or it
-      is exposed to Alabama's void rule for restraints outside the listed
-      categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -305,11 +293,7 @@ fields:
       percent thresholds are the common tighter alternatives).
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -331,9 +315,7 @@ fields:
     type: boolean
     description: >-
       Whether Employee is a physician. Set this explicitly from Employee's
-      licensed role to include physician-specific terms. For Indiana, the
-      applicable provisions vary by execution date and employer type, and may
-      require a release buyout term or exclude the non-compete entirely.
+      licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-montana/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-montana/metadata.yaml
@@ -70,7 +70,7 @@ fields:
     default_value_rationale: The default recites the access-to-confidential-information and compensation the agreement itself provides and ties them to the covenants, addressing Montana's independent-consideration requirement for post-hire covenants. Counsel should replace it with the specific negotiated benefit, or rely on the job offer where the covenant is signed as part of pre-employment negotiations.
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -93,7 +93,7 @@ fields:
     default_value_rationale: A relationship-based class keyed to a recent lookback keeps the restraint partial rather than a workforce-wide hiring ban.
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -151,7 +151,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -174,7 +174,7 @@ fields:
     default_value_rationale: Five percent of any class of publicly traded securities is the modal passive-investment carve-out threshold observed in benchmarked, publicly-filed employee agreements that include the carve-out (lower 1-3 percent thresholds are the common tighter alternatives); a clause that forbids ordinary public shares restricts more than any protectable interest requires and pushes a Montana covenant toward the void column.
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-montana/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-montana/template.mdoc
@@ -133,11 +133,7 @@ fields:
       pre-employment negotiations.
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -171,10 +167,7 @@ fields:
       partial rather than a workforce-wide hiring ban.
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -272,12 +265,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: >-
-      Whether the no-business-with-covered-customers covenant is included. A
-      non-dealing covenant has no named Alabama category of its own, so it must
-      be drafted to fit inside the current-customer non-solicit exception or it
-      is exposed to Alabama's void rule for restraints outside the listed
-      categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -311,11 +299,7 @@ fields:
       interest requires and pushes a Montana covenant toward the void column.
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-nebraska/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-nebraska/metadata.yaml
@@ -63,7 +63,7 @@ fields:
     default_value_rationale: 24 months is common for non-trade-secret confidentiality obligations in employment agreements. Nebraska measures every restraint against what is reasonably necessary and refuses to trim the excess, so a finite term keeps an open-ended lid on non-secret information from reading as unjustified breadth.
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -86,7 +86,7 @@ fields:
     default_value_rationale: 12 months is the most common lookback period for employee non-solicitation scope; keeping the class to colleagues the worker actually worked with makes it easier to defend as protecting a legitimate interest.
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -141,7 +141,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -164,7 +164,7 @@ fields:
     default_value_rationale: Five percent of any class of publicly traded securities is the modal passive-investment carve-out threshold observed in benchmarked, publicly-filed employee agreements that include the carve-out (lower 1-3 percent thresholds are the common tighter alternatives). A clause that technically forbids holding ordinary public shares restrains the worker far beyond any customer relationship or secret, which Nebraska's third requirement — undue harshness on the employee — counts against the covenant.
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -185,7 +185,7 @@ fields:
     default_value_rationale: 24 months is common for employment non-disparagement provisions.
   - name: worker_is_physician
     type: boolean
-    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.
+    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-nebraska/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-nebraska/template.mdoc
@@ -129,11 +129,7 @@ fields:
       unjustified breadth.
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -168,10 +164,7 @@ fields:
       makes it easier to defend as protecting a legitimate interest.
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -275,12 +268,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: >-
-      Whether the no-business-with-covered-customers covenant is included. A
-      non-dealing covenant has no named Alabama category of its own, so it must
-      be drafted to fit inside the current-customer non-solicit exception or it
-      is exposed to Alabama's void rule for restraints outside the listed
-      categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -317,11 +305,7 @@ fields:
       covenant.
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -348,9 +332,7 @@ fields:
     type: boolean
     description: >-
       Whether Employee is a physician. Set this explicitly from Employee's
-      licensed role to include physician-specific terms. For Indiana, the
-      applicable provisions vary by execution date and employer type, and may
-      require a release buyout term or exclude the non-compete entirely.
+      licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-nevada/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-nevada/metadata.yaml
@@ -60,7 +60,7 @@ fields:
     default_value_rationale: A finite term for non-trade-secret information helps keep the post-termination confidentiality covenant reasonable in scope and duration, as the NRS 613.200(4) safe harbor requires. 24 months is common for non-trade-secret confidentiality obligations in employment agreements.
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -83,7 +83,7 @@ fields:
     default_value_rationale: 12 months is the most common lookback period for employee non-solicitation scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -149,7 +149,7 @@ fields:
     default_value_rationale: The default recites the access-to-confidential-information and compensation the agreement itself provides and ties them to the covenants, addressing Nevada's valuable-consideration and proportionality conditions. Counsel should replace it with the specific negotiated benefit where the restraint is significant.
   - name: nondealing_included
     type: boolean
-    description: Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -171,7 +171,7 @@ fields:
     default_value_rationale: Five percent of any class of publicly traded securities is the modal passive-investment carve-out threshold observed in benchmarked, publicly-filed employee agreements that include the carve-out (lower 1-3 percent thresholds are the common tighter alternatives), and keeps ordinary public-share ownership off Nevada's undue-hardship scale.
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-nevada/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-nevada/template.mdoc
@@ -97,11 +97,7 @@ fields:
       for non-trade-secret confidentiality obligations in employment agreements.
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -133,10 +129,7 @@ fields:
       scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -258,12 +251,7 @@ fields:
       restraint is significant.
   - name: nondealing_included
     type: boolean
-    description: >-
-      Whether the no-business-with-covered-customers covenant is included. A
-      non-dealing covenant has no named Alabama category of its own, so it must
-      be drafted to fit inside the current-customer non-solicit exception or it
-      is exposed to Alabama's void rule for restraints outside the listed
-      categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -292,11 +280,7 @@ fields:
       ordinary public-share ownership off Nevada's undue-hardship scale.
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-new-hampshire/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-new-hampshire/metadata.yaml
@@ -60,7 +60,7 @@ fields:
     default_value_rationale: 24 months is common for non-trade-secret confidentiality obligations in employment agreements. New Hampshire recognizes confidential information short of trade-secret status as protectable (Hobert), but a finite term keeps the obligation within the reasonableness test while trade-secret protection runs with secrecy under RSA 350-B:1.
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -83,7 +83,7 @@ fields:
     default_value_rationale: 12 months is the most common lookback period for employee non-solicitation scope. New Hampshire held that ordinary recruiting and hiring cost is not a protectable interest (Olsten), so the class should stay tied to colleagues the departing worker actually worked with.
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -149,7 +149,7 @@ fields:
     default_value_rationale: The default recites employment or continued employment, a consideration basis New Hampshire accepts for a covenant not to compete, together with the compensation and confidential-information access the agreement itself provides. Counsel should replace it with the specific negotiated benefit where one exists.
   - name: nondealing_included
     type: boolean
-    description: Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -172,7 +172,7 @@ fields:
     default_value_rationale: Five percent of any class of publicly traded securities is the modal passive-investment carve-out threshold observed in benchmarked, publicly-filed employee agreements that include the carve-out (lower 1-3 percent thresholds are the common tighter alternatives). A carve-out that technically forbids index funds and ordinary public shares adds gratuitous weight to the undue-hardship prong of the Foster test.
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-new-hampshire/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-new-hampshire/template.mdoc
@@ -100,11 +100,7 @@ fields:
       protection runs with secrecy under RSA 350-B:1.
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -139,10 +135,7 @@ fields:
       colleagues the departing worker actually worked with.
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -269,12 +262,7 @@ fields:
       where one exists.
   - name: nondealing_included
     type: boolean
-    description: >-
-      Whether the no-business-with-covered-customers covenant is included. A
-      non-dealing covenant has no named Alabama category of its own, so it must
-      be drafted to fit inside the current-customer non-solicit exception or it
-      is exposed to Alabama's void rule for restraints outside the listed
-      categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -309,11 +297,7 @@ fields:
       weight to the undue-hardship prong of the Foster test.
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-new-jersey/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-new-jersey/metadata.yaml
@@ -60,7 +60,7 @@ fields:
     default_value_rationale: 24 months is common for non-trade-secret confidentiality obligations in employment agreements.
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -83,7 +83,7 @@ fields:
     default_value_rationale: 12 months is the most common lookback period for employee non-solicitation scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -140,7 +140,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -162,7 +162,7 @@ fields:
     default_value_rationale: Five percent of any class of publicly traded securities is the modal passive-investment carve-out threshold observed in benchmarked, publicly-filed employee agreements that include the carve-out (lower 1-3 percent thresholds are the common tighter alternatives).
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -182,7 +182,7 @@ fields:
     default_value_rationale: 24 months is common for employment non-disparagement provisions.
   - name: worker_is_physician
     type: boolean
-    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.
+    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-new-jersey/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-new-jersey/template.mdoc
@@ -102,11 +102,7 @@ fields:
       employment agreements.
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -139,10 +135,7 @@ fields:
       scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -240,12 +233,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: >-
-      Whether the no-business-with-covered-customers covenant is included. A
-      non-dealing covenant has no named Alabama category of its own, so it must
-      be drafted to fit inside the current-customer non-solicit exception or it
-      is exposed to Alabama's void rule for restraints outside the listed
-      categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -273,11 +261,7 @@ fields:
       percent thresholds are the common tighter alternatives).
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -299,9 +283,7 @@ fields:
     type: boolean
     description: >-
       Whether Employee is a physician. Set this explicitly from Employee's
-      licensed role to include physician-specific terms. For Indiana, the
-      applicable provisions vary by execution date and employer type, and may
-      require a release buyout term or exclude the non-compete entirely.
+      licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-new-mexico/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-new-mexico/metadata.yaml
@@ -89,7 +89,7 @@ fields:
     rationale_source: editorial
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -112,7 +112,7 @@ fields:
     default_value_rationale: 12 months is the most common lookback period for employee non-solicitation scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -172,7 +172,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -194,7 +194,7 @@ fields:
     default_value_rationale: Five percent of any class of publicly traded securities is the modal passive-investment carve-out threshold observed in benchmarked, publicly-filed employee agreements that include the carve-out (lower 1-3 percent thresholds are the common tighter alternatives).
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-new-mexico/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-new-mexico/template.mdoc
@@ -168,11 +168,7 @@ fields:
     rationale_source: editorial
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -204,10 +200,7 @@ fields:
       scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -305,12 +298,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: >-
-      Whether the no-business-with-covered-customers covenant is included. A
-      non-dealing covenant has no named Alabama category of its own, so it must
-      be drafted to fit inside the current-customer non-solicit exception or it
-      is exposed to Alabama's void rule for restraints outside the listed
-      categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -338,11 +326,7 @@ fields:
       percent thresholds are the common tighter alternatives).
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-new-york/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-new-york/metadata.yaml
@@ -60,7 +60,7 @@ fields:
     default_value_rationale: 24 months is common for non-trade-secret confidentiality obligations in employment agreements. New York declines to protect general knowledge and routine operational information, so a finite term on ordinary confidential material avoids the appearance of overreach.
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -83,7 +83,7 @@ fields:
     default_value_rationale: 12 months is the most common lookback period for employee non-solicitation scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -141,7 +141,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -163,7 +163,7 @@ fields:
     default_value_rationale: Five percent of any class of publicly traded securities is the modal passive-investment carve-out threshold observed in benchmarked, publicly-filed employee agreements that include the carve-out (lower 1-3 percent thresholds are the common tighter alternatives). A carve-out below a stated threshold keeps a passive index-fund holding from adding hardship on the undue-hardship prong without protecting any recognized interest.
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -183,7 +183,7 @@ fields:
     default_value_rationale: 24 months is common for employment non-disparagement provisions.
   - name: worker_is_physician
     type: boolean
-    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.
+    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-new-york/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-new-york/template.mdoc
@@ -103,11 +103,7 @@ fields:
       material avoids the appearance of overreach.
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -141,10 +137,7 @@ fields:
       scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -251,12 +244,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: >-
-      Whether the no-business-with-covered-customers covenant is included. A
-      non-dealing covenant has no named Alabama category of its own, so it must
-      be drafted to fit inside the current-customer non-solicit exception or it
-      is exposed to Alabama's void rule for restraints outside the listed
-      categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -286,11 +274,7 @@ fields:
       on the undue-hardship prong without protecting any recognized interest.
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -312,9 +296,7 @@ fields:
     type: boolean
     description: >-
       Whether Employee is a physician. Set this explicitly from Employee's
-      licensed role to include physician-specific terms. For Indiana, the
-      applicable provisions vary by execution date and employer type, and may
-      require a release buyout term or exclude the non-compete entirely.
+      licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-north-carolina/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-north-carolina/metadata.yaml
@@ -69,7 +69,7 @@ fields:
     default_value_rationale: 24 months is common for non-trade-secret confidentiality obligations in employment agreements. North Carolina construes restraints strictly against the drafter and never trims them, so a perpetual lid on ordinary business information reads as overreach.
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -92,7 +92,7 @@ fields:
     default_value_rationale: 12 months is the most common lookback period for employee non-solicitation scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -149,7 +149,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -171,7 +171,7 @@ fields:
     default_value_rationale: Five percent of any class of publicly traded securities is the modal passive-investment carve-out threshold observed in benchmarked, publicly-filed employee agreements that include the carve-out (lower 1-3 percent thresholds are the common tighter alternatives). Because a North Carolina court strikes rather than narrows an overbroad restraint, a clean passive-holdings carve-out avoids gratuitous overbreadth like a technical ban on index funds and ordinary public shares.
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -191,7 +191,7 @@ fields:
     default_value_rationale: 24 months is common for employment non-disparagement provisions.
   - name: worker_is_physician
     type: boolean
-    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.
+    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-north-carolina/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-north-carolina/template.mdoc
@@ -131,11 +131,7 @@ fields:
       business information reads as overreach.
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -168,10 +164,7 @@ fields:
       scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -272,12 +265,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: >-
-      Whether the no-business-with-covered-customers covenant is included. A
-      non-dealing covenant has no named Alabama category of its own, so it must
-      be drafted to fit inside the current-customer non-solicit exception or it
-      is exposed to Alabama's void rule for restraints outside the listed
-      categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -308,11 +296,7 @@ fields:
       ban on index funds and ordinary public shares.
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -334,9 +318,7 @@ fields:
     type: boolean
     description: >-
       Whether Employee is a physician. Set this explicitly from Employee's
-      licensed role to include physician-specific terms. For Indiana, the
-      applicable provisions vary by execution date and employer type, and may
-      require a release buyout term or exclude the non-compete entirely.
+      licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-ohio/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-ohio/metadata.yaml
@@ -60,7 +60,7 @@ fields:
     default_value_rationale: 24 months is common for non-trade-secret confidentiality obligations in employment agreements.
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -83,7 +83,7 @@ fields:
     default_value_rationale: 12 months is the most common lookback period for employee non-solicitation scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -141,7 +141,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -163,7 +163,7 @@ fields:
     default_value_rationale: Five percent of any class of publicly traded securities is the modal passive-investment carve-out threshold observed in benchmarked, publicly-filed employee agreements that include the carve-out (lower 1-3 percent thresholds are the common tighter alternatives).
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -183,7 +183,7 @@ fields:
     default_value_rationale: 24 months is common for employment non-disparagement provisions.
   - name: worker_is_physician
     type: boolean
-    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.
+    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-ohio/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-ohio/template.mdoc
@@ -99,11 +99,7 @@ fields:
       employment agreements.
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -136,10 +132,7 @@ fields:
       scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -234,12 +227,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: >-
-      Whether the no-business-with-covered-customers covenant is included. A
-      non-dealing covenant has no named Alabama category of its own, so it must
-      be drafted to fit inside the current-customer non-solicit exception or it
-      is exposed to Alabama's void rule for restraints outside the listed
-      categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -267,11 +255,7 @@ fields:
       percent thresholds are the common tighter alternatives).
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -293,9 +277,7 @@ fields:
     type: boolean
     description: >-
       Whether Employee is a physician. Set this explicitly from Employee's
-      licensed role to include physician-specific terms. For Indiana, the
-      applicable provisions vary by execution date and employer type, and may
-      require a release buyout term or exclude the non-compete entirely.
+      licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-oregon/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-oregon/metadata.yaml
@@ -60,7 +60,7 @@ fields:
     default_value_rationale: 24 months is common for non-trade-secret confidentiality obligations in employment agreements, and it tracks Oregon's protectable-interest line between trade secrets (perpetual) and competitively sensitive confidential information that would not qualify as a trade secret under ORS 653.295(2).
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -83,7 +83,7 @@ fields:
     default_value_rationale: 12 months is the most common lookback period for employee non-solicitation scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -148,7 +148,7 @@ fields:
     default_value_rationale: The default recites the two halves of the ORS 653.295(7) formula so the pay-to-enforce path is available where the employee falls below the salary threshold. Counsel should confirm the payment is actually committed in writing; the garden-leave path overrides only subsections (1)(b) and (e) — the notice-or-advancement gateway, protectable interest, and 30-day delivery conditions still apply.
   - name: nondealing_included
     type: boolean
-    description: Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -171,7 +171,7 @@ fields:
     default_value_rationale: Five percent of any class of publicly traded securities is the modal passive-investment carve-out threshold observed in benchmarked, publicly-filed employee agreements that include the carve-out (lower 1-3 percent thresholds are the common tighter alternatives).
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-oregon/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-oregon/template.mdoc
@@ -99,11 +99,7 @@ fields:
       information that would not qualify as a trade secret under ORS 653.295(2).
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -136,10 +132,7 @@ fields:
       scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -261,12 +254,7 @@ fields:
       delivery conditions still apply.
   - name: nondealing_included
     type: boolean
-    description: >-
-      Whether the no-business-with-covered-customers covenant is included. A
-      non-dealing covenant has no named Alabama category of its own, so it must
-      be drafted to fit inside the current-customer non-solicit exception or it
-      is exposed to Alabama's void rule for restraints outside the listed
-      categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -299,11 +287,7 @@ fields:
       percent thresholds are the common tighter alternatives).
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-pennsylvania/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-pennsylvania/metadata.yaml
@@ -69,7 +69,7 @@ fields:
     default_value_rationale: 24 months is common for non-trade-secret confidentiality obligations in employment agreements.
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -92,7 +92,7 @@ fields:
     default_value_rationale: 12 months is the most common lookback period for employee non-solicitation scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -150,7 +150,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -172,7 +172,7 @@ fields:
     default_value_rationale: Five percent of any class of publicly traded securities is the modal passive-investment carve-out threshold observed in benchmarked, publicly-filed employee agreements that include the carve-out (lower 1-3 percent thresholds are the common tighter alternatives).
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -192,7 +192,7 @@ fields:
     default_value_rationale: 24 months is common for employment non-disparagement provisions.
   - name: worker_is_physician
     type: boolean
-    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.
+    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-pennsylvania/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-pennsylvania/template.mdoc
@@ -125,11 +125,7 @@ fields:
       employment agreements.
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -162,10 +158,7 @@ fields:
       scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -268,12 +261,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: >-
-      Whether the no-business-with-covered-customers covenant is included. A
-      non-dealing covenant has no named Alabama category of its own, so it must
-      be drafted to fit inside the current-customer non-solicit exception or it
-      is exposed to Alabama's void rule for restraints outside the listed
-      categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -301,11 +289,7 @@ fields:
       percent thresholds are the common tighter alternatives).
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -327,9 +311,7 @@ fields:
     type: boolean
     description: >-
       Whether Employee is a physician. Set this explicitly from Employee's
-      licensed role to include physician-specific terms. For Indiana, the
-      applicable provisions vary by execution date and employer type, and may
-      require a release buyout term or exclude the non-compete entirely.
+      licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-puerto-rico/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-puerto-rico/metadata.yaml
@@ -60,7 +60,7 @@ fields:
     section: Confidentiality
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -83,7 +83,7 @@ fields:
     section: Employee Non-Solicitation
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -106,10 +106,10 @@ fields:
     section: Customer Non-Solicitation
   - name: noncompete_included
     type: boolean
-    description: Whether the non-competition covenant is included. Under Alabama law an employee may agree to a geographically limited non-compete; this template recites the employee-exception basis, ties the covenant to a listed protectable interest, and biases the duration into the two-year presumptively reasonable window.
+    description: Whether the non-competition covenant is included.
     display_label: Non-Competition Included
     section: Non-Competition
-    default_value_rationale: Conservative default. Non-competes are the most heavily scrutinized covenant; include only after confirming the restraint fits Alabama's employee exception for a specified geographic area, a competing business, and an existing employment relationship; protects a listed interest; stays within the two-year presumption; will be signed by all parties, including the employer; and does not restrain a member of a recognized profession from practicing that profession. The party seeking enforcement bears the burden of proof on every element.
+    default_value_rationale: Conservative default. Non-competes are the most heavily scrutinized covenant; include only after confirming enforceability under the agreement's governing law and tailoring the restraint to a legitimate protectable interest.
     rationale_source: editorial
     default: true
   - name: noncompete_duration
@@ -141,7 +141,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -163,7 +163,7 @@ fields:
     section: Definitions
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-puerto-rico/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-puerto-rico/template.mdoc
@@ -130,11 +130,7 @@ fields:
     section: Confidentiality
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -166,10 +162,7 @@ fields:
     section: Employee Non-Solicitation
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -200,23 +193,14 @@ fields:
     section: Customer Non-Solicitation
   - name: noncompete_included
     type: boolean
-    description: >-
-      Whether the non-competition covenant is included. Under Alabama law an
-      employee may agree to a geographically limited non-compete; this template
-      recites the employee-exception basis, ties the covenant to a listed
-      protectable interest, and biases the duration into the two-year
-      presumptively reasonable window.
+    description: Whether the non-competition covenant is included.
     display_label: Non-Competition Included
     section: Non-Competition
     default_value_rationale: >-
       Conservative default. Non-competes are the most heavily scrutinized
-      covenant; include only after confirming the restraint fits Alabama's
-      employee exception for a specified geographic area, a competing business,
-      and an existing employment relationship; protects a listed interest; stays
-      within the two-year presumption; will be signed by all parties, including
-      the employer; and does not restrain a member of a recognized profession
-      from practicing that profession. The party seeking enforcement bears the
-      burden of proof on every element.
+      covenant; include only after confirming enforceability under the
+      agreement's governing law and tailoring the restraint to a legitimate
+      protectable interest.
     rationale_source: editorial
     default: true
   - name: noncompete_duration
@@ -256,12 +240,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: >-
-      Whether the no-business-with-covered-customers covenant is included. A
-      non-dealing covenant has no named Alabama category of its own, so it must
-      be drafted to fit inside the current-customer non-solicit exception or it
-      is exposed to Alabama's void rule for restraints outside the listed
-      categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -289,11 +268,7 @@ fields:
     section: Definitions
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-rhode-island/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-rhode-island/metadata.yaml
@@ -62,7 +62,7 @@ fields:
     default_value_rationale: 24 months is common for non-trade-secret confidentiality obligations in employment agreements. The Noncompetition Agreement Act excludes nondisclosure and confidentiality agreements from the non-compete definition only so long as the clause stays a confidentiality clause; a finite term for ordinary information keeps the NDA from reading as a hidden activity restraint.
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -85,7 +85,7 @@ fields:
     default_value_rationale: 12 months is the most common lookback period for employee non-solicitation scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -147,7 +147,7 @@ fields:
     default_value_rationale: Blank is the conservative default because a named-competitor list should be supplied only when the employer can identify actual competitors whose inclusion helps narrow the restraint.
   - name: nondealing_included
     type: boolean
-    description: Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -169,7 +169,7 @@ fields:
     default_value_rationale: Five percent of any class of publicly traded securities is the modal passive-investment carve-out threshold observed in benchmarked, publicly-filed employee agreements that include the carve-out (lower 1-3 percent thresholds are the common tighter alternatives). A carve-out below a stated threshold keeps the covenant from restraining ordinary public-share ownership no legitimate interest requires — gratuitous overbreadth in a state that enforces restraints only as far as apparently necessary.
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-rhode-island/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-rhode-island/template.mdoc
@@ -146,11 +146,7 @@ fields:
       hidden activity restraint.
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -183,10 +179,7 @@ fields:
       scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -296,12 +289,7 @@ fields:
       inclusion helps narrow the restraint.
   - name: nondealing_included
     type: boolean
-    description: >-
-      Whether the no-business-with-covered-customers covenant is included. A
-      non-dealing covenant has no named Alabama category of its own, so it must
-      be drafted to fit inside the current-customer non-solicit exception or it
-      is exposed to Alabama's void rule for restraints outside the listed
-      categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -333,11 +321,7 @@ fields:
       necessary.
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-south-carolina/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-south-carolina/metadata.yaml
@@ -76,7 +76,7 @@ fields:
     default_value_rationale: 'A finite term is essential in South Carolina: an untimed nondisclosure provision that operates as a covenant not to compete violates public policy. 24 months is a common, conservative term for non-trade-secret confidentiality that keeps the clause from reading as an indefinite functional non-compete.'
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -99,7 +99,7 @@ fields:
     default_value_rationale: 12 months is a common lookback period for employee non-solicitation scope, tied to the colleagues the departing worker actually worked with.
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -124,10 +124,10 @@ fields:
     default_value_rationale: '12 months tracks the look-back window a District of South Carolina court upheld: a covenant limited to customers the employee had contact with during his last twelve months of employment withstood an overbreadth challenge.'
   - name: noncompete_included
     type: boolean
-    description: Whether the non-competition covenant is included. Under Alabama law an employee may agree to a geographically limited non-compete; this template recites the employee-exception basis, ties the covenant to a listed protectable interest, and biases the duration into the two-year presumptively reasonable window.
+    description: Whether the non-competition covenant is included.
     display_label: Non-Competition Included
     section: Non-Competition
-    default_value_rationale: Conservative default. Non-competes are the most heavily scrutinized covenant; include only after confirming the restraint fits Alabama's employee exception for a specified geographic area, a competing business, and an existing employment relationship; protects a listed interest; stays within the two-year presumption; will be signed by all parties, including the employer; and does not restrain a member of a recognized profession from practicing that profession. The party seeking enforcement bears the burden of proof on every element.
+    default_value_rationale: Conservative default. Non-competes are the most heavily scrutinized covenant; include only after confirming enforceability under the agreement's governing law and tailoring the restraint to a legitimate protectable interest.
     rationale_source: editorial
     default: true
   - name: noncompete_duration
@@ -177,7 +177,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -199,7 +199,7 @@ fields:
     default_value_rationale: Five percent of any class of publicly traded securities is the modal passive-investment carve-out threshold observed in benchmarked, publicly-filed employee agreements that include the carve-out (lower 1-3 percent thresholds are the common tighter alternatives), and it keeps the covenant from restraining ordinary public shareholding — an easy example against the harshness factor.
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-south-carolina/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-south-carolina/template.mdoc
@@ -137,11 +137,7 @@ fields:
       functional non-compete.
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -174,10 +170,7 @@ fields:
       tied to the colleagues the departing worker actually worked with.
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -215,23 +208,14 @@ fields:
       challenge.
   - name: noncompete_included
     type: boolean
-    description: >-
-      Whether the non-competition covenant is included. Under Alabama law an
-      employee may agree to a geographically limited non-compete; this template
-      recites the employee-exception basis, ties the covenant to a listed
-      protectable interest, and biases the duration into the two-year
-      presumptively reasonable window.
+    description: Whether the non-competition covenant is included.
     display_label: Non-Competition Included
     section: Non-Competition
     default_value_rationale: >-
       Conservative default. Non-competes are the most heavily scrutinized
-      covenant; include only after confirming the restraint fits Alabama's
-      employee exception for a specified geographic area, a competing business,
-      and an existing employment relationship; protects a listed interest; stays
-      within the two-year presumption; will be signed by all parties, including
-      the employer; and does not restrain a member of a recognized profession
-      from practicing that profession. The party seeking enforcement bears the
-      burden of proof on every element.
+      covenant; include only after confirming enforceability under the
+      agreement's governing law and tailoring the restraint to a legitimate
+      protectable interest.
     rationale_source: editorial
     default: true
   - name: noncompete_duration
@@ -317,12 +301,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: >-
-      Whether the no-business-with-covered-customers covenant is included. A
-      non-dealing covenant has no named Alabama category of its own, so it must
-      be drafted to fit inside the current-customer non-solicit exception or it
-      is exposed to Alabama's void rule for restraints outside the listed
-      categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -352,11 +331,7 @@ fields:
       against the harshness factor.
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-south-dakota/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-south-dakota/metadata.yaml
@@ -83,7 +83,7 @@ fields:
     default_value_rationale: 12 months is the most common lookback period for employee non-solicitation scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -150,7 +150,7 @@ fields:
     default_value_rationale: Five percent of any class of publicly traded securities is the modal passive-investment carve-out threshold observed in benchmarked, publicly-filed employee agreements that include the carve-out (lower 1-3 percent thresholds are the common tighter alternatives); a clause that technically forbids holding ordinary public shares restrains more than any of the statutory exceptions describes.
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-south-dakota/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-south-dakota/template.mdoc
@@ -143,10 +143,7 @@ fields:
       scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -261,11 +258,7 @@ fields:
       of the statutory exceptions describes.
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-tennessee/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-tennessee/metadata.yaml
@@ -60,7 +60,7 @@ fields:
     default_value_rationale: 24 months is common for non-trade-secret confidentiality obligations in employment agreements.
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -83,7 +83,7 @@ fields:
     default_value_rationale: 12 months is the most common lookback period for employee non-solicitation scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -143,7 +143,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -165,7 +165,7 @@ fields:
     default_value_rationale: Five percent of any class of publicly traded securities is the modal passive-investment carve-out threshold observed in benchmarked, publicly-filed employee agreements that include the carve-out (lower 1-3 percent thresholds are the common tighter alternatives).
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -185,7 +185,7 @@ fields:
     default_value_rationale: 24 months is common for employment non-disparagement provisions.
   - name: worker_is_physician
     type: boolean
-    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.
+    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-tennessee/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-tennessee/template.mdoc
@@ -104,11 +104,7 @@ fields:
       employment agreements.
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -141,10 +137,7 @@ fields:
       scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -249,12 +242,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: >-
-      Whether the no-business-with-covered-customers covenant is included. A
-      non-dealing covenant has no named Alabama category of its own, so it must
-      be drafted to fit inside the current-customer non-solicit exception or it
-      is exposed to Alabama's void rule for restraints outside the listed
-      categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -282,11 +270,7 @@ fields:
       percent thresholds are the common tighter alternatives).
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -308,9 +292,7 @@ fields:
     type: boolean
     description: >-
       Whether Employee is a physician. Set this explicitly from Employee's
-      licensed role to include physician-specific terms. For Indiana, the
-      applicable provisions vary by execution date and employer type, and may
-      require a release buyout term or exclude the non-compete entirely.
+      licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-texas/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-texas/metadata.yaml
@@ -60,7 +60,7 @@ fields:
     default_value_rationale: 24 months is common for non-trade-secret confidentiality obligations in employment agreements.
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -83,7 +83,7 @@ fields:
     default_value_rationale: 12 months is the most common lookback period for employee non-solicitation scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -142,7 +142,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -164,7 +164,7 @@ fields:
     default_value_rationale: Five percent of any class of publicly traded securities is the modal passive-investment carve-out threshold observed in benchmarked, publicly-filed employee agreements that include the carve-out (lower 1-3 percent thresholds are the common tighter alternatives).
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -184,7 +184,7 @@ fields:
     default_value_rationale: 24 months is common for employment non-disparagement provisions.
   - name: worker_is_physician
     type: boolean
-    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.
+    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-texas/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-texas/template.mdoc
@@ -94,11 +94,7 @@ fields:
       employment agreements.
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -130,10 +126,7 @@ fields:
       scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -225,12 +218,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: >-
-      Whether the no-business-with-covered-customers covenant is included. A
-      non-dealing covenant has no named Alabama category of its own, so it must
-      be drafted to fit inside the current-customer non-solicit exception or it
-      is exposed to Alabama's void rule for restraints outside the listed
-      categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -258,11 +246,7 @@ fields:
       percent thresholds are the common tighter alternatives).
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -284,9 +268,7 @@ fields:
     type: boolean
     description: >-
       Whether Employee is a physician. Set this explicitly from Employee's
-      licensed role to include physician-specific terms. For Indiana, the
-      applicable provisions vary by execution date and employer type, and may
-      require a release buyout term or exclude the non-compete entirely.
+      licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-utah/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-utah/metadata.yaml
@@ -61,7 +61,7 @@ fields:
     default_value_rationale: Utah leaves confidentiality agreements outside the Noncompetition Agreement Act's non-compete definition and one-year cap, but a confidentiality obligation on non-trade-secret information still should be reasonable. A finite term such as 24 months is defensible; a perpetual lid on non-secret information invites recharacterization as a disguised restraint on working.
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -84,7 +84,7 @@ fields:
     default_value_rationale: No Utah statute fixes the lookback for a covered-employee class; 12 months is the most common window and keeps the no-poach class tied to colleagues the departing worker actually worked with, consistent with common-law reasonableness.
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-utah/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-utah/template.mdoc
@@ -102,11 +102,7 @@ fields:
       restraint on working.
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -141,10 +137,7 @@ fields:
       reasonableness.
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-vermont/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-vermont/metadata.yaml
@@ -60,7 +60,7 @@ fields:
     default_value_rationale: 24 months is common for non-trade-secret confidentiality obligations in employment agreements. A perpetual lid on non-secret material operates as an indirect restraint and inherits the same Andrus reasonableness scrutiny as a non-compete, so ordinary confidential information carries a finite term.
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -83,7 +83,7 @@ fields:
     default_value_rationale: 12 months is the most common lookback period for employee non-solicitation scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -140,7 +140,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -162,7 +162,7 @@ fields:
     default_value_rationale: Five percent of any class of publicly traded securities is the modal passive-investment carve-out threshold observed in benchmarked, publicly-filed employee agreements that include the carve-out (lower 1-3 percent thresholds are the common tighter alternatives).
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -182,7 +182,7 @@ fields:
     default_value_rationale: 24 months is common for employment non-disparagement provisions.
   - name: worker_is_physician
     type: boolean
-    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.
+    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-vermont/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-vermont/template.mdoc
@@ -108,11 +108,7 @@ fields:
       term.
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -145,10 +141,7 @@ fields:
       scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -249,12 +242,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: >-
-      Whether the no-business-with-covered-customers covenant is included. A
-      non-dealing covenant has no named Alabama category of its own, so it must
-      be drafted to fit inside the current-customer non-solicit exception or it
-      is exposed to Alabama's void rule for restraints outside the listed
-      categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -282,11 +270,7 @@ fields:
       percent thresholds are the common tighter alternatives).
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -308,9 +292,7 @@ fields:
     type: boolean
     description: >-
       Whether Employee is a physician. Set this explicitly from Employee's
-      licensed role to include physician-specific terms. For Indiana, the
-      applicable provisions vary by execution date and employer type, and may
-      require a release buyout term or exclude the non-compete entirely.
+      licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-virginia/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-virginia/metadata.yaml
@@ -103,7 +103,7 @@ fields:
     default_value_rationale: 12 months is the most common lookback period for employee non-solicitation scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -164,7 +164,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -186,7 +186,7 @@ fields:
     default_value_rationale: Five percent of any class of publicly traded securities is the modal passive-investment carve-out threshold observed in benchmarked, publicly-filed employee agreements that include the carve-out (lower 1-3 percent thresholds are the common tighter alternatives), and a de minimis floor keeps an ownership restraint from reading as unduly harsh under the Omniplex second prong.
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-virginia/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-virginia/template.mdoc
@@ -191,10 +191,7 @@ fields:
       scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -301,12 +298,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: >-
-      Whether the no-business-with-covered-customers covenant is included. A
-      non-dealing covenant has no named Alabama category of its own, so it must
-      be drafted to fit inside the current-customer non-solicit exception or it
-      is exposed to Alabama's void rule for restraints outside the listed
-      categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -336,11 +328,7 @@ fields:
       Omniplex second prong.
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-washington/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-washington/metadata.yaml
@@ -63,7 +63,7 @@ fields:
     rationale_source: editorial
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -86,7 +86,7 @@ fields:
     default_value_rationale: 12 months is the most common lookback period for employee non-solicitation scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -155,7 +155,7 @@ fields:
     requirement_id: REQ-labor-and-employment-law.restrictive-covenant-agreement.washington.require-independent-consideration-for-post-hire-covenants
   - name: nondealing_included
     type: boolean
-    description: Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -180,7 +180,7 @@ fields:
     benchmark_ref: restrictive-covenant/passive-ownership-carveout
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-washington/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-washington/template.mdoc
@@ -109,11 +109,7 @@ fields:
     rationale_source: editorial
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -147,10 +143,7 @@ fields:
       scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -295,12 +288,7 @@ fields:
       REQ-labor-and-employment-law.restrictive-covenant-agreement.washington.require-independent-consideration-for-post-hire-covenants
   - name: nondealing_included
     type: boolean
-    description: >-
-      Whether the no-business-with-covered-customers covenant is included. A
-      non-dealing covenant has no named Alabama category of its own, so it must
-      be drafted to fit inside the current-customer non-solicit exception or it
-      is exposed to Alabama's void rule for restraints outside the listed
-      categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -338,11 +326,7 @@ fields:
     benchmark_ref: restrictive-covenant/passive-ownership-carveout
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-west-virginia/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-west-virginia/metadata.yaml
@@ -70,7 +70,7 @@ fields:
     default_value_rationale: West Virginia requires new consideration for a covenant contracted after employment has commenced without restriction; continued at-will employment alone is not enough. Left blank by default because an agreement signed at the outset of employment is supported by the offer and commencement of employment; when signed later, counsel should recite the specific covenant-linked value.
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -93,7 +93,7 @@ fields:
     default_value_rationale: 12 months is the most common lookback period for employee non-solicitation scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -152,7 +152,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -174,7 +174,7 @@ fields:
     default_value_rationale: Five percent of any class of publicly traded securities is the modal passive-investment carve-out threshold observed in benchmarked, publicly-filed employee agreements that include the carve-out (lower 1-3 percent thresholds are the common tighter alternatives). A clause that forbids ordinary index funds and public shares reads as gratuitous overbreadth — the kind of grasping detail that can make a covenant look designed to intimidate rather than protect.
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -202,7 +202,7 @@ fields:
     default_value_rationale: 24 months is common for employment non-disparagement provisions.
   - name: worker_is_physician
     type: boolean
-    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.
+    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-west-virginia/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-west-virginia/template.mdoc
@@ -134,11 +134,7 @@ fields:
       covenant-linked value.
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -173,10 +169,7 @@ fields:
       scope.
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -281,12 +274,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: >-
-      Whether the no-business-with-covered-customers covenant is included. A
-      non-dealing covenant has no named Alabama category of its own, so it must
-      be drafted to fit inside the current-customer non-solicit exception or it
-      is exposed to Alabama's void rule for restraints outside the listed
-      categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -317,11 +305,7 @@ fields:
       designed to intimidate rather than protect.
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -362,9 +346,7 @@ fields:
     type: boolean
     description: >-
       Whether Employee is a physician. Set this explicitly from Employee's
-      licensed role to include physician-specific terms. For Indiana, the
-      applicable provisions vary by execution date and employer type, and may
-      require a release buyout term or exclude the non-compete entirely.
+      licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-wisconsin/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-wisconsin/metadata.yaml
@@ -64,7 +64,7 @@ fields:
     default_value_rationale: 24 months is an editorial finite term for non-trade-secret confidential information. A finite term helps avoid turning ordinary business information into an indefinite restraint; Wisconsin authority warns that a perpetual limit on ordinary business information can be treated as an unenforceable restraint.
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -88,7 +88,7 @@ fields:
     default_value_rationale: 12 months is an editorial look-back window. It ties the covered class to colleagues the departing worker actually worked with, supervised, or gained material information about, avoiding an all-workforce no-poach clause that Wisconsin authority treats as overbroad.
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -151,7 +151,7 @@ fields:
     default_value_rationale: Leave this optional field blank unless counsel identifies specific competitors that should narrow the non-compete. The blank default avoids inventing competitor names.
   - name: nondealing_included
     type: boolean
-    description: Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -174,7 +174,7 @@ fields:
     default_value_rationale: Five percent of any class of publicly traded securities is the modal passive-investment carve-out threshold observed in benchmarked, publicly-filed employee agreements that include the carve-out (lower 1-3 percent thresholds are the common tighter alternatives). A clause that forbids holding ordinary public shares restrains the worker far beyond any protectable interest and feeds the harsh-or-oppressive reasonableness factor.
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-wisconsin/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-wisconsin/template.mdoc
@@ -110,11 +110,7 @@ fields:
       unenforceable restraint.
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -150,10 +146,7 @@ fields:
       clause that Wisconsin authority treats as overbroad.
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -258,12 +251,7 @@ fields:
       inventing competitor names.
   - name: nondealing_included
     type: boolean
-    description: >-
-      Whether the no-business-with-covered-customers covenant is included. A
-      non-dealing covenant has no named Alabama category of its own, so it must
-      be drafted to fit inside the current-customer non-solicit exception or it
-      is exposed to Alabama's void rule for restraints outside the listed
-      categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -300,11 +288,7 @@ fields:
       factor.
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-wyoming/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-wyoming/metadata.yaml
@@ -60,7 +60,7 @@ fields:
     section: Confidentiality
   - name: employee_nonsolicit_included
     type: boolean
-    description: Whether the employee no-hire / non-solicitation covenant is included. Alabama's only category for restraints touching another party's workers is the no-hire exception for workers in a position uniquely essential to the management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -83,7 +83,7 @@ fields:
     section: Employee Non-Solicitation
   - name: customer_nonsolicit_included
     type: boolean
-    description: Whether the current-customer non-solicitation covenant is included. Alabama gives this covenant its own category, limited to current customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -142,7 +142,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: Whether the no-business-with-covered-customers covenant is included. A non-dealing covenant has no named Alabama category of its own, so it must be drafted to fit inside the current-customer non-solicit exception or it is exposed to Alabama's void rule for restraints outside the listed categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -164,7 +164,7 @@ fields:
     section: Definitions
   - name: noninvestment_included
     type: boolean
-    description: Whether the non-investment covenant is included. A non-investment covenant has no named Alabama category; one genuine use is restraining a licensed professional's business conduct outside the practice of the profession, which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -184,7 +184,7 @@ fields:
     section: Non-Disparagement
   - name: worker_is_physician
     type: boolean
-    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms. For Indiana, the applicable provisions vary by execution date and employer type, and may require a release buyout term or exclude the non-compete entirely.
+    description: Whether Employee is a physician. Set this explicitly from Employee's licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-wyoming/template.mdoc
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-wyoming/template.mdoc
@@ -149,11 +149,7 @@ fields:
     section: Confidentiality
   - name: employee_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the employee no-hire / non-solicitation covenant is included.
-      Alabama's only category for restraints touching another party's workers is
-      the no-hire exception for workers in a position uniquely essential to the
-      management, organization, or service of the business.
+    description: Whether the employee no-hire / non-solicitation covenant is included.
     display_label: Employee No-Hire Included
     section: Employee Non-Solicitation
     rationale_source: editorial
@@ -185,10 +181,7 @@ fields:
     section: Employee Non-Solicitation
   - name: customer_nonsolicit_included
     type: boolean
-    description: >-
-      Whether the current-customer non-solicitation covenant is included.
-      Alabama gives this covenant its own category, limited to current
-      customers.
+    description: Whether the current-customer non-solicitation covenant is included.
     display_label: Customer Non-Solicitation Included
     default: true
     section: Customer Non-Solicitation
@@ -278,12 +271,7 @@ fields:
     section: Non-Competition
   - name: nondealing_included
     type: boolean
-    description: >-
-      Whether the no-business-with-covered-customers covenant is included. A
-      non-dealing covenant has no named Alabama category of its own, so it must
-      be drafted to fit inside the current-customer non-solicit exception or it
-      is exposed to Alabama's void rule for restraints outside the listed
-      categories.
+    description: Whether the no-business-with-covered-customers covenant is included.
     display_label: No Business with Covered Customers Included
     default: false
     section: No Business with Covered Customers
@@ -311,11 +299,7 @@ fields:
     section: Definitions
   - name: noninvestment_included
     type: boolean
-    description: >-
-      Whether the non-investment covenant is included. A non-investment covenant
-      has no named Alabama category; one genuine use is restraining a licensed
-      professional's business conduct outside the practice of the profession,
-      which sits outside Alabama's professional exemption.
+    description: Whether the non-investment covenant is included.
     display_label: Non-Investment Included
     default: false
     section: Non-Investment
@@ -349,9 +333,7 @@ fields:
     type: boolean
     description: >-
       Whether Employee is a physician. Set this explicitly from Employee's
-      licensed role to include physician-specific terms. For Indiana, the
-      applicable provisions vary by execution date and employer type, and may
-      require a release buyout term or exclude the non-compete entirely.
+      licensed role to include physician-specific terms.
     display_label: Employee Is a Physician
     section: Physician
 omitted_clauses: drop


### PR DESCRIPTION
## Summary

- project the canonical jurisdiction-metadata cleanup from UseJunior/legal-explainer#1936
- remove 214 leaked Alabama/Indiana metadata values from 47 non-matching restrictive-covenant jurisdictions
- reconcile all 48 affected projected template directories byte-for-byte with the upstream mirror
- regenerate the templates snapshot

## SSOT

Legal Explainer remains the canonical source. This PR contains only its downstream Open Agreements projection plus the generated snapshot. The reusable audit guard lives upstream to avoid duplicate enforcement logic.

Upstream: https://github.com/UseJunior/legal-explainer/pull/1936

## Validation

- `npm run build`
- `npm run lint`
- `node bin/open-agreements.js validate` (103 templates, 4 external templates, 7 field selectors)
- `npm run check:templates-snapshot`
- documentation, preview, manifest, README, and llms drift gates
- exact-byte reconciliation for 48 projected directories
- real Puerto Rico restrictive-covenant fill to DOCX; expected parties/title present and no Alabama/Indiana leakage
- representative timeout retries: 5/5 passed in isolation

The fully parallel local Vitest phase hit existing 5-second timeouts under resource contention (1006 passed; failures were timeouts only); CI remains the authoritative clean-run gate.