### PR TITLE
fix(release): stop the pack guard failing on files it just found

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,14 +111,33 @@ jobs:
       - name: Verify package contents
         shell: bash
         run: |
-          PACK_OUTPUT="$(npm pack --dry-run 2>&1)"
-          echo "$PACK_OUTPUT"
-          for required_file in gemini-extension.json AGENTS.md server.json; do
-            if ! echo "$PACK_OUTPUT" | grep -q "$required_file"; then
-              echo "FATAL: $required_file is missing from the npm tarball. Add it to the files array in package.json."
-              exit 1
-            fi
-          done
+          # Check the required files against the JSON file list, not against a
+          # grep of npm's human-readable notice output. The previous form was
+          #
+          #   echo "$PACK_OUTPUT" | grep -q "$required_file"
+          #
+          # which fails under this step's `shell: bash` (-eo pipefail) as soon
+          # as the tarball listing grows: `grep -q` exits at the FIRST match,
+          # `echo` takes EPIPE on the ~900 lines it has not written yet and
+          # returns nonzero, and pipefail hands that failure to the `if !`.
+          # A required file that appears EARLY in the listing therefore reports
+          # as missing precisely because it was found. That is what blocked the
+          # v0.9.0 release at 1,771 files, with `npm notice 690B
+          # gemini-extension.json` visible in the very output the guard greps.
+          npm pack --dry-run --json | node -e '
+            const data = JSON.parse(require("fs").readFileSync(0, "utf8"));
+            const files = new Set((data[0].files || []).map((f) => f.path));
+            const required = ["gemini-extension.json", "AGENTS.md", "server.json"];
+            const missing = required.filter((f) => !files.has(f));
+            if (missing.length) {
+              console.error(
+                `FATAL: missing from the npm tarball: ${missing.join(", ")}.\n` +
+                  "Add them to the files array in package.json.",
+              );
+              process.exit(1);
+            }
+            console.log(`OK: all ${required.length} required files present (${files.size} total).`);
+          '
           npm pack --dry-run --json | node -e '
             const data = JSON.parse(require("fs").readFileSync(0, "utf8"));
             const bundled = data[0].bundled || [];


### PR DESCRIPTION
## Blocking the v0.9.0 release

Preflight fails with:

```
FATAL: gemini-extension.json is missing from the npm tarball. Add it to the files array in package.json.
```

The file is **not** missing. `npm notice 690B gemini-extension.json` appears at line 305 of the same output the guard greps, and the FATAL lands at line 1215. Nothing published — every downstream job skipped, npm is still 0.8.0.

## Mechanism

The step declares `shell: bash`, which GitHub maps to `bash --noprofile --norc -eo pipefail {0}`. In:

```bash
echo "$PACK_OUTPUT" | grep -q "$required_file"
```

`grep -q` exits at the **first** match. `gemini-extension.json` sits ~300 lines into a ~1,200-line listing, so grep is gone while `echo` still has ~900 lines to write. `echo` takes EPIPE, returns nonzero, and **`pipefail` promotes that to the pipeline's exit status** — so `if !` fires.

A required file reports as missing *precisely because it was found early*. The second re-run made it explicit:

```
line 4: echo: write error: Broken pipe
FATAL: gemini-extension.json is missing from the npm tarball.
```

Files appearing late in the listing, or listings short enough that `echo` finishes first, are unaffected — which is why this only began biting as the tarball reached 1,771 files. It is not related to the lockfile prune in #679; the file count is driven by `templates/` and `dist/`.

## Fix

Check the required files against `npm pack --dry-run --json` — the same source the very next step already trusts for its bundled-dependency assertion. No pipe from a shell builtin, no dependency on npm's human-readable format, and all missing files are reported at once rather than one per run.

## Verification

Run locally under the same `bash -eo pipefail` flags:

| case | result |
|---|---|
| **old** logic, real pack output | reproduces the exact FATAL, exit 1 |
| **new** logic | `OK: all 3 required files present (1594 total).`, exit 0 |
| **new** logic, deliberately absent file | `FATAL: missing from the npm tarball: NOPE-does-not-exist.json.`, exit 1 |

The negative control matters: the point is to fix the false positive without weakening the guard.

## After merge

Re-run the release by dispatching against the existing tag rather than cutting a new version:

```
gh workflow run release.yml --ref main -f release_tag=v0.9.0
```

`workflow_dispatch` takes the workflow file from `main` (fixed) and checks out the code at `v0.9.0`, so the tag stays untouched and 0.9.0 is not burned.

https://claude.ai/code/session_01W2qUuRAmiL31tmQsvJ2e9e