### PR TITLE
feat(ci): self-heal derived artifacts on sync-bot PRs via a two-workflow split

### DIFF
--- a/.github/workflows/derived-regen-apply.yml
+++ b/.github/workflows/derived-regen-apply.yml
@@ -1,0 +1,221 @@
+---
+# Privileged half of the derived-artifact self-heal (see #675).
+#
+# Runs on workflow_run, so the workflow definition always comes from the default
+# branch and cannot be edited by the pull request it acts on. Its one job is to
+# take the patch built by derived-regen-build.yml and push it onto the bot's PR
+# branch, so the derived-artifact gates go green without a human regenerating by
+# hand.
+#
+# The rule that makes this safe: THIS JOB NEVER EXECUTES PULL-REQUEST CODE.
+# No npm install, no repo-local action, no generator, no lifecycle script. It
+# runs git, gh, and two scripts read from a base-branch checkout. That is what
+# the earlier single-workflow attempt got wrong — it minted a write-capable App
+# token in the same job that ran `npm ci` on PR-controlled code, so anyone able
+# to push to the bot's branch could have run arbitrary code with that token.
+name: Regenerate derived artifacts (apply)
+
+"on":
+  workflow_run:
+    workflows: ["Regenerate derived artifacts (build)"]
+    types: [completed]
+
+# GITHUB_TOKEN stays read-only. The write capability arrives only in the final
+# push step, from a separately minted App token.
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  apply-patch:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    runs-on: ubuntu-latest
+    # One push at a time per branch; a second run would race the first's commit.
+    concurrency:
+      group: derived-regen-apply-${{ github.event.workflow_run.head_branch }}
+      cancel-in-progress: false
+    steps:
+      - name: Check for the App credentials
+        id: creds
+        env:
+          APP_ID: ${{ secrets.DERIVED_REGEN_APP_ID }}
+        run: |
+          if [ -z "${APP_ID}" ]; then
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::DERIVED_REGEN_APP_ID is not configured; self-heal skipped." \
+              "Bot PRs will keep failing the derived-artifact gates until it is set."
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # The base branch is trusted ground: it supplies the allowlist and the
+      # gatekeeper script. Nothing from the pull request is read here.
+      - name: Check out the base branch (trusted)
+        if: steps.creds.outputs.configured == 'true'
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+          path: base
+
+      # Re-derive every fact from the trusted workflow_run payload plus the API.
+      # The build job's `if:` gate is a convenience; this is the real check.
+      - name: Validate the originating pull request
+        if: steps.creds.outputs.configured == 'true'
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          EXPECTED_AUTHOR: "oa-ssot-sync[bot]"
+        run: |
+          set -euo pipefail
+
+          # Ask for PRs whose head is this branch, in this repo.
+          owner="${REPO%%/*}"
+          matches=$(gh api "repos/${REPO}/pulls" \
+            -f state=open -f head="${owner}:${HEAD_BRANCH}" \
+            --jq 'length')
+          if [ "${matches}" != "1" ]; then
+            echo "::notice::Expected exactly one open PR for ${HEAD_BRANCH}, found ${matches}; skipping."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          read -r number author head_sha head_repo < <(gh api "repos/${REPO}/pulls" \
+            -f state=open -f head="${owner}:${HEAD_BRANCH}" \
+            --jq '.[0] | "\(.number) \(.user.login) \(.head.sha) \(.head.repo.full_name)"')
+
+          if [ "${author}" != "${EXPECTED_AUTHOR}" ]; then
+            echo "::notice::PR #${number} is authored by ${author}, not ${EXPECTED_AUTHOR}; skipping."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "${head_repo}" != "${REPO}" ]; then
+            echo "::notice::PR #${number} head is on ${head_repo}, not ${REPO}; skipping."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # The branch must still be exactly where the patch was built. If it
+          # moved, the patch is stale and the next build run will supersede it.
+          if [ "${head_sha}" != "${HEAD_SHA}" ]; then
+            echo "::notice::PR #${number} moved from ${HEAD_SHA} to ${head_sha}; skipping this stale patch."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "PR #${number} validated: ${author} @ ${head_sha} on ${HEAD_BRANCH}."
+          echo "number=${number}" >> "$GITHUB_OUTPUT"
+          echo "proceed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Download the candidate patch
+        if: steps.creds.outputs.configured == 'true' && steps.pr.outputs.proceed == 'true'
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: derived-patch
+          path: incoming
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # No artifact means the build job found nothing stale. That is the steady
+      # state once a branch has been healed, so it is a success, not a failure.
+      - name: Note when there is nothing to apply
+        if: steps.creds.outputs.configured == 'true' && steps.pr.outputs.proceed == 'true' && steps.download.outcome != 'success'
+        run: echo "::notice::No patch artifact; derived artifacts were already current."
+
+      # THE trust boundary. Runs the gatekeeper from the base checkout, so the
+      # allowlist is the base branch's registry and not one the PR supplied.
+      - name: Validate the patch against the derived-artifact allowlist
+        if: steps.creds.outputs.configured == 'true' && steps.pr.outputs.proceed == 'true' && steps.download.outcome == 'success'
+        run: node base/scripts/validate_derived_patch.mjs "${GITHUB_WORKSPACE}/incoming/derived.patch"
+
+      - name: Check out the pull request head
+        if: steps.creds.outputs.configured == 'true' && steps.pr.outputs.proceed == 'true' && steps.download.outcome == 'success'
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          persist-credentials: false
+          path: work
+
+      - name: Apply the patch and commit
+        if: steps.creds.outputs.configured == 'true' && steps.pr.outputs.proceed == 'true' && steps.download.outcome == 'success'
+        id: commit
+        working-directory: work
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          set -euo pipefail
+          # git apply only writes files; it does not run repo code.
+          git apply --binary --index "${GITHUB_WORKSPACE}/incoming/derived.patch"
+
+          # Belt and braces: nothing outside the allowlist may be staged, even
+          # if the gatekeeper somehow let it through.
+          allowed=()
+          while IFS= read -r line; do
+            [ -n "${line}" ] && allowed+=("${line}")
+          done < <(node "${GITHUB_WORKSPACE}/base/scripts/derived_artifacts.mjs" --list-paths)
+          if [ "${#allowed[@]}" -eq 0 ]; then
+            echo "::error::The derived-artifact registry listed no paths."
+            exit 1
+          fi
+          staged=$(git diff --cached --name-only)
+          while IFS= read -r file; do
+            [ -z "${file}" ] && continue
+            ok=false
+            for entry in "${allowed[@]}"; do
+              case "${file}" in
+                "${entry}"|"${entry}"/*) ok=true; break ;;
+              esac
+            done
+            if [ "${ok}" != "true" ]; then
+              echo "::error::Staged file outside the derived-artifact allowlist: ${file}"
+              exit 1
+            fi
+          done <<< "${staged}"
+
+          if git diff --cached --quiet; then
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
+            echo "Nothing staged after apply; leaving the branch alone."
+            exit 0
+          fi
+
+          # Separate -m flags rather than one embedded newline-bearing string:
+          # git joins them with blank lines, and the YAML block scalar stays flat.
+          git -c user.name="oa-ssot-sync[bot]" \
+              -c user.email="oa-ssot-sync[bot]@users.noreply.github.com" \
+              commit \
+              -m "chore(derived): regenerate derived artifacts" \
+              -m "The sync bot writes sources without running this repo's generators, so the projections registered in scripts/derived_artifacts.mjs drifted. Regenerated by derived-regen-build.yml and applied here; no hand edits." \
+              -m "Refs #${PR_NUMBER}"
+          echo "pushed=true" >> "$GITHUB_OUTPUT"
+
+      # Minted last, and used only by the step below, so no PR-controlled code
+      # has ever run in this job while a write-capable token was present.
+      - name: Generate GitHub App token
+        if: steps.commit.outputs.pushed == 'true'
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.DERIVED_REGEN_APP_ID }}
+          private-key: ${{ secrets.DERIVED_REGEN_PRIVATE_KEY }}
+
+      - name: Push onto the bot's branch
+        if: steps.commit.outputs.pushed == 'true'
+        working-directory: work
+        env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          set -euo pipefail
+          # A plain (non-force) push. The new commit's parent is the SHA the
+          # patch was built against, so if the branch moved in the meantime the
+          # push is rejected rather than clobbering someone else's work.
+          git push "https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            "HEAD:refs/heads/${HEAD_BRANCH}"
+          echo "Pushed regenerated derived artifacts to ${HEAD_BRANCH}."

--- a/.github/workflows/derived-regen-build.yml
+++ b/.github/workflows/derived-regen-build.yml
@@ -1,0 +1,82 @@
+---
+# Unprivileged half of the derived-artifact self-heal (see #675).
+#
+# The sync bot pushes source updates without running this repo's generators, so
+# its pull requests are born red on the derived-artifact gates. This workflow
+# regenerates the projections and emits a patch. It deliberately holds NO
+# secrets and NO write access: it runs pull-request-controlled code (npm
+# lifecycle scripts, a repo-local action, the generators themselves), so
+# anything it produces is treated as untrusted input by the applier.
+#
+# The privileged counterpart is derived-regen-apply.yml, which validates the
+# patch against the registry allowlist before applying it.
+name: Regenerate derived artifacts (build)
+
+"on":
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build-patch:
+    # Cheap pre-filter only. This is not the security boundary — the applier
+    # re-validates every one of these facts from its own trusted event payload,
+    # because this job's output can be influenced by the code it runs.
+    if: >-
+      github.event.pull_request.user.login == 'oa-ssot-sync[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # Bind to the exact commit, never the branch name: head.ref can move
+          # under us between this run and the applier's.
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies (retry)
+        uses: ./.github/actions/npm-ci-retry
+
+      - name: Regenerate derived artifacts
+        run: npm run generate:derived
+
+      - name: Build path-scoped patch
+        id: patch
+        run: |
+          set -euo pipefail
+          # Read loop rather than `mapfile`, which needs bash 4+. Keeping this
+          # portable means the same lines can be rehearsed on any shell.
+          paths=()
+          while IFS= read -r line; do
+            [ -n "${line}" ] && paths+=("${line}")
+          done < <(node scripts/derived_artifacts.mjs --list-paths)
+          if [ "${#paths[@]}" -eq 0 ]; then
+            echo "::error::The derived-artifact registry listed no paths."
+            exit 1
+          fi
+          git add --all -- "${paths[@]}"
+          # --binary so the plugin tree's non-text files survive the round trip.
+          git diff --cached --binary -- "${paths[@]}" > "${RUNNER_TEMP}/derived.patch"
+          if [ -s "${RUNNER_TEMP}/derived.patch" ]; then
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+            echo "Derived artifacts are stale; emitting a patch for the applier."
+          else
+            echo "stale=false" >> "$GITHUB_OUTPUT"
+            echo "Derived artifacts already current; nothing to do."
+          fi
+
+      - name: Upload patch
+        if: steps.patch.outputs.stale == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: derived-patch
+          path: ${{ runner.temp }}/derived.patch
+          if-no-files-found: error
+          retention-days: 1

--- a/scripts/derived_artifacts.mjs
+++ b/scripts/derived_artifacts.mjs
@@ -122,10 +122,23 @@ function check() {
   process.exitCode = 1;
 }
 
+// Prints one registered path per line and exits. This is the allowlist the
+// privileged half of the self-heal split validates a patch against, so it must
+// stay readable without installing anything: node builtins only, no deps, no
+// build. The privileged workflow runs this from the *base* branch, never from
+// the pull request, so a PR cannot widen its own allowlist by editing the
+// registry.
+function listPaths() {
+  for (const path of allPaths) console.log(path);
+}
+
 const mode = process.argv[2] ?? "--generate";
 if (mode === "--check") check();
 else if (mode === "--generate") generate();
+else if (mode === "--list-paths") listPaths();
 else {
-  console.error(`Unknown argument: ${mode} (expected --generate or --check)`);
+  console.error(
+    `Unknown argument: ${mode} (expected --generate, --check, or --list-paths)`
+  );
   process.exitCode = 2;
 }

--- a/scripts/validate_derived_patch.mjs
+++ b/scripts/validate_derived_patch.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * Gatekeeper for the derived-artifact self-heal split.
+ *
+ * The unprivileged half of the split runs pull-request-controlled code and
+ * emits a patch. This script is the only thing standing between that patch and
+ * a privileged `git apply` + push, so it is deliberately paranoid and refuses
+ * anything it does not positively recognise.
+ *
+ * It MUST be run from a checkout of the base branch, never from the pull
+ * request: the allowlist comes from scripts/derived_artifacts.mjs, and a PR that
+ * could supply its own copy of the registry could authorise writes to any path.
+ *
+ * Usage: node scripts/validate_derived_patch.mjs <patch-file>
+ */
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+function fail(message) {
+  console.error(`Refusing patch: ${message}`);
+  process.exit(1);
+}
+
+function allowlist() {
+  const out = execFileSync(
+    process.execPath,
+    [resolve(repoRoot, "scripts/derived_artifacts.mjs"), "--list-paths"],
+    { cwd: repoRoot, encoding: "utf-8" }
+  );
+  const paths = out.split("\n").map((line) => line.trim()).filter(Boolean);
+  if (paths.length === 0) fail("the derived-artifact registry listed no paths.");
+  return paths;
+}
+
+/**
+ * A path is allowed when it *is* a registered entry or sits beneath one. The
+ * prefix test appends "/" so that a registered "plugins/open-agreements" cannot
+ * be stretched into "plugins/open-agreements-evil".
+ */
+function isAllowed(path, allowed) {
+  return allowed.some((entry) => path === entry || path.startsWith(`${entry}/`));
+}
+
+function assertSafePath(path, allowed, context) {
+  if (path.startsWith("/")) fail(`absolute path in ${context}: ${path}`);
+  if (path.split("/").includes("..")) fail(`path traversal in ${context}: ${path}`);
+  if (!isAllowed(path, allowed)) {
+    fail(`${context} touches an unregistered path: ${path}`);
+  }
+}
+
+/** Unquote a git diff path, dropping the a/ or b/ prefix. */
+function normalize(raw) {
+  let path = raw.trim();
+  if (path.startsWith('"') && path.endsWith('"')) {
+    // Git quotes paths containing specials; a quoted path in a machine-generated
+    // patch over ASCII artifact names is unexpected enough to reject outright.
+    fail(`quoted path in patch: ${path}`);
+  }
+  if (path === "/dev/null") return null;
+  if (path.startsWith("a/") || path.startsWith("b/")) path = path.slice(2);
+  return path;
+}
+
+const patchFile = process.argv[2];
+if (!patchFile) fail("no patch file given.");
+
+const patch = readFileSync(patchFile, "utf-8");
+if (patch.trim().length === 0) fail("patch is empty.");
+
+const allowed = allowlist();
+let fileCount = 0;
+
+for (const line of patch.split("\n")) {
+  if (line.startsWith("diff --git ")) {
+    fileCount += 1;
+    // "diff --git a/x b/y" — split on " b/" so a space-bearing name still pairs.
+    const rest = line.slice("diff --git ".length);
+    const split = rest.indexOf(" b/");
+    if (split === -1) fail(`unparseable diff header: ${line}`);
+    const before = normalize(rest.slice(0, split));
+    const after = normalize(rest.slice(split + 1));
+    for (const path of [before, after]) {
+      if (path) assertSafePath(path, allowed, "diff header");
+    }
+    continue;
+  }
+
+  if (line.startsWith("--- ") || line.startsWith("+++ ")) {
+    const path = normalize(line.slice(4));
+    if (path) assertSafePath(path, allowed, "file header");
+    continue;
+  }
+
+  if (line.startsWith("rename from ") || line.startsWith("rename to ") ||
+      line.startsWith("copy from ") || line.startsWith("copy to ")) {
+    const path = normalize(line.slice(line.indexOf(" ", line.indexOf(" ") + 1) + 1));
+    if (path) assertSafePath(path, allowed, "rename/copy header");
+    continue;
+  }
+
+  // Symlinks turn a content write into a write anywhere the link points.
+  if (/^(old|new|deleted file|new file) mode 120000$/.test(line.trim())) {
+    fail("patch creates or modifies a symlink.");
+  }
+}
+
+if (fileCount === 0) fail("patch contains no file diffs.");
+
+console.log(
+  `Patch accepted: ${fileCount} file diff(s), all within the ${allowed.length} registered derived path(s).`
+);

--- a/scripts/validate_derived_patch.test.mjs
+++ b/scripts/validate_derived_patch.test.mjs
@@ -1,0 +1,148 @@
+/**
+ * Behavioural tests for the derived-artifact patch gatekeeper.
+ *
+ * This script is the trust boundary of the self-heal split: everything it
+ * accepts gets applied and pushed by a privileged job. So the cases that matter
+ * most are the refusals. Each drives the real script end to end and asserts on
+ * the exit code, against this repo's actual allowlist.
+ */
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const validator = join(repoRoot, "scripts", "validate_derived_patch.mjs");
+
+let dir;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "derived-patch-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+/** Run the validator over `body`; return { code, output }. */
+function validate(body) {
+  const file = join(dir, "derived.patch");
+  writeFileSync(file, body);
+  try {
+    const output = execFileSync(process.execPath, [validator, file], {
+      encoding: "utf-8",
+      stdio: "pipe",
+    });
+    return { code: 0, output };
+  } catch (error) {
+    return { code: error.status ?? 1, output: `${error.stdout ?? ""}${error.stderr ?? ""}` };
+  }
+}
+
+/** A minimal well-formed single-file diff. */
+function diffFor(path) {
+  return [
+    `diff --git a/${path} b/${path}`,
+    "index 1111111..2222222 100644",
+    `--- a/${path}`,
+    `+++ b/${path}`,
+    "@@ -1 +1 @@",
+    "-old",
+    "+new",
+    "",
+  ].join("\n");
+}
+
+describe("derived patch gatekeeper", () => {
+  it("accepts a patch confined to a registered path", () => {
+    const result = validate(diffFor("README.md"));
+    expect(result.code).toBe(0);
+    expect(result.output).toContain("Patch accepted");
+  });
+
+  it("accepts a file nested under a registered directory", () => {
+    const result = validate(diffFor("plugins/open-agreements/skills/x/content/ohio.md"));
+    expect(result.code).toBe(0);
+  });
+
+  it("refuses a patch that touches source outside the registry", () => {
+    const result = validate(diffFor("src/core/engine.ts"));
+    expect(result.code).toBe(1);
+    expect(result.output).toContain("unregistered path");
+  });
+
+  it("refuses a patch that rewrites a workflow", () => {
+    const result = validate(diffFor(".github/workflows/ci.yml"));
+    expect(result.code).toBe(1);
+  });
+
+  // The prefix test must not let a registered directory name be stretched into
+  // a sibling that merely starts with the same characters.
+  it("refuses a sibling path that only shares a registered prefix", () => {
+    const result = validate(diffFor("plugins/open-agreements-evil/payload.md"));
+    expect(result.code).toBe(1);
+    expect(result.output).toContain("unregistered path");
+  });
+
+  it("refuses path traversal", () => {
+    const result = validate(diffFor("README.md/../../../../etc/passwd"));
+    expect(result.code).toBe(1);
+  });
+
+  it("refuses an absolute path", () => {
+    const body = [
+      "diff --git a//etc/passwd b//etc/passwd",
+      "--- a//etc/passwd",
+      "+++ b//etc/passwd",
+      "@@ -1 +1 @@",
+      "-x",
+      "+y",
+      "",
+    ].join("\n");
+    expect(validate(body).code).toBe(1);
+  });
+
+  it("refuses a symlink", () => {
+    const body = [
+      "diff --git a/llms.txt b/llms.txt",
+      "new file mode 120000",
+      "--- /dev/null",
+      "+++ b/llms.txt",
+      "@@ -0,0 +1 @@",
+      "+/etc/passwd",
+      "",
+    ].join("\n");
+    const result = validate(body);
+    expect(result.code).toBe(1);
+    expect(result.output).toContain("symlink");
+  });
+
+  it("refuses a rename whose destination escapes the registry", () => {
+    const body = [
+      "diff --git a/llms.txt b/llms.txt",
+      "similarity index 100%",
+      "rename from llms.txt",
+      "rename to src/core/engine.ts",
+      "",
+    ].join("\n");
+    expect(validate(body).code).toBe(1);
+  });
+
+  it("refuses an empty patch", () => {
+    const result = validate("");
+    expect(result.code).toBe(1);
+    expect(result.output).toContain("empty");
+  });
+
+  it("refuses a patch with no file diffs at all", () => {
+    const result = validate("just some prose, no diff headers\n");
+    expect(result.code).toBe(1);
+    expect(result.output).toContain("no file diffs");
+  });
+
+  // One good path does not launder a bad one in the same patch.
+  it("refuses a mixed patch containing one unregistered file", () => {
+    const result = validate(diffFor("llms.txt") + diffFor("package.json"));
+    expect(result.code).toBe(1);
+  });
+});


### PR DESCRIPTION
Implements the two-workflow split specified in #675. Closes #675.

## The problem

The sync bot writes sources without running this repo's generators, so its PRs are **born red** on the derived-artifact gates and a human regenerates by hand. It happened again yesterday on `update/corpus`, after #673.

#673 shipped the gate but **deliberately withdrew** the self-heal: that version minted a write-capable App token in the same job that ran `npm ci`, a repo-local action, and the generators — all PR-controlled code. Author-login and same-repo gates aren't spoofable, but they don't make executing that code safe.

## The split

**`derived-regen-build.yml` — unprivileged.** Runs the PR's code. `contents: read`, no secrets. Regenerates, emits a patch restricted to registered derived paths. If nothing drifted, it uploads nothing.

**`derived-regen-apply.yml` — privileged.** Runs on `workflow_run`, so its definition always comes from the default branch and the PR cannot edit the workflow acting on it.

> **It never executes pull-request code.** No install, no repo-local action, no generator, no lifecycle script — just `git`, `gh`, and two scripts read from a base-branch checkout.

It re-derives every fact from its own trusted payload rather than trusting the build job, validates the patch, applies it, and **only then** mints the token — in the last step before the push.

## What carries the safety

**The gatekeeper** (`scripts/validate_derived_patch.mjs`) parses diff, file, and rename headers and refuses anything not at or beneath a registered path, plus absolute paths, traversal, quoted paths, and symlink modes. It runs from the **base** checkout, never the PR — so a PR cannot widen its own allowlist by editing the registry. Its prefix test appends `/` so `plugins/open-agreements` can't be stretched into `plugins/open-agreements-evil`.

**The allowlist stays single-sourced.** `derived_artifacts.mjs` grows `--list-paths` rather than the workflow carrying a second copy of the registry to rot. Same array `--check` and `--generate` use; needs no install.

**The push is plain, not forced.** The new commit's parent is the SHA the patch was built against, so a branch that moved gets a *rejected push* rather than clobbered work. The applier also re-checks the branch tip via the API first, and binds to `head.sha` throughout rather than the race-prone `head.ref`.

Belt and braces: the staged file list is re-checked against the allowlist after `git apply`, so the gatekeeper isn't a single point of failure.

## ⚠️ Requires two new secrets

`DERIVED_REGEN_APP_ID` and `DERIVED_REGEN_PRIVATE_KEY`, for a **dedicated contents-only App** rather than the broadly-privileged release App. Until they're set the applier logs a notice and skips — **merging this changes nothing until the App exists.**

## Verification

12 tests in `scripts/validate_derived_patch.test.mjs`, mostly refusals:

| Case | Result |
|---|---|
| Smuggled source file (`src/core/engine.ts`) | refused |
| Workflow rewrite (`.github/workflows/ci.yml`) | refused |
| Prefix-stretch sibling (`plugins/open-agreements-evil/`) | refused |
| Path traversal | refused |
| Absolute path | refused |
| Symlink mode `120000` | refused |
| Rename escaping the registry | refused |
| Empty patch / no file diffs | refused |
| Mixed patch — one good path doesn't launder a bad one | refused |
| Registered path, and a file nested under one | accepted |

Both workflows' shell halves were **rehearsed end to end** against a throwaway repo: build emits a correctly scoped patch and excludes an unrelated source edit; apply validates, applies, and commits it; the no-drift case uploads nothing so the applier no-ops.

Suite: **1075 passed / 6 skipped** (1063 baseline + 12 new). `lint`, `build`, `check:derived` clean.

## Still the better answer

The bot-side fix in #675 — have the sync bot run `generate:derived` before it pushes — remains preferable if it ever becomes practical: no privileged workflow, no trust boundary to get right.
