### PR TITLE
chore: ignore local peer-review scratch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ tests/test_documents/
 # AI agent config
 GEMINI.local.md
 gemini-extension.local.json
+.peer-review/
 
 # Python virtual env
 .venv/


### PR DESCRIPTION
## Summary

- ignore the local `.peer-review/` scratch directory
- prevent review artifacts from being staged accidentally in this public repository

## Validation

- `npm run build`
- `npm run lint`
- `npm run test:run`
- `node bin/open-agreements.js validate`