### PR TITLE
feat(cli): add local persistent agreements

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -36,14 +36,17 @@ jobs:
             BASE_SHA="HEAD~1"
           fi
 
-          # Ensure no template with allow_derivatives=false has been modified.
+          # Ensure no template content with allow_derivatives=false has been modified.
+          # metadata.yaml may change to add or maintain non-content capability manifests.
           # Slugs live two levels deep: templates/<source>-<rights>/<slug>/ (#1249).
           for dir in templates/*/*/; do
             if [ -f "$dir/metadata.yaml" ]; then
               allow=$(grep 'allow_derivatives:' "$dir/metadata.yaml" | awk '{print $2}')
               if [ "$allow" = "false" ]; then
-                if git diff --name-only "$BASE_SHA" 2>/dev/null | grep -q "$dir"; then
+                changed_files=$(git diff --name-only "$BASE_SHA" -- "$dir" 2>/dev/null | grep -vFx "${dir}metadata.yaml" || true)
+                if [ -n "$changed_files" ]; then
                   echo "ERROR: Modified template in $dir which has allow_derivatives=false"
+                  printf '%s\n' "$changed_files"
                   exit 1
                 fi
               fi

--- a/bin/open-agreements.js
+++ b/bin/open-agreements.js
@@ -1,4 +1,9 @@
 #!/usr/bin/env node
 import { runCli } from '../dist/cli/index.js';
 
-await runCli(process.argv);
+try {
+  await runCli(process.argv);
+} catch (error) {
+  console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+  process.exitCode = 1;
+}

--- a/docs/adding-templates.md
+++ b/docs/adding-templates.md
@@ -56,6 +56,12 @@ fields:
 priority_fields:
   - party_name
   - effective_date
+artifact_kind: agreement       # agreement | consent | notice | letter | checklist | policy | other
+capabilities: [create, review, render]
+party_roles: [company, employee]
+signature_roles: [company, employee]
+mutation_policy: fields_only   # terms | fields_only | immutable
+maturity: experimental         # experimental | beta | stable
 # Optional: structured credits for contributors who materially shaped the template.
 # See CONTRIBUTING.md ("Template credits") for the policy.
 credits:
@@ -65,6 +71,14 @@ credits:
 # Optional: neutral prose identifying the source materials this template was derived from.
 derived_from: Publicly available materials from ...
 ```
+
+The six capability-manifest fields are required in every shipped
+`metadata.yaml`. `capabilities` states which persistent-local-agreement
+operations are supported. `party_roles` and `signature_roles` use stable,
+snake-case semantic role names. `fields_only` limits persisted terms to names
+declared in `fields`; `immutable` is appropriate for review-only upstream
+artifacts. Do not declare `create` or `render` for a network-backed field
+selector or a no-derivatives external form.
 
 #### Field types
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -49,6 +49,26 @@ open-agreements fill openagreements-employment-offer-letter \
 Use `open-agreements fill --help` for memo output paths, jurisdiction overrides,
 and baseline comparison options.
 
+## Manage persistent local agreements
+
+```bash
+open-agreements agreements create <template> --data terms.json
+open-agreements agreements list [--json]
+open-agreements agreements show <id> [--json]
+open-agreements agreements update <id> --revision 1 --set field=value
+open-agreements agreements review <id>
+open-agreements agreements render <id> --output agreement.docx
+```
+
+Agreement state stays on the local filesystem under
+`.open-agreements/agreements/<id>/`; add `.open-agreements/` to the consuming
+project's `.gitignore`. Set `OPEN_AGREEMENTS_STATE_ROOT` to override the
+agreements directory. Updates merge declared template fields, advance the
+revision, and can use `--revision` for optimistic concurrency. Review persists
+unfilled-priority, provenance-drift, and rendered-document integrity warnings.
+Render uses the existing local template engine and records the output SHA-256.
+These commands do not log in, send documents, or access the network.
+
 ## Validate templates and field-selectors
 
 ```bash

--- a/integration-tests/workflow-license-check.test.ts
+++ b/integration-tests/workflow-license-check.test.ts
@@ -37,8 +37,17 @@ describe('validate workflow license-diff logic', () => {
     await allureStep('Assert non-derivative enforcement block', () => {
       expect(VALIDATE_WORKFLOW).toContain('allow_derivatives:');
       expect(VALIDATE_WORKFLOW).toContain('if [ "$allow" = "false" ]; then');
-      expect(VALIDATE_WORKFLOW).toContain('git diff --name-only "$BASE_SHA"');
+      expect(VALIDATE_WORKFLOW).toContain('git diff --name-only "$BASE_SHA" -- "$dir"');
       expect(VALIDATE_WORKFLOW).toContain('exit 1');
+    });
+  });
+
+  it('permits metadata-only changes in no-derivatives template directories', async () => {
+    await allureParameter('workflow', '.github/workflows/validate.yml');
+
+    await allureStep('Assert capability manifest metadata is excluded exactly', () => {
+      expect(VALIDATE_WORKFLOW).toContain('grep -vFx "${dir}metadata.yaml"');
+      expect(VALIDATE_WORKFLOW).toContain('if [ -n "$changed_files" ]; then');
     });
   });
 });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,6 +19,15 @@ import {
   runChecklistPatchApply,
 } from '../commands/checklist.js';
 import { type MemoFormat } from '../core/employment/memo.js';
+import {
+  loadAgreementTerms,
+  runAgreementCreate,
+  runAgreementList,
+  runAgreementRender,
+  runAgreementReview,
+  runAgreementShow,
+  runAgreementUpdate,
+} from '../commands/agreements.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -82,6 +91,67 @@ export function createProgram(): Command {
     });
 
   program.addCommand(fillCmd);
+
+  // --- Local persistent agreements ---
+
+  const agreementsCmd = new Command('agreements');
+  agreementsCmd.description('Create and manage local persistent agreements');
+
+  agreementsCmd
+    .command('create <template>')
+    .description('Create a local agreement from a template')
+    .option('-d, --data <json-file>', 'JSON file with initial terms')
+    .option('--set <key=value...>', 'Set an initial term (repeatable)')
+    .action(async (template: string, opts: { data?: string; set?: string[] }) => {
+      await runAgreementCreate({ template, terms: loadAgreementTerms(opts.data, opts.set) });
+    });
+
+  agreementsCmd
+    .command('list')
+    .description('List local agreements')
+    .option('--json', 'Output machine-readable JSON')
+    .action(async (opts: { json?: boolean }) => {
+      await runAgreementList(opts);
+    });
+
+  agreementsCmd
+    .command('show <id>')
+    .description('Show a local agreement')
+    .option('--json', 'Output the full agreement record')
+    .action(async (id: string, opts: { json?: boolean }) => {
+      await runAgreementShow({ id, json: opts.json });
+    });
+
+  agreementsCmd
+    .command('update <id>')
+    .description('Merge terms into a local agreement and advance its revision')
+    .option('-d, --data <json-file>', 'JSON file with terms to merge')
+    .option('--set <key=value...>', 'Set a term (repeatable)')
+    .option('--revision <number>', 'Require this current revision before updating')
+    .action(async (id: string, opts: { data?: string; set?: string[]; revision?: string }) => {
+      await runAgreementUpdate({
+        id,
+        terms: loadAgreementTerms(opts.data, opts.set),
+        revision: opts.revision === undefined ? undefined : Number(opts.revision),
+      });
+    });
+
+  agreementsCmd
+    .command('review <id>')
+    .description('Review local terms and template provenance, persisting warnings')
+    .action(async (id: string) => {
+      await runAgreementReview({ id });
+    });
+
+  agreementsCmd
+    .command('render <id>')
+    .description('Render the current agreement revision to DOCX')
+    .option('-o, --output <path>', 'Output DOCX path')
+    .action(async (id: string, opts: { output?: string }) => {
+      await runAgreementRender({ id, output: opts.output });
+    });
+
+  program.addCommand(agreementsCmd);
 
   // --- Validate command ---
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -127,12 +127,12 @@ export function createProgram(): Command {
     .description('Merge terms into a local agreement and advance its revision')
     .option('-d, --data <json-file>', 'JSON file with terms to merge')
     .option('--set <key=value...>', 'Set a term (repeatable)')
-    .option('--revision <number>', 'Require this current revision before updating')
-    .action(async (id: string, opts: { data?: string; set?: string[]; revision?: string }) => {
+    .option('--revision <number>', 'Require this current revision before updating', parsePositiveRevision)
+    .action(async (id: string, opts: { data?: string; set?: string[]; revision?: number }) => {
       await runAgreementUpdate({
         id,
         terms: loadAgreementTerms(opts.data, opts.set),
-        revision: opts.revision === undefined ? undefined : Number(opts.revision),
+        revision: opts.revision,
       });
     });
 
@@ -359,6 +359,14 @@ export function createProgram(): Command {
   program.addCommand(checklistCmd);
 
   return program;
+}
+
+function parsePositiveRevision(value: string): number {
+  const revision = Number(value);
+  if (!Number.isInteger(revision) || revision < 1) {
+    throw new Error(`Invalid --revision: "${value}" (expected a positive integer)`);
+  }
+  return revision;
 }
 
 function buildMemoArgs(opts: {

--- a/src/commands/agreements.test.ts
+++ b/src/commands/agreements.test.ts
@@ -142,6 +142,18 @@ maturity: experimental
     expect(results.filter((result) => result.status === 'rejected')).toHaveLength(1);
   });
 
+  it('agreements update reclaims a lock owned by a dead process', async () => {
+    const created = await create();
+    writeFileSync(join(stateRoot, created.id, '.lock'), '2147483647\n0\n');
+    const updated = await runAgreementUpdate({
+      id: created.id,
+      terms: { party_name: 'Recovered' },
+      revision: 1,
+      root: stateRoot,
+    });
+    expect(updated).toMatchObject({ revision: 2, terms: { party_name: 'Recovered' } });
+  });
+
   it('agreements update rejects empty and unknown fields', async () => {
     const created = await create();
     await expect(runAgreementUpdate({ id: created.id, terms: {}, root: stateRoot }))

--- a/src/commands/agreements.test.ts
+++ b/src/commands/agreements.test.ts
@@ -1,0 +1,140 @@
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  runAgreementCreate,
+  runAgreementList,
+  runAgreementRender,
+  runAgreementReview,
+  runAgreementShow,
+  runAgreementUpdate,
+} from './agreements.js';
+
+describe('local agreement commands', () => {
+  let tempRoot: string;
+  let stateRoot: string;
+  let templateDir: string;
+  let previousContentRoots: string | undefined;
+
+  beforeEach(() => {
+    tempRoot = mkdtempSync(join(tmpdir(), 'open-agreements-local-'));
+    stateRoot = join(tempRoot, 'state');
+    templateDir = join(tempRoot, 'templates', 'fixtures-cc0', 'fixture-nda');
+    mkdirSync(templateDir, { recursive: true });
+    writeFileSync(join(templateDir, 'template.docx'), 'fixture template bytes');
+    writeFileSync(join(templateDir, 'metadata.yaml'), `
+name: Fixture NDA
+source_url: https://example.com/fixture-nda
+version: "1.2.3"
+license: CC0-1.0
+allow_derivatives: true
+attribution_text: Fixture
+fields:
+  - name: party_name
+    type: string
+    description: Party name
+priority_fields:
+  - party_name
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles:
+  - disclosing_party
+  - receiving_party
+signature_roles:
+  - disclosing_party
+  - receiving_party
+mutation_policy: fields_only
+maturity: experimental
+`.trimStart());
+    previousContentRoots = process.env.OPEN_AGREEMENTS_CONTENT_ROOTS;
+    process.env.OPEN_AGREEMENTS_CONTENT_ROOTS = tempRoot;
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    if (previousContentRoots === undefined) delete process.env.OPEN_AGREEMENTS_CONTENT_ROOTS;
+    else process.env.OPEN_AGREEMENTS_CONTENT_ROOTS = previousContentRoots;
+    vi.restoreAllMocks();
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  async function create(terms: Record<string, unknown> = {}) {
+    return runAgreementCreate({ template: 'fixture-nda', terms, root: stateRoot });
+  }
+
+  it('agreements create persists template provenance, revision, and terms', async () => {
+    const record = await create({ party_name: 'Acme' });
+    const stored = JSON.parse(readFileSync(join(stateRoot, record.id, 'agreement.json'), 'utf-8'));
+    expect(stored).toMatchObject({
+      id: record.id,
+      template: { id: 'fixture-nda', version: '1.2.3' },
+      revision: 1,
+      terms: { party_name: 'Acme' },
+      review: null,
+      rendered_document: null,
+    });
+    expect(stored.template.source_sha256).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('agreements list returns persisted records', async () => {
+    const created = await create();
+    const records = await runAgreementList({ root: stateRoot });
+    expect(records.map((record) => record.id)).toEqual([created.id]);
+  });
+
+  it('agreements show returns the complete record', async () => {
+    const created = await create({ party_name: 'Acme' });
+    const shown = await runAgreementShow({ id: created.id, json: true, root: stateRoot });
+    expect(shown).toEqual(created);
+  });
+
+  it('agreements update merges terms, advances revision, and enforces optimistic revision', async () => {
+    const created = await create({ party_name: 'Acme', unchanged: true });
+    const updated = await runAgreementUpdate({
+      id: created.id,
+      terms: { party_name: 'Beta' },
+      revision: 1,
+      root: stateRoot,
+    });
+    expect(updated).toMatchObject({ revision: 2, terms: { party_name: 'Beta', unchanged: true } });
+    await expect(runAgreementUpdate({ id: created.id, terms: {}, revision: 1, root: stateRoot }))
+      .rejects.toThrow('Revision conflict');
+  });
+
+  it('agreements review persists missing-priority warnings for the current revision', async () => {
+    const created = await create();
+    const reviewed = await runAgreementReview({ id: created.id, root: stateRoot });
+    expect(reviewed.review).toMatchObject({
+      revision: 1,
+      warnings: ['Priority term is unfilled: party_name'],
+    });
+  });
+
+  it('agreements render persists the rendered document SHA-256', async () => {
+    const created = await create({ party_name: 'Acme' });
+    const output = join(tempRoot, 'rendered.docx');
+    const rendered = await runAgreementRender({
+      id: created.id,
+      output,
+      root: stateRoot,
+      renderer: async (options) => {
+        writeFileSync(options.outputPath, 'rendered fixture bytes');
+        return {
+          outputPath: options.outputPath,
+          metadata: (await import('../core/metadata.js')).loadMetadata(options.templateDir),
+          fieldsUsed: ['party_name'],
+          providedFieldsUsed: ['party_name'],
+          fillCommandCount: 1,
+          warnings: [],
+        };
+      },
+    });
+    expect(rendered.rendered_document).toMatchObject({ revision: 1, path: output });
+    expect(rendered.rendered_document?.sha256).toMatch(/^[a-f0-9]{64}$/);
+  });
+});

--- a/src/commands/agreements.test.ts
+++ b/src/commands/agreements.test.ts
@@ -1,7 +1,9 @@
+import { createHash } from 'node:crypto';
 import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, vi } from 'vitest';
+import { itAllure } from '../../integration-tests/helpers/allure-test.js';
 import {
   runAgreementCreate,
   runAgreementList,
@@ -10,6 +12,8 @@ import {
   runAgreementShow,
   runAgreementUpdate,
 } from './agreements.js';
+
+const it = itAllure.epic('Filling & Rendering');
 
 describe('local agreement commands', () => {
   let tempRoot: string;
@@ -34,8 +38,22 @@ fields:
   - name: party_name
     type: string
     description: Party name
+  - name: unchanged
+    type: boolean
+    description: Unchanged flag
+  - name: a
+    type: number
+    description: Concurrent value A
+  - name: b
+    type: number
+    description: Concurrent value B
+  - name: defaulted_term
+    type: string
+    description: Defaulted priority term
+    default: present
 priority_fields:
   - party_name
+  - defaulted_term
 artifact_kind: agreement
 capabilities:
   - create
@@ -81,6 +99,14 @@ maturity: experimental
     expect(stored.template.source_sha256).toMatch(/^[a-f0-9]{64}$/);
   });
 
+  it('agreements create hashes template.fill.docx when both artifacts exist', async () => {
+    writeFileSync(join(templateDir, 'template.fill.docx'), 'actual fill source');
+    const record = await create();
+    expect(record.template.source_sha256).toBe(
+      createHash('sha256').update('actual fill source').digest('hex')
+    );
+  });
+
   it('agreements list returns persisted records', async () => {
     const created = await create();
     const records = await runAgreementList({ root: stateRoot });
@@ -102,8 +128,26 @@ maturity: experimental
       root: stateRoot,
     });
     expect(updated).toMatchObject({ revision: 2, terms: { party_name: 'Beta', unchanged: true } });
-    await expect(runAgreementUpdate({ id: created.id, terms: {}, revision: 1, root: stateRoot }))
+    await expect(runAgreementUpdate({ id: created.id, terms: { party_name: 'Gamma' }, revision: 1, root: stateRoot }))
       .rejects.toThrow('Revision conflict');
+  });
+
+  it('agreements update serializes concurrent optimistic updates', async () => {
+    const created = await create();
+    const results = await Promise.allSettled([
+      runAgreementUpdate({ id: created.id, terms: { a: 1 }, revision: 1, root: stateRoot }),
+      runAgreementUpdate({ id: created.id, terms: { b: 1 }, revision: 1, root: stateRoot }),
+    ]);
+    expect(results.filter((result) => result.status === 'fulfilled')).toHaveLength(1);
+    expect(results.filter((result) => result.status === 'rejected')).toHaveLength(1);
+  });
+
+  it('agreements update rejects empty and unknown fields', async () => {
+    const created = await create();
+    await expect(runAgreementUpdate({ id: created.id, terms: {}, root: stateRoot }))
+      .rejects.toThrow('At least one term');
+    await expect(runAgreementUpdate({ id: created.id, terms: { invented: true }, root: stateRoot }))
+      .rejects.toThrow('Unknown term field');
   });
 
   it('agreements review persists missing-priority warnings for the current revision', async () => {
@@ -113,6 +157,16 @@ maturity: experimental
       revision: 1,
       warnings: ['Priority term is unfilled: party_name'],
     });
+  });
+
+  it('agreements list skips corrupt sibling records', async () => {
+    const created = await create();
+    const corruptId = '11111111-1111-4111-8111-111111111111';
+    mkdirSync(join(stateRoot, corruptId), { recursive: true });
+    writeFileSync(join(stateRoot, corruptId, 'agreement.json'), '{broken');
+    const records = await runAgreementList({ root: stateRoot });
+    expect(records.map((record) => record.id)).toEqual([created.id]);
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('skipping unreadable agreement'));
   });
 
   it('agreements render persists the rendered document SHA-256', async () => {
@@ -130,11 +184,15 @@ maturity: experimental
           fieldsUsed: ['party_name'],
           providedFieldsUsed: ['party_name'],
           fillCommandCount: 1,
-          warnings: [],
+          warnings: ['fixture render warning'],
         };
       },
     });
-    expect(rendered.rendered_document).toMatchObject({ revision: 1, path: output });
+    expect(rendered.rendered_document).toMatchObject({
+      revision: 1,
+      path: output,
+      warnings: ['fixture render warning'],
+    });
     expect(rendered.rendered_document?.sha256).toMatch(/^[a-f0-9]{64}$/);
   });
 });

--- a/src/commands/agreements.ts
+++ b/src/commands/agreements.ts
@@ -1,0 +1,238 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { z } from 'zod';
+import { fillTemplate } from '../core/engine.js';
+import { loadMetadata } from '../core/metadata.js';
+import { findTemplateDir } from '../utils/paths.js';
+
+const Sha256Schema = z.string().regex(/^[a-f0-9]{64}$/);
+const AgreementIdSchema = z.string().uuid();
+
+export const AgreementRecordSchema = z.object({
+  id: z.string().uuid(),
+  template: z.object({
+    id: z.string().min(1),
+    version: z.string(),
+    source_sha256: Sha256Schema,
+  }),
+  revision: z.number().int().positive(),
+  terms: z.record(z.string(), z.unknown()),
+  review: z.object({
+    revision: z.number().int().positive(),
+    warnings: z.array(z.string()),
+    reviewed_at: z.string().datetime(),
+  }).nullable(),
+  rendered_document: z.object({
+    revision: z.number().int().positive(),
+    path: z.string(),
+    sha256: Sha256Schema,
+    rendered_at: z.string().datetime(),
+  }).nullable(),
+  created_at: z.string().datetime(),
+  updated_at: z.string().datetime(),
+});
+
+export type AgreementRecord = z.infer<typeof AgreementRecordSchema>;
+
+interface CommandOptions {
+  root?: string;
+}
+
+function agreementsRoot(root?: string): string {
+  return root ?? process.env.OPEN_AGREEMENTS_STATE_ROOT ?? join(process.cwd(), '.open-agreements', 'agreements');
+}
+
+function agreementDir(id: string, root?: string): string {
+  return join(agreementsRoot(root), AgreementIdSchema.parse(id));
+}
+
+function recordPath(id: string, root?: string): string {
+  return join(agreementDir(id, root), 'agreement.json');
+}
+
+function sha256(buffer: Buffer): string {
+  return createHash('sha256').update(buffer).digest('hex');
+}
+
+function readRecord(id: string, root?: string): AgreementRecord {
+  const path = recordPath(id, root);
+  if (!existsSync(path)) throw new Error(`Agreement not found: "${id}"`);
+  return AgreementRecordSchema.parse(JSON.parse(readFileSync(path, 'utf-8')));
+}
+
+async function writeRecord(record: AgreementRecord, root?: string): Promise<void> {
+  const dir = agreementDir(record.id, root);
+  await mkdir(dir, { recursive: true });
+  const target = recordPath(record.id, root);
+  const temporary = join(dir, `.agreement-${process.pid}-${randomUUID()}.tmp`);
+  await writeFile(temporary, `${JSON.stringify(record, null, 2)}\n`, 'utf-8');
+  const { rename } = await import('node:fs/promises');
+  await rename(temporary, target);
+}
+
+function resolveTemplateSource(templateDir: string): string {
+  for (const name of ['template.docx', 'template.fill.docx']) {
+    const candidate = join(templateDir, name);
+    if (existsSync(candidate)) return candidate;
+  }
+  throw new Error(`Template source DOCX not found in ${templateDir}`);
+}
+
+function requireTemplate(templateId: string, capability: 'create' | 'review' | 'render') {
+  const templateDir = findTemplateDir(templateId);
+  if (!templateDir) throw new Error(`Template not found or not locally mutable: "${templateId}"`);
+  const metadata = loadMetadata(templateDir);
+  if (!metadata.capabilities.includes(capability)) {
+    throw new Error(`Template "${templateId}" does not support the ${capability} capability`);
+  }
+  return { templateDir, metadata, sourcePath: resolveTemplateSource(templateDir) };
+}
+
+export interface AgreementCreateArgs extends CommandOptions {
+  template: string;
+  terms?: Record<string, unknown>;
+  id?: string;
+}
+
+export async function runAgreementCreate(args: AgreementCreateArgs): Promise<AgreementRecord> {
+  const { metadata, sourcePath } = requireTemplate(args.template, 'create');
+  const id = args.id ?? randomUUID();
+  if (existsSync(recordPath(id, args.root))) throw new Error(`Agreement already exists: "${id}"`);
+  const now = new Date().toISOString();
+  const record: AgreementRecord = {
+    id,
+    template: {
+      id: args.template,
+      version: metadata.version,
+      source_sha256: sha256(readFileSync(sourcePath)),
+    },
+    revision: 1,
+    terms: args.terms ?? {},
+    review: null,
+    rendered_document: null,
+    created_at: now,
+    updated_at: now,
+  };
+  AgreementRecordSchema.parse(record);
+  await writeRecord(record, args.root);
+  console.log(`Created agreement ${id} from ${args.template} (revision 1)`);
+  return record;
+}
+
+export async function runAgreementList(args: CommandOptions & { json?: boolean } = {}): Promise<AgreementRecord[]> {
+  const root = agreementsRoot(args.root);
+  const records = !existsSync(root) ? [] : readdirSync(root, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && AgreementIdSchema.safeParse(entry.name).success && existsSync(recordPath(entry.name, args.root)))
+    .map((entry) => readRecord(entry.name, args.root))
+    .sort((a, b) => b.updated_at.localeCompare(a.updated_at));
+  if (args.json) console.log(JSON.stringify(records, null, 2));
+  else if (records.length === 0) console.log('No agreements found.');
+  else records.forEach((record) => console.log(`${record.id}  ${record.template.id}  revision ${record.revision}`));
+  return records;
+}
+
+export async function runAgreementShow(args: CommandOptions & { id: string; json?: boolean }): Promise<AgreementRecord> {
+  const record = readRecord(args.id, args.root);
+  if (args.json) console.log(JSON.stringify(record, null, 2));
+  else {
+    console.log(`${record.id}\nTemplate: ${record.template.id}@${record.template.version}\nRevision: ${record.revision}`);
+    console.log(`Terms: ${Object.keys(record.terms).length}\nReview warnings: ${record.review?.warnings.length ?? 'not reviewed'}`);
+    console.log(`Rendered: ${record.rendered_document?.path ?? 'not rendered'}`);
+  }
+  return record;
+}
+
+export interface AgreementUpdateArgs extends CommandOptions {
+  id: string;
+  terms: Record<string, unknown>;
+  revision?: number;
+}
+
+export async function runAgreementUpdate(args: AgreementUpdateArgs): Promise<AgreementRecord> {
+  const current = readRecord(args.id, args.root);
+  const { metadata } = requireTemplate(current.template.id, 'create');
+  if (metadata.mutation_policy === 'immutable') throw new Error(`Agreement ${args.id} is immutable`);
+  if (args.revision !== undefined && args.revision !== current.revision) {
+    throw new Error(`Revision conflict: expected ${args.revision}, current revision is ${current.revision}`);
+  }
+  const next: AgreementRecord = {
+    ...current,
+    revision: current.revision + 1,
+    terms: { ...current.terms, ...args.terms },
+    review: null,
+    rendered_document: null,
+    updated_at: new Date().toISOString(),
+  };
+  await writeRecord(next, args.root);
+  console.log(`Updated agreement ${args.id} to revision ${next.revision}`);
+  return next;
+}
+
+export async function runAgreementReview(args: CommandOptions & { id: string }): Promise<AgreementRecord> {
+  const current = readRecord(args.id, args.root);
+  const { metadata, sourcePath } = requireTemplate(current.template.id, 'review');
+  const warnings: string[] = [];
+  for (const field of metadata.priority_fields) {
+    const value = current.terms[field];
+    if (value === undefined || value === '' || (Array.isArray(value) && value.length === 0)) {
+      warnings.push(`Priority term is unfilled: ${field}`);
+    }
+  }
+  if (metadata.version !== current.template.version) warnings.push(`Template version changed: ${current.template.version} -> ${metadata.version}`);
+  if (sha256(readFileSync(sourcePath)) !== current.template.source_sha256) warnings.push('Template source SHA-256 has changed since creation');
+  if (current.rendered_document && current.rendered_document.revision !== current.revision) warnings.push('Rendered document is stale');
+  const next: AgreementRecord = {
+    ...current,
+    review: { revision: current.revision, warnings, reviewed_at: new Date().toISOString() },
+    updated_at: new Date().toISOString(),
+  };
+  await writeRecord(next, args.root);
+  warnings.forEach((warning) => console.warn(`Warning: ${warning}`));
+  console.log(`Reviewed agreement ${args.id}: ${warnings.length} warning(s)`);
+  return next;
+}
+
+export interface AgreementRenderArgs extends CommandOptions {
+  id: string;
+  output?: string;
+  renderer?: typeof fillTemplate;
+}
+
+export async function runAgreementRender(args: AgreementRenderArgs): Promise<AgreementRecord> {
+  const current = readRecord(args.id, args.root);
+  const { templateDir, sourcePath } = requireTemplate(current.template.id, 'render');
+  if (sha256(readFileSync(sourcePath)) !== current.template.source_sha256) {
+    throw new Error('Template source SHA-256 has changed; create a new agreement before rendering');
+  }
+  const outputPath = resolve(args.output ?? join(agreementDir(args.id, args.root), `document-r${current.revision}.docx`));
+  await mkdir(dirname(outputPath), { recursive: true });
+  await (args.renderer ?? fillTemplate)({ templateDir, values: current.terms, outputPath });
+  const documentHash = sha256(readFileSync(outputPath));
+  const next: AgreementRecord = {
+    ...current,
+    rendered_document: {
+      revision: current.revision,
+      path: outputPath,
+      sha256: documentHash,
+      rendered_at: new Date().toISOString(),
+    },
+    updated_at: new Date().toISOString(),
+  };
+  await writeRecord(next, args.root);
+  console.log(`Rendered agreement ${args.id}\nOutput: ${outputPath}\nSHA-256: ${documentHash}`);
+  return next;
+}
+
+export function loadAgreementTerms(path?: string, sets: string[] = []): Record<string, unknown> {
+  const terms = path
+    ? z.record(z.string(), z.unknown()).parse(JSON.parse(readFileSync(path, 'utf-8')))
+    : {};
+  for (const pair of sets) {
+    const separator = pair.indexOf('=');
+    if (separator < 1) throw new Error(`Invalid --set format: "${pair}" (expected key=value)`);
+    terms[pair.slice(0, separator)] = pair.slice(separator + 1);
+  }
+  return terms;
+}

--- a/src/commands/agreements.ts
+++ b/src/commands/agreements.ts
@@ -1,6 +1,6 @@
 import { createHash, randomUUID } from 'node:crypto';
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, open, rename, unlink, writeFile } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
 import { z } from 'zod';
 import { fillTemplate } from '../core/engine.js';
@@ -28,11 +28,12 @@ export const AgreementRecordSchema = z.object({
     revision: z.number().int().positive(),
     path: z.string(),
     sha256: Sha256Schema,
+    warnings: z.array(z.string()),
     rendered_at: z.string().datetime(),
   }).nullable(),
   created_at: z.string().datetime(),
   updated_at: z.string().datetime(),
-});
+}).passthrough();
 
 export type AgreementRecord = z.infer<typeof AgreementRecordSchema>;
 
@@ -59,7 +60,9 @@ function sha256(buffer: Buffer): string {
 function readRecord(id: string, root?: string): AgreementRecord {
   const path = recordPath(id, root);
   if (!existsSync(path)) throw new Error(`Agreement not found: "${id}"`);
-  return AgreementRecordSchema.parse(JSON.parse(readFileSync(path, 'utf-8')));
+  const record = AgreementRecordSchema.parse(JSON.parse(readFileSync(path, 'utf-8')));
+  if (record.id !== id) throw new Error(`Agreement record ID mismatch: expected "${id}", found "${record.id}"`);
+  return record;
 }
 
 async function writeRecord(record: AgreementRecord, root?: string): Promise<void> {
@@ -68,16 +71,45 @@ async function writeRecord(record: AgreementRecord, root?: string): Promise<void
   const target = recordPath(record.id, root);
   const temporary = join(dir, `.agreement-${process.pid}-${randomUUID()}.tmp`);
   await writeFile(temporary, `${JSON.stringify(record, null, 2)}\n`, 'utf-8');
-  const { rename } = await import('node:fs/promises');
   await rename(temporary, target);
 }
 
+async function withAgreementLock<T>(id: string, root: string | undefined, operation: () => Promise<T>): Promise<T> {
+  const dir = agreementDir(id, root);
+  await mkdir(dir, { recursive: true });
+  const lockPath = join(dir, '.lock');
+  let handle;
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    try {
+      handle = await open(lockPath, 'wx');
+      break;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+      await new Promise((resolveDelay) => setTimeout(resolveDelay, 10));
+    }
+  }
+  if (!handle) throw new Error(`Agreement ${id} is busy; try again`);
+  try {
+    return await operation();
+  } finally {
+    await handle.close();
+    await unlink(lockPath).catch(() => undefined);
+  }
+}
+
 function resolveTemplateSource(templateDir: string): string {
-  for (const name of ['template.docx', 'template.fill.docx']) {
+  for (const name of ['template.fill.docx', 'template.docx']) {
     const candidate = join(templateDir, name);
     if (existsSync(candidate)) return candidate;
   }
   throw new Error(`Template source DOCX not found in ${templateDir}`);
+}
+
+function validateTerms(metadata: ReturnType<typeof loadMetadata>, terms: Record<string, unknown>): void {
+  if (metadata.mutation_policy !== 'fields_only') return;
+  const allowed = new Set(metadata.fields.map((field) => field.name));
+  const unknown = Object.keys(terms).filter((key) => !allowed.has(key));
+  if (unknown.length > 0) throw new Error(`Unknown term field(s): ${unknown.join(', ')}`);
 }
 
 function requireTemplate(templateId: string, capability: 'create' | 'review' | 'render') {
@@ -98,6 +130,7 @@ export interface AgreementCreateArgs extends CommandOptions {
 
 export async function runAgreementCreate(args: AgreementCreateArgs): Promise<AgreementRecord> {
   const { metadata, sourcePath } = requireTemplate(args.template, 'create');
+  validateTerms(metadata, args.terms ?? {});
   const id = args.id ?? randomUUID();
   if (existsSync(recordPath(id, args.root))) throw new Error(`Agreement already exists: "${id}"`);
   const now = new Date().toISOString();
@@ -123,10 +156,18 @@ export async function runAgreementCreate(args: AgreementCreateArgs): Promise<Agr
 
 export async function runAgreementList(args: CommandOptions & { json?: boolean } = {}): Promise<AgreementRecord[]> {
   const root = agreementsRoot(args.root);
-  const records = !existsSync(root) ? [] : readdirSync(root, { withFileTypes: true })
-    .filter((entry) => entry.isDirectory() && AgreementIdSchema.safeParse(entry.name).success && existsSync(recordPath(entry.name, args.root)))
-    .map((entry) => readRecord(entry.name, args.root))
-    .sort((a, b) => b.updated_at.localeCompare(a.updated_at));
+  const records: AgreementRecord[] = [];
+  if (existsSync(root)) {
+    for (const entry of readdirSync(root, { withFileTypes: true })) {
+      if (!entry.isDirectory() || !AgreementIdSchema.safeParse(entry.name).success || !existsSync(recordPath(entry.name, args.root))) continue;
+      try {
+        records.push(readRecord(entry.name, args.root));
+      } catch (error) {
+        console.warn(`Warning: skipping unreadable agreement ${entry.name}: ${(error as Error).message}`);
+      }
+    }
+    records.sort((a, b) => b.updated_at.localeCompare(a.updated_at));
+  }
   if (args.json) console.log(JSON.stringify(records, null, 2));
   else if (records.length === 0) console.log('No agreements found.');
   else records.forEach((record) => console.log(`${record.id}  ${record.template.id}  revision ${record.revision}`));
@@ -151,47 +192,59 @@ export interface AgreementUpdateArgs extends CommandOptions {
 }
 
 export async function runAgreementUpdate(args: AgreementUpdateArgs): Promise<AgreementRecord> {
-  const current = readRecord(args.id, args.root);
-  const { metadata } = requireTemplate(current.template.id, 'create');
-  if (metadata.mutation_policy === 'immutable') throw new Error(`Agreement ${args.id} is immutable`);
-  if (args.revision !== undefined && args.revision !== current.revision) {
-    throw new Error(`Revision conflict: expected ${args.revision}, current revision is ${current.revision}`);
-  }
-  const next: AgreementRecord = {
-    ...current,
-    revision: current.revision + 1,
-    terms: { ...current.terms, ...args.terms },
-    review: null,
-    rendered_document: null,
-    updated_at: new Date().toISOString(),
-  };
-  await writeRecord(next, args.root);
-  console.log(`Updated agreement ${args.id} to revision ${next.revision}`);
-  return next;
+  if (Object.keys(args.terms).length === 0) throw new Error('At least one term is required for update');
+  return withAgreementLock(args.id, args.root, async () => {
+    const current = readRecord(args.id, args.root);
+    const { metadata } = requireTemplate(current.template.id, 'create');
+    if (metadata.mutation_policy === 'immutable') throw new Error(`Agreement ${args.id} is immutable`);
+    validateTerms(metadata, args.terms);
+    if (args.revision !== undefined && args.revision !== current.revision) {
+      throw new Error(`Revision conflict: expected ${args.revision}, current revision is ${current.revision}`);
+    }
+    const next: AgreementRecord = {
+      ...current,
+      revision: current.revision + 1,
+      terms: { ...current.terms, ...args.terms },
+      review: null,
+      rendered_document: null,
+      updated_at: new Date().toISOString(),
+    };
+    await writeRecord(next, args.root);
+    console.log(`Updated agreement ${args.id} to revision ${next.revision}`);
+    return next;
+  });
 }
 
 export async function runAgreementReview(args: CommandOptions & { id: string }): Promise<AgreementRecord> {
-  const current = readRecord(args.id, args.root);
-  const { metadata, sourcePath } = requireTemplate(current.template.id, 'review');
-  const warnings: string[] = [];
-  for (const field of metadata.priority_fields) {
-    const value = current.terms[field];
-    if (value === undefined || value === '' || (Array.isArray(value) && value.length === 0)) {
-      warnings.push(`Priority term is unfilled: ${field}`);
+  return withAgreementLock(args.id, args.root, async () => {
+    const current = readRecord(args.id, args.root);
+    const { metadata, sourcePath } = requireTemplate(current.template.id, 'review');
+    const warnings: string[] = [];
+    for (const fieldName of metadata.priority_fields) {
+      const field = metadata.fields.find((candidate) => candidate.name === fieldName);
+      const value = current.terms[fieldName] ?? field?.default;
+      if (value === undefined || value === '' || (Array.isArray(value) && value.length === 0)) {
+        warnings.push(`Priority term is unfilled: ${fieldName}`);
+      }
     }
-  }
-  if (metadata.version !== current.template.version) warnings.push(`Template version changed: ${current.template.version} -> ${metadata.version}`);
-  if (sha256(readFileSync(sourcePath)) !== current.template.source_sha256) warnings.push('Template source SHA-256 has changed since creation');
-  if (current.rendered_document && current.rendered_document.revision !== current.revision) warnings.push('Rendered document is stale');
-  const next: AgreementRecord = {
-    ...current,
-    review: { revision: current.revision, warnings, reviewed_at: new Date().toISOString() },
-    updated_at: new Date().toISOString(),
-  };
-  await writeRecord(next, args.root);
-  warnings.forEach((warning) => console.warn(`Warning: ${warning}`));
-  console.log(`Reviewed agreement ${args.id}: ${warnings.length} warning(s)`);
-  return next;
+    if (metadata.version !== current.template.version) warnings.push(`Template version changed: ${current.template.version} -> ${metadata.version}`);
+    if (sha256(readFileSync(sourcePath)) !== current.template.source_sha256) warnings.push('Template source SHA-256 has changed since creation');
+    if (current.rendered_document) {
+      if (current.rendered_document.revision !== current.revision) warnings.push('Rendered document is stale');
+      else if (!existsSync(current.rendered_document.path)) warnings.push('Rendered document is missing');
+      else if (sha256(readFileSync(current.rendered_document.path)) !== current.rendered_document.sha256) warnings.push('Rendered document SHA-256 does not match');
+      warnings.push(...current.rendered_document.warnings.map((warning) => `Render warning: ${warning}`));
+    }
+    const next: AgreementRecord = {
+      ...current,
+      review: { revision: current.revision, warnings, reviewed_at: new Date().toISOString() },
+      updated_at: new Date().toISOString(),
+    };
+    await writeRecord(next, args.root);
+    warnings.forEach((warning) => console.warn(`Warning: ${warning}`));
+    console.log(`Reviewed agreement ${args.id}: ${warnings.length} warning(s)`);
+    return next;
+  });
 }
 
 export interface AgreementRenderArgs extends CommandOptions {
@@ -201,28 +254,32 @@ export interface AgreementRenderArgs extends CommandOptions {
 }
 
 export async function runAgreementRender(args: AgreementRenderArgs): Promise<AgreementRecord> {
-  const current = readRecord(args.id, args.root);
-  const { templateDir, sourcePath } = requireTemplate(current.template.id, 'render');
-  if (sha256(readFileSync(sourcePath)) !== current.template.source_sha256) {
-    throw new Error('Template source SHA-256 has changed; create a new agreement before rendering');
-  }
-  const outputPath = resolve(args.output ?? join(agreementDir(args.id, args.root), `document-r${current.revision}.docx`));
-  await mkdir(dirname(outputPath), { recursive: true });
-  await (args.renderer ?? fillTemplate)({ templateDir, values: current.terms, outputPath });
-  const documentHash = sha256(readFileSync(outputPath));
-  const next: AgreementRecord = {
-    ...current,
-    rendered_document: {
-      revision: current.revision,
-      path: outputPath,
-      sha256: documentHash,
-      rendered_at: new Date().toISOString(),
-    },
-    updated_at: new Date().toISOString(),
-  };
-  await writeRecord(next, args.root);
-  console.log(`Rendered agreement ${args.id}\nOutput: ${outputPath}\nSHA-256: ${documentHash}`);
-  return next;
+  return withAgreementLock(args.id, args.root, async () => {
+    const current = readRecord(args.id, args.root);
+    const { templateDir, sourcePath } = requireTemplate(current.template.id, 'render');
+    if (sha256(readFileSync(sourcePath)) !== current.template.source_sha256) {
+      throw new Error('Template source SHA-256 has changed; create a new agreement before rendering');
+    }
+    const outputPath = resolve(args.output ?? join(agreementDir(args.id, args.root), `document-r${current.revision}.docx`));
+    await mkdir(dirname(outputPath), { recursive: true });
+    const result = await (args.renderer ?? fillTemplate)({ templateDir, values: current.terms, outputPath });
+    const documentHash = sha256(readFileSync(outputPath));
+    const next: AgreementRecord = {
+      ...current,
+      rendered_document: {
+        revision: current.revision,
+        path: outputPath,
+        sha256: documentHash,
+        warnings: result.warnings,
+        rendered_at: new Date().toISOString(),
+      },
+      updated_at: new Date().toISOString(),
+    };
+    await writeRecord(next, args.root);
+    result.warnings.forEach((warning) => console.warn(`Warning: ${warning}`));
+    console.log(`Rendered agreement ${args.id}\nOutput: ${outputPath}\nSHA-256: ${documentHash}`);
+    return next;
+  });
 }
 
 export function loadAgreementTerms(path?: string, sets: string[] = []): Record<string, unknown> {

--- a/src/commands/agreements.ts
+++ b/src/commands/agreements.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from 'node:crypto';
-import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { mkdir, open, rename, unlink, writeFile } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
 import { z } from 'zod';
@@ -76,24 +76,48 @@ async function writeRecord(record: AgreementRecord, root?: string): Promise<void
 
 async function withAgreementLock<T>(id: string, root: string | undefined, operation: () => Promise<T>): Promise<T> {
   const dir = agreementDir(id, root);
-  await mkdir(dir, { recursive: true });
+  if (!existsSync(recordPath(id, root))) throw new Error(`Agreement not found: "${id}"`);
   const lockPath = join(dir, '.lock');
   let handle;
-  for (let attempt = 0; attempt < 100; attempt += 1) {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
     try {
       handle = await open(lockPath, 'wx');
+      await handle.writeFile(`${process.pid}\n${Date.now()}\n`, 'utf-8');
       break;
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
-      await new Promise((resolveDelay) => setTimeout(resolveDelay, 10));
+      if (isStaleLock(lockPath)) {
+        await unlink(lockPath).catch(() => undefined);
+        continue;
+      }
+      await new Promise((resolveDelay) => setTimeout(resolveDelay, 25));
     }
   }
-  if (!handle) throw new Error(`Agreement ${id} is busy; try again`);
+  if (!handle) throw new Error(`Agreement ${id} is busy; lock held at ${lockPath}`);
   try {
     return await operation();
   } finally {
     await handle.close();
     await unlink(lockPath).catch(() => undefined);
+  }
+}
+
+function isStaleLock(lockPath: string): boolean {
+  try {
+    const [pidText] = readFileSync(lockPath, 'utf-8').trim().split(/\s+/);
+    const pid = Number(pidText);
+    if (Number.isInteger(pid) && pid > 0) {
+      try {
+        process.kill(pid, 0);
+        return false;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ESRCH') return true;
+        return false;
+      }
+    }
+    return Date.now() - statSync(lockPath).mtimeMs > 5 * 60 * 1000;
+  } catch {
+    return false;
   }
 }
 

--- a/src/core/metadata.test.ts
+++ b/src/core/metadata.test.ts
@@ -12,12 +12,47 @@ import {
   FieldDefinitionSchema,
   CleanConfigSchema,
   GuidanceOutputSchema,
+  TemplateCapabilityManifestSchema,
 } from './metadata.js';
 
 type SafeParseSchema = {
   safeParse: (payload: unknown) => { success: boolean };
 };
 const it = itAllure.epic('Discovery & Metadata');
+
+describe('TemplateCapabilityManifestSchema', () => {
+  it('accepts a complete local-agreement capability manifest', async () => {
+    await expectSafeParseOutcome(
+      'TemplateCapabilityManifestSchema',
+      TemplateCapabilityManifestSchema,
+      {
+        artifact_kind: 'agreement',
+        capabilities: ['create', 'review', 'render'],
+        party_roles: ['company', 'employee'],
+        signature_roles: ['company_signatory', 'employee'],
+        mutation_policy: 'terms',
+        maturity: 'experimental',
+      },
+      true
+    );
+  });
+
+  it('rejects unknown capabilities and maturity values', async () => {
+    await expectSafeParseOutcome(
+      'TemplateCapabilityManifestSchema',
+      TemplateCapabilityManifestSchema,
+      {
+        artifact_kind: 'agreement',
+        capabilities: ['send'],
+        party_roles: [],
+        signature_roles: [],
+        mutation_policy: 'terms',
+        maturity: 'production',
+      },
+      false
+    );
+  });
+});
 
 async function expectSafeParseOutcome(
   schemaName: string,
@@ -501,7 +536,17 @@ describe('FieldDefinitionSchema', () => {
   });
 });
 
+const BASE_CAPABILITY_MANIFEST = {
+  artifact_kind: 'agreement' as const,
+  capabilities: ['create', 'review', 'render'] as const,
+  party_roles: ['disclosing_party', 'receiving_party'],
+  signature_roles: ['disclosing_party', 'receiving_party'],
+  mutation_policy: 'fields_only' as const,
+  maturity: 'experimental' as const,
+};
+
 const BASE_TEMPLATE_METADATA = {
+  ...BASE_CAPABILITY_MANIFEST,
   name: 'Test NDA',
   source_url: 'https://example.com/nda',
   version: '1.0',
@@ -541,6 +586,7 @@ describe('TemplateMetadataSchema', () => {
       'TemplateMetadataSchema',
       TemplateMetadataSchema,
       {
+        ...BASE_CAPABILITY_MANIFEST,
         name: 'Test NDA',
         source_url: 'https://example.com/nda',
         version: '1.0',
@@ -756,6 +802,7 @@ describe('TemplateMetadataSchema', () => {
       'TemplateMetadataSchema',
       TemplateMetadataSchema,
       {
+        ...BASE_CAPABILITY_MANIFEST,
         name: 'Test Consent',
         source_url: 'https://example.com/consent',
         version: '1.0',
@@ -779,6 +826,7 @@ describe('TemplateMetadataSchema', () => {
   it('defaults missing credits to empty array', async () => {
     const parsed = await allureStep('Parse template metadata without credits', () =>
       TemplateMetadataSchema.parse({
+        ...BASE_CAPABILITY_MANIFEST,
         name: 'Test NDA',
         source_url: 'https://example.com/nda',
         version: '1.0',

--- a/src/core/metadata.test.ts
+++ b/src/core/metadata.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import yaml from 'js-yaml';
 import {
   allureJsonAttachment,
   allureParameter,
@@ -35,6 +38,25 @@ describe('TemplateCapabilityManifestSchema', () => {
       },
       true
     );
+  });
+
+  it('requires every shipped metadata file to declare the full manifest explicitly', async () => {
+    const files: string[] = [];
+    const walk = (directory: string): void => {
+      for (const entry of readdirSync(directory, { withFileTypes: true })) {
+        const path = join(directory, entry.name);
+        if (entry.isDirectory()) walk(path);
+        else if (entry.name === 'metadata.yaml') files.push(path);
+      }
+    };
+    walk(join(process.cwd(), 'templates'));
+    const keys = ['artifact_kind', 'capabilities', 'party_roles', 'signature_roles', 'mutation_policy', 'maturity'];
+    for (const file of files) {
+      const parsed = yaml.load(readFileSync(file, 'utf-8')) as Record<string, unknown>;
+      expect(keys.filter((key) => !(key in parsed)), file).toEqual([]);
+      expect(TemplateCapabilityManifestSchema.safeParse(parsed).success, file).toBe(true);
+    }
+    expect(files).toHaveLength(116);
   });
 
   it('rejects unknown capabilities and maturity values', async () => {

--- a/src/core/metadata.test.ts
+++ b/src/core/metadata.test.ts
@@ -572,6 +572,7 @@ function buildExternalMetadataPayload(fields: unknown[]) {
 
 function buildFieldSelectorMetadataPayload(fields: unknown[]) {
   return {
+    ...BASE_CAPABILITY_MANIFEST,
     name: 'Fixture FieldSelector',
     source_url: 'https://example.com/source.docx',
     source_version: '1.0',
@@ -886,6 +887,7 @@ describe('FieldSelectorMetadataSchema', () => {
       'FieldSelectorMetadataSchema',
       FieldSelectorMetadataSchema,
       {
+        ...BASE_CAPABILITY_MANIFEST,
         name: 'NVCA Voting Agreement',
         source_url: 'https://nvca.org/document.docx',
         source_version: '10-1-2025',
@@ -911,6 +913,7 @@ describe('FieldSelectorMetadataSchema', () => {
   it('defaults optional to false', async () => {
     const parsed = await allureStep('Parse fieldSelector metadata with optional omitted', () =>
       FieldSelectorMetadataSchema.parse({
+        ...BASE_CAPABILITY_MANIFEST,
         name: 'Test',
         source_url: 'https://example.com/doc.docx',
         source_version: '1.0',

--- a/src/core/metadata.ts
+++ b/src/core/metadata.ts
@@ -324,12 +324,12 @@ const TemplateCreditSchema = z.object({
 });
 
 export const TemplateCapabilityManifestSchema = z.object({
-  artifact_kind: z.enum(['agreement', 'consent', 'notice', 'letter', 'checklist', 'policy', 'other']),
-  capabilities: z.array(z.enum(['create', 'review', 'render'])).nonempty(),
-  party_roles: z.array(z.string().trim().min(1)),
-  signature_roles: z.array(z.string().trim().min(1)),
-  mutation_policy: z.enum(['terms', 'fields_only', 'immutable']),
-  maturity: z.enum(['experimental', 'beta', 'stable']),
+  artifact_kind: z.enum(['agreement', 'consent', 'notice', 'letter', 'checklist', 'policy', 'other']).default('other'),
+  capabilities: z.array(z.enum(['create', 'review', 'render'])).nonempty().default(['review']),
+  party_roles: z.array(z.string().trim().min(1)).default([]),
+  signature_roles: z.array(z.string().trim().min(1)).default([]),
+  mutation_policy: z.enum(['terms', 'fields_only', 'immutable']).default('immutable'),
+  maturity: z.enum(['experimental', 'beta', 'stable']).default('experimental'),
 });
 export type TemplateCapabilityManifest = z.infer<typeof TemplateCapabilityManifestSchema>;
 
@@ -540,6 +540,7 @@ export const FieldSelectorMetadataSchema = z.object({
   fields: z.array(FieldDefinitionSchema).default([]),
   priority_fields: z.array(z.string()).default([]),
   market_data_citations: z.array(MarketDataCitationSchema).optional(),
+  ...TemplateCapabilityManifestSchema.shape,
 }).superRefine((meta, ctx) => {
   validatePriorityFields(meta.fields, meta.priority_fields, ctx);
   validateDerivedBooleanCollisions(meta.fields, ctx);

--- a/src/core/metadata.ts
+++ b/src/core/metadata.ts
@@ -323,6 +323,16 @@ const TemplateCreditSchema = z.object({
   profile_url: z.string().url().optional(),
 });
 
+export const TemplateCapabilityManifestSchema = z.object({
+  artifact_kind: z.enum(['agreement', 'consent', 'notice', 'letter', 'checklist', 'policy', 'other']),
+  capabilities: z.array(z.enum(['create', 'review', 'render'])).nonempty(),
+  party_roles: z.array(z.string().trim().min(1)),
+  signature_roles: z.array(z.string().trim().min(1)),
+  mutation_policy: z.enum(['terms', 'fields_only', 'immutable']),
+  maturity: z.enum(['experimental', 'beta', 'stable']),
+});
+export type TemplateCapabilityManifest = z.infer<typeof TemplateCapabilityManifestSchema>;
+
 function validatePriorityFields(
   fields: FieldDefinition[],
   priorityFields: string[],
@@ -421,6 +431,7 @@ const TemplateMetadataBaseSchema = z.object({
   priority_fields: z.array(z.string()).default([]),
   credits: z.array(TemplateCreditSchema).default([]),
   derived_from: z.string().optional(),
+  ...TemplateCapabilityManifestSchema.shape,
 });
 
 export const TemplateMetadataSchema = TemplateMetadataBaseSchema.superRefine((meta, ctx) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,13 +40,30 @@ export {
   LicenseEnum,
   StabilityEnum,
   FieldDefinitionSchema,
+  TemplateCapabilityManifestSchema,
   type TemplateMetadata,
   type FieldSelectorMetadata,
   type CleanConfig,
   type FieldDefinition,
+  type TemplateCapabilityManifest,
   type License,
   type Stability,
 } from './core/metadata.js';
+
+// Local persistent agreements
+export {
+  AgreementRecordSchema,
+  runAgreementCreate,
+  runAgreementList,
+  runAgreementShow,
+  runAgreementUpdate,
+  runAgreementReview,
+  runAgreementRender,
+  type AgreementRecord,
+  type AgreementCreateArgs,
+  type AgreementUpdateArgs,
+  type AgreementRenderArgs,
+} from './commands/agreements.js';
 
 // External template engine
 export {

--- a/templates/bonterms-cc0-1.0/bonterms-mutual-nda/metadata.yaml
+++ b/templates/bonterms-cc0-1.0/bonterms-mutual-nda/metadata.yaml
@@ -135,3 +135,12 @@ priority_fields:
   - confidentiality_period
   - governing_law
   - courts
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/bonterms-cc0-1.0/bonterms-mutual-nda/metadata.yaml
+++ b/templates/bonterms-cc0-1.0/bonterms-mutual-nda/metadata.yaml
@@ -140,7 +140,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - party_1
+  - party_2
+signature_roles:
+  - party_1
+  - party_2
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/bonterms-cc0-1.0/bonterms-professional-services-agreement/metadata.yaml
+++ b/templates/bonterms-cc0-1.0/bonterms-professional-services-agreement/metadata.yaml
@@ -51,7 +51,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - provider
+  - customer
+signature_roles:
+  - provider
+  - customer
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/bonterms-cc0-1.0/bonterms-professional-services-agreement/metadata.yaml
+++ b/templates/bonterms-cc0-1.0/bonterms-professional-services-agreement/metadata.yaml
@@ -46,3 +46,12 @@ priority_fields:
   - effective_date
   - governing_law
   - courts
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/common-paper-cc-by-4.0/common-paper-ai-addendum-in-app/metadata.yaml
+++ b/templates/common-paper-cc-by-4.0/common-paper-ai-addendum-in-app/metadata.yaml
@@ -110,3 +110,12 @@ fields:
     description: Customer AI-specific Covered Claims apply
     section: AI Liability
 priority_fields: []
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/common-paper-cc-by-4.0/common-paper-ai-addendum/metadata.yaml
+++ b/templates/common-paper-cc-by-4.0/common-paper-ai-addendum/metadata.yaml
@@ -173,7 +173,13 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - company
+  - provider
+  - customer
+signature_roles:
+  - provider
+  - customer
+  - company
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/common-paper-cc-by-4.0/common-paper-ai-addendum/metadata.yaml
+++ b/templates/common-paper-cc-by-4.0/common-paper-ai-addendum/metadata.yaml
@@ -168,3 +168,12 @@ fields:
 priority_fields:
   - company_name
   - agreement_description
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/common-paper-cc-by-4.0/common-paper-amendment/metadata.yaml
+++ b/templates/common-paper-cc-by-4.0/common-paper-amendment/metadata.yaml
@@ -107,7 +107,13 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - company
+  - party_1
+  - party_2
+signature_roles:
+  - party_1
+  - party_2
+  - company
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/common-paper-cc-by-4.0/common-paper-amendment/metadata.yaml
+++ b/templates/common-paper-cc-by-4.0/common-paper-amendment/metadata.yaml
@@ -102,3 +102,12 @@ priority_fields:
   - amendment_effective_date
   - amendment_topic
   - amendment_details
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/common-paper-cc-by-4.0/common-paper-business-associate-agreement/metadata.yaml
+++ b/templates/common-paper-cc-by-4.0/common-paper-business-associate-agreement/metadata.yaml
@@ -170,7 +170,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - company
+  - provider
+signature_roles:
+  - provider
+  - company
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/common-paper-cc-by-4.0/common-paper-business-associate-agreement/metadata.yaml
+++ b/templates/common-paper-cc-by-4.0/common-paper-business-associate-agreement/metadata.yaml
@@ -165,3 +165,12 @@ priority_fields:
   - company_name
   - party_role
   - principal_agreement
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/common-paper-cc-by-4.0/common-paper-cloud-service-agreement/metadata.yaml
+++ b/templates/common-paper-cc-by-4.0/common-paper-cloud-service-agreement/metadata.yaml
@@ -408,7 +408,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - provider
+  - customer
+signature_roles:
+  - provider
+  - customer
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/common-paper-cc-by-4.0/common-paper-cloud-service-agreement/metadata.yaml
+++ b/templates/common-paper-cc-by-4.0/common-paper-cloud-service-agreement/metadata.yaml
@@ -403,3 +403,12 @@ priority_fields:
   - subscription_period
   - governing_law
   - jurisdiction
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/common-paper-cc-by-4.0/common-paper-csa-click-through/metadata.yaml
+++ b/templates/common-paper-cc-by-4.0/common-paper-csa-click-through/metadata.yaml
@@ -79,7 +79,9 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - provider
+signature_roles:
+  - provider
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/common-paper-cc-by-4.0/common-paper-csa-click-through/metadata.yaml
+++ b/templates/common-paper-cc-by-4.0/common-paper-csa-click-through/metadata.yaml
@@ -74,3 +74,12 @@ priority_fields:
   - cloud_service
   - governing_law
   - jurisdiction
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/common-paper-cc-by-4.0/common-paper-csa-with-ai/metadata.yaml
+++ b/templates/common-paper-cc-by-4.0/common-paper-csa-with-ai/metadata.yaml
@@ -604,3 +604,12 @@ priority_fields:
   - subscription_period
   - governing_law
   - jurisdiction
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/common-paper-cc-by-4.0/common-paper-csa-with-ai/metadata.yaml
+++ b/templates/common-paper-cc-by-4.0/common-paper-csa-with-ai/metadata.yaml
@@ -609,7 +609,13 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - company
+  - provider
+  - customer
+signature_roles:
+  - provider
+  - customer
+  - company
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/common-paper-cc-by-4.0/common-paper-csa-with-sla/metadata.yaml
+++ b/templates/common-paper-cc-by-4.0/common-paper-csa-with-sla/metadata.yaml
@@ -550,7 +550,13 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - company
+  - provider
+  - customer
+signature_roles:
+  - provider
+  - customer
+  - company
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/common-paper-cc-by-4.0/common-paper-csa-with-sla/metadata.yaml
+++ b/templates/common-paper-cc-by-4.0/common-paper-csa-with-sla/metadata.yaml
@@ -545,3 +545,12 @@ priority_fields:
   - subscription_period
   - governing_law
   - jurisdiction
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/common-paper-cc-by-4.0/common-paper-csa-without-sla/metadata.yaml
+++ b/templates/common-paper-cc-by-4.0/common-paper-csa-without-sla/metadata.yaml
@@ -514,3 +514,12 @@ priority_fields:
   - subscription_period
   - governing_law
   - jurisdiction
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/common-paper-cc-by-4.0/common-paper-csa-without-sla/metadata.yaml
+++ b/templates/common-paper-cc-by-4.0/common-paper-csa-without-sla/metadata.yaml
@@ -519,7 +519,13 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - company
+  - provider
+  - customer
+signature_roles:
+  - provider
+  - customer
+  - company
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/common-paper-cc-by-4.0/common-paper-data-processing-agreement/metadata.yaml
+++ b/templates/common-paper-cc-by-4.0/common-paper-data-processing-agreement/metadata.yaml
@@ -530,7 +530,13 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - company
+  - provider
+  - customer
+signature_roles:
+  - provider
+  - customer
+  - company
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/common-paper-cc-by-4.0/common-paper-data-processing-agreement/metadata.yaml
+++ b/templates/common-paper-cc-by-4.0/common-paper-data-processing-agreement/metadata.yaml
@@ -525,3 +525,12 @@ priority_fields:
   - provider_address
   - provider_role
   - governing_law
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/common-paper-cc-by-4.0/common-paper-design-partner-agreement/metadata.yaml
+++ b/templates/common-paper-cc-by-4.0/common-paper-design-partner-agreement/metadata.yaml
@@ -156,3 +156,12 @@ priority_fields:
   - product_description
   - governing_law
   - jurisdiction
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/common-paper-cc-by-4.0/common-paper-design-partner-agreement/metadata.yaml
+++ b/templates/common-paper-cc-by-4.0/common-paper-design-partner-agreement/metadata.yaml
@@ -161,7 +161,13 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - company
+  - provider
+  - partner
+signature_roles:
+  - provider
+  - partner
+  - company
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/common-paper-cc-by-4.0/common-paper-independent-contractor-agreement/metadata.yaml
+++ b/templates/common-paper-cc-by-4.0/common-paper-independent-contractor-agreement/metadata.yaml
@@ -113,7 +113,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - company
+  - contractor
+signature_roles:
+  - company
+  - contractor
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/common-paper-cc-by-4.0/common-paper-independent-contractor-agreement/metadata.yaml
+++ b/templates/common-paper-cc-by-4.0/common-paper-independent-contractor-agreement/metadata.yaml
@@ -108,3 +108,12 @@ priority_fields:
   - timeline
   - governing_law
   - jurisdiction
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/common-paper-cc-by-4.0/common-paper-letter-of-intent/metadata.yaml
+++ b/templates/common-paper-cc-by-4.0/common-paper-letter-of-intent/metadata.yaml
@@ -96,7 +96,13 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - company
+  - provider
+  - customer
+signature_roles:
+  - provider
+  - customer
+  - company
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/common-paper-cc-by-4.0/common-paper-letter-of-intent/metadata.yaml
+++ b/templates/common-paper-cc-by-4.0/common-paper-letter-of-intent/metadata.yaml
@@ -91,3 +91,12 @@ priority_fields:
   - product_description
   - launch_date
   - fees_description
+artifact_kind: letter
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/common-paper-cc-by-4.0/common-paper-mutual-nda/metadata.yaml
+++ b/templates/common-paper-cc-by-4.0/common-paper-mutual-nda/metadata.yaml
@@ -108,3 +108,12 @@ priority_fields:
   - confidentiality_term_start
   - governing_law
   - jurisdiction
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/common-paper-cc-by-4.0/common-paper-mutual-nda/metadata.yaml
+++ b/templates/common-paper-cc-by-4.0/common-paper-mutual-nda/metadata.yaml
@@ -113,7 +113,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - party_1
+  - party_2
+signature_roles:
+  - party_1
+  - party_2
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/common-paper-cc-by-4.0/common-paper-one-way-nda/metadata.yaml
+++ b/templates/common-paper-cc-by-4.0/common-paper-one-way-nda/metadata.yaml
@@ -95,7 +95,9 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - recipient
+signature_roles:
+  - recipient
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/common-paper-cc-by-4.0/common-paper-one-way-nda/metadata.yaml
+++ b/templates/common-paper-cc-by-4.0/common-paper-one-way-nda/metadata.yaml
@@ -90,3 +90,12 @@ priority_fields:
   - confidentiality_term_start
   - governing_law
   - jurisdiction
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/common-paper-cc-by-4.0/common-paper-order-form-with-sla/metadata.yaml
+++ b/templates/common-paper-cc-by-4.0/common-paper-order-form-with-sla/metadata.yaml
@@ -258,3 +258,12 @@ priority_fields:
   - key_terms_effective_date
   - cloud_service
   - subscription_period
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/common-paper-cc-by-4.0/common-paper-order-form-with-sla/metadata.yaml
+++ b/templates/common-paper-cc-by-4.0/common-paper-order-form-with-sla/metadata.yaml
@@ -263,7 +263,13 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - company
+  - provider
+  - customer
+signature_roles:
+  - provider
+  - customer
+  - company
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/common-paper-cc-by-4.0/common-paper-order-form/metadata.yaml
+++ b/templates/common-paper-cc-by-4.0/common-paper-order-form/metadata.yaml
@@ -205,7 +205,13 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - company
+  - provider
+  - customer
+signature_roles:
+  - provider
+  - customer
+  - company
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/common-paper-cc-by-4.0/common-paper-order-form/metadata.yaml
+++ b/templates/common-paper-cc-by-4.0/common-paper-order-form/metadata.yaml
@@ -200,3 +200,12 @@ priority_fields:
   - key_terms_effective_date
   - cloud_service
   - subscription_period
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/common-paper-cc-by-4.0/common-paper-partnership-agreement/metadata.yaml
+++ b/templates/common-paper-cc-by-4.0/common-paper-partnership-agreement/metadata.yaml
@@ -373,7 +373,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - company
+  - partner
+signature_roles:
+  - company
+  - partner
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/common-paper-cc-by-4.0/common-paper-partnership-agreement/metadata.yaml
+++ b/templates/common-paper-cc-by-4.0/common-paper-partnership-agreement/metadata.yaml
@@ -368,3 +368,12 @@ priority_fields:
   - company_name
   - governing_law
   - jurisdiction
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/common-paper-cc-by-4.0/common-paper-pilot-agreement/metadata.yaml
+++ b/templates/common-paper-cc-by-4.0/common-paper-pilot-agreement/metadata.yaml
@@ -149,3 +149,12 @@ priority_fields:
   - pilot_period
   - governing_law
   - jurisdiction
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/common-paper-cc-by-4.0/common-paper-pilot-agreement/metadata.yaml
+++ b/templates/common-paper-cc-by-4.0/common-paper-pilot-agreement/metadata.yaml
@@ -154,7 +154,13 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - company
+  - provider
+  - customer
+signature_roles:
+  - provider
+  - customer
+  - company
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/common-paper-cc-by-4.0/common-paper-professional-services-agreement/metadata.yaml
+++ b/templates/common-paper-cc-by-4.0/common-paper-professional-services-agreement/metadata.yaml
@@ -459,3 +459,12 @@ priority_fields:
   - payment_terms
   - governing_law
   - jurisdiction
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/common-paper-cc-by-4.0/common-paper-professional-services-agreement/metadata.yaml
+++ b/templates/common-paper-cc-by-4.0/common-paper-professional-services-agreement/metadata.yaml
@@ -464,7 +464,13 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - company
+  - provider
+  - customer
+signature_roles:
+  - provider
+  - customer
+  - company
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/common-paper-cc-by-4.0/common-paper-software-license-agreement/metadata.yaml
+++ b/templates/common-paper-cc-by-4.0/common-paper-software-license-agreement/metadata.yaml
@@ -14,3 +14,12 @@ attribution_text: >-
   Copyright Common Paper, Inc.
 fields: []
 priority_fields: []
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/common-paper-cc-by-4.0/common-paper-statement-of-work/metadata.yaml
+++ b/templates/common-paper-cc-by-4.0/common-paper-statement-of-work/metadata.yaml
@@ -185,7 +185,13 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - company
+  - provider
+  - customer
+signature_roles:
+  - provider
+  - customer
+  - company
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/common-paper-cc-by-4.0/common-paper-statement-of-work/metadata.yaml
+++ b/templates/common-paper-cc-by-4.0/common-paper-statement-of-work/metadata.yaml
@@ -180,3 +180,12 @@ priority_fields:
   - key_terms_effective_date
   - sow_number
   - payment_terms
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/common-paper-cc-by-4.0/common-paper-term-sheet/metadata.yaml
+++ b/templates/common-paper-cc-by-4.0/common-paper-term-sheet/metadata.yaml
@@ -77,3 +77,12 @@ priority_fields:
   - company_name
   - topic
   - topic_details
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/common-paper-cc-by-4.0/common-paper-term-sheet/metadata.yaml
+++ b/templates/common-paper-cc-by-4.0/common-paper-term-sheet/metadata.yaml
@@ -82,7 +82,13 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - company
+  - party_1
+  - party_2
+signature_roles:
+  - party_1
+  - party_2
+  - company
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/nvca-free-non-redistributable/nvca-certificate-of-incorporation/metadata.yaml
+++ b/templates/nvca-free-non-redistributable/nvca-certificate-of-incorporation/metadata.yaml
@@ -186,3 +186,12 @@ priority_fields:
   - total_authorized_shares
   - common_shares_authorized
   - preferred_shares_authorized
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/nvca-free-non-redistributable/nvca-certificate-of-incorporation/metadata.yaml
+++ b/templates/nvca-free-non-redistributable/nvca-certificate-of-incorporation/metadata.yaml
@@ -188,10 +188,8 @@ priority_fields:
   - preferred_shares_authorized
 artifact_kind: agreement
 capabilities:
-  - create
   - review
-  - render
 party_roles: []
 signature_roles: []
-mutation_policy: fields_only
+mutation_policy: immutable
 maturity: experimental

--- a/templates/nvca-free-non-redistributable/nvca-indemnification-agreement/metadata.yaml
+++ b/templates/nvca-free-non-redistributable/nvca-indemnification-agreement/metadata.yaml
@@ -89,10 +89,8 @@ priority_fields:
   - certificate_name
 artifact_kind: agreement
 capabilities:
-  - create
   - review
-  - render
 party_roles: []
 signature_roles: []
-mutation_policy: fields_only
+mutation_policy: immutable
 maturity: experimental

--- a/templates/nvca-free-non-redistributable/nvca-indemnification-agreement/metadata.yaml
+++ b/templates/nvca-free-non-redistributable/nvca-indemnification-agreement/metadata.yaml
@@ -87,3 +87,12 @@ priority_fields:
   - indemnitee_pronoun_possessive_plural
   - bylaws_name
   - certificate_name
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/nvca-free-non-redistributable/nvca-investors-rights-agreement/metadata.yaml
+++ b/templates/nvca-free-non-redistributable/nvca-investors-rights-agreement/metadata.yaml
@@ -72,3 +72,12 @@ priority_fields:
   - judicial_district
   - business_description
   - effective_date
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/nvca-free-non-redistributable/nvca-investors-rights-agreement/metadata.yaml
+++ b/templates/nvca-free-non-redistributable/nvca-investors-rights-agreement/metadata.yaml
@@ -74,10 +74,8 @@ priority_fields:
   - effective_date
 artifact_kind: agreement
 capabilities:
-  - create
   - review
-  - render
 party_roles: []
 signature_roles: []
-mutation_policy: fields_only
+mutation_policy: immutable
 maturity: experimental

--- a/templates/nvca-free-non-redistributable/nvca-management-rights-letter/metadata.yaml
+++ b/templates/nvca-free-non-redistributable/nvca-management-rights-letter/metadata.yaml
@@ -64,10 +64,8 @@ priority_fields:
   - zip_code
 artifact_kind: letter
 capabilities:
-  - create
   - review
-  - render
 party_roles: []
 signature_roles: []
-mutation_policy: fields_only
+mutation_policy: immutable
 maturity: experimental

--- a/templates/nvca-free-non-redistributable/nvca-management-rights-letter/metadata.yaml
+++ b/templates/nvca-free-non-redistributable/nvca-management-rights-letter/metadata.yaml
@@ -62,3 +62,12 @@ priority_fields:
   - state
   - street_address
   - zip_code
+artifact_kind: letter
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/nvca-free-non-redistributable/nvca-rofr-co-sale-agreement/metadata.yaml
+++ b/templates/nvca-free-non-redistributable/nvca-rofr-co-sale-agreement/metadata.yaml
@@ -79,10 +79,8 @@ priority_fields:
   - rofr_response_days
 artifact_kind: agreement
 capabilities:
-  - create
   - review
-  - render
 party_roles: []
 signature_roles: []
-mutation_policy: fields_only
+mutation_policy: immutable
 maturity: experimental

--- a/templates/nvca-free-non-redistributable/nvca-rofr-co-sale-agreement/metadata.yaml
+++ b/templates/nvca-free-non-redistributable/nvca-rofr-co-sale-agreement/metadata.yaml
@@ -77,3 +77,12 @@ priority_fields:
   - effective_date
   - specify_percentage
   - rofr_response_days
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/nvca-free-non-redistributable/nvca-stock-purchase-agreement/metadata.yaml
+++ b/templates/nvca-free-non-redistributable/nvca-stock-purchase-agreement/metadata.yaml
@@ -145,3 +145,12 @@ priority_fields:
   - director_names
   - board_size
   - minimum_shares_initial_closing
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/nvca-free-non-redistributable/nvca-stock-purchase-agreement/metadata.yaml
+++ b/templates/nvca-free-non-redistributable/nvca-stock-purchase-agreement/metadata.yaml
@@ -147,10 +147,8 @@ priority_fields:
   - minimum_shares_initial_closing
 artifact_kind: agreement
 capabilities:
-  - create
   - review
-  - render
 party_roles: []
 signature_roles: []
-mutation_policy: fields_only
+mutation_policy: immutable
 maturity: experimental

--- a/templates/nvca-free-non-redistributable/nvca-voting-agreement/metadata.yaml
+++ b/templates/nvca-free-non-redistributable/nvca-voting-agreement/metadata.yaml
@@ -69,10 +69,8 @@ priority_fields:
   - specify_percentage
 artifact_kind: agreement
 capabilities:
-  - create
   - review
-  - render
 party_roles: []
 signature_roles: []
-mutation_policy: fields_only
+mutation_policy: immutable
 maturity: experimental

--- a/templates/nvca-free-non-redistributable/nvca-voting-agreement/metadata.yaml
+++ b/templates/nvca-free-non-redistributable/nvca-voting-agreement/metadata.yaml
@@ -67,3 +67,12 @@ priority_fields:
   - judicial_district
   - state_of_incorporation_lower
   - specify_percentage
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-board-consent-safe/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-board-consent-safe/metadata.yaml
@@ -35,3 +35,12 @@ priority_fields:
   - effective_date
   - purchase_amount
   - board_members
+artifact_kind: consent
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-board-consent-safe/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-board-consent-safe/metadata.yaml
@@ -40,7 +40,8 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
+party_roles:
+  - company
 signature_roles: []
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-board-ratifying-consent/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-board-ratifying-consent/metadata.yaml
@@ -60,7 +60,8 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
+party_roles:
+  - company
 signature_roles: []
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-board-ratifying-consent/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-board-ratifying-consent/metadata.yaml
@@ -55,3 +55,12 @@ priority_fields:
   - defective_acts
   - failure_of_authorization
   - director_signatories
+artifact_kind: consent
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-colorado-restrictive-covenant-notice/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-colorado-restrictive-covenant-notice/metadata.yaml
@@ -58,3 +58,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: notice
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-colorado-restrictive-covenant-notice/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-colorado-restrictive-covenant-notice/metadata.yaml
@@ -63,7 +63,9 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
+party_roles:
+  - employee
+  - employer
 signature_roles: []
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-confidentiality-invention-assignment-agreement-nevada/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-confidentiality-invention-assignment-agreement-nevada/metadata.yaml
@@ -60,3 +60,12 @@ fields:
     default: state and federal courts in the governing law state
     section: Legal
 priority_fields: []
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-confidentiality-invention-assignment-agreement-nevada/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-confidentiality-invention-assignment-agreement-nevada/metadata.yaml
@@ -65,7 +65,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - company
+  - employee
+signature_roles:
+  - company
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-confidentiality-invention-assignment-agreement/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-confidentiality-invention-assignment-agreement/metadata.yaml
@@ -63,7 +63,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - company
+  - employee
+signature_roles:
+  - company
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-confidentiality-invention-assignment-agreement/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-confidentiality-invention-assignment-agreement/metadata.yaml
@@ -58,3 +58,12 @@ fields:
     default: state and federal courts in the governing law state
     section: Legal
 priority_fields: []
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-due-diligence-request-list/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-due-diligence-request-list/metadata.yaml
@@ -102,3 +102,12 @@ priority_fields:
   - cross_border_rider_enabled
   - materiality_threshold_usd
   - lookback_years
+artifact_kind: checklist
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-employment-offer-letter-california/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-employment-offer-letter-california/metadata.yaml
@@ -77,7 +77,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-employment-offer-letter-california/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-employment-offer-letter-california/metadata.yaml
@@ -72,3 +72,12 @@ priority_fields: []
 omitted_clauses: drop
 distribution: bundled
 artifact_type: template
+artifact_kind: letter
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-employment-offer-letter-florida/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-employment-offer-letter-florida/metadata.yaml
@@ -77,7 +77,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-employment-offer-letter-florida/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-employment-offer-letter-florida/metadata.yaml
@@ -72,3 +72,12 @@ priority_fields: []
 omitted_clauses: drop
 distribution: bundled
 artifact_type: template
+artifact_kind: letter
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-employment-offer-letter-illinois/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-employment-offer-letter-illinois/metadata.yaml
@@ -77,7 +77,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-employment-offer-letter-illinois/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-employment-offer-letter-illinois/metadata.yaml
@@ -72,3 +72,12 @@ priority_fields: []
 omitted_clauses: drop
 distribution: bundled
 artifact_type: template
+artifact_kind: letter
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-employment-offer-letter-massachusetts/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-employment-offer-letter-massachusetts/metadata.yaml
@@ -77,7 +77,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-employment-offer-letter-massachusetts/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-employment-offer-letter-massachusetts/metadata.yaml
@@ -72,3 +72,12 @@ priority_fields: []
 omitted_clauses: drop
 distribution: bundled
 artifact_type: template
+artifact_kind: letter
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-employment-offer-letter-new-york/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-employment-offer-letter-new-york/metadata.yaml
@@ -77,7 +77,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-employment-offer-letter-new-york/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-employment-offer-letter-new-york/metadata.yaml
@@ -72,3 +72,12 @@ priority_fields: []
 omitted_clauses: drop
 distribution: bundled
 artifact_type: template
+artifact_kind: letter
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-employment-offer-letter-pennsylvania/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-employment-offer-letter-pennsylvania/metadata.yaml
@@ -77,7 +77,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-employment-offer-letter-pennsylvania/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-employment-offer-letter-pennsylvania/metadata.yaml
@@ -72,3 +72,12 @@ priority_fields: []
 omitted_clauses: drop
 distribution: bundled
 artifact_type: template
+artifact_kind: letter
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-employment-offer-letter-texas/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-employment-offer-letter-texas/metadata.yaml
@@ -77,7 +77,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-employment-offer-letter-texas/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-employment-offer-letter-texas/metadata.yaml
@@ -72,3 +72,12 @@ priority_fields: []
 omitted_clauses: drop
 distribution: bundled
 artifact_type: template
+artifact_kind: letter
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-employment-offer-letter/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-employment-offer-letter/metadata.yaml
@@ -81,7 +81,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-employment-offer-letter/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-employment-offer-letter/metadata.yaml
@@ -76,3 +76,12 @@ fields:
     description: Date by which the offer must be accepted
     section: Timing
 priority_fields: []
+artifact_kind: letter
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-founder-ip-confidentiality-confirmation/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-founder-ip-confidentiality-confirmation/metadata.yaml
@@ -39,3 +39,12 @@ priority_fields:
   - founder_name
   - ciiaa_reference
   - separation_date
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-founder-ip-confidentiality-confirmation/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-founder-ip-confidentiality-confirmation/metadata.yaml
@@ -44,7 +44,9 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - founder
+signature_roles:
+  - founder
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-founder-separation-board-consent/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-founder-separation-board-consent/metadata.yaml
@@ -66,3 +66,12 @@ priority_fields:
   - consent_date
   - founder_name
   - rspa_reference
+artifact_kind: consent
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-founder-separation-board-consent/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-founder-separation-board-consent/metadata.yaml
@@ -71,7 +71,8 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
+party_roles:
+  - founder
 signature_roles: []
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-founder-separation-cap-table-update-instructions/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-founder-separation-cap-table-update-instructions/metadata.yaml
@@ -59,7 +59,8 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
+party_roles:
+  - founder
 signature_roles: []
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-founder-separation-cap-table-update-instructions/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-founder-separation-cap-table-update-instructions/metadata.yaml
@@ -54,3 +54,12 @@ priority_fields:
   - founder_name
   - certificate_numbers
   - shares_cancelled
+artifact_kind: checklist
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-founder-separation-records-checklist/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-founder-separation-records-checklist/metadata.yaml
@@ -39,3 +39,12 @@ priority_fields:
   - founder_name
   - separation_date
   - minute_book_location
+artifact_kind: checklist
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-founder-separation-records-checklist/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-founder-separation-records-checklist/metadata.yaml
@@ -44,7 +44,8 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
+party_roles:
+  - founder
 signature_roles: []
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-founder-separation-resignation-letter/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-founder-separation-resignation-letter/metadata.yaml
@@ -31,3 +31,12 @@ priority_fields:
   - founder_name
   - resignation_effective_date
   - resigned_positions
+artifact_kind: letter
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-founder-separation-resignation-letter/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-founder-separation-resignation-letter/metadata.yaml
@@ -36,7 +36,9 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - founder
+signature_roles:
+  - founder
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-founder-separation-stockholder-consent/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-founder-separation-stockholder-consent/metadata.yaml
@@ -55,7 +55,8 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
+party_roles:
+  - founder
 signature_roles: []
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-founder-separation-stockholder-consent/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-founder-separation-stockholder-consent/metadata.yaml
@@ -50,3 +50,12 @@ priority_fields:
   - consent_date
   - founder_name
   - stockholder_action
+artifact_kind: consent
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-founder-share-repurchase-notice/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-founder-share-repurchase-notice/metadata.yaml
@@ -59,3 +59,12 @@ priority_fields:
   - founder_name
   - rspa_reference
   - repurchase_window_days
+artifact_kind: notice
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-founder-share-repurchase-notice/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-founder-share-repurchase-notice/metadata.yaml
@@ -64,7 +64,8 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
+party_roles:
+  - founder
 signature_roles: []
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-founder-stock-assignment-separate/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-founder-stock-assignment-separate/metadata.yaml
@@ -39,3 +39,12 @@ priority_fields:
   - founder_name
   - shares_assigned
   - certificate_number
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-founder-stock-assignment-separate/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-founder-stock-assignment-separate/metadata.yaml
@@ -44,7 +44,9 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - founder
+signature_roles:
+  - founder
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-founder-stock-repurchase-agreement/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-founder-stock-repurchase-agreement/metadata.yaml
@@ -65,3 +65,12 @@ priority_fields:
   - rspa_reference
   - shares_repurchased
   - aggregate_price
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-founder-stock-repurchase-agreement/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-founder-stock-repurchase-agreement/metadata.yaml
@@ -70,7 +70,9 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - founder
+signature_roles:
+  - founder
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-privacy-policy/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-privacy-policy/metadata.yaml
@@ -87,3 +87,12 @@ priority_fields:
   - business_legal_name
   - policy_effective_date
   - personal_data_categories
+artifact_kind: policy
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-alabama/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-alabama/metadata.yaml
@@ -210,7 +210,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-alabama/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-alabama/metadata.yaml
@@ -205,3 +205,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-alaska/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-alaska/metadata.yaml
@@ -203,7 +203,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-alaska/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-alaska/metadata.yaml
@@ -198,3 +198,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-arizona/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-arizona/metadata.yaml
@@ -197,7 +197,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-arizona/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-arizona/metadata.yaml
@@ -192,3 +192,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-arkansas/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-arkansas/metadata.yaml
@@ -209,7 +209,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-arkansas/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-arkansas/metadata.yaml
@@ -204,3 +204,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-california/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-california/metadata.yaml
@@ -74,7 +74,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-california/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-california/metadata.yaml
@@ -69,3 +69,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-colorado/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-colorado/metadata.yaml
@@ -209,7 +209,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-colorado/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-colorado/metadata.yaml
@@ -204,3 +204,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-connecticut/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-connecticut/metadata.yaml
@@ -191,3 +191,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-connecticut/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-connecticut/metadata.yaml
@@ -196,7 +196,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-delaware/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-delaware/metadata.yaml
@@ -191,3 +191,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-delaware/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-delaware/metadata.yaml
@@ -196,7 +196,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-district-of-columbia/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-district-of-columbia/metadata.yaml
@@ -173,3 +173,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-district-of-columbia/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-district-of-columbia/metadata.yaml
@@ -178,7 +178,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-florida/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-florida/metadata.yaml
@@ -217,3 +217,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-florida/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-florida/metadata.yaml
@@ -222,7 +222,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-georgia/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-georgia/metadata.yaml
@@ -224,7 +224,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-georgia/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-georgia/metadata.yaml
@@ -219,3 +219,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-hawaii/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-hawaii/metadata.yaml
@@ -210,7 +210,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-hawaii/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-hawaii/metadata.yaml
@@ -205,3 +205,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-idaho/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-idaho/metadata.yaml
@@ -212,7 +212,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-idaho/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-idaho/metadata.yaml
@@ -207,3 +207,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-illinois/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-illinois/metadata.yaml
@@ -202,7 +202,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-illinois/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-illinois/metadata.yaml
@@ -197,3 +197,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-indiana/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-indiana/metadata.yaml
@@ -200,3 +200,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-indiana/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-indiana/metadata.yaml
@@ -205,7 +205,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-iowa/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-iowa/metadata.yaml
@@ -191,3 +191,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-iowa/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-iowa/metadata.yaml
@@ -196,7 +196,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-kansas/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-kansas/metadata.yaml
@@ -196,3 +196,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-kansas/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-kansas/metadata.yaml
@@ -201,7 +201,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-kentucky/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-kentucky/metadata.yaml
@@ -215,7 +215,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-kentucky/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-kentucky/metadata.yaml
@@ -210,3 +210,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-louisiana/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-louisiana/metadata.yaml
@@ -202,7 +202,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-louisiana/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-louisiana/metadata.yaml
@@ -197,3 +197,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-maine/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-maine/metadata.yaml
@@ -243,7 +243,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-maine/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-maine/metadata.yaml
@@ -238,3 +238,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-maryland/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-maryland/metadata.yaml
@@ -203,7 +203,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-maryland/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-maryland/metadata.yaml
@@ -198,3 +198,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-massachusetts/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-massachusetts/metadata.yaml
@@ -203,3 +203,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-massachusetts/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-massachusetts/metadata.yaml
@@ -208,7 +208,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-michigan/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-michigan/metadata.yaml
@@ -209,7 +209,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-michigan/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-michigan/metadata.yaml
@@ -204,3 +204,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-minnesota/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-minnesota/metadata.yaml
@@ -114,3 +114,12 @@ priority_fields:
   - effective_date
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-minnesota/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-minnesota/metadata.yaml
@@ -119,7 +119,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-mississippi/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-mississippi/metadata.yaml
@@ -191,3 +191,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-mississippi/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-mississippi/metadata.yaml
@@ -196,7 +196,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-missouri/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-missouri/metadata.yaml
@@ -202,3 +202,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-missouri/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-missouri/metadata.yaml
@@ -207,7 +207,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-montana/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-montana/metadata.yaml
@@ -210,7 +210,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-montana/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-montana/metadata.yaml
@@ -205,3 +205,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-nebraska/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-nebraska/metadata.yaml
@@ -199,7 +199,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-nebraska/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-nebraska/metadata.yaml
@@ -194,3 +194,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-nevada/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-nevada/metadata.yaml
@@ -200,7 +200,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-nevada/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-nevada/metadata.yaml
@@ -195,3 +195,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-new-hampshire/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-new-hampshire/metadata.yaml
@@ -202,7 +202,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-new-hampshire/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-new-hampshire/metadata.yaml
@@ -197,3 +197,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-new-jersey/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-new-jersey/metadata.yaml
@@ -191,3 +191,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-new-jersey/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-new-jersey/metadata.yaml
@@ -196,7 +196,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-new-mexico/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-new-mexico/metadata.yaml
@@ -228,7 +228,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-new-mexico/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-new-mexico/metadata.yaml
@@ -223,3 +223,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-new-york/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-new-york/metadata.yaml
@@ -197,7 +197,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-new-york/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-new-york/metadata.yaml
@@ -192,3 +192,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-north-carolina/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-north-carolina/metadata.yaml
@@ -200,3 +200,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-north-carolina/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-north-carolina/metadata.yaml
@@ -205,7 +205,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-north-dakota/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-north-dakota/metadata.yaml
@@ -105,7 +105,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-north-dakota/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-north-dakota/metadata.yaml
@@ -100,3 +100,12 @@ priority_fields:
   - effective_date
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-ohio/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-ohio/metadata.yaml
@@ -197,7 +197,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-ohio/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-ohio/metadata.yaml
@@ -192,3 +192,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-oklahoma/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-oklahoma/metadata.yaml
@@ -116,3 +116,12 @@ priority_fields:
   - effective_date
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-oklahoma/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-oklahoma/metadata.yaml
@@ -121,7 +121,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-oregon/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-oregon/metadata.yaml
@@ -201,3 +201,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-oregon/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-oregon/metadata.yaml
@@ -206,7 +206,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-pennsylvania/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-pennsylvania/metadata.yaml
@@ -201,3 +201,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-pennsylvania/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-pennsylvania/metadata.yaml
@@ -206,7 +206,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-puerto-rico/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-puerto-rico/metadata.yaml
@@ -192,7 +192,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-puerto-rico/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-puerto-rico/metadata.yaml
@@ -187,3 +187,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-rhode-island/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-rhode-island/metadata.yaml
@@ -203,7 +203,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-rhode-island/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-rhode-island/metadata.yaml
@@ -198,3 +198,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-south-carolina/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-south-carolina/metadata.yaml
@@ -228,7 +228,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-south-carolina/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-south-carolina/metadata.yaml
@@ -223,3 +223,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-south-dakota/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-south-dakota/metadata.yaml
@@ -185,7 +185,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-south-dakota/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-south-dakota/metadata.yaml
@@ -180,3 +180,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-tennessee/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-tennessee/metadata.yaml
@@ -199,7 +199,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-tennessee/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-tennessee/metadata.yaml
@@ -194,3 +194,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-texas/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-texas/metadata.yaml
@@ -198,7 +198,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-texas/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-texas/metadata.yaml
@@ -193,3 +193,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-utah/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-utah/metadata.yaml
@@ -169,7 +169,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-utah/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-utah/metadata.yaml
@@ -164,3 +164,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-vermont/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-vermont/metadata.yaml
@@ -191,3 +191,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-vermont/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-vermont/metadata.yaml
@@ -196,7 +196,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-virginia/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-virginia/metadata.yaml
@@ -215,7 +215,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-virginia/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-virginia/metadata.yaml
@@ -210,3 +210,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-washington/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-washington/metadata.yaml
@@ -212,7 +212,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-washington/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-washington/metadata.yaml
@@ -207,3 +207,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-west-virginia/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-west-virginia/metadata.yaml
@@ -216,7 +216,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-west-virginia/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-west-virginia/metadata.yaml
@@ -211,3 +211,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-wisconsin/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-wisconsin/metadata.yaml
@@ -204,7 +204,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-wisconsin/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-wisconsin/metadata.yaml
@@ -199,3 +199,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-wyoming/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-wyoming/metadata.yaml
@@ -198,7 +198,11 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
-signature_roles: []
+party_roles:
+  - employee
+  - employer
+signature_roles:
+  - employer
+  - employee
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-wyoming/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-restrictive-covenant-wyoming/metadata.yaml
@@ -193,3 +193,12 @@ priority_fields:
   - employee_name
 distribution: bundled
 artifact_type: template
+artifact_kind: agreement
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-stockholder-consent-safe/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-stockholder-consent-safe/metadata.yaml
@@ -35,3 +35,12 @@ priority_fields:
   - effective_date
   - purchase_amount
   - stockholders
+artifact_kind: consent
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-stockholder-consent-safe/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-stockholder-consent-safe/metadata.yaml
@@ -40,7 +40,8 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
+party_roles:
+  - company
 signature_roles: []
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-stockholder-ratifying-consent/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-stockholder-ratifying-consent/metadata.yaml
@@ -48,7 +48,8 @@ capabilities:
   - create
   - review
   - render
-party_roles: []
+party_roles:
+  - company
 signature_roles: []
 mutation_policy: fields_only
 maturity: experimental

--- a/templates/openagreements-cc-by-4.0/openagreements-stockholder-ratifying-consent/metadata.yaml
+++ b/templates/openagreements-cc-by-4.0/openagreements-stockholder-ratifying-consent/metadata.yaml
@@ -43,3 +43,12 @@ priority_fields:
   - board_consent_reference
   - defective_acts
   - stockholder_signatories
+artifact_kind: consent
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc0-1.0/openagreements-closing-checklist/metadata.yaml
+++ b/templates/openagreements-cc0-1.0/openagreements-closing-checklist/metadata.yaml
@@ -81,3 +81,12 @@ fields:
 priority_fields:
   - deal_name
   - updated_at
+artifact_kind: checklist
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/openagreements-cc0-1.0/openagreements-working-group-list/metadata.yaml
+++ b/templates/openagreements-cc0-1.0/openagreements-working-group-list/metadata.yaml
@@ -37,3 +37,12 @@ fields:
         description: Contact email address for the member
 priority_fields:
   - deal_name
+artifact_kind: checklist
+capabilities:
+  - create
+  - review
+  - render
+party_roles: []
+signature_roles: []
+mutation_policy: fields_only
+maturity: experimental

--- a/templates/yc-cc-by-nd-4.0/yc-safe-discount/metadata.yaml
+++ b/templates/yc-cc-by-nd-4.0/yc-safe-discount/metadata.yaml
@@ -68,3 +68,10 @@ priority_fields:
   - company_name_caps
   - name
   - title
+artifact_kind: agreement
+capabilities:
+  - review
+party_roles: []
+signature_roles: []
+mutation_policy: immutable
+maturity: experimental

--- a/templates/yc-cc-by-nd-4.0/yc-safe-mfn/metadata.yaml
+++ b/templates/yc-cc-by-nd-4.0/yc-safe-mfn/metadata.yaml
@@ -65,3 +65,10 @@ priority_fields:
   - company_name_caps
   - name
   - title
+artifact_kind: agreement
+capabilities:
+  - review
+party_roles: []
+signature_roles: []
+mutation_policy: immutable
+maturity: experimental

--- a/templates/yc-cc-by-nd-4.0/yc-safe-pro-rata-side-letter/metadata.yaml
+++ b/templates/yc-cc-by-nd-4.0/yc-safe-pro-rata-side-letter/metadata.yaml
@@ -50,3 +50,10 @@ priority_fields:
   - investor_name_caps
   - name
   - title
+artifact_kind: letter
+capabilities:
+  - review
+party_roles: []
+signature_roles: []
+mutation_policy: immutable
+maturity: experimental

--- a/templates/yc-cc-by-nd-4.0/yc-safe-valuation-cap/metadata.yaml
+++ b/templates/yc-cc-by-nd-4.0/yc-safe-valuation-cap/metadata.yaml
@@ -65,3 +65,10 @@ priority_fields:
   - company
   - name
   - title
+artifact_kind: agreement
+capabilities:
+  - review
+party_roles: []
+signature_roles: []
+mutation_policy: immutable
+maturity: experimental


### PR DESCRIPTION
## Summary

- add `agreements create|list|show|update|review|render` for project-local persistent agreement records
- persist template provenance, optimistic revisions, terms, review/render warnings, and document SHA-256 values under `.open-agreements/agreements/<id>/`
- add validated capability manifests to all 116 catalog metadata files
- enforce declared fields, source drift/integrity checks, atomic writes, process-safe locking, and stale-lock recovery
- document the local lifecycle and template capability contract
- keep the existing `fill` command unchanged; add no login, send, or network behavior

## Verification

- `npm run build`
- `npm run lint`
- `npm run check:allure-labels`
- `npm run check:templates-snapshot`
- `npm run check:claude-plugin`
- `npm run check:docs`
- `node bin/open-agreements.js validate`
- `npx vitest run` — 1,085 passed, 6 skipped before the unrelated-main rebase
- post-rebase focused suite — 70 passed
- real bundled-template CLI lifecycle and DOCX integrity check

## Peer review

Claude Fable 5 performed three dynamic reviews with repo access and executable verification. Initial blocker/major findings were fixed in follow-up commits. Final verdict: **MERGEABLE — 0 BLOCKER, 0 MAJOR**.

Non-blocking follow-up candidates noted by the reviewer: improve one-line Zod error formatting, curate a few heuristic role labels, consider relative rendered-document paths, and harden a theoretical micro-race while reclaiming a stale lock.

## Boundaries

- no authentication
- no send/e-sign workflow
- no network access in agreement commands
- `src/commands/fill.ts` unchanged
