### PR TITLE
feat(mcp): expose forms-survey evidence as MCP resources

### DIFF
--- a/packages/contract-templates-mcp/README.md
+++ b/packages/contract-templates-mcp/README.md
@@ -11,6 +11,19 @@ This package exposes local template tools over MCP:
 - `fill_template`
 - `get_apap_template` — export an eligible OpenAgreements-authored template as an APAP Template
 - `create_apap_agreement_docx` — render APAP Concerto agreement data to a local DOCX path
+- `get_forms_survey_evidence` — fetch a published forms-provider survey's evidence: a summary by
+  default, or one requirement's evidence cells via `requirement_id`
+
+It also exposes MCP **resources**: one resource per currently published
+forms-provider survey evidence dataset (`resources/list` / `resources/read`).
+The listing is discovered live from `openagreements.org/llms.txt` (the
+upstream-gated public listing), so unlisted surveys are never exposed and no
+survey slugs are hardcoded. Resource URIs are the canonical public URLs
+(`https://openagreements.org/api/surveys/{topic}/forms-evidence`), reads return
+the raw JSON payload (its top-level `asOf` field carries the review date, also
+surfaced as `_meta.asOf`), and no authentication is required. Large surveys
+approach 1 MB — prefer the `get_forms_survey_evidence` tool when only part of
+the evidence is needed.
 
 The APAP pilot is intentionally limited to the OpenAgreements-authored CIIAA.
 The DOCX tool returns a file path rather than inline base64 so clients do not

--- a/packages/contract-templates-mcp/src/core/server.ts
+++ b/packages/contract-templates-mcp/src/core/server.ts
@@ -28,7 +28,11 @@ const SERVER_INFO = {
 
 const FALLBACK_PROTOCOL_VERSION = '2024-11-05';
 
-/** MCP spec error code for resources/read of an unknown resource. */
+/**
+ * Resource-not-found error code per the MCP 2024-11-05 through 2025-06-18
+ * specs (the current draft moves to -32602, keeping -32002 for backward
+ * compatibility — revisit if this server adopts a newer protocol version).
+ */
 const RESOURCE_NOT_FOUND_ERROR_CODE = -32002;
 
 export function runStdioServer(): void {

--- a/packages/contract-templates-mcp/src/core/server.ts
+++ b/packages/contract-templates-mcp/src/core/server.ts
@@ -1,3 +1,4 @@
+import { listSurveyResources, readSurveyResource, SurveyFetchError } from './surveys.js';
 import { callTool, listToolDescriptors, type ToolCallResult } from './tools.js';
 
 type JsonRpcId = number | string | null;
@@ -27,6 +28,9 @@ const SERVER_INFO = {
 
 const FALLBACK_PROTOCOL_VERSION = '2024-11-05';
 
+/** MCP spec error code for resources/read of an unknown resource. */
+const RESOURCE_NOT_FOUND_ERROR_CODE = -32002;
+
 export function runStdioServer(): void {
   const parser = new StdioMessageParser();
 
@@ -49,73 +53,129 @@ export function runStdioServer(): void {
 }
 
 async function handleMessage(message: unknown): Promise<void> {
+  const response = await dispatchMessage(message);
+  if (response !== null) {
+    sendResponse(response);
+  }
+}
+
+/**
+ * Dispatch one JSON-RPC message and return the response to send, or null when
+ * no response is due (notifications, malformed messages). Exported for tests.
+ */
+export async function dispatchMessage(message: unknown): Promise<JsonRpcResponse | null> {
   if (!isRequestObject(message)) {
-    return;
+    return null;
   }
 
   const request = message as JsonRpcRequest;
   const id = request.id ?? null;
 
   if (request.method === 'notifications/initialized') {
-    return;
+    return null;
   }
 
   if (request.method === 'initialize') {
-    sendResponse({
+    return {
       jsonrpc: '2.0',
       id,
       result: {
         protocolVersion: pickProtocolVersion(request.params),
         capabilities: {
           tools: {},
+          resources: {},
         },
         serverInfo: SERVER_INFO,
       },
-    });
-    return;
+    };
   }
 
   if (request.id === undefined) {
-    return;
+    return null;
   }
 
   if (request.method === 'ping') {
-    sendResponse({
-      jsonrpc: '2.0',
-      id,
-      result: {},
-    });
-    return;
+    return { jsonrpc: '2.0', id, result: {} };
   }
 
   if (request.method === 'tools/list') {
-    sendResponse({
+    return {
       jsonrpc: '2.0',
       id,
       result: {
         tools: listToolDescriptors(),
       },
-    });
-    return;
+    };
   }
 
   if (request.method === 'tools/call') {
     const call = parseToolCall(request.params);
     if (!call) {
-      sendError(id, -32602, 'Invalid params for tools/call. Expected { name: string, arguments?: object }.');
-      return;
+      return errorResponse(id, -32602, 'Invalid params for tools/call. Expected { name: string, arguments?: object }.');
     }
 
     const result = await callTool(call.name, call.argumentsValue);
-    sendResponse({
-      jsonrpc: '2.0',
-      id,
-      result,
-    });
-    return;
+    return { jsonrpc: '2.0', id, result };
   }
 
-  sendError(id, -32601, `Method not found: ${request.method}`);
+  if (request.method === 'resources/list') {
+    try {
+      const resources = await listSurveyResources();
+      return { jsonrpc: '2.0', id, result: { resources } };
+    } catch (error) {
+      return errorResponse(id, -32603, `Failed to list resources: ${describeError(error)}`);
+    }
+  }
+
+  if (request.method === 'resources/templates/list') {
+    return { jsonrpc: '2.0', id, result: { resourceTemplates: [] } };
+  }
+
+  if (request.method === 'resources/read') {
+    const uri = parseResourceReadUri(request.params);
+    if (uri === null) {
+      return errorResponse(id, -32602, 'Invalid params for resources/read. Expected { uri: string }.');
+    }
+
+    try {
+      const contents = await readSurveyResource(uri);
+      if (contents === null) {
+        return errorResponse(id, RESOURCE_NOT_FOUND_ERROR_CODE, `Resource not found: ${uri}`, { uri });
+      }
+      return { jsonrpc: '2.0', id, result: { contents: [contents] } };
+    } catch (error) {
+      return errorResponse(id, -32603, `Failed to read resource: ${describeError(error)}`);
+    }
+  }
+
+  return errorResponse(id, -32601, `Method not found: ${request.method}`);
+}
+
+function describeError(error: unknown): string {
+  if (error instanceof SurveyFetchError) {
+    return error.message;
+  }
+  return error instanceof Error ? error.message : String(error);
+}
+
+function parseResourceReadUri(params: unknown): string | null {
+  if (!params || typeof params !== 'object') {
+    return null;
+  }
+  const uri = (params as Record<string, unknown>).uri;
+  return typeof uri === 'string' && uri.length > 0 ? uri : null;
+}
+
+function errorResponse(id: JsonRpcId, code: number, message: string, data?: unknown): JsonRpcResponse {
+  return {
+    jsonrpc: '2.0',
+    id,
+    error: {
+      code,
+      message,
+      ...(data === undefined ? {} : { data }),
+    },
+  };
 }
 
 function parseToolCall(params: unknown): { name: string; argumentsValue: unknown } | null {
@@ -147,18 +207,6 @@ function pickProtocolVersion(params: unknown): string {
 
 function sendResponse(response: JsonRpcResponse): void {
   process.stdout.write(JSON.stringify(response) + '\n');
-}
-
-function sendError(id: JsonRpcId, code: number, message: string, data?: unknown): void {
-  sendResponse({
-    jsonrpc: '2.0',
-    id,
-    error: {
-      code,
-      message,
-      ...(data === undefined ? {} : { data }),
-    },
-  });
 }
 
 function isRequestObject(value: unknown): value is JsonRpcRequest {

--- a/packages/contract-templates-mcp/src/core/surveys.ts
+++ b/packages/contract-templates-mcp/src/core/surveys.ts
@@ -27,9 +27,11 @@ const EVIDENCE_URI_PATTERN =
 
 const FETCH_TIMEOUT_MS = 15_000;
 
-// Upstream serves llms.txt through a CDN with hour-scale caching; a short
+// Upstream serves llms.txt through Vercel's CDN (observed
+// `cache-control: public, max-age=0, must-revalidate` with CDN HITs); a short
 // in-process cache just avoids refetching it for back-to-back MCP calls in
-// one session while keeping the unlisted-gate window small.
+// one session. A survey newly unlisted upstream can therefore stay visible
+// here for up to this TTL on top of whatever the upstream cache windows allow.
 const LISTING_CACHE_TTL_MS = 60_000;
 
 export const SURVEY_EVIDENCE_MIME_TYPE = 'application/json';
@@ -70,17 +72,20 @@ type FetchLike = (url: string, init: { signal: AbortSignal; headers: Record<stri
 
 let _fetchOverride: FetchLike | null = null;
 let _listingCache: { surveys: SurveyDescriptor[]; expiresAt: number } | null = null;
+let _listingInFlight: Promise<SurveyDescriptor[]> | null = null;
 
 /** Inject a fetch implementation — for testing only. */
 export function _setFetchOverride(fetchLike: FetchLike | null): void {
   _fetchOverride = fetchLike;
   _listingCache = null;
+  _listingInFlight = null;
 }
 
 /** Reset cached listing state — for testing only. */
 export function _resetSurveyState(): void {
   _fetchOverride = null;
   _listingCache = null;
+  _listingInFlight = null;
 }
 
 async function httpGet(url: string): Promise<{ status: number; text: string }> {
@@ -112,25 +117,37 @@ export function topicFromResourceUri(uri: string): string | null {
   return match ? match[1] : null;
 }
 
+export interface FormsSurveysParseResult {
+  /** Whether the "## Forms Surveys" heading was present at all. */
+  headingFound: boolean;
+  /** Number of "- " list lines seen inside the section (parseable or not). */
+  entryLineCount: number;
+  surveys: SurveyDescriptor[];
+}
+
 /**
  * Parse the "## Forms Surveys" section of llms.txt into survey descriptors.
  * Exported for tests.
  */
-export function parseFormsSurveysSection(llmsTxt: string): SurveyDescriptor[] {
+export function parseFormsSurveysSection(llmsTxt: string): FormsSurveysParseResult {
   const lines = llmsTxt.split('\n');
   const surveys: SurveyDescriptor[] = [];
   const seen = new Set<string>();
   let inSection = false;
+  let headingFound = false;
+  let entryLineCount = 0;
 
   for (const rawLine of lines) {
     const line = rawLine.trim();
     if (line.startsWith('## ')) {
       inSection = line === FORMS_SURVEYS_HEADING;
+      headingFound = headingFound || inSection;
       continue;
     }
     if (!inSection || !line.startsWith('- ')) {
       continue;
     }
+    entryLineCount += 1;
 
     const titleMatch = /^- \[([^\]]+)\]/.exec(line);
     const urlMatch = /\((https:\/\/openagreements\.org\/api\/surveys\/[a-z0-9-]+\/forms-evidence)\)/.exec(line);
@@ -145,26 +162,54 @@ export function parseFormsSurveysSection(llmsTxt: string): SurveyDescriptor[] {
     surveys.push({ topic, title: titleMatch[1], uri: urlMatch[1] });
   }
 
-  return surveys;
+  return { headingFound, entryLineCount, surveys };
 }
 
 /**
  * List the currently published forms-provider surveys by reading the live,
- * upstream-gated listing. Cached briefly in-process.
+ * upstream-gated listing. Cached briefly in-process; concurrent cold calls
+ * share a single upstream fetch.
+ *
+ * A missing or unparseable "## Forms Surveys" section is an upstream-contract
+ * failure and throws rather than caching an empty listing — otherwise a
+ * formatting change upstream would silently make every survey "not found".
+ * A heading that is present but intentionally empty is a valid empty listing.
  */
 export async function listPublishedSurveys(): Promise<SurveyDescriptor[]> {
   if (_listingCache && _listingCache.expiresAt > Date.now()) {
     return _listingCache.surveys;
   }
-
-  const { status, text } = await httpGet(LLMS_TXT_URL);
-  if (status !== 200) {
-    throw new SurveyFetchError(`Survey listing unavailable: ${LLMS_TXT_URL} returned HTTP ${status}`, status);
+  if (_listingInFlight) {
+    return _listingInFlight;
   }
 
-  const surveys = parseFormsSurveysSection(text);
-  _listingCache = { surveys, expiresAt: Date.now() + LISTING_CACHE_TTL_MS };
-  return surveys;
+  _listingInFlight = (async () => {
+    const { status, text } = await httpGet(LLMS_TXT_URL);
+    if (status !== 200) {
+      throw new SurveyFetchError(`Survey listing unavailable: ${LLMS_TXT_URL} returned HTTP ${status}`, status);
+    }
+
+    const parsed = parseFormsSurveysSection(text);
+    if (!parsed.headingFound) {
+      throw new SurveyFetchError(
+        `Survey listing format changed: no "${FORMS_SURVEYS_HEADING}" section in ${LLMS_TXT_URL}`,
+      );
+    }
+    if (parsed.entryLineCount > 0 && parsed.surveys.length === 0) {
+      throw new SurveyFetchError(
+        `Survey listing format changed: "${FORMS_SURVEYS_HEADING}" entries in ${LLMS_TXT_URL} no longer parse`,
+      );
+    }
+
+    _listingCache = { surveys: parsed.surveys, expiresAt: Date.now() + LISTING_CACHE_TTL_MS };
+    return parsed.surveys;
+  })();
+
+  try {
+    return await _listingInFlight;
+  } finally {
+    _listingInFlight = null;
+  }
 }
 
 /** MCP resource descriptors for resources/list. */

--- a/packages/contract-templates-mcp/src/core/surveys.ts
+++ b/packages/contract-templates-mcp/src/core/surveys.ts
@@ -1,0 +1,261 @@
+/**
+ * Forms-provider survey evidence, exposed as MCP resources (open-agreements#672).
+ *
+ * The datasets live on openagreements.org (served by the web property), not in
+ * this repository. Two upstream surfaces matter here:
+ *
+ * - `GET /llms.txt` — its "## Forms Surveys" section is generated from the
+ *   upstream `listPublicFormsProviderSurveys()` gate, so it enumerates exactly
+ *   the surveys that are published (`unlisted: false`). This module treats that
+ *   section as the authoritative live listing and NEVER hardcodes survey slugs.
+ * - `GET /api/surveys/{topic}/forms-evidence` — the evidence dataset itself.
+ *   NOTE: upstream intentionally keeps unlisted surveys reachable at this URL
+ *   (unlisted means "unadvertised", not "blocked"), so this endpoint alone is
+ *   NOT the unlisted gate. To honor the gate at read time, reads first require
+ *   membership in the live listing above, then fetch the dataset.
+ *
+ * Both surfaces are public, unauthenticated GETs; this module adds no auth.
+ */
+
+const OPENAGREEMENTS_ORIGIN = 'https://openagreements.org';
+const LLMS_TXT_URL = `${OPENAGREEMENTS_ORIGIN}/llms.txt`;
+const FORMS_SURVEYS_HEADING = '## Forms Surveys';
+
+const TOPIC_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
+const EVIDENCE_URI_PATTERN =
+  /^https:\/\/openagreements\.org\/api\/surveys\/([a-z0-9][a-z0-9-]*)\/forms-evidence$/;
+
+const FETCH_TIMEOUT_MS = 15_000;
+
+// Upstream serves llms.txt through a CDN with hour-scale caching; a short
+// in-process cache just avoids refetching it for back-to-back MCP calls in
+// one session while keeping the unlisted-gate window small.
+const LISTING_CACHE_TTL_MS = 60_000;
+
+export const SURVEY_EVIDENCE_MIME_TYPE = 'application/json';
+
+export interface SurveyDescriptor {
+  topic: string;
+  title: string;
+  uri: string;
+}
+
+export interface SurveyResourceDescriptor {
+  uri: string;
+  name: string;
+  title: string;
+  description: string;
+  mimeType: string;
+}
+
+export interface SurveyResourceContents {
+  uri: string;
+  mimeType: string;
+  text: string;
+  _meta?: Record<string, unknown>;
+}
+
+export class SurveyFetchError extends Error {
+  constructor(message: string, readonly status?: number) {
+    super(message);
+    this.name = 'SurveyFetchError';
+  }
+}
+
+type FetchLike = (url: string, init: { signal: AbortSignal; headers: Record<string, string> }) => Promise<{
+  ok: boolean;
+  status: number;
+  text: () => Promise<string>;
+}>;
+
+let _fetchOverride: FetchLike | null = null;
+let _listingCache: { surveys: SurveyDescriptor[]; expiresAt: number } | null = null;
+
+/** Inject a fetch implementation — for testing only. */
+export function _setFetchOverride(fetchLike: FetchLike | null): void {
+  _fetchOverride = fetchLike;
+  _listingCache = null;
+}
+
+/** Reset cached listing state — for testing only. */
+export function _resetSurveyState(): void {
+  _fetchOverride = null;
+  _listingCache = null;
+}
+
+async function httpGet(url: string): Promise<{ status: number; text: string }> {
+  const fetchImpl: FetchLike = _fetchOverride ?? (fetch as unknown as FetchLike);
+  let response: Awaited<ReturnType<FetchLike>>;
+  try {
+    response = await fetchImpl(url, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      headers: { accept: 'application/json, text/plain;q=0.9, */*;q=0.1' },
+    });
+  } catch (error) {
+    const details = error instanceof Error ? error.message : String(error);
+    throw new SurveyFetchError(`Failed to fetch ${url}: ${details}`);
+  }
+  return { status: response.status, text: await response.text() };
+}
+
+export function surveyEvidenceUrl(topic: string): string {
+  return `${OPENAGREEMENTS_ORIGIN}/api/surveys/${topic}/forms-evidence`;
+}
+
+export function isValidTopic(topic: string): boolean {
+  return TOPIC_PATTERN.test(topic);
+}
+
+/** Extract the survey topic from a resource URI, or null if it is not a survey-evidence URI. */
+export function topicFromResourceUri(uri: string): string | null {
+  const match = EVIDENCE_URI_PATTERN.exec(uri);
+  return match ? match[1] : null;
+}
+
+/**
+ * Parse the "## Forms Surveys" section of llms.txt into survey descriptors.
+ * Exported for tests.
+ */
+export function parseFormsSurveysSection(llmsTxt: string): SurveyDescriptor[] {
+  const lines = llmsTxt.split('\n');
+  const surveys: SurveyDescriptor[] = [];
+  const seen = new Set<string>();
+  let inSection = false;
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (line.startsWith('## ')) {
+      inSection = line === FORMS_SURVEYS_HEADING;
+      continue;
+    }
+    if (!inSection || !line.startsWith('- ')) {
+      continue;
+    }
+
+    const titleMatch = /^- \[([^\]]+)\]/.exec(line);
+    const urlMatch = /\((https:\/\/openagreements\.org\/api\/surveys\/[a-z0-9-]+\/forms-evidence)\)/.exec(line);
+    if (!titleMatch || !urlMatch) {
+      continue;
+    }
+    const topic = topicFromResourceUri(urlMatch[1]);
+    if (!topic || seen.has(topic)) {
+      continue;
+    }
+    seen.add(topic);
+    surveys.push({ topic, title: titleMatch[1], uri: urlMatch[1] });
+  }
+
+  return surveys;
+}
+
+/**
+ * List the currently published forms-provider surveys by reading the live,
+ * upstream-gated listing. Cached briefly in-process.
+ */
+export async function listPublishedSurveys(): Promise<SurveyDescriptor[]> {
+  if (_listingCache && _listingCache.expiresAt > Date.now()) {
+    return _listingCache.surveys;
+  }
+
+  const { status, text } = await httpGet(LLMS_TXT_URL);
+  if (status !== 200) {
+    throw new SurveyFetchError(`Survey listing unavailable: ${LLMS_TXT_URL} returned HTTP ${status}`, status);
+  }
+
+  const surveys = parseFormsSurveysSection(text);
+  _listingCache = { surveys, expiresAt: Date.now() + LISTING_CACHE_TTL_MS };
+  return surveys;
+}
+
+/** MCP resource descriptors for resources/list. */
+export async function listSurveyResources(): Promise<SurveyResourceDescriptor[]> {
+  const surveys = await listPublishedSurveys();
+  return surveys.map((survey) => ({
+    uri: survey.uri,
+    name: `forms-survey-evidence:${survey.topic}`,
+    title: `${survey.title} — evidence dataset`,
+    description:
+      `Complete evidence dataset behind the "${survey.title}" forms survey: compared requirements, ` +
+      'surveyed forms with public source URLs, and every evidence cell (verbatim sentence, operative ' +
+      "phrase, section, and clause id). The payload's top-level asOf field carries the review date. " +
+      'Large surveys can approach 1 MB; the get_forms_survey_evidence tool returns a summary or a ' +
+      "single requirement's evidence instead.",
+    mimeType: SURVEY_EVIDENCE_MIME_TYPE,
+  }));
+}
+
+export interface SurveyEvidenceFetchResult {
+  found: boolean;
+  /** Raw JSON text of the evidence payload (present when found). */
+  text?: string;
+  /** Parsed payload (present when found and parseable). */
+  payload?: SurveyEvidencePayload;
+}
+
+export interface SurveyEvidencePayload {
+  type?: string;
+  slug?: string;
+  asOf?: string;
+  sample?: unknown;
+  evidenceCellCount?: number;
+  requirements?: Array<{ id: string; label: string; valueType?: string }>;
+  forms?: Array<{ id: string; name: string; sourceUrl: string }>;
+  cells?: Record<string, Record<string, unknown>>;
+}
+
+/**
+ * Fetch the evidence dataset for a survey, honoring the unlisted gate: the
+ * topic must appear in the live published listing before the dataset is
+ * fetched. Returns { found: false } for unknown or unlisted surveys.
+ */
+export async function fetchSurveyEvidence(topic: string): Promise<SurveyEvidenceFetchResult> {
+  if (!isValidTopic(topic)) {
+    return { found: false };
+  }
+
+  const published = await listPublishedSurveys();
+  if (!published.some((survey) => survey.topic === topic)) {
+    return { found: false };
+  }
+
+  const { status, text } = await httpGet(surveyEvidenceUrl(topic));
+  if (status === 404) {
+    return { found: false };
+  }
+  if (status !== 200) {
+    throw new SurveyFetchError(`Survey evidence fetch failed: HTTP ${status} for topic "${topic}"`, status);
+  }
+
+  let payload: SurveyEvidencePayload | undefined;
+  try {
+    payload = JSON.parse(text) as SurveyEvidencePayload;
+  } catch {
+    throw new SurveyFetchError(`Survey evidence for "${topic}" is not valid JSON`);
+  }
+
+  return { found: true, text, payload };
+}
+
+/**
+ * Read one survey resource for resources/read. Returns null when the URI is
+ * not a survey-evidence URI or the survey is not published (unknown/unlisted).
+ */
+export async function readSurveyResource(uri: string): Promise<SurveyResourceContents | null> {
+  const topic = topicFromResourceUri(uri);
+  if (!topic) {
+    return null;
+  }
+
+  const result = await fetchSurveyEvidence(topic);
+  if (!result.found || result.text === undefined) {
+    return null;
+  }
+
+  const asOf = result.payload?.asOf;
+  return {
+    uri,
+    mimeType: SURVEY_EVIDENCE_MIME_TYPE,
+    text: result.text,
+    ...(typeof asOf === 'string' ? { _meta: { asOf } } : {}),
+  };
+}

--- a/packages/contract-templates-mcp/src/core/tools.ts
+++ b/packages/contract-templates-mcp/src/core/tools.ts
@@ -78,6 +78,18 @@ const GetFormsSurveyEvidenceArgsSchema = z
   })
   .strict();
 
+// Lightweight shape check on the fields this tool consumes, so upstream schema
+// drift surfaces as SURVEY_FETCH_FAILED instead of a misleading tool error or
+// silently empty output. resources/read still returns the raw JSON verbatim.
+const SurveyEvidencePayloadSchema = z.object({
+  asOf: z.string().optional(),
+  sample: z.unknown().optional(),
+  evidenceCellCount: z.number().int().optional(),
+  requirements: z.array(z.object({ id: z.string(), label: z.string(), valueType: z.string().optional() })),
+  forms: z.array(z.object({ id: z.string(), name: z.string(), sourceUrl: z.string() })),
+  cells: z.record(z.string(), z.record(z.string(), z.unknown())).optional(),
+});
+
 const CreateApapAgreementDocxArgsSchema = z.object({
   template_id: z.string().min(1),
   agreement_data: z.record(z.string(), z.unknown()),
@@ -547,26 +559,35 @@ const tools: ToolDefinition[] = [
         );
       }
 
-      const payload = result.payload;
+      const parsedPayload = SurveyEvidencePayloadSchema.safeParse(result.payload);
+      if (!parsedPayload.success) {
+        return toolError(
+          'get_forms_survey_evidence',
+          'SURVEY_FETCH_FAILED',
+          `Survey evidence for "${input.topic}" has an unexpected shape: ${formatZodError(parsedPayload.error)}`,
+        );
+      }
+
+      const payload = parsedPayload.data;
       const base = {
         topic: input.topic,
         as_of: payload.asOf ?? null,
         sample: payload.sample ?? null,
         evidence_cell_count: payload.evidenceCellCount ?? null,
-        forms: payload.forms ?? [],
+        forms: payload.forms,
         resource_uri: surveyEvidenceUrl(input.topic),
       };
 
       if (input.requirement_id === undefined) {
         return successResult('get_forms_survey_evidence', {
           ...base,
-          requirements: payload.requirements ?? [],
+          requirements: payload.requirements,
         });
       }
 
-      const requirement = (payload.requirements ?? []).find((item) => item.id === input.requirement_id);
+      const requirement = payload.requirements.find((item) => item.id === input.requirement_id);
       if (!requirement) {
-        const available = (payload.requirements ?? []).map((item) => item.id);
+        const available = payload.requirements.map((item) => item.id);
         return toolError(
           'get_forms_survey_evidence',
           'REQUIREMENT_NOT_FOUND',

--- a/packages/contract-templates-mcp/src/core/tools.ts
+++ b/packages/contract-templates-mcp/src/core/tools.ts
@@ -5,6 +5,7 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { promisify } from 'node:util';
 import { z } from 'zod';
+import { fetchSurveyEvidence, isValidTopic, surveyEvidenceUrl, SurveyFetchError } from './surveys.js';
 
 type JsonSchema = Record<string, unknown>;
 
@@ -69,6 +70,13 @@ const FillTemplateArgsSchema = z.object({
 const GetApapTemplateArgsSchema = z.object({
   template_id: z.string().min(1),
 });
+
+const GetFormsSurveyEvidenceArgsSchema = z
+  .object({
+    topic: z.string().min(1).max(128),
+    requirement_id: z.string().min(1).max(256).optional(),
+  })
+  .strict();
 
 const CreateApapAgreementDocxArgsSchema = z.object({
   template_id: z.string().min(1),
@@ -481,6 +489,97 @@ const tools: ToolDefinition[] = [
       } catch (error) {
         return toolError('create_apap_agreement_docx', 'DOCX_RENDER_FAILED', extractErrorMessage(error));
       }
+    },
+  },
+  {
+    name: 'get_forms_survey_evidence',
+    description:
+      'Fetch evidence from a published OpenAgreements forms-provider survey (clause-by-clause market ' +
+      'benchmarks of real-world forms). Without requirement_id, returns a summary: survey metadata ' +
+      '(including as_of freshness), the compared requirements, and the surveyed forms — but no evidence ' +
+      'cells. With requirement_id, additionally returns that one requirement\'s evidence cells across all ' +
+      'surveyed forms (verbatim sentence, operative phrase, section, clause id). The complete dataset for ' +
+      'each survey is also available as an MCP resource (see resources/list); large surveys approach 1 MB, ' +
+      'so prefer this tool when only part of the evidence is needed. Only currently published surveys are ' +
+      'reachable; the live listing is discovered from openagreements.org and never hardcoded.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        topic: {
+          type: 'string',
+          description: 'Survey topic slug, e.g. "employment-offer-letter". Discover slugs via resources/list.',
+        },
+        requirement_id: {
+          type: 'string',
+          description:
+            'Optional requirement id (from the summary\'s requirements list) to return that requirement\'s evidence cells.',
+        },
+      },
+      required: ['topic'],
+      additionalProperties: false,
+    },
+    annotations: { readOnlyHint: true, destructiveHint: false },
+    invoke: async (args) => {
+      const input = GetFormsSurveyEvidenceArgsSchema.parse(args ?? {});
+
+      if (!isValidTopic(input.topic)) {
+        return toolError(
+          'get_forms_survey_evidence',
+          'SURVEY_NOT_FOUND',
+          `Invalid survey topic: "${input.topic}". Topics are lowercase slugs like "employment-offer-letter".`,
+        );
+      }
+
+      let result;
+      try {
+        result = await fetchSurveyEvidence(input.topic);
+      } catch (error) {
+        const message = error instanceof SurveyFetchError ? error.message : extractErrorMessage(error);
+        return toolError('get_forms_survey_evidence', 'SURVEY_FETCH_FAILED', message);
+      }
+
+      if (!result.found || !result.payload) {
+        return toolError(
+          'get_forms_survey_evidence',
+          'SURVEY_NOT_FOUND',
+          `No published forms survey found for topic "${input.topic}". ` +
+            'Use resources/list to discover currently published surveys.',
+        );
+      }
+
+      const payload = result.payload;
+      const base = {
+        topic: input.topic,
+        as_of: payload.asOf ?? null,
+        sample: payload.sample ?? null,
+        evidence_cell_count: payload.evidenceCellCount ?? null,
+        forms: payload.forms ?? [],
+        resource_uri: surveyEvidenceUrl(input.topic),
+      };
+
+      if (input.requirement_id === undefined) {
+        return successResult('get_forms_survey_evidence', {
+          ...base,
+          requirements: payload.requirements ?? [],
+        });
+      }
+
+      const requirement = (payload.requirements ?? []).find((item) => item.id === input.requirement_id);
+      if (!requirement) {
+        const available = (payload.requirements ?? []).map((item) => item.id);
+        return toolError(
+          'get_forms_survey_evidence',
+          'REQUIREMENT_NOT_FOUND',
+          `Requirement "${input.requirement_id}" not found in survey "${input.topic}". ` +
+            `Available requirement ids: ${available.join(', ')}`,
+        );
+      }
+
+      return successResult('get_forms_survey_evidence', {
+        ...base,
+        requirement,
+        cells: payload.cells?.[input.requirement_id] ?? {},
+      });
     },
   },
 ];

--- a/packages/contract-templates-mcp/src/index.ts
+++ b/packages/contract-templates-mcp/src/index.ts
@@ -1,2 +1,8 @@
-export { runStdioServer } from './core/server.js';
+export { dispatchMessage, runStdioServer } from './core/server.js';
+export {
+  listPublishedSurveys,
+  listSurveyResources,
+  readSurveyResource,
+  SurveyFetchError,
+} from './core/surveys.js';
 export { callTool, listToolDescriptors, type ToolCallResult } from './core/tools.js';

--- a/packages/contract-templates-mcp/tests/surveys.test.ts
+++ b/packages/contract-templates-mcp/tests/surveys.test.ts
@@ -112,12 +112,34 @@ afterEach(() => {
 
 describe('forms-survey listing parser', () => {
   it('parses only the Forms Surveys section of llms.txt', () => {
-    const surveys = parseFormsSurveysSection(LLMS_TXT_FIXTURE);
+    const { headingFound, surveys } = parseFormsSurveysSection(LLMS_TXT_FIXTURE);
+    expect(headingFound).toBe(true);
     expect(surveys.map((s) => s.topic)).toEqual(['employment-offer-letter', 'restrictive-covenant']);
     expect(surveys[0].title).toBe('Employee offer letters, compared clause by clause');
     expect(surveys[0].uri).toBe(EVIDENCE_URL('employment-offer-letter'));
     // The decoy under "## Something Else" must not leak into the listing.
     expect(surveys.some((s) => s.topic === 'decoy-survey')).toBe(false);
+  });
+
+  it('parses CRLF-terminated llms.txt identically', () => {
+    const { surveys } = parseFormsSurveysSection(LLMS_TXT_FIXTURE.replace(/\n/g, '\r\n'));
+    expect(surveys.map((s) => s.topic)).toEqual(['employment-offer-letter', 'restrictive-covenant']);
+  });
+
+  it('distinguishes a missing heading from an intentionally empty section', () => {
+    const missing = parseFormsSurveysSection('# OpenAgreements\n\n## Templates\n- [T](https://openagreements.org/templates/t)\n');
+    expect(missing.headingFound).toBe(false);
+    expect(missing.surveys).toEqual([]);
+
+    const empty = parseFormsSurveysSection('## Forms Surveys\n\n## Templates\n');
+    expect(empty.headingFound).toBe(true);
+    expect(empty.entryLineCount).toBe(0);
+    expect(empty.surveys).toEqual([]);
+
+    const malformed = parseFormsSurveysSection('## Forms Surveys\n- Employee offer letters (format changed, no links)\n');
+    expect(malformed.headingFound).toBe(true);
+    expect(malformed.entryLineCount).toBe(1);
+    expect(malformed.surveys).toEqual([]);
   });
 
   it('extracts topics only from exact evidence URIs', () => {
@@ -148,6 +170,48 @@ describe('survey resources', () => {
     await listPublishedSurveys();
     await listPublishedSurveys();
     expect(requested.filter((url) => url.endsWith('/llms.txt'))).toHaveLength(1);
+  });
+
+  it('deduplicates concurrent cold listing fetches', async () => {
+    const requested = installMockFetch(standardRoutes());
+    const [a, b, c] = await Promise.all([listPublishedSurveys(), listPublishedSurveys(), listPublishedSurveys()]);
+    expect(requested.filter((url) => url.endsWith('/llms.txt'))).toHaveLength(1);
+    expect(a).toEqual(b);
+    expect(b).toEqual(c);
+  });
+
+  it('does not cache a failed listing fetch — retries are possible', async () => {
+    const routes = standardRoutes();
+    routes['https://openagreements.org/llms.txt'] = { status: 503, body: 'down' };
+    const requested = installMockFetch(routes);
+    await expect(listPublishedSurveys()).rejects.toThrow('503');
+
+    // Restore upstream; the next call must refetch and succeed.
+    routes['https://openagreements.org/llms.txt'] = { status: 200, body: LLMS_TXT_FIXTURE };
+    const surveys = await listPublishedSurveys();
+    expect(surveys).toHaveLength(2);
+    expect(requested.filter((url) => url.endsWith('/llms.txt'))).toHaveLength(2);
+  });
+
+  it('treats a missing Forms Surveys section as an upstream failure, not an empty catalog', async () => {
+    const routes = standardRoutes();
+    routes['https://openagreements.org/llms.txt'] = { status: 200, body: '## Templates\n- [T](https://openagreements.org/templates/t)\n' };
+    installMockFetch(routes);
+    await expect(listPublishedSurveys()).rejects.toThrow('Forms Surveys');
+  });
+
+  it('treats unparseable Forms Surveys entries as an upstream failure', async () => {
+    const routes = standardRoutes();
+    routes['https://openagreements.org/llms.txt'] = { status: 200, body: '## Forms Surveys\n- Employee offer letters (no links anymore)\n' };
+    installMockFetch(routes);
+    await expect(listPublishedSurveys()).rejects.toThrow('no longer parse');
+  });
+
+  it('accepts a present-but-empty Forms Surveys section as a valid empty catalog', async () => {
+    const routes = standardRoutes();
+    routes['https://openagreements.org/llms.txt'] = { status: 200, body: '## Forms Surveys\n\n## Templates\n' };
+    installMockFetch(routes);
+    await expect(listPublishedSurveys()).resolves.toEqual([]);
   });
 
   it('reads a published survey resource and surfaces asOf in _meta', async () => {
@@ -316,6 +380,23 @@ describe('get_forms_survey_evidence tool', () => {
 
     expect(result.isError).toBe(true);
     expect((payload.error as Record<string, unknown>).code).toBe('SURVEY_NOT_FOUND');
+  });
+
+  it('rejects a drifted payload shape with SURVEY_FETCH_FAILED', async () => {
+    const routes = standardRoutes();
+    routes[EVIDENCE_URL('employment-offer-letter')] = {
+      status: 200,
+      // requirements drifted from objects to bare strings
+      body: JSON.stringify({ ...OFFER_LETTER_PAYLOAD, requirements: ['position-and-title'] }),
+    };
+    installMockFetch(routes);
+    const result = await callTool('get_forms_survey_evidence', { topic: 'employment-offer-letter' });
+    const payload = getPayload(result);
+
+    expect(result.isError).toBe(true);
+    const error = payload.error as Record<string, unknown>;
+    expect(error.code).toBe('SURVEY_FETCH_FAILED');
+    expect(error.message).toContain('unexpected shape');
   });
 
   it('surfaces upstream fetch failures as SURVEY_FETCH_FAILED', async () => {

--- a/packages/contract-templates-mcp/tests/surveys.test.ts
+++ b/packages/contract-templates-mcp/tests/surveys.test.ts
@@ -1,0 +1,331 @@
+import { afterEach, describe, expect } from 'vitest';
+import { itAllure } from '../../../integration-tests/helpers/allure-test.js';
+import { dispatchMessage } from '../src/core/server.js';
+import {
+  _resetSurveyState,
+  _setFetchOverride,
+  fetchSurveyEvidence,
+  listPublishedSurveys,
+  listSurveyResources,
+  parseFormsSurveysSection,
+  readSurveyResource,
+  topicFromResourceUri,
+} from '../src/core/surveys.js';
+import { callTool } from '../src/core/tools.js';
+
+const it = itAllure.epic('Platform & Distribution');
+
+const EVIDENCE_URL = (topic: string) => `https://openagreements.org/api/surveys/${topic}/forms-evidence`;
+
+// Mirrors the live llms.txt shape: "## Forms Surveys" entries link both the
+// HTML survey page and the JSON evidence endpoint. `secret-benchmark` is
+// deliberately absent — it stands in for an unlisted survey that upstream
+// keeps reachable by direct URL but advertises nowhere.
+const LLMS_TXT_FIXTURE = [
+  '# OpenAgreements',
+  '',
+  '## Templates',
+  '- [Some Template](https://openagreements.org/templates/some-template)',
+  '',
+  '## Forms Surveys',
+  `- [Employee offer letters, compared clause by clause](https://openagreements.org/surveys/employment-offer-letter/forms) — clause-by-clause market benchmark: [HTML](https://openagreements.org/surveys/employment-offer-letter/forms), [JSON evidence](${EVIDENCE_URL('employment-offer-letter')})`,
+  `- [Employee restrictive covenants](https://openagreements.org/surveys/restrictive-covenant/forms) — clause-by-clause market benchmark: [HTML](https://openagreements.org/surveys/restrictive-covenant/forms), [JSON evidence](${EVIDENCE_URL('restrictive-covenant')})`,
+  '',
+  '## Something Else',
+  `- [Decoy entry](${EVIDENCE_URL('decoy-survey')})`,
+].join('\n');
+
+const OFFER_LETTER_PAYLOAD = {
+  type: 'forms-provider-survey-evidence',
+  slug: 'employment-offer-letter',
+  asOf: '2026-06-30',
+  sample: { prevalenceUnit: 'form', formCount: 3 },
+  evidenceCellCount: 2,
+  requirements: [
+    { id: 'position-and-title', label: 'Position / title stated' },
+    { id: 'at-will', label: 'At-will employment stated', valueType: 'boolean' },
+  ],
+  forms: [
+    { id: 'openagreements', name: 'OpenAgreements', sourceUrl: 'https://openagreements.org/templates/openagreements-employment-offer-letter' },
+  ],
+  cells: {
+    'position-and-title': {
+      openagreements: {
+        sentence: 'Employee will join Company in the position listed in Cover Terms.',
+        operative: 'the position listed in Cover Terms',
+        truncated: false,
+        sectionName: 'Position, Scope, and Reporting',
+        sectionOutlineLabel: null,
+        clauseId: 'position-scope-and-reporting',
+      },
+    },
+    'at-will': {
+      openagreements: {
+        sentence: 'Employment with Company is at will.',
+        operative: 'at will',
+        truncated: false,
+        sectionName: 'At-Will Employment',
+        sectionOutlineLabel: null,
+        clauseId: 'at-will-employment',
+      },
+    },
+  },
+};
+
+// The unlisted survey: reachable at its direct URL upstream (200), but absent
+// from the published listing. The MCP surface must not expose it.
+const UNLISTED_PAYLOAD = {
+  ...OFFER_LETTER_PAYLOAD,
+  slug: 'secret-benchmark',
+};
+
+interface MockRoute {
+  status: number;
+  body: string;
+}
+
+function installMockFetch(routes: Record<string, MockRoute>): string[] {
+  const requested: string[] = [];
+  _setFetchOverride(async (url) => {
+    requested.push(url);
+    const route = routes[url];
+    if (!route) {
+      return { ok: false, status: 404, text: async () => '{"error":"Survey not found"}' };
+    }
+    return { ok: route.status === 200, status: route.status, text: async () => route.body };
+  });
+  return requested;
+}
+
+function standardRoutes(): Record<string, MockRoute> {
+  return {
+    'https://openagreements.org/llms.txt': { status: 200, body: LLMS_TXT_FIXTURE },
+    [EVIDENCE_URL('employment-offer-letter')]: { status: 200, body: JSON.stringify(OFFER_LETTER_PAYLOAD) },
+    [EVIDENCE_URL('restrictive-covenant')]: { status: 200, body: JSON.stringify({ ...OFFER_LETTER_PAYLOAD, slug: 'restrictive-covenant' }) },
+    [EVIDENCE_URL('secret-benchmark')]: { status: 200, body: JSON.stringify(UNLISTED_PAYLOAD) },
+  };
+}
+
+afterEach(() => {
+  _resetSurveyState();
+});
+
+describe('forms-survey listing parser', () => {
+  it('parses only the Forms Surveys section of llms.txt', () => {
+    const surveys = parseFormsSurveysSection(LLMS_TXT_FIXTURE);
+    expect(surveys.map((s) => s.topic)).toEqual(['employment-offer-letter', 'restrictive-covenant']);
+    expect(surveys[0].title).toBe('Employee offer letters, compared clause by clause');
+    expect(surveys[0].uri).toBe(EVIDENCE_URL('employment-offer-letter'));
+    // The decoy under "## Something Else" must not leak into the listing.
+    expect(surveys.some((s) => s.topic === 'decoy-survey')).toBe(false);
+  });
+
+  it('extracts topics only from exact evidence URIs', () => {
+    expect(topicFromResourceUri(EVIDENCE_URL('privacy-policy'))).toBe('privacy-policy');
+    expect(topicFromResourceUri('https://openagreements.org/surveys/privacy-policy/forms')).toBeNull();
+    expect(topicFromResourceUri('https://evil.example/api/surveys/privacy-policy/forms-evidence')).toBeNull();
+    expect(topicFromResourceUri(`${EVIDENCE_URL('privacy-policy')}/extra`)).toBeNull();
+  });
+});
+
+describe('survey resources', () => {
+  it('lists one resource per published survey with asOf guidance', async () => {
+    installMockFetch(standardRoutes());
+    const resources = await listSurveyResources();
+
+    expect(resources).toHaveLength(2);
+    expect(resources[0]).toMatchObject({
+      uri: EVIDENCE_URL('employment-offer-letter'),
+      name: 'forms-survey-evidence:employment-offer-letter',
+      mimeType: 'application/json',
+    });
+    expect(resources[0].title).toContain('Employee offer letters');
+    expect(resources[0].description).toContain('asOf');
+  });
+
+  it('caches the published listing between calls', async () => {
+    const requested = installMockFetch(standardRoutes());
+    await listPublishedSurveys();
+    await listPublishedSurveys();
+    expect(requested.filter((url) => url.endsWith('/llms.txt'))).toHaveLength(1);
+  });
+
+  it('reads a published survey resource and surfaces asOf in _meta', async () => {
+    installMockFetch(standardRoutes());
+    const contents = await readSurveyResource(EVIDENCE_URL('employment-offer-letter'));
+
+    expect(contents).not.toBeNull();
+    expect(contents?.mimeType).toBe('application/json');
+    expect(contents?._meta).toEqual({ asOf: '2026-06-30' });
+    const parsed = JSON.parse(contents?.text ?? '');
+    expect(parsed.slug).toBe('employment-offer-letter');
+    expect(parsed.asOf).toBe('2026-06-30');
+    expect(parsed.cells['position-and-title'].openagreements.operative).toBe('the position listed in Cover Terms');
+  });
+
+  it('refuses to read an unlisted survey even though its direct URL serves 200', async () => {
+    const requested = installMockFetch(standardRoutes());
+    const contents = await readSurveyResource(EVIDENCE_URL('secret-benchmark'));
+
+    expect(contents).toBeNull();
+    // The gate must short-circuit before the evidence endpoint is contacted.
+    expect(requested).not.toContain(EVIDENCE_URL('secret-benchmark'));
+  });
+
+  it('returns null for a survey the evidence endpoint 404s', async () => {
+    const routes = standardRoutes();
+    routes[EVIDENCE_URL('restrictive-covenant')] = { status: 404, body: '{"error":"Survey not found"}' };
+    installMockFetch(routes);
+    const contents = await readSurveyResource(EVIDENCE_URL('restrictive-covenant'));
+    expect(contents).toBeNull();
+  });
+
+  it('rejects invalid topics before any evidence fetch', async () => {
+    const requested = installMockFetch(standardRoutes());
+    const result = await fetchSurveyEvidence('../../etc/passwd');
+    expect(result.found).toBe(false);
+    expect(requested).toHaveLength(0);
+  });
+});
+
+describe('server resource dispatch', () => {
+  it('advertises the resources capability on initialize', async () => {
+    const response = await dispatchMessage({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} });
+    const result = response?.result as { capabilities: Record<string, unknown> };
+    expect(result.capabilities).toHaveProperty('tools');
+    expect(result.capabilities).toHaveProperty('resources');
+  });
+
+  it('serves resources/list and resources/read end-to-end', async () => {
+    installMockFetch(standardRoutes());
+
+    const listResponse = await dispatchMessage({ jsonrpc: '2.0', id: 2, method: 'resources/list' });
+    const listResult = listResponse?.result as { resources: Array<{ uri: string }> };
+    expect(listResult.resources.map((r) => r.uri)).toEqual([
+      EVIDENCE_URL('employment-offer-letter'),
+      EVIDENCE_URL('restrictive-covenant'),
+    ]);
+
+    const readResponse = await dispatchMessage({
+      jsonrpc: '2.0',
+      id: 3,
+      method: 'resources/read',
+      params: { uri: EVIDENCE_URL('employment-offer-letter') },
+    });
+    const readResult = readResponse?.result as {
+      contents: Array<{ uri: string; mimeType: string; text: string; _meta?: Record<string, unknown> }>;
+    };
+    expect(readResult.contents).toHaveLength(1);
+    expect(readResult.contents[0].uri).toBe(EVIDENCE_URL('employment-offer-letter'));
+    expect(readResult.contents[0]._meta).toEqual({ asOf: '2026-06-30' });
+    expect(JSON.parse(readResult.contents[0].text).evidenceCellCount).toBe(2);
+  });
+
+  it('returns -32002 for unknown and unlisted resource URIs', async () => {
+    installMockFetch(standardRoutes());
+
+    const unlisted = await dispatchMessage({
+      jsonrpc: '2.0',
+      id: 4,
+      method: 'resources/read',
+      params: { uri: EVIDENCE_URL('secret-benchmark') },
+    });
+    expect(unlisted?.error?.code).toBe(-32002);
+
+    const nonSurvey = await dispatchMessage({
+      jsonrpc: '2.0',
+      id: 5,
+      method: 'resources/read',
+      params: { uri: 'https://openagreements.org/llms.txt' },
+    });
+    expect(nonSurvey?.error?.code).toBe(-32002);
+  });
+
+  it('rejects malformed resources/read params', async () => {
+    const response = await dispatchMessage({ jsonrpc: '2.0', id: 6, method: 'resources/read', params: {} });
+    expect(response?.error?.code).toBe(-32602);
+  });
+
+  it('reports listing failures as internal errors, not empty lists', async () => {
+    installMockFetch({ 'https://openagreements.org/llms.txt': { status: 503, body: 'nope' } });
+    const response = await dispatchMessage({ jsonrpc: '2.0', id: 7, method: 'resources/list' });
+    expect(response?.error?.code).toBe(-32603);
+    expect(response?.error?.message).toContain('503');
+  });
+
+  it('serves an empty resources/templates/list', async () => {
+    const response = await dispatchMessage({ jsonrpc: '2.0', id: 8, method: 'resources/templates/list' });
+    expect(response?.result).toEqual({ resourceTemplates: [] });
+  });
+});
+
+describe('get_forms_survey_evidence tool', () => {
+  function getPayload(result: Awaited<ReturnType<typeof callTool>>): Record<string, unknown> {
+    return (result.structuredContent ?? {}) as Record<string, unknown>;
+  }
+
+  it('returns a summary without evidence cells by default', async () => {
+    installMockFetch(standardRoutes());
+    const result = await callTool('get_forms_survey_evidence', { topic: 'employment-offer-letter' });
+    const payload = getPayload(result);
+
+    expect(result.isError).toBeUndefined();
+    expect(payload.ok).toBe(true);
+    const data = payload.data as Record<string, unknown>;
+    expect(data.as_of).toBe('2026-06-30');
+    expect(data.evidence_cell_count).toBe(2);
+    expect((data.requirements as unknown[]).length).toBe(2);
+    expect((data.forms as unknown[]).length).toBe(1);
+    expect(data.resource_uri).toBe(EVIDENCE_URL('employment-offer-letter'));
+    expect(data.cells).toBeUndefined();
+  });
+
+  it('returns one requirement\'s cells when requirement_id is given', async () => {
+    installMockFetch(standardRoutes());
+    const result = await callTool('get_forms_survey_evidence', {
+      topic: 'employment-offer-letter',
+      requirement_id: 'at-will',
+    });
+    const data = getPayload(result).data as Record<string, unknown>;
+
+    expect((data.requirement as Record<string, unknown>).id).toBe('at-will');
+    const cells = data.cells as Record<string, Record<string, unknown>>;
+    expect(cells.openagreements.operative).toBe('at will');
+    // Requirement mode must not carry the whole requirements catalog.
+    expect(data.requirements).toBeUndefined();
+  });
+
+  it('lists available requirement ids when requirement_id is unknown', async () => {
+    installMockFetch(standardRoutes());
+    const result = await callTool('get_forms_survey_evidence', {
+      topic: 'employment-offer-letter',
+      requirement_id: 'nonexistent',
+    });
+    const payload = getPayload(result);
+
+    expect(result.isError).toBe(true);
+    const error = payload.error as Record<string, unknown>;
+    expect(error.code).toBe('REQUIREMENT_NOT_FOUND');
+    expect(error.message).toContain('position-and-title');
+  });
+
+  it('refuses unlisted surveys with SURVEY_NOT_FOUND', async () => {
+    installMockFetch(standardRoutes());
+    const result = await callTool('get_forms_survey_evidence', { topic: 'secret-benchmark' });
+    const payload = getPayload(result);
+
+    expect(result.isError).toBe(true);
+    expect((payload.error as Record<string, unknown>).code).toBe('SURVEY_NOT_FOUND');
+  });
+
+  it('surfaces upstream fetch failures as SURVEY_FETCH_FAILED', async () => {
+    const routes = standardRoutes();
+    routes[EVIDENCE_URL('employment-offer-letter')] = { status: 500, body: 'server error' };
+    installMockFetch(routes);
+    const result = await callTool('get_forms_survey_evidence', { topic: 'employment-offer-letter' });
+    const payload = getPayload(result);
+
+    expect(result.isError).toBe(true);
+    expect((payload.error as Record<string, unknown>).code).toBe('SURVEY_FETCH_FAILED');
+  });
+});

--- a/packages/contract-templates-mcp/tests/tools.test.ts
+++ b/packages/contract-templates-mcp/tests/tools.test.ts
@@ -84,6 +84,7 @@ describe('contract-templates-mcp tools', () => {
       'fill_template',
       'get_apap_template',
       'create_apap_agreement_docx',
+      'get_forms_survey_evidence',
     ]);
   });
 


### PR DESCRIPTION
Closes #672

Exposes the forms-provider survey evidence sets as MCP resources on the contract-templates MCP server (the backend behind `openagreements.org/api/mcp`), plus a companion tool for partial reads.

## What changed

- **`resources` capability** added to the server (`initialize` now advertises `tools` + `resources`), with `resources/list`, `resources/read`, and `resources/templates/list` handlers. The stdio server's dispatch was factored into an exported `dispatchMessage()` so the JSON-RPC surface is unit-testable.
- **New module `src/core/surveys.ts`**: live discovery + gated fetch of survey evidence.
- **New tool `get_forms_survey_evidence`** (`topic`, optional `requirement_id`): summary without evidence cells by default; one requirement's cells across all surveyed forms when `requirement_id` is given.
- Tests mock the HTTP layer (no network in CI); the shape was verified against the live API during development.

## Resolution of the issue's five design questions

1. **One resource per survey vs. listing tool** — one resource per survey, enumerated by `resources/list`. But enumeration is *live*, not hardcoded: `resources/list` fetches `openagreements.org/llms.txt` and parses the `## Forms Surveys` section, which upstream generates from `listPublicFormsProviderSurveys()`. New surveys appear automatically; nothing in this repo names a survey slug.
2. **~1 MB single reads** — measured against what this server already returns: `fill_template` with `inline_base64` returns whole DOCX files inline (tens to hundreds of KB of base64), and `list_templates` pages at 25 items precisely because the catalog outgrew single-response size (#603). A 992 KB read (`restrictive-covenant`, ~250K tokens) is transport-safe for typical clients but floods an agent's context. So the resource read stays whole-document (the honest model), and the companion tool provides the practical path: its summary mode is a few KB, and one requirement's row measured ~1.5 KB/form on the live data.
3. **Resource vs. tool** — both, as the issue suggested they're not exclusive: resources for the static-document model and client-side resource discovery; the tool for filtered access.
4. **Unlisted gate** — **important correction to the issue's premise**: I read the upstream source (`pages/api/surveys/[topic]/forms-evidence.ts` and `lib/forms-survey.ts` in legal-explainer) and the forms-evidence endpoint does *not* gate `unlisted` — upstream deliberately keeps unlisted surveys reachable at their direct URL while advertising them nowhere ("unlisted means unadvertised, not blocked"). The gate lives in the listing surfaces. So honoring the gate "from the API response" means: reads require membership in the live llms.txt listing (cached in-process for 60 s) *before* fetching the evidence, and a 404 from the evidence endpoint is also treated as not-found. An unlisted survey is therefore neither listed nor readable through MCP, without reimplementing the unlisted rule.
5. **`asOf` freshness** — the raw payload (with top-level `asOf`) is returned verbatim as the resource text, and `asOf` is additionally lifted into `_meta.asOf` on the resource contents; the tool returns it as `as_of`. It can't appear in `resources/list` metadata without fetching all five payloads (~1.6 MB) per listing call, so list-time descriptions point at where it lives.

## Other decisions

- **Resource URIs are the canonical public URLs** (`https://openagreements.org/api/surveys/{topic}/forms-evidence`) rather than a custom scheme — honest provenance, and an HTTP-capable client can fetch the same URI directly.
- **Unknown resource reads** return JSON-RPC `-32002` (MCP's resource-not-found code).
- **No new dependency**: uses Node ≥20 global `fetch` (package already requires Node ≥20); tests inject a fetch override.
- **No auth** anywhere in the path — both upstream surfaces are public GETs.

## Live verification (dev machine, not CI)

Drove the built stdio server end-to-end against the real API: `resources/list` returned all 5 published surveys; `resources/read` of `employment-offer-letter` returned 56 KB JSON with `_meta.asOf = 2026-06-30`; a fabricated topic returned `-32002`; the tool's requirement filter returned one row.

https://claude.ai/code/session_01HX8k8K4wpAQXfehdH158cc
