### PR TITLE
feat(mcp): expose derived_from and credits through the template distribution contract

### DIFF
--- a/integration-tests/template-listing-provenance.test.ts
+++ b/integration-tests/template-listing-provenance.test.ts
@@ -1,0 +1,90 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect } from 'vitest';
+import { itAllure } from './helpers/allure-test.js';
+import { listTemplateItems } from '../src/core/template-listing.js';
+
+const ENV_KEY = 'OPEN_AGREEMENTS_CONTENT_ROOTS';
+const originalEnv = process.env[ENV_KEY];
+const tempDirs: string[] = [];
+const it = itAllure.epic('Platform & Distribution');
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  if (originalEnv === undefined) {
+    delete process.env[ENV_KEY];
+  } else {
+    process.env[ENV_KEY] = originalEnv;
+  }
+});
+
+// Provenance contract (open-agreements#533): `derived_from` and `credits` are
+// validated metadata fields already present in CLI JSON output; the shared
+// TemplateListItem projection must carry them too so MCP/API consumers see
+// them. Credits stay structured (name/role/profile_url) — never flattened
+// into display prose. Policy for WHEN templates declare them is #244.
+describe('template listing provenance projection (#533)', () => {
+  it('projects declared derived_from and structured credits through listTemplateItems', () => {
+    const root = mkdtempSync(join(tmpdir(), 'oa-listing-provenance-'));
+    tempDirs.push(root);
+
+    // S3 layout (#1249): slugs live two levels deep as templates/<segment>/<slug>/.
+    const templateDir = join(root, 'templates', 'override-cc-by-4.0', 'provenance-fixture-template');
+    mkdirSync(templateDir, { recursive: true });
+    writeFileSync(
+      join(templateDir, 'metadata.yaml'),
+      [
+        'name: Provenance Fixture Template',
+        'description: Fixture template exercising provenance projection',
+        'source_url: https://example.com/provenance-template.docx',
+        'version: "1.0"',
+        'license: CC-BY-4.0',
+        'allow_derivatives: true',
+        'attribution_text: Example attribution',
+        'derived_from: Adapted from the ExampleCo form agreement (2024 edition).',
+        'credits:',
+        '  - name: Jane Drafter',
+        '    role: drafter',
+        '    profile_url: https://example.com/jane',
+        '  - name: Sam Reviewer',
+        '    role: reviewer',
+        'fields:',
+        '  - name: company_name',
+        '    type: string',
+        '    description: Company name',
+        'priority_fields:',
+        '  - company_name',
+        '',
+      ].join('\n'),
+      'utf-8',
+    );
+
+    process.env[ENV_KEY] = root;
+
+    const items = listTemplateItems();
+    const item = items.find((entry) => entry.name === 'provenance-fixture-template');
+    expect(item).toBeDefined();
+
+    expect(item!.derived_from).toBe('Adapted from the ExampleCo form agreement (2024 edition).');
+    // Structured role/name data passes through as-is — not flattened to prose.
+    expect(item!.credits).toEqual([
+      { name: 'Jane Drafter', role: 'drafter', profile_url: 'https://example.com/jane' },
+      { name: 'Sam Reviewer', role: 'reviewer' },
+    ]);
+  });
+
+  it('omits derived_from and yields empty credits for templates that declare neither', () => {
+    delete process.env[ENV_KEY];
+
+    const items = listTemplateItems();
+    // Vendored third-party template with no provenance metadata declared.
+    const item = items.find((entry) => entry.name === 'common-paper-mutual-nda');
+    expect(item).toBeDefined();
+
+    expect('derived_from' in item!).toBe(false);
+    expect(item!.credits).toEqual([]);
+  });
+});

--- a/packages/contract-templates-mcp/src/core/tools.ts
+++ b/packages/contract-templates-mcp/src/core/tools.ts
@@ -109,6 +109,13 @@ interface TemplateField {
   items?: TemplateField[];
 }
 
+/** Structured contributor provenance entry (open-agreements#533). */
+interface TemplateCredit {
+  name: string;
+  role: string;
+  profile_url?: string;
+}
+
 interface TemplateRecord {
   name: string;
   display_name?: string;
@@ -120,6 +127,10 @@ interface TemplateRecord {
   attribution_text?: string;
   /** Maturity signal (open-agreements#243); null for templates that don't declare it. */
   stability?: string | null;
+  /** Expository provenance text (open-agreements#533); null/undefined when not declared. */
+  derived_from?: string | null;
+  /** Structured contributor provenance (open-agreements#533); empty when not declared. */
+  credits?: TemplateCredit[];
   fields: TemplateField[];
 }
 
@@ -323,6 +334,8 @@ const tools: ToolDefinition[] = [
             source: mod.sourceName(meta.source_url as string),
             attribution_text: meta.attribution_text as string | undefined,
             stability: (meta.stability as string | undefined) ?? null,
+            derived_from: (meta.derived_from as string | undefined) ?? null,
+            credits: (meta.credits as TemplateCredit[] | undefined) ?? [],
             fields: mod.mapFields(meta.fields as Record<string, unknown>[], meta.priority_fields as string[]),
           };
           return successResult('get_template', { template: normalizeTemplate(template) });
@@ -688,6 +701,10 @@ function normalizeTemplate(template: TemplateRecord): Record<string, unknown> {
     source: template.source,
     attribution_text: template.attribution_text ?? null,
     stability: template.stability ?? null,
+    // Provenance surface (open-agreements#533): expository derived_from text and
+    // structured credits (role/name/profile_url) pass through un-flattened.
+    derived_from: template.derived_from ?? null,
+    credits: template.credits ?? [],
     fields: stripDisplayLabels(template.fields),
   };
 }
@@ -699,6 +716,8 @@ function stripDisplayLabels(fields: TemplateField[]): TemplateField[] {
   });
 }
 
+// Compact list entries deliberately omit provenance (derived_from/credits) —
+// they are full-detail surfaces served by get_template (open-agreements#533).
 function compactTemplate(template: TemplateRecord): Record<string, unknown> {
   const trimmedDisplayName = template.display_name?.trim();
   return {

--- a/packages/contract-templates-mcp/src/core/tools.ts
+++ b/packages/contract-templates-mcp/src/core/tools.ts
@@ -109,10 +109,11 @@ interface TemplateField {
   items?: TemplateField[];
 }
 
-/** Structured contributor provenance entry (open-agreements#533). */
+/** Structured contributor provenance entry (open-agreements#533). Role set
+ * mirrors the closed TemplateCreditRoleEnum in src/core/metadata.ts. */
 interface TemplateCredit {
   name: string;
-  role: string;
+  role: 'drafter' | 'drafting_editor' | 'reviewer' | 'maintainer';
   profile_url?: string;
 }
 

--- a/packages/contract-templates-mcp/tests/tools.test.ts
+++ b/packages/contract-templates-mcp/tests/tools.test.ts
@@ -137,6 +137,9 @@ describe('contract-templates-mcp tools', () => {
       expect(t.fields).toBeUndefined();
       expect(t.license).toBeUndefined();
       expect(t.name).toBeUndefined();
+      // Provenance stays out of the compact list — full-detail via get_template (#533).
+      expect(t.derived_from).toBeUndefined();
+      expect(t.credits).toBeUndefined();
     }
   });
 
@@ -283,6 +286,17 @@ describe('contract-templates-mcp tools', () => {
     );
     const tpTemplate = (thirdParty.data as Record<string, unknown>).template as Record<string, unknown>;
     expect(tpTemplate.stability).toBeNull();
+  });
+
+  it('get_template returns null derived_from and empty credits when metadata declares neither (#533)', async () => {
+    // Vendored third-party template with no provenance metadata declared:
+    // the keys are present in the contract but null/empty, not errors.
+    const result = await callTool('get_template', { template_id: 'common-paper-mutual-nda' });
+    const payload = getPayload(result);
+    expect(result.isError).toBeUndefined();
+    const template = (payload.data as Record<string, unknown>).template as Record<string, unknown>;
+    expect(template.derived_from).toBeNull();
+    expect(template.credits).toEqual([]);
   });
 
   it('get_template returns options for enum fields matching source metadata', async () => {
@@ -537,6 +551,33 @@ describe('contract-templates-mcp tools', () => {
   describe('with module override', () => {
     afterEach(() => {
       _resetModuleCache();
+    });
+
+    it('get_template surfaces declared derived_from and structured credits (#533)', async () => {
+      _setModuleOverride(mockModules({
+        loadMetadata: () => ({
+          name: 'Provenance Template',
+          source_url: 'https://example.com/provenance-template.docx',
+          fields: [],
+          priority_fields: [],
+          derived_from: 'Adapted from the ExampleCo form agreement (2024 edition).',
+          credits: [
+            { name: 'Jane Drafter', role: 'drafter', profile_url: 'https://example.com/jane' },
+            { name: 'Sam Reviewer', role: 'reviewer' },
+          ],
+        }),
+      }));
+
+      const result = await callTool('get_template', { template_id: 'provenance-template' });
+      const payload = getPayload(result);
+      expect(result.isError).toBeUndefined();
+      const template = (payload.data as Record<string, unknown>).template as Record<string, unknown>;
+      expect(template.derived_from).toBe('Adapted from the ExampleCo form agreement (2024 edition).');
+      // Structured role/name data passes through as-is — not flattened to prose.
+      expect(template.credits).toEqual([
+        { name: 'Jane Drafter', role: 'drafter', profile_url: 'https://example.com/jane' },
+        { name: 'Sam Reviewer', role: 'reviewer' },
+      ]);
     });
 
     it('get_template catches loadMetadata error', async () => {

--- a/src/core/metadata.ts
+++ b/src/core/metadata.ts
@@ -322,6 +322,9 @@ const TemplateCreditSchema = z.object({
   role: TemplateCreditRoleEnum,
   profile_url: z.string().url().optional(),
 });
+/** Structured credit entry (name/role, optional profile_url) — shared with the
+ * template-listing projection so MCP/API output preserves the structure (#533). */
+export type TemplateCredit = z.infer<typeof TemplateCreditSchema>;
 
 export const TemplateCapabilityManifestSchema = z.object({
   artifact_kind: z.enum(['agreement', 'consent', 'notice', 'letter', 'checklist', 'policy', 'other']).default('other'),

--- a/src/core/template-listing.ts
+++ b/src/core/template-listing.ts
@@ -7,7 +7,9 @@
  * - MCP `tools.ts` (via dynamic import or npm dependency)
  */
 
-import { loadMetadata, type FieldDefinition } from './metadata.js';
+import { loadMetadata, type FieldDefinition, type TemplateCredit } from './metadata.js';
+
+export type { TemplateCredit } from './metadata.js';
 import { listTemplateEntries } from '../utils/paths.js';
 
 // ---------------------------------------------------------------------------
@@ -39,6 +41,10 @@ export interface TemplateListItem {
   allow_derivatives: boolean;
   /** Maturity signal (open-agreements#243); undefined for templates that don't declare it. */
   stability?: string;
+  /** Expository provenance text (open-agreements#533); undefined for templates that don't declare it. */
+  derived_from?: string;
+  /** Structured contributor provenance (open-agreements#533); empty for templates that don't declare it. */
+  credits: TemplateCredit[];
   fields: TemplateListField[];
 }
 
@@ -146,6 +152,8 @@ export function listTemplateItems(): TemplateListItem[] {
         attribution_text: meta.attribution_text,
         allow_derivatives: meta.allow_derivatives,
         ...(meta.stability !== undefined ? { stability: meta.stability } : {}),
+        ...(meta.derived_from !== undefined ? { derived_from: meta.derived_from } : {}),
+        credits: meta.credits ?? [],
         fields: mapFields(meta.fields, meta.priority_fields),
       });
     } catch {


### PR DESCRIPTION
Closes #533

## What

`derived_from` and `credits` are validated template metadata fields that already appear in CLI JSON output, but were omitted from the shared `TemplateListItem` projection and consequently from `contract-templates-mcp` output. This PR plumbs them through the Open Agreements distribution contract (CLI/MCP/API); website presentation is tracked upstream separately.

## Changes

- **`src/core/metadata.ts`** — export `TemplateCredit` (inferred from the existing zod schema) so downstream projections share the structured type.
- **`src/core/template-listing.ts`** — `TemplateListItem` gains `derived_from?: string` (spread-if-declared, mirroring the `stability` pattern) and `credits: TemplateCredit[]` (always an array, mirroring CLI JSON output which defaults to `[]`).
- **`packages/contract-templates-mcp/src/core/tools.ts`** — `get_template` (both the direct-lookup path and the normalized fallback path) now returns `derived_from` (`null` when undeclared) and `credits` (structured `{name, role, profile_url?}` entries, passed through un-flattened). **Compact `list_templates` output is deliberately unchanged** — provenance is a full-detail surface served by `get_template`, consistent with how `fields`/`license`/`attribution_text` are already list-omitted; no existing consumer needs it in the compact view.

## Tests

- `integration-tests/template-listing-provenance.test.ts` — populated case via an `OPEN_AGREEMENTS_CONTENT_ROOTS` override fixture (two credits, one with `profile_url`, one without) asserting structured pass-through; absent case against `common-paper-mutual-nda` (key omitted / empty array).
- `packages/contract-templates-mcp/tests/tools.test.ts` — `get_template` populated case via module-override fixture; absent case (`null` / `[]`) against a real template; explicit compact-list omission assertions (the existing exact-keys assertion also guards this).

No real bundled template currently declares either field (policy is #244), so populated cases use fixtures; the plumbing is exercised end-to-end regardless.

`npm run build && npm run lint && npm run validate && npx vitest run` → 1171 passed, 6 skipped. `check:derived` clean (snapshot already carried these fields via CLI output).

https://claude.ai/code/session_01HX8k8K4wpAQXfehdH158cc
