### PR TITLE
feat(mcp): add unified list_content/get_content discovery tools

### DIFF
--- a/packages/contract-templates-mcp/README.md
+++ b/packages/contract-templates-mcp/README.md
@@ -8,11 +8,26 @@ This package exposes local template tools over MCP:
 
 - `list_templates`
 - `get_template`
+- `list_content` — enumerate all first-class content (templates, practice guides, reviewer
+  checklists, law surveys) as one paginated catalog with stable `content_id`s, an optional
+  `type` filter, and an optional substring `query`
+- `get_content` — fetch one item by `content_id`: full canonical markdown plus provenance
+  metadata for guides/checklists/surveys, or the full template definition for templates
 - `fill_template`
 - `get_apap_template` — export an eligible OpenAgreements-authored template as an APAP Template
 - `create_apap_agreement_docx` — render APAP Concerto agreement data to a local DOCX path
 - `get_forms_survey_evidence` — fetch a published forms-provider survey's evidence: a summary by
   default, or one requirement's evidence cells via `requirement_id`
+
+**Discovery → retrieval flow**: call `list_content` (optionally filtered by `type`:
+`template`, `practice_guide`, `checklist`, or `survey`) to discover stable IDs, then
+`get_content` with a `content_id` to retrieve the full item. Templates are fillable
+DOCX agreement forms; practice guides are source-cited legal explainers; checklists
+are clause-by-clause reviewer checklists; surveys are state-by-state / worldwide
+comparison matrices. The three markdown types are served from a local
+`open-agreements` repository checkout (they are not shipped in this npm package);
+when they are unavailable in the current runtime, `list_content` reports them under
+`unavailable_types` with a reason rather than returning silently empty results.
 
 It also exposes MCP **resources**: one resource per currently published
 forms-provider survey evidence dataset (`resources/list` / `resources/read`).

--- a/packages/contract-templates-mcp/src/core/tools.ts
+++ b/packages/contract-templates-mcp/src/core/tools.ts
@@ -79,6 +79,41 @@ const GetTemplateArgsSchema = z.object({
   template_id: z.string().min(1),
 });
 
+/**
+ * list_content cursors bind the pagination position to the filter they were
+ * issued under (type/query fingerprint). Replaying a cursor with a different
+ * filter would otherwise silently skip or duplicate records, because the
+ * position is lexical over the *filtered* catalog.
+ */
+function encodeContentCursor(contentId: string, type?: string, query?: string): string {
+  return Buffer.from(
+    JSON.stringify({ after: contentId, type: type ?? null, query: query ?? null }),
+    'utf8',
+  ).toString('base64');
+}
+
+function decodeContentCursor(cursor: string, type?: string, query?: string): string {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(cursor, 'base64').toString('utf8'));
+  } catch {
+    throw new InvalidCursorError('Invalid cursor: malformed payload');
+  }
+  if (parsed === null || typeof parsed !== 'object') {
+    throw new InvalidCursorError('Invalid cursor: malformed payload');
+  }
+  const record = parsed as { after?: unknown; type?: unknown; query?: unknown };
+  if (typeof record.after !== 'string' || record.after.length === 0) {
+    throw new InvalidCursorError('Invalid cursor: malformed payload');
+  }
+  if ((record.type ?? null) !== (type ?? null) || (record.query ?? null) !== (query ?? null)) {
+    throw new InvalidCursorError(
+      'Invalid cursor: issued under a different type/query filter. Restart from the first page.',
+    );
+  }
+  return record.after;
+}
+
 // Same strict validation conventions as ListTemplatesArgsSchema.
 const ListContentArgsSchema = z
   .object({
@@ -288,7 +323,10 @@ async function importRepoModules(): Promise<RepoModules | null> {
         mapFields: listing.mapFields,
         exportTemplateToApap: apap.exportTemplateToApap,
         fillApapAgreementToDocx: apap.fillApapAgreementToDocx,
-        ...(content && typeof content.listDocContentItems === 'function'
+        ...(content &&
+        typeof content.listDocContentItems === 'function' &&
+        typeof content.listDocContentTypesAvailable === 'function' &&
+        typeof content.findDocContentItem === 'function'
           ? {
               listDocContentItems: content.listDocContentItems,
               listDocContentTypesAvailable: content.listDocContentTypesAvailable,
@@ -316,7 +354,9 @@ async function importRepoModules(): Promise<RepoModules | null> {
         mapFields: mod.mapFields ?? ((f: TemplateField[]) => f),
         exportTemplateToApap: mod.exportTemplateToApap,
         fillApapAgreementToDocx: mod.fillApapAgreementToDocx,
-        ...(typeof mod.listDocContentItems === 'function'
+        ...(typeof mod.listDocContentItems === 'function' &&
+        typeof mod.listDocContentTypesAvailable === 'function' &&
+        typeof mod.findDocContentItem === 'function'
           ? {
               listDocContentItems: mod.listDocContentItems,
               listDocContentTypesAvailable: mod.listDocContentTypesAvailable,
@@ -503,7 +543,7 @@ const tools: ToolDefinition[] = [
 
       let startIndex = 0;
       if (input.cursor !== undefined) {
-        const afterId = decodeCursor(input.cursor);
+        const afterId = decodeContentCursor(input.cursor, input.type, input.query);
         const found = filtered.findIndex((entry) => entry.content_id.localeCompare(afterId) > 0);
         if (found === -1) {
           throw new InvalidCursorError('Invalid cursor: points beyond catalog tail');
@@ -515,7 +555,7 @@ const tools: ToolDefinition[] = [
       const consumed = startIndex + page.length;
       const nextCursor =
         page.length > 0 && consumed < filtered.length
-          ? encodeCursor(page[page.length - 1].content_id)
+          ? encodeContentCursor(page[page.length - 1].content_id, input.type, input.query)
           : null;
 
       return successResult('list_content', {
@@ -581,7 +621,12 @@ const tools: ToolDefinition[] = [
       }
 
       const mod = await importRepoModules();
-      if (!mod?.findDocContentItem) {
+      if (!mod?.findDocContentItem || !mod.listDocContentTypesAvailable) {
+        return toolError('get_content', 'CONTENT_UNAVAILABLE', DOC_CONTENT_UNAVAILABLE_REASON);
+      }
+      // A type whose local bundle is absent in this runtime is unavailable, not
+      // "not found" — mirrors list_content's unavailable_types reporting.
+      if (!mod.listDocContentTypesAvailable().includes(typeToken as DocContentType)) {
         return toolError('get_content', 'CONTENT_UNAVAILABLE', DOC_CONTENT_UNAVAILABLE_REASON);
       }
       const item = mod.findDocContentItem(input.content_id);

--- a/packages/contract-templates-mcp/src/core/tools.ts
+++ b/packages/contract-templates-mcp/src/core/tools.ts
@@ -18,6 +18,25 @@ const LIST_TEMPLATES_MAX_LIMIT = 100;
 
 const LIST_TEMPLATES_CURSOR_MAX_LENGTH = 512;
 
+/**
+ * Unified content catalog (open-agreements#635). `template` is served from the
+ * template catalog; the markdown types are served from the repository's local
+ * content bundles (practice-guides/, checklists/, surveys/) via
+ * src/core/content-listing.ts.
+ */
+const CONTENT_TYPES = ['template', 'practice_guide', 'checklist', 'survey'] as const;
+type ContentType = (typeof CONTENT_TYPES)[number];
+type DocContentType = Exclude<ContentType, 'template'>;
+const DOC_CONTENT_TYPES: DocContentType[] = ['practice_guide', 'checklist', 'survey'];
+
+const CONTENT_QUERY_MAX_LENGTH = 200;
+const CONTENT_ID_MAX_LENGTH = 512;
+
+const DOC_CONTENT_UNAVAILABLE_REASON =
+  'Practice guides, checklists, and surveys are served from a full open-agreements repository ' +
+  'checkout; they are not shipped in the npm package. Clone ' +
+  'https://github.com/open-agreements/open-agreements or browse https://openagreements.org.';
+
 const ListTemplatesArgsSchema = z
   .object({
     cursor: z.string().min(1).max(LIST_TEMPLATES_CURSOR_MAX_LENGTH).optional(),
@@ -59,6 +78,28 @@ function decodeCursor(cursor: string): string {
 const GetTemplateArgsSchema = z.object({
   template_id: z.string().min(1),
 });
+
+// Same strict validation conventions as ListTemplatesArgsSchema.
+const ListContentArgsSchema = z
+  .object({
+    type: z.enum(CONTENT_TYPES).optional(),
+    query: z.string().min(1).max(CONTENT_QUERY_MAX_LENGTH).optional(),
+    cursor: z.string().min(1).max(LIST_TEMPLATES_CURSOR_MAX_LENGTH).optional(),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(LIST_TEMPLATES_MAX_LIMIT)
+      .optional()
+      .default(LIST_TEMPLATES_DEFAULT_LIMIT),
+  })
+  .strict();
+
+const GetContentArgsSchema = z
+  .object({
+    content_id: z.string().min(1).max(CONTENT_ID_MAX_LENGTH),
+  })
+  .strict();
 
 const FillTemplateArgsSchema = z.object({
   template: z.string().min(1),
@@ -135,6 +176,37 @@ interface TemplateRecord {
   fields: TemplateField[];
 }
 
+/** Compact doc-content entry, mirroring DocContentItem in src/core/content-listing.ts. */
+interface DocContentRecord {
+  content_id: string;
+  type: DocContentType;
+  title: string;
+  description: string | null;
+  topic: string;
+  jurisdiction: string | null;
+  format: 'markdown';
+  source_url: string | null;
+  updated_at: string | null;
+  tags: string[];
+  repo_path: string;
+}
+
+interface DocContentDetailRecord extends DocContentRecord {
+  markdown: string;
+}
+
+/** Uniform compact entry returned by list_content across all content types. */
+interface ContentListEntry {
+  content_id: string;
+  type: ContentType;
+  title: string;
+  description: string | null;
+  topic: string;
+  jurisdiction: string | null;
+  format: string;
+  updated_at: string | null;
+}
+
 export interface ToolCallResult {
   content: Array<{ type: 'text'; text: string }>;
   isError?: boolean;
@@ -171,6 +243,11 @@ interface RepoModules {
     agreementData: Record<string, unknown>;
     outputPath: string;
   }) => Promise<unknown>;
+  // Optional — absent when the underlying open-agreements version predates
+  // the unified content catalog (open-agreements#635).
+  listDocContentItems?: () => DocContentRecord[];
+  listDocContentTypesAvailable?: () => DocContentType[];
+  findDocContentItem?: (contentId: string) => DocContentDetailRecord | undefined;
 }
 
 let _modules: RepoModules | null = null;
@@ -189,13 +266,16 @@ async function importRepoModules(): Promise<RepoModules | null> {
       const metadataUrl = pathToFileURL(resolve(root, 'dist', 'core', 'metadata.js')).href;
       const engineUrl = pathToFileURL(resolve(root, 'dist', 'core', 'engine.js')).href;
       const apapUrl = pathToFileURL(resolve(root, 'dist', 'core', 'apap.js')).href;
+      const contentUrl = pathToFileURL(resolve(root, 'dist', 'core', 'content-listing.js')).href;
 
-      const [listing, paths, metadata, engine, apap] = await Promise.all([
+      const [listing, paths, metadata, engine, apap, content] = await Promise.all([
         import(listingUrl),
         import(pathsUrl),
         import(metadataUrl),
         import(engineUrl),
         import(apapUrl),
+        // Tolerate a stale local dist built before content-listing existed.
+        import(contentUrl).catch(() => null),
       ]);
 
       _modules = {
@@ -208,6 +288,13 @@ async function importRepoModules(): Promise<RepoModules | null> {
         mapFields: listing.mapFields,
         exportTemplateToApap: apap.exportTemplateToApap,
         fillApapAgreementToDocx: apap.fillApapAgreementToDocx,
+        ...(content && typeof content.listDocContentItems === 'function'
+          ? {
+              listDocContentItems: content.listDocContentItems,
+              listDocContentTypesAvailable: content.listDocContentTypesAvailable,
+              findDocContentItem: content.findDocContentItem,
+            }
+          : {}),
       };
       return _modules;
     } catch { /* fall through */ }
@@ -229,6 +316,13 @@ async function importRepoModules(): Promise<RepoModules | null> {
         mapFields: mod.mapFields ?? ((f: TemplateField[]) => f),
         exportTemplateToApap: mod.exportTemplateToApap,
         fillApapAgreementToDocx: mod.fillApapAgreementToDocx,
+        ...(typeof mod.listDocContentItems === 'function'
+          ? {
+              listDocContentItems: mod.listDocContentItems,
+              listDocContentTypesAvailable: mod.listDocContentTypesAvailable,
+              findDocContentItem: mod.findDocContentItem,
+            }
+          : {}),
       };
       return _modules;
     }
@@ -316,42 +410,200 @@ const tools: ToolDefinition[] = [
     annotations: { readOnlyHint: true, destructiveHint: false },
     invoke: async (args) => {
       const input = GetTemplateArgsSchema.parse(args ?? {});
-      const mod = await importRepoModules();
-
-      if (mod) {
-        // O(1) direct lookup via findTemplateDir + loadMetadata
-        const dir = mod.findTemplateDir(input.template_id);
-        if (!dir) {
-          return toolError('get_template', 'TEMPLATE_NOT_FOUND', `Template not found: "${input.template_id}"`);
-        }
-        try {
-          const meta = mod.loadMetadata(dir);
-          const template: TemplateRecord = {
-            name: input.template_id,
-            category: mod.categoryFromId(input.template_id),
-            description: (meta.description ?? meta.name) as string,
-            license: (meta.license as string) ?? null,
-            source_url: meta.source_url as string,
-            source: mod.sourceName(meta.source_url as string),
-            attribution_text: meta.attribution_text as string | undefined,
-            stability: (meta.stability as string | undefined) ?? null,
-            derived_from: (meta.derived_from as string | undefined) ?? null,
-            credits: (meta.credits as TemplateCredit[] | undefined) ?? [],
-            fields: mod.mapFields(meta.fields as Record<string, unknown>[], meta.priority_fields as string[]),
-          };
-          return successResult('get_template', { template: normalizeTemplate(template) });
-        } catch {
-          return toolError('get_template', 'TEMPLATE_NOT_FOUND', `Template not found: "${input.template_id}"`);
-        }
-      }
-
-      // Child process fallback — load all and filter
-      const items = await loadTemplates();
-      const template = items.find((item) => item.name === input.template_id);
+      const template = await getTemplateRecord(input.template_id);
       if (!template) {
         return toolError('get_template', 'TEMPLATE_NOT_FOUND', `Template not found: "${input.template_id}"`);
       }
       return successResult('get_template', { template: normalizeTemplate(template) });
+    },
+  },
+  {
+    name: 'list_content',
+    description:
+      'List all first-class OpenAgreements content — fillable templates, practice guides, RFC 2119-style ' +
+      'reviewer checklists, and law surveys — as one paginated compact catalog with stable content IDs in ' +
+      'deterministic lexicographic order. Returns lightweight metadata for discovery; call get_content ' +
+      '(or get_template) for the full item. Non-template content is served from a local ' +
+      'open-agreements repository checkout; when it is not available in this runtime, the affected types ' +
+      'are reported under unavailable_types with a reason instead of appearing as silently empty.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        type: {
+          type: 'string',
+          enum: [...CONTENT_TYPES],
+          description:
+            'Optional content-type filter: "template" (fillable DOCX templates), "practice_guide" ' +
+            '(source-cited legal practice guides), "checklist" (clause-by-clause reviewer checklists), ' +
+            'or "survey" (state-by-state / worldwide comparison matrices). Omit for all types.',
+        },
+        query: {
+          type: 'string',
+          maxLength: CONTENT_QUERY_MAX_LENGTH,
+          description:
+            'Optional case-insensitive substring filter matched against content ID, title, description, and topic.',
+        },
+        cursor: {
+          type: 'string',
+          description: 'Opaque pagination cursor returned by a prior call. Omit on the first page.',
+        },
+        limit: {
+          type: 'integer',
+          minimum: 1,
+          maximum: LIST_TEMPLATES_MAX_LIMIT,
+          description: `Page size (default ${LIST_TEMPLATES_DEFAULT_LIMIT}, max ${LIST_TEMPLATES_MAX_LIMIT}).`,
+        },
+      },
+      additionalProperties: false,
+    },
+    annotations: { readOnlyHint: true, destructiveHint: false },
+    invoke: async (args) => {
+      const input = ListContentArgsSchema.parse(args ?? {});
+      const mod = await importRepoModules();
+
+      const docTypesInScope: DocContentType[] =
+        input.type === undefined
+          ? DOC_CONTENT_TYPES
+          : input.type === 'template'
+            ? []
+            : [input.type];
+
+      const entries: ContentListEntry[] = [];
+      if (input.type === undefined || input.type === 'template') {
+        for (const template of await loadTemplates()) {
+          entries.push(templateContentEntry(template));
+        }
+      }
+
+      const unavailable: Array<{ type: DocContentType; reason: string }> = [];
+      if (docTypesInScope.length > 0) {
+        if (mod?.listDocContentItems && mod.listDocContentTypesAvailable) {
+          const available = new Set(mod.listDocContentTypesAvailable());
+          for (const type of docTypesInScope) {
+            if (!available.has(type)) {
+              unavailable.push({ type, reason: DOC_CONTENT_UNAVAILABLE_REASON });
+            }
+          }
+          const inScope = new Set<string>(docTypesInScope);
+          for (const item of mod.listDocContentItems()) {
+            if (inScope.has(item.type)) {
+              entries.push(docContentEntry(item));
+            }
+          }
+        } else {
+          for (const type of docTypesInScope) {
+            unavailable.push({ type, reason: DOC_CONTENT_UNAVAILABLE_REASON });
+          }
+        }
+      }
+
+      const filtered =
+        input.query === undefined ? entries : entries.filter(contentQueryMatcher(input.query));
+      filtered.sort((a, b) => a.content_id.localeCompare(b.content_id));
+
+      let startIndex = 0;
+      if (input.cursor !== undefined) {
+        const afterId = decodeCursor(input.cursor);
+        const found = filtered.findIndex((entry) => entry.content_id.localeCompare(afterId) > 0);
+        if (found === -1) {
+          throw new InvalidCursorError('Invalid cursor: points beyond catalog tail');
+        }
+        startIndex = found;
+      }
+
+      const page = filtered.slice(startIndex, startIndex + input.limit);
+      const consumed = startIndex + page.length;
+      const nextCursor =
+        page.length > 0 && consumed < filtered.length
+          ? encodeCursor(page[page.length - 1].content_id)
+          : null;
+
+      return successResult('list_content', {
+        items: page,
+        total_count: filtered.length,
+        next_cursor: nextCursor,
+        ...(unavailable.length > 0 ? { unavailable_types: unavailable } : {}),
+      });
+    },
+  },
+  {
+    name: 'get_content',
+    description:
+      'Fetch one OpenAgreements content item by its stable content_id (from list_content). Markdown ' +
+      'content (practice guides, checklists, surveys) returns the full canonical document plus ' +
+      'source/provenance metadata; template content returns the same full definition as get_template ' +
+      'under a "template" key.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        content_id: {
+          type: 'string',
+          description:
+            'Stable content ID, e.g. "template/common-paper-mutual-nda", ' +
+            '"practice_guide/wage-and-hour/us", "checklist/safes/yc-post-money-safe-valuation-cap", ' +
+            'or "survey/non-compete/us".',
+        },
+      },
+      required: ['content_id'],
+      additionalProperties: false,
+    },
+    annotations: { readOnlyHint: true, destructiveHint: false },
+    invoke: async (args) => {
+      const input = GetContentArgsSchema.parse(args ?? {});
+      const slashIndex = input.content_id.indexOf('/');
+      const typeToken = slashIndex === -1 ? '' : input.content_id.slice(0, slashIndex);
+      const rest = slashIndex === -1 ? '' : input.content_id.slice(slashIndex + 1);
+
+      if (!(CONTENT_TYPES as readonly string[]).includes(typeToken) || rest.length === 0) {
+        return toolError(
+          'get_content',
+          'CONTENT_NOT_FOUND',
+          `Unknown content ID: "${input.content_id}". Content IDs look like "template/<template_id>", ` +
+            '"practice_guide/<topic>/<doc>", "checklist/<topic>/<doc>", or "survey/<topic>/<doc>" — ' +
+            'discover them via list_content.',
+        );
+      }
+
+      if (typeToken === 'template') {
+        const template = await getTemplateRecord(rest);
+        if (!template) {
+          return toolError('get_content', 'CONTENT_NOT_FOUND', `Content not found: "${input.content_id}"`);
+        }
+        const compact = templateContentEntry(template);
+        return successResult('get_content', {
+          content: {
+            ...compact,
+            content_id: input.content_id,
+            source_url: template.source_url ?? null,
+            template: normalizeTemplate(template),
+          },
+        });
+      }
+
+      const mod = await importRepoModules();
+      if (!mod?.findDocContentItem) {
+        return toolError('get_content', 'CONTENT_UNAVAILABLE', DOC_CONTENT_UNAVAILABLE_REASON);
+      }
+      const item = mod.findDocContentItem(input.content_id);
+      if (!item) {
+        return toolError('get_content', 'CONTENT_NOT_FOUND', `Content not found: "${input.content_id}"`);
+      }
+      return successResult('get_content', {
+        content: {
+          content_id: item.content_id,
+          type: item.type,
+          title: item.title,
+          description: item.description,
+          topic: item.topic,
+          jurisdiction: item.jurisdiction,
+          format: item.format,
+          updated_at: item.updated_at,
+          source_url: item.source_url,
+          tags: item.tags,
+          repo_path: item.repo_path,
+          markdown: item.markdown,
+        },
+      });
     },
   },
   {
@@ -689,6 +941,84 @@ async function loadTemplates(): Promise<TemplateRecord[]> {
     throw new Error('Invalid list output from open-agreements command.');
   }
   return parsed.items;
+}
+
+/**
+ * Load one template's full record — O(1) direct lookup in-process, full-list
+ * filter in the child-process fallback. Shared by get_template and get_content.
+ */
+async function getTemplateRecord(templateId: string): Promise<TemplateRecord | undefined> {
+  const mod = await importRepoModules();
+
+  if (mod) {
+    // O(1) direct lookup via findTemplateDir + loadMetadata
+    const dir = mod.findTemplateDir(templateId);
+    if (!dir) {
+      return undefined;
+    }
+    try {
+      const meta = mod.loadMetadata(dir);
+      return {
+        name: templateId,
+        display_name: meta.name as string | undefined,
+        category: mod.categoryFromId(templateId),
+        description: (meta.description ?? meta.name) as string,
+        license: (meta.license as string) ?? null,
+        source_url: meta.source_url as string,
+        source: mod.sourceName(meta.source_url as string),
+        attribution_text: meta.attribution_text as string | undefined,
+        stability: (meta.stability as string | undefined) ?? null,
+        derived_from: (meta.derived_from as string | undefined) ?? null,
+        credits: (meta.credits as TemplateCredit[] | undefined) ?? [],
+        fields: mod.mapFields(meta.fields as Record<string, unknown>[], meta.priority_fields as string[]),
+      };
+    } catch {
+      return undefined;
+    }
+  }
+
+  // Child process fallback — load all and filter
+  const items = await loadTemplates();
+  return items.find((item) => item.name === templateId);
+}
+
+/** Map one template record into the uniform compact content-catalog entry. */
+function templateContentEntry(template: TemplateRecord): ContentListEntry {
+  const trimmedDisplayName = template.display_name?.trim();
+  return {
+    content_id: `template/${template.name}`,
+    type: 'template',
+    title: trimmedDisplayName && trimmedDisplayName.length > 0 ? trimmedDisplayName : template.name,
+    description: template.description ?? null,
+    topic: template.category,
+    jurisdiction: null,
+    format: 'docx_template',
+    updated_at: null,
+  };
+}
+
+/** Map one markdown doc item into the uniform compact content-catalog entry. */
+function docContentEntry(item: DocContentRecord): ContentListEntry {
+  return {
+    content_id: item.content_id,
+    type: item.type,
+    title: item.title,
+    description: item.description,
+    topic: item.topic,
+    jurisdiction: item.jurisdiction,
+    format: item.format,
+    updated_at: item.updated_at,
+  };
+}
+
+/** Case-insensitive substring match on the compact discovery fields. */
+function contentQueryMatcher(query: string): (entry: ContentListEntry) => boolean {
+  const needle = query.toLowerCase();
+  return (entry) =>
+    entry.content_id.toLowerCase().includes(needle) ||
+    entry.title.toLowerCase().includes(needle) ||
+    (entry.description ?? '').toLowerCase().includes(needle) ||
+    entry.topic.toLowerCase().includes(needle);
 }
 
 function normalizeTemplate(template: TemplateRecord): Record<string, unknown> {

--- a/packages/contract-templates-mcp/tests/content-tools.test.ts
+++ b/packages/contract-templates-mcp/tests/content-tools.test.ts
@@ -199,16 +199,69 @@ describe('list_content / get_content (open-agreements#635)', () => {
   });
 
   it('rejects malformed and beyond-tail cursors as INVALID_ARGUMENT', async () => {
-    const malformed = await callTool('list_content', { cursor: '!!!not-base64!!!' });
-    expect(malformed.isError).toBe(true);
-    expect(getError(malformed).code).toBe('INVALID_ARGUMENT');
+    const malformedInputs = [
+      '!!!not-base64!!!',
+      Buffer.from('after:template/foo', 'utf8').toString('base64'), // legacy non-JSON shape
+      Buffer.from('{"no_after":true}', 'utf8').toString('base64'),
+      Buffer.from('{"after":""}', 'utf8').toString('base64'),
+    ];
+    for (const cursor of malformedInputs) {
+      const result = await callTool('list_content', { cursor });
+      expect(result.isError).toBe(true);
+      expect(getError(result).code).toBe('INVALID_ARGUMENT');
+    }
 
     const beyondTail = await callTool('list_content', {
-      cursor: Buffer.from('after:zzzzzzzzzzzz', 'utf8').toString('base64'),
+      cursor: Buffer.from(
+        JSON.stringify({ after: 'zzzzzzzzzzzz', type: null, query: null }),
+        'utf8',
+      ).toString('base64'),
     });
     expect(beyondTail.isError).toBe(true);
     expect(getError(beyondTail).code).toBe('INVALID_ARGUMENT');
     expect(getError(beyondTail).message).toContain('beyond catalog tail');
+  });
+
+  it('rejects a cursor replayed under a different type or query filter', async () => {
+    const firstPage = await callTool('list_content', { limit: 5 });
+    const cursor = getData(firstPage).next_cursor as string;
+    expect(typeof cursor).toBe('string');
+
+    // Same (absent) filters: the cursor is valid.
+    const samePage = await callTool('list_content', { cursor, limit: 5 });
+    expect(samePage.isError).toBeUndefined();
+
+    for (const args of [
+      { cursor, type: 'practice_guide' },
+      { cursor, query: 'wage-and-hour' },
+    ]) {
+      const result = await callTool('list_content', args);
+      expect(result.isError).toBe(true);
+      expect(getError(result).code).toBe('INVALID_ARGUMENT');
+      expect(getError(result).message).toContain('different type/query filter');
+    }
+
+    // And the reverse: a filtered cursor replayed unfiltered is rejected too.
+    const filteredPage = await callTool('list_content', { type: 'checklist', limit: 5 });
+    const filteredCursor = getData(filteredPage).next_cursor as string;
+    expect(typeof filteredCursor).toBe('string');
+    const unfilteredReplay = await callTool('list_content', { cursor: filteredCursor });
+    expect(unfilteredReplay.isError).toBe(true);
+    expect(getError(unfilteredReplay).code).toBe('INVALID_ARGUMENT');
+  });
+
+  it('meets per-type catalog floor counts in a full repo checkout', async () => {
+    const floors: Record<string, number> = {
+      template: 50,
+      practice_guide: 100,
+      checklist: 30,
+      survey: 5,
+    };
+    for (const [type, floor] of Object.entries(floors)) {
+      const result = await callTool('list_content', { type, limit: 1 });
+      expect(result.isError).toBeUndefined();
+      expect(getData(result).total_count as number).toBeGreaterThanOrEqual(floor);
+    }
   });
 
   it('rejects invalid type, limit, query, and unknown arguments', async () => {
@@ -352,6 +405,57 @@ describe('list_content / get_content (open-agreements#635)', () => {
       expect(result.isError).toBe(true);
       expect(getError(result).code).toBe('CONTENT_UNAVAILABLE');
       expect((getError(result).message as string)).toContain('openagreements.org');
+    });
+
+    it('distinguishes unavailable types from missing content when partially available', async () => {
+      const guide = {
+        content_id: 'practice_guide/mock-topic/us',
+        type: 'practice_guide',
+        title: 'Mock Guide',
+        description: null,
+        topic: 'mock-topic',
+        jurisdiction: 'us',
+        format: 'markdown',
+        source_url: null,
+        updated_at: null,
+        tags: [],
+        repo_path: 'practice-guides/mock-topic/us.md',
+      };
+      _setModuleOverride(
+        mockModules({
+          listDocContentItems: () => [guide],
+          listDocContentTypesAvailable: () => ['practice_guide'],
+          findDocContentItem: (id: string) =>
+            id === guide.content_id ? { ...guide, markdown: '# Mock Guide' } : undefined,
+        }),
+      );
+
+      // list_content: only the absent bundles are reported unavailable.
+      const listing = await callTool('list_content', {});
+      const data = getData(listing);
+      expect((data.items as ContentEntry[]).map((item) => item.content_id)).toEqual([
+        guide.content_id,
+      ]);
+      expect((data.unavailable_types as Array<{ type: string }>).map((entry) => entry.type)).toEqual(
+        ['checklist', 'survey'],
+      );
+
+      // get_content: absent bundle → CONTENT_UNAVAILABLE, not CONTENT_NOT_FOUND.
+      const unavailable = await callTool('get_content', {
+        content_id: 'checklist/safes/yc-post-money-safe-valuation-cap',
+      });
+      expect(unavailable.isError).toBe(true);
+      expect(getError(unavailable).code).toBe('CONTENT_UNAVAILABLE');
+
+      // get_content: available bundle, unknown doc → CONTENT_NOT_FOUND.
+      const notFound = await callTool('get_content', { content_id: 'practice_guide/mock-topic/nowhere' });
+      expect(notFound.isError).toBe(true);
+      expect(getError(notFound).code).toBe('CONTENT_NOT_FOUND');
+
+      // get_content: available bundle, known doc → full content.
+      const found = await callTool('get_content', { content_id: guide.content_id });
+      expect(found.isError).toBeUndefined();
+      expect((getData(found).content as Record<string, unknown>).markdown).toBe('# Mock Guide');
     });
   });
 });

--- a/packages/contract-templates-mcp/tests/content-tools.test.ts
+++ b/packages/contract-templates-mcp/tests/content-tools.test.ts
@@ -1,0 +1,357 @@
+import { afterEach, describe, expect } from 'vitest';
+import { itAllure } from '../../../integration-tests/helpers/allure-test.js';
+import { callTool, listToolDescriptors, _resetModuleCache, _setModuleOverride } from '../src/core/tools.js';
+
+const it = itAllure.epic('Platform & Distribution');
+
+const CONTENT_TYPES = ['template', 'practice_guide', 'checklist', 'survey'] as const;
+const DOC_CONTENT_TYPES = ['practice_guide', 'checklist', 'survey'] as const;
+
+const COMPACT_KEYS = [
+  'content_id',
+  'description',
+  'format',
+  'jurisdiction',
+  'title',
+  'topic',
+  'type',
+  'updated_at',
+];
+
+function getPayload(result: Awaited<ReturnType<typeof callTool>>): Record<string, unknown> {
+  return (result.structuredContent ?? {}) as Record<string, unknown>;
+}
+
+function getData(result: Awaited<ReturnType<typeof callTool>>): Record<string, unknown> {
+  return getPayload(result).data as Record<string, unknown>;
+}
+
+function getError(result: Awaited<ReturnType<typeof callTool>>): Record<string, unknown> {
+  return getPayload(result).error as Record<string, unknown>;
+}
+
+interface ContentEntry {
+  content_id: string;
+  type: string;
+  title: string;
+  description: string | null;
+  topic: string;
+  jurisdiction: string | null;
+  format: string;
+  updated_at: string | null;
+}
+
+async function fetchFullContentCatalog(
+  extraArgs: Record<string, unknown> = {},
+): Promise<ContentEntry[]> {
+  const all: ContentEntry[] = [];
+  let cursor: string | undefined;
+  do {
+    const args: Record<string, unknown> = { ...extraArgs, limit: 100 };
+    if (cursor !== undefined) args.cursor = cursor;
+    const result = await callTool('list_content', args);
+    expect(result.isError).toBeUndefined();
+    const data = getData(result);
+    all.push(...(data.items as ContentEntry[]));
+    cursor = (data.next_cursor as string | null) ?? undefined;
+  } while (cursor !== undefined);
+  return all;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function mockModules(overrides: Record<string, unknown> = {}): any {
+  return {
+    listTemplateItems: () => [],
+    findTemplateDir: () => undefined,
+    loadMetadata: () => ({ name: 'mock', fields: [], priority_fields: [] }),
+    fillTemplate: async () => ({}),
+    categoryFromId: () => 'general',
+    sourceName: () => null,
+    mapFields: (f: unknown[]) => f,
+    exportTemplateToApap: () => ({}),
+    fillApapAgreementToDocx: async () => ({}),
+    ...overrides,
+  };
+}
+
+describe('list_content / get_content (open-agreements#635)', () => {
+  it('exposes both tools as read-only', () => {
+    const descriptors = listToolDescriptors().filter(
+      (tool) => tool.name === 'list_content' || tool.name === 'get_content',
+    );
+    expect(descriptors).toHaveLength(2);
+    for (const descriptor of descriptors) {
+      expect(descriptor.annotations).toEqual({ readOnlyHint: true, destructiveHint: false });
+      expect(descriptor.inputSchema.additionalProperties).toBe(false);
+    }
+  });
+
+  it('returns a compact paginated catalog in deterministic order', async () => {
+    const result = await callTool('list_content', {});
+    expect(result.isError).toBeUndefined();
+    const payload = getPayload(result);
+    expect(payload.ok).toBe(true);
+    expect(payload.tool).toBe('list_content');
+
+    const data = getData(result);
+    const items = data.items as ContentEntry[];
+    expect(items.length).toBe(25); // default page size, catalog is far larger
+    expect(typeof data.total_count).toBe('number');
+    expect((data.total_count as number)).toBeGreaterThan(25);
+    expect(typeof data.next_cursor).toBe('string');
+    // In a full repo checkout every content type is available.
+    expect(data.unavailable_types).toBeUndefined();
+
+    for (const item of items) {
+      expect(Object.keys(item).sort()).toEqual(COMPACT_KEYS);
+      expect(CONTENT_TYPES).toContain(item.type);
+      expect(item.content_id.startsWith(`${item.type}/`)).toBe(true);
+      expect(item.title.length).toBeGreaterThan(0);
+    }
+
+    const ids = items.map((item) => item.content_id);
+    expect([...ids].sort((a, b) => a.localeCompare(b))).toEqual(ids);
+  });
+
+  it('enumerates every content type without repository paths', async () => {
+    for (const type of CONTENT_TYPES) {
+      const result = await callTool('list_content', { type, limit: 100 });
+      expect(result.isError).toBeUndefined();
+      const data = getData(result);
+      const items = data.items as ContentEntry[];
+      expect(items.length).toBeGreaterThan(0);
+      expect(items.every((item) => item.type === type)).toBe(true);
+      expect(data.unavailable_types).toBeUndefined();
+    }
+  });
+
+  it('marks markdown items with provenance-bearing metadata', async () => {
+    const result = await callTool('list_content', { type: 'survey', limit: 100 });
+    const items = getData(result).items as ContentEntry[];
+    expect(items.length).toBeGreaterThan(0);
+    for (const item of items) {
+      expect(item.format).toBe('markdown');
+      expect(item.topic.length).toBeGreaterThan(0);
+    }
+    // Known stable survey from the repo bundle.
+    expect(items.map((item) => item.content_id)).toContain('survey/wage-and-hour/us');
+  });
+
+  it('lists templates with docx_template format and template/ ids', async () => {
+    const result = await callTool('list_content', { type: 'template', limit: 100 });
+    const items = getData(result).items as ContentEntry[];
+    expect(items.length).toBeGreaterThan(0);
+    for (const item of items) {
+      expect(item.format).toBe('docx_template');
+      expect(item.jurisdiction).toBeNull();
+    }
+    expect(items.map((item) => item.content_id)).toContain('template/common-paper-mutual-nda');
+  });
+
+  it('filters with query across compact fields, case-insensitively', async () => {
+    const result = await callTool('list_content', { query: 'Wage-And-Hour', limit: 100 });
+    expect(result.isError).toBeUndefined();
+    const data = getData(result);
+    const items = data.items as ContentEntry[];
+    expect(items.length).toBeGreaterThan(0);
+    for (const item of items) {
+      const haystack = [item.content_id, item.title, item.description ?? '', item.topic]
+        .join('\n')
+        .toLowerCase();
+      expect(haystack).toContain('wage-and-hour');
+    }
+    const types = new Set(items.map((item) => item.type));
+    expect(types.has('practice_guide')).toBe(true);
+    expect(types.has('survey')).toBe(true);
+  });
+
+  it('returns an empty page (not an error) for a query with no matches', async () => {
+    const result = await callTool('list_content', { query: 'zz-no-such-content-zz' });
+    expect(result.isError).toBeUndefined();
+    const data = getData(result);
+    expect(data.items).toEqual([]);
+    expect(data.total_count).toBe(0);
+    expect(data.next_cursor).toBeNull();
+  });
+
+  it('paginates the full catalog without gaps or duplicates', async () => {
+    const paged: ContentEntry[] = [];
+    let cursor: string | undefined;
+    let totalCount = 0;
+    do {
+      const args: Record<string, unknown> = { limit: 50 };
+      if (cursor !== undefined) args.cursor = cursor;
+      const result = await callTool('list_content', args);
+      expect(result.isError).toBeUndefined();
+      const data = getData(result);
+      totalCount = data.total_count as number;
+      paged.push(...(data.items as ContentEntry[]));
+      cursor = (data.next_cursor as string | null) ?? undefined;
+    } while (cursor !== undefined);
+
+    expect(paged.length).toBe(totalCount);
+    const ids = paged.map((item) => item.content_id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect([...ids].sort((a, b) => a.localeCompare(b))).toEqual(ids);
+
+    const single = await fetchFullContentCatalog();
+    expect(single.map((item) => item.content_id)).toEqual(ids);
+  });
+
+  it('rejects malformed and beyond-tail cursors as INVALID_ARGUMENT', async () => {
+    const malformed = await callTool('list_content', { cursor: '!!!not-base64!!!' });
+    expect(malformed.isError).toBe(true);
+    expect(getError(malformed).code).toBe('INVALID_ARGUMENT');
+
+    const beyondTail = await callTool('list_content', {
+      cursor: Buffer.from('after:zzzzzzzzzzzz', 'utf8').toString('base64'),
+    });
+    expect(beyondTail.isError).toBe(true);
+    expect(getError(beyondTail).code).toBe('INVALID_ARGUMENT');
+    expect(getError(beyondTail).message).toContain('beyond catalog tail');
+  });
+
+  it('rejects invalid type, limit, query, and unknown arguments', async () => {
+    const badInputs: Array<Record<string, unknown>> = [
+      { type: 'blog_post' },
+      { limit: 0 },
+      { limit: 101 },
+      { limit: 2.5 },
+      { query: '' },
+      { query: 'x'.repeat(201) },
+      { unexpected: true },
+    ];
+    for (const args of badInputs) {
+      const result = await callTool('list_content', args);
+      expect(result.isError).toBe(true);
+      expect(getError(result).code).toBe('INVALID_ARGUMENT');
+    }
+  });
+
+  it('returns the full canonical markdown document from get_content', async () => {
+    const result = await callTool('get_content', { content_id: 'practice_guide/wage-and-hour/us' });
+    expect(result.isError).toBeUndefined();
+    const content = getData(result).content as Record<string, unknown>;
+    expect(content.content_id).toBe('practice_guide/wage-and-hour/us');
+    expect(content.type).toBe('practice_guide');
+    expect(content.format).toBe('markdown');
+    expect(content.topic).toBe('wage-and-hour');
+    expect(content.jurisdiction).toBe('us');
+    expect(content.source_url).toBe('https://openagreements.org/practice-guides/wage-and-hour/us');
+    expect(content.repo_path).toBe('practice-guides/wage-and-hour/us.md');
+    const markdown = content.markdown as string;
+    expect(markdown).toContain('Fair Labor Standards Act');
+    expect(markdown.length).toBeGreaterThan(1000);
+  });
+
+  it('resolves every listed markdown type through get_content', async () => {
+    for (const type of DOC_CONTENT_TYPES) {
+      const listing = await callTool('list_content', { type, limit: 1 });
+      const [first] = getData(listing).items as ContentEntry[];
+      expect(first).toBeDefined();
+      const result = await callTool('get_content', { content_id: first.content_id });
+      expect(result.isError).toBeUndefined();
+      const content = getData(result).content as Record<string, unknown>;
+      expect(content.content_id).toBe(first.content_id);
+      expect(content.type).toBe(type);
+      expect(content.title).toBe(first.title);
+      expect((content.markdown as string).length).toBeGreaterThan(0);
+    }
+  });
+
+  it('returns template content matching get_template', async () => {
+    const result = await callTool('get_content', { content_id: 'template/common-paper-mutual-nda' });
+    expect(result.isError).toBeUndefined();
+    const content = getData(result).content as Record<string, unknown>;
+    expect(content.type).toBe('template');
+    expect(content.format).toBe('docx_template');
+
+    const viaGetTemplate = await callTool('get_template', { template_id: 'common-paper-mutual-nda' });
+    expect(content.template).toEqual(getData(viaGetTemplate).template);
+  });
+
+  it('returns CONTENT_NOT_FOUND for unknown, malformed, and traversal ids', async () => {
+    const badIds = [
+      'practice_guide/wage-and-hour/no-such-doc',
+      'template/no-such-template',
+      'no-slash-at-all',
+      'blog_post/some/id',
+      'practice_guide/wage-and-hour',
+      'checklist/../../package',
+      'survey/wage-and-hour/index',
+      'survey/wage-and-hour/log',
+    ];
+    for (const contentId of badIds) {
+      const result = await callTool('get_content', { content_id: contentId });
+      expect(result.isError).toBe(true);
+      expect(getError(result).code).toBe('CONTENT_NOT_FOUND');
+    }
+  });
+
+  it('rejects empty and oversized content ids as INVALID_ARGUMENT', async () => {
+    for (const args of [{}, { content_id: '' }, { content_id: 'x'.repeat(513) }]) {
+      const result = await callTool('get_content', args);
+      expect(result.isError).toBe(true);
+      expect(getError(result).code).toBe('INVALID_ARGUMENT');
+    }
+  });
+
+  describe('runtimes without local content bundles', () => {
+    afterEach(() => {
+      _resetModuleCache();
+    });
+
+    it('reports markdown types as unavailable with a reason instead of silently empty', async () => {
+      _setModuleOverride(mockModules());
+      const result = await callTool('list_content', {});
+      expect(result.isError).toBeUndefined();
+      const data = getData(result);
+      expect(data.items).toEqual([]);
+      expect(data.total_count).toBe(0);
+      const unavailable = data.unavailable_types as Array<{ type: string; reason: string }>;
+      expect(unavailable.map((entry) => entry.type)).toEqual([...DOC_CONTENT_TYPES]);
+      for (const entry of unavailable) {
+        expect(entry.reason).toContain('not shipped in the npm package');
+      }
+    });
+
+    it('does not report unavailable types for a template-only listing', async () => {
+      _setModuleOverride(
+        mockModules({
+          listTemplateItems: () => [
+            { name: 'mock-template', display_name: 'Mock', category: 'general', description: 'd', fields: [] },
+          ],
+        }),
+      );
+      const result = await callTool('list_content', { type: 'template' });
+      const data = getData(result);
+      expect((data.items as ContentEntry[]).map((item) => item.content_id)).toEqual([
+        'template/mock-template',
+      ]);
+      expect(data.unavailable_types).toBeUndefined();
+    });
+
+    it('reports empty available doc types as unavailable, not empty content', async () => {
+      _setModuleOverride(
+        mockModules({
+          listDocContentItems: () => [],
+          listDocContentTypesAvailable: () => [],
+          findDocContentItem: () => undefined,
+        }),
+      );
+      const result = await callTool('list_content', { type: 'checklist' });
+      const data = getData(result);
+      expect(data.items).toEqual([]);
+      const unavailable = data.unavailable_types as Array<{ type: string }>;
+      expect(unavailable.map((entry) => entry.type)).toEqual(['checklist']);
+    });
+
+    it('returns CONTENT_UNAVAILABLE from get_content for markdown content', async () => {
+      _setModuleOverride(mockModules());
+      const result = await callTool('get_content', { content_id: 'checklist/safes/yc-post-money-safe-valuation-cap' });
+      expect(result.isError).toBe(true);
+      expect(getError(result).code).toBe('CONTENT_UNAVAILABLE');
+      expect((getError(result).message as string)).toContain('openagreements.org');
+    });
+  });
+});

--- a/packages/contract-templates-mcp/tests/tools.test.ts
+++ b/packages/contract-templates-mcp/tests/tools.test.ts
@@ -81,6 +81,8 @@ describe('contract-templates-mcp tools', () => {
     expect(names).toEqual([
       'list_templates',
       'get_template',
+      'list_content',
+      'get_content',
       'fill_template',
       'get_apap_template',
       'create_apap_agreement_docx',

--- a/src/core/content-listing.test.ts
+++ b/src/core/content-listing.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect } from 'vitest';
+import { itAllure } from '../../integration-tests/helpers/allure-test.js';
+import {
+  DOC_CONTENT_TYPES,
+  findDocContentItem,
+  listDocContentItems,
+  listDocContentTypesAvailable,
+} from './content-listing.js';
+
+const it = itAllure.epic('Discovery & Metadata');
+
+const CONTENT_ID_PATTERN = /^(practice_guide|checklist|survey)(\/[a-z0-9][a-z0-9-]*){2,}$/;
+
+describe('content-listing', () => {
+  it('reports all three markdown content types available in the repo checkout', () => {
+    expect(listDocContentTypesAvailable()).toEqual(['practice_guide', 'checklist', 'survey']);
+  });
+
+  it('lists documents for every type with stable ids in deterministic order', () => {
+    const items = listDocContentItems();
+    expect(items.length).toBeGreaterThan(100);
+
+    const ids = items.map((item) => item.content_id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect([...ids].sort((a, b) => a.localeCompare(b))).toEqual(ids);
+
+    const seenTypes = new Set(items.map((item) => item.type));
+    for (const type of DOC_CONTENT_TYPES) {
+      expect(seenTypes.has(type)).toBe(true);
+    }
+
+    for (const item of items) {
+      expect(item.content_id).toMatch(CONTENT_ID_PATTERN);
+      expect(item.content_id.startsWith(`${item.type}/${item.topic}/`)).toBe(true);
+      expect(item.format).toBe('markdown');
+      expect(item.title.length).toBeGreaterThan(0);
+      expect(item.repo_path.endsWith('.md')).toBe(true);
+      // Navigation and changelog scaffolding never surfaces as content.
+      expect(item.repo_path.endsWith('/index.md')).toBe(false);
+      expect(item.repo_path.endsWith('/log.md')).toBe(false);
+    }
+  });
+
+  it('extracts frontmatter metadata for a known practice guide', () => {
+    const items = listDocContentItems();
+    const guide = items.find((item) => item.content_id === 'practice_guide/wage-and-hour/us');
+    expect(guide).toBeDefined();
+    expect(guide?.title).toContain('Wage and Hour Law');
+    expect(guide?.description).toBeTruthy();
+    expect(guide?.topic).toBe('wage-and-hour');
+    expect(guide?.jurisdiction).toBe('us');
+    expect(guide?.source_url).toBe('https://openagreements.org/practice-guides/wage-and-hour/us');
+    expect(guide?.updated_at).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(guide?.tags).toContain('wage-and-hour');
+    expect(guide?.repo_path).toBe('practice-guides/wage-and-hour/us.md');
+  });
+
+  it('derives nested jurisdictions and leaves non-jurisdictional docs null', () => {
+    const items = listDocContentItems();
+    const california = items.find(
+      (item) => item.content_id === 'practice_guide/wage-and-hour/us/california',
+    );
+    expect(california?.jurisdiction).toBe('us/california');
+
+    const checklist = items.find(
+      (item) => item.content_id === 'checklist/safes/yc-post-money-safe-valuation-cap',
+    );
+    expect(checklist).toBeDefined();
+    expect(checklist?.jurisdiction).toBeNull();
+  });
+
+  it('round-trips a listed item through findDocContentItem with full markdown', () => {
+    const [first] = listDocContentItems();
+    const detail = findDocContentItem(first.content_id);
+    expect(detail).toBeDefined();
+    expect(detail?.content_id).toBe(first.content_id);
+    expect(detail?.title).toBe(first.title);
+    expect(detail?.markdown.length).toBeGreaterThan(0);
+    expect(detail?.markdown).toContain(detail?.title ?? '');
+  });
+
+  it('rejects traversal, malformed, and unknown ids', () => {
+    const badIds = [
+      'practice_guide/../templates/x',
+      'practice_guide/wage-and-hour/../../../etc/passwd',
+      'practice_guide/wage-and-hour', // missing document segment
+      'practice_guide/Wage-And-Hour/us', // uppercase segments never match
+      'checklist/safes/index',
+      'checklist/safes/log',
+      'template/common-paper-mutual-nda', // templates are not doc content
+      'survey/no-such-topic/us',
+      '',
+    ];
+    for (const contentId of badIds) {
+      expect(findDocContentItem(contentId)).toBeUndefined();
+    }
+  });
+
+  it('treats a missing content root as no available types and zero items', () => {
+    expect(listDocContentTypesAvailable('/nonexistent/content-root')).toEqual([]);
+    expect(listDocContentItems('/nonexistent/content-root')).toEqual([]);
+    expect(findDocContentItem('practice_guide/wage-and-hour/us', '/nonexistent/content-root')).toBeUndefined();
+  });
+});

--- a/src/core/content-listing.ts
+++ b/src/core/content-listing.ts
@@ -1,0 +1,259 @@
+/**
+ * Shared content-listing module (open-agreements#635).
+ *
+ * Canonical helpers for enumerating the repository's non-template first-class
+ * legal content — practice guides, reviewer checklists, and law surveys — as a
+ * flat, deterministic catalog with stable IDs. Used by:
+ * - MCP `tools.ts` (`list_content` / `get_content`, via dynamic import or npm
+ *   dependency), alongside `template-listing.ts` for templates
+ * - future hosted-MCP parity in the openagreements.org deploy (which already
+ *   consumes `template-listing.ts` the same way)
+ *
+ * The content lives as markdown bundles at the repository root
+ * (`practice-guides/`, `checklists/`, `surveys/` — the product-line-first
+ * views; the topic-first `legal-practice-library/` duplicates the same
+ * documents and is intentionally NOT indexed to keep IDs unique). These
+ * directories are part of the git repository but are NOT shipped in the npm
+ * package (`files` in package.json), so callers must treat "no content roots
+ * present" as a valid runtime state, reported by
+ * `listDocContentTypesAvailable()`.
+ */
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join, relative, resolve, sep } from 'node:path';
+import yaml from 'js-yaml';
+import { getPackageRoot } from '../utils/paths.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Non-template content types served from local markdown bundles. */
+export type DocContentType = 'practice_guide' | 'checklist' | 'survey';
+
+/** Every content type addressable through the unified content catalog. */
+export type ContentType = 'template' | DocContentType;
+
+/** Repository directory backing each markdown-bundle content type. */
+export const DOC_CONTENT_DIRS: Record<DocContentType, string> = {
+  practice_guide: 'practice-guides',
+  checklist: 'checklists',
+  survey: 'surveys',
+};
+
+export const DOC_CONTENT_TYPES = Object.keys(DOC_CONTENT_DIRS) as DocContentType[];
+
+export interface DocContentItem {
+  /** Stable ID: `<type>/<topic>/<doc path>`, e.g. `practice_guide/wage-and-hour/us`. */
+  content_id: string;
+  type: DocContentType;
+  title: string;
+  description: string | null;
+  /** First path segment under the content root, e.g. `wage-and-hour`. */
+  topic: string;
+  /**
+   * Jurisdiction path derived from the document location (`us`,
+   * `us/california`, `worldwide`, …), or null for non-jurisdictional docs.
+   */
+  jurisdiction: string | null;
+  format: 'markdown';
+  /** Canonical public URL from frontmatter `resource`, when declared. */
+  source_url: string | null;
+  /** Frontmatter `timestamp` (review/update date), when declared. */
+  updated_at: string | null;
+  tags: string[];
+  /** Repository-relative markdown file path (provenance). */
+  repo_path: string;
+}
+
+export interface DocContentDetail extends DocContentItem {
+  /** Full canonical markdown file content, frontmatter included. */
+  markdown: string;
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+/**
+ * One path segment of a doc slug. Deliberately strict (lowercase kebab, no
+ * dots) so IDs can never traverse outside the content roots.
+ */
+const SLUG_SEGMENT_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
+
+/** Files that are navigation/changelog scaffolding, not content documents. */
+const NON_DOCUMENT_BASENAMES = new Set(['index.md', 'log.md']);
+
+const JURISDICTION_ROOTS = new Set(['us', 'worldwide']);
+
+function isValidSlugPath(segments: string[]): boolean {
+  return segments.length >= 2 && segments.every((segment) => SLUG_SEGMENT_PATTERN.test(segment));
+}
+
+interface Frontmatter {
+  title?: unknown;
+  description?: unknown;
+  resource?: unknown;
+  timestamp?: unknown;
+  tags?: unknown;
+}
+
+function parseFrontmatter(text: string): Frontmatter {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/.exec(text);
+  if (!match) return {};
+  try {
+    const parsed = yaml.load(match[1]);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Frontmatter;
+    }
+  } catch {
+    // Unparseable frontmatter → fall back to heading-derived metadata.
+  }
+  return {};
+}
+
+function firstHeading(text: string): string | null {
+  const match = /^# +(.+)$/m.exec(text);
+  if (!match) return null;
+  // Strip footnote markers like `[^about]` that decorate projected headings.
+  return match[1].replace(/\[\^[^\]]*\]/g, '').trim() || null;
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+}
+
+function asTags(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((tag): tag is string => typeof tag === 'string');
+}
+
+/** Recursively collect document files under `dir`, as root-relative segment arrays. */
+function walkDocuments(dir: string, prefix: string[] = []): string[][] {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const results: string[][] = [];
+  for (const entry of [...entries].sort((a, b) => a.name.localeCompare(b.name))) {
+    if (entry.isDirectory()) {
+      if (!SLUG_SEGMENT_PATTERN.test(entry.name)) continue;
+      results.push(...walkDocuments(join(dir, entry.name), [...prefix, entry.name]));
+      continue;
+    }
+    if (!entry.isFile()) continue;
+    if (!entry.name.endsWith('.md') || NON_DOCUMENT_BASENAMES.has(entry.name)) continue;
+    const slug = entry.name.slice(0, -'.md'.length);
+    if (!SLUG_SEGMENT_PATTERN.test(slug)) continue;
+    results.push([...prefix, slug]);
+  }
+  return results;
+}
+
+function deriveJurisdiction(segments: string[]): string | null {
+  // segments are the path parts after the topic, e.g. ['us', 'california'].
+  if (segments.length === 0 || !JURISDICTION_ROOTS.has(segments[0])) return null;
+  return segments.join('/');
+}
+
+function buildItem(
+  type: DocContentType,
+  segments: string[],
+  contentRoot: string,
+): DocContentItem | null {
+  // Every document lives at least one level under a topic directory.
+  if (!isValidSlugPath(segments)) return null;
+
+  const repoPath = `${DOC_CONTENT_DIRS[type]}/${segments.join('/')}.md`;
+  const absolutePath = join(contentRoot, repoPath);
+  let text: string;
+  try {
+    text = readFileSync(absolutePath, 'utf-8');
+  } catch {
+    return null;
+  }
+
+  const frontmatter = parseFrontmatter(text);
+  const title = asString(frontmatter.title) ?? firstHeading(text) ?? segments[segments.length - 1];
+
+  return {
+    content_id: `${type}/${segments.join('/')}`,
+    type,
+    title,
+    description: asString(frontmatter.description),
+    topic: segments[0],
+    jurisdiction: deriveJurisdiction(segments.slice(1)),
+    format: 'markdown',
+    source_url: asString(frontmatter.resource),
+    updated_at: asString(frontmatter.timestamp),
+    tags: asTags(frontmatter.tags),
+    repo_path: repoPath,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Which markdown-bundle content types are servable from `contentRoot` (the
+ * package root by default). The npm package does not ship these directories,
+ * so an installed-package runtime typically returns `[]` — callers should
+ * surface that as "content unavailable in this runtime", not as empty content.
+ */
+export function listDocContentTypesAvailable(contentRoot?: string): DocContentType[] {
+  const root = resolve(contentRoot ?? getPackageRoot());
+  return DOC_CONTENT_TYPES.filter((type) => existsSync(join(root, DOC_CONTENT_DIRS[type])));
+}
+
+/**
+ * List every practice guide, checklist, and survey document as a flat catalog,
+ * sorted lexicographically by `content_id` (deterministic order). Missing
+ * content directories contribute zero items.
+ */
+export function listDocContentItems(contentRoot?: string): DocContentItem[] {
+  const root = resolve(contentRoot ?? getPackageRoot());
+  const items: DocContentItem[] = [];
+
+  for (const type of DOC_CONTENT_TYPES) {
+    const typeRoot = join(root, DOC_CONTENT_DIRS[type]);
+    if (!existsSync(typeRoot)) continue;
+    for (const segments of walkDocuments(typeRoot)) {
+      const item = buildItem(type, segments, root);
+      if (item) items.push(item);
+    }
+  }
+
+  items.sort((a, b) => a.content_id.localeCompare(b.content_id));
+  return items;
+}
+
+/**
+ * Resolve one content ID (e.g. `checklist/safes/yc-post-money-safe-valuation-cap`)
+ * to its full canonical document. Returns undefined for unknown IDs, IDs of the
+ * wrong shape, and anything that would escape the content roots.
+ */
+export function findDocContentItem(
+  contentId: string,
+  contentRoot?: string,
+): DocContentDetail | undefined {
+  const root = resolve(contentRoot ?? getPackageRoot());
+  const [type, ...segments] = contentId.split('/');
+  if (!DOC_CONTENT_TYPES.includes(type as DocContentType)) return undefined;
+  if (!isValidSlugPath(segments)) return undefined;
+
+  const typeRoot = resolve(join(root, DOC_CONTENT_DIRS[type as DocContentType]));
+  const filePath = resolve(join(typeRoot, `${segments.join('/')}.md`));
+  const rel = relative(typeRoot, filePath);
+  if (rel.startsWith('..') || rel.startsWith(sep)) return undefined;
+  if (NON_DOCUMENT_BASENAMES.has(`${segments[segments.length - 1]}.md`)) return undefined;
+  if (!existsSync(filePath)) return undefined;
+
+  const item = buildItem(type as DocContentType, segments, root);
+  if (!item) return undefined;
+
+  return { ...item, markdown: readFileSync(filePath, 'utf-8') };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -216,6 +216,19 @@ export {
   type TemplateListField,
 } from './core/template-listing.js';
 
+// Unified content listing (practice guides, checklists, surveys)
+export {
+  listDocContentItems,
+  listDocContentTypesAvailable,
+  findDocContentItem,
+  DOC_CONTENT_DIRS,
+  DOC_CONTENT_TYPES,
+  type ContentType,
+  type DocContentType,
+  type DocContentItem,
+  type DocContentDetail,
+} from './core/content-listing.js';
+
 // Template discovery
 export { listTemplateEntries, findTemplateDir, type ContentEntry } from './utils/paths.js';
 


### PR DESCRIPTION
## Summary

Adds the unified, read-only content-discovery pair proposed in #635 to the contract-templates MCP server:

- **`list_content`** — enumerates all first-class OpenAgreements content (`template`, `practice_guide`, `checklist`, `survey`) as one paginated compact catalog with stable `content_id`s in deterministic lexicographic order. Inputs (`type?`, `query?`, `cursor?`, `limit?`) reuse `list_templates`' exact validation conventions: strict zod schema, bounded limit (default 25, max 100), opaque base64 `after:` cursor with the same malformed/beyond-tail error behavior.
- **`get_content`** — retrieves one item by `content_id`. Markdown types return the full canonical document plus provenance metadata (`source_url` from frontmatter `resource`, `updated_at` from frontmatter `timestamp`, `repo_path`, `tags`, derived `jurisdiction`); `template/<id>` returns the same full definition as `get_template` under a `template` key.

## What each type is wired to (all real, none fabricated)

Investigation confirmed all four content types have real local representations in this repo:

| type | source | count today |
|---|---|---|
| `template` | existing template catalog (`template-listing.ts` / `list --json` fallback) | 105 |
| `practice_guide` | `practice-guides/` markdown bundle (YAML frontmatter per doc) | 234 |
| `checklist` | `checklists/` markdown bundle | 61 |
| `survey` | `surveys/` markdown bundle | 8 |

The topic-first `legal-practice-library/` bundle duplicates the same documents and is intentionally **not** indexed (would create duplicate IDs). `index.md`/`log.md` navigation/changelog scaffolding is excluded.

## Design notes

- New shared module `src/core/content-listing.ts` (exported from the package root), mirroring how `template-listing.ts` is shared with the openagreements.org deploy — that is the path to hosted-MCP parity, which lives in the private deploy repo and is a follow-up there, not in this PR.
- The three markdown bundles are **not** shipped in the npm package (`files` in package.json — they total ~17 MB). Rather than ballooning the package or fabricating remote data, an installed-package runtime reports the affected types under `unavailable_types: [{type, reason}]` (list) / `CONTENT_UNAVAILABLE` (get) with a pointer to the repo and openagreements.org, instead of returning silently empty results.
- Content IDs are strictly validated per segment (lowercase kebab), so traversal attempts (`checklist/../../…`) resolve to `CONTENT_NOT_FOUND`.
- `get_template` now shares its lookup helper with `get_content`; its behavior and payload are unchanged, and `list_templates`/`get_template` remain fully backward-compatible on top of #533's `derived_from`/`credits` additions.
- Per the issue's compatibility note, MCP Resources exposure is deferred; tools are the portable baseline.
- The "OpenSpec change before implementation" acceptance item is intentionally skipped: OpenSpec was removed from this repo (#572).

## Testing

- `src/core/content-listing.test.ts` — listing determinism/uniqueness, frontmatter extraction, nested jurisdiction derivation, round-trip, traversal/malformed-ID rejection, missing-root behavior.
- `packages/contract-templates-mcp/tests/content-tools.test.ts` — every content type enumerable; compact-shape exact keys; query filtering incl. empty results; full-catalog pagination walk (no gaps/dupes); malformed + beyond-tail cursors; strict input rejection; `get_content` markdown + template parity with `get_template`; not-found/traversal IDs; unavailable-runtime behavior via module override.
- `npm run build && npm run lint && npm run validate && npx vitest run` — green locally (a first parallel run hit the known allure-wrapper "no vitest context" flake in 3 unrelated files; clean on rerun: 103 files passed, 3 skipped).

Closes #635

https://claude.ai/code/session_01HX8k8K4wpAQXfehdH158cc
