### PR TITLE
fix(fill): guard the % doubling trap the way $ is guarded

### DIFF
--- a/integration-tests/fill-pipeline.test.ts
+++ b/integration-tests/fill-pipeline.test.ts
@@ -116,6 +116,14 @@ function footerXml(text: string): string {
   );
 }
 
+/** Helper to make footnotes XML with the given text. */
+function footnotesXml(text: string): string {
+  return (
+    '<?xml version="1.0" encoding="UTF-8"?>' +
+    `<w:footnotes xmlns:w="${W_NS}"><w:footnote w:id="1"><w:p><w:r><w:t xml:space="preserve">${text}</w:t></w:r></w:p></w:footnote></w:footnotes>`
+  );
+}
+
 /** Helper to make endnotes XML with the given text. */
 function endnotesXml(text: string): string {
   return (
@@ -262,6 +270,23 @@ describe('detectPercentFields', () => {
     expect(fields.has('endnote_rate')).toBe(true);
   });
 
+  it('scans footnotes, which the general part list excludes', () => {
+    // getGeneralTextPartNames() drops word/footnotes.xml because the cleaner has
+    // to special-case its separator paragraphs. Detection only reads, and a
+    // footnote rendering "8%%" is a corrupt executed document.
+    const buf = buildDocxBuffer(docXml(['Body text']), {
+      'word/footnotes.xml': footnotesXml('Rate {footnote_rate}%'),
+    });
+    expect(detectPercentFields(buf).has('footnote_rate')).toBe(true);
+  });
+
+  it('abstains when the body owns the sign and a footnote occurrence does not', () => {
+    const buf = buildDocxBuffer(docXml(['at least {threshold}% of the shares']), {
+      'word/footnotes.xml': footnotesXml('as measured by {threshold} of the shares'),
+    });
+    expect(detectPercentFields(buf).size).toBe(0);
+  });
+
   it('does not mistake a leading-$ currency field for a percent field', () => {
     const buf = buildDocxBuffer(docXml(['Amount: ${purchase_amount} in cash']));
     expect(detectPercentFields(buf).size).toBe(0);
@@ -393,6 +418,28 @@ describe('verifyTemplateFill', () => {
     const result = verifyTemplateFill(path);
     expect(result.passed).toBe(false);
     const check = result.checks.find((c) => c.name === 'No double percent signs');
+    expect(check?.passed).toBe(false);
+    rmSync(path.replace('/test.docx', ''), { recursive: true, force: true });
+  });
+
+  it('catches a double percent sign inside a footnote', () => {
+    const path = buildDocxFile(docXml(['Body is clean']), {
+      'word/footnotes.xml': footnotesXml('Rate 8%% per annum'),
+    });
+    const result = verifyTemplateFill(path);
+    const check = result.checks.find((c) => c.name === 'No double percent signs');
+    expect(check?.passed).toBe(false);
+    expect(check?.details).toContain('8%%');
+    expect(result.passed).toBe(false);
+    rmSync(path.replace('/test.docx', ''), { recursive: true, force: true });
+  });
+
+  it('catches a double dollar sign inside a footnote', () => {
+    const path = buildDocxFile(docXml(['Body is clean']), {
+      'word/footnotes.xml': footnotesXml('Amount $$50,000'),
+    });
+    const result = verifyTemplateFill(path);
+    const check = result.checks.find((c) => c.name === 'No double dollar signs');
     expect(check?.passed).toBe(false);
     rmSync(path.replace('/test.docx', ''), { recursive: true, force: true });
   });
@@ -1367,6 +1414,29 @@ describe('Integration: template percentage sanitization (issue #719)', () => {
 
     expect(outText).toContain('rate equal to 8%.');
     expect(outText).not.toMatch(/%[\s\u00A0]*%/);
+  });
+
+  it('sanitizes a percentage that lives only in a footnote', async () => {
+    const buf = buildDocxBuffer(docXml(['Body text with no percentage.']), {
+      'word/footnotes.xml': footnotesXml('Rate {rate}%'),
+    });
+
+    const result = await fillDocx({
+      templateBuffer: buf,
+      data: { rate: '8%' },
+      stripParagraphPatterns: [],
+    });
+
+    const footnoteXmlOut = new AdmZip(Buffer.from(result))
+      .getEntry('word/footnotes.xml')!
+      .getData()
+      .toString('utf-8');
+    const footnoteText = (footnoteXmlOut.match(/<w:t[^>]*>([\s\S]*?)<\/w:t>/g) ?? [])
+      .map((t) => t.replace(/<[^>]+>/g, ''))
+      .join('');
+
+    expect(footnoteText).toBe('Rate 8%');
+    expect(footnoteText).not.toContain('%%');
   });
 
   it('leaves the sign alone when the source does not supply it', async () => {

--- a/integration-tests/fill-pipeline.test.ts
+++ b/integration-tests/fill-pipeline.test.ts
@@ -13,7 +13,14 @@ function templateDirFor(slug: string): string {
 }
 import { tmpdir } from 'node:os';
 import AdmZip from 'adm-zip';
-import { detectCurrencyFields, sanitizeCurrencyValuesFromDocx, verifyTemplateFill, BLANK_PLACEHOLDER } from '../src/core/fill-utils.js';
+import {
+  detectCurrencyFields,
+  sanitizeCurrencyValuesFromDocx,
+  detectPercentFields,
+  sanitizePercentValuesFromDocx,
+  verifyTemplateFill,
+  BLANK_PLACEHOLDER,
+} from '../src/core/fill-utils.js';
 import { prepareFillData, fillDocx, formatDocumentDate } from '../src/core/fill-pipeline.js';
 import { runFillPipeline } from '../src/core/unified-pipeline.js';
 import { loadMetadata } from '../src/core/metadata.js';
@@ -83,6 +90,14 @@ function docXmlSplitRuns(runTexts: string[]): string {
     '<?xml version="1.0" encoding="UTF-8"?>' +
     `<w:document xmlns:w="${W_NS}"><w:body><w:p>${runs}</w:p></w:body></w:document>`
   );
+}
+
+/** Concatenate every <w:t> in a filled DOCX body into one string. */
+function docxBodyText(buf: Buffer): string {
+  const xml = new AdmZip(buf).getEntry('word/document.xml')!.getData().toString('utf-8');
+  return (xml.match(/<w:t[^>]*>([\s\S]*?)<\/w:t>/g) ?? [])
+    .map((t) => t.replace(/<[^>]+>/g, ''))
+    .join('');
 }
 
 /** Helper to make header XML with the given text. */
@@ -197,6 +212,125 @@ describe('sanitizeCurrencyValuesFromDocx', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Section 1b: Percentage Sanitization (issue #719)
+// ---------------------------------------------------------------------------
+
+describe('detectPercentFields', () => {
+  it('detects a field whose tag is immediately followed by %', () => {
+    const buf = buildDocxBuffer(docXml(['A rate of {interest_rate}% per annum']));
+    expect(detectPercentFields(buf).has('interest_rate')).toBe(true);
+  });
+
+  it('detects the field when {tag} and % are split across runs', () => {
+    const buf = buildDocxBuffer(docXmlSplitRuns(['A rate of ', '{interest_rate}', '%']));
+    expect(detectPercentFields(buf).has('interest_rate')).toBe(true);
+  });
+
+  it('tolerates whitespace between the tag and the sign', () => {
+    const spaced = buildDocxBuffer(docXml(['Holders of {threshold} % of the shares']));
+    expect(detectPercentFields(spaced).has('threshold')).toBe(true);
+    const nbsp = buildDocxBuffer(docXml(['Holders of {threshold}\u00A0% of the shares']));
+    expect(detectPercentFields(nbsp).has('threshold')).toBe(true);
+  });
+
+  it('returns an empty set when the source owns no adjacent %', () => {
+    const buf = buildDocxBuffer(docXml(['Holders of {threshold} of the shares']));
+    expect(detectPercentFields(buf).size).toBe(0);
+  });
+
+  it('does not report a field whose occurrences disagree about the sign', () => {
+    // The recipes are split on which side of the seam owns the sign: the ROFR
+    // & co-sale replacement key "[specify percentage]%" absorbs the source %,
+    // the certificate of incorporation leaves it in place. A document that
+    // lands both shapes for one field has no value that renders correctly
+    // everywhere, so we strip nothing and let the verifier flag the artifact.
+    const buf = buildDocxBuffer(
+      docXml(['at least {threshold}% of the shares', 'no less than {threshold} of the shares'])
+    );
+    expect(detectPercentFields(buf).size).toBe(0);
+  });
+
+  it('scans headers, footers and endnotes', () => {
+    const buf = buildDocxBuffer(docXml(['Body text']), {
+      'word/header1.xml': headerXml('Cap: {header_rate}%'),
+      'word/footer1.xml': footerXml('Floor: {footer_rate}%'),
+      'word/endnotes.xml': endnotesXml('Note: {endnote_rate}%'),
+    });
+    const fields = detectPercentFields(buf);
+    expect(fields.has('header_rate')).toBe(true);
+    expect(fields.has('footer_rate')).toBe(true);
+    expect(fields.has('endnote_rate')).toBe(true);
+  });
+
+  it('does not mistake a leading-$ currency field for a percent field', () => {
+    const buf = buildDocxBuffer(docXml(['Amount: ${purchase_amount} in cash']));
+    expect(detectPercentFields(buf).size).toBe(0);
+  });
+});
+
+describe('sanitizePercentValuesFromDocx', () => {
+  it('strips a trailing % for detected percent fields', () => {
+    const buf = buildDocxBuffer(docXml(['A rate of {interest_rate}% per annum']));
+    const result = sanitizePercentValuesFromDocx(
+      { interest_rate: '8%', name: 'Acme' },
+      buf
+    );
+    expect(result.interest_rate).toBe('8');
+    expect(result.name).toBe('Acme');
+  });
+
+  it('absorbs whitespace before the sign, ordinary and non-breaking', () => {
+    const buf = buildDocxBuffer(docXml(['A rate of {interest_rate}% per annum']));
+    expect(sanitizePercentValuesFromDocx({ interest_rate: '8 %' }, buf).interest_rate).toBe('8');
+    expect(
+      sanitizePercentValuesFromDocx({ interest_rate: '8\u00A0%' }, buf).interest_rate
+    ).toBe('8');
+    expect(
+      sanitizePercentValuesFromDocx({ interest_rate: '8\u202F%' }, buf).interest_rate
+    ).toBe('8');
+  });
+
+  it('leaves a value that already omits the sign untouched', () => {
+    const buf = buildDocxBuffer(docXml(['A rate of {interest_rate}% per annum']));
+    expect(sanitizePercentValuesFromDocx({ interest_rate: '8' }, buf).interest_rate).toBe('8');
+  });
+
+  it('does not blank a value that is nothing but a percent sign', () => {
+    const buf = buildDocxBuffer(docXml(['A rate of {interest_rate}% per annum']));
+    expect(sanitizePercentValuesFromDocx({ interest_rate: '%' }, buf).interest_rate).toBe('%');
+  });
+
+  it('only strips a % at the very end of the value', () => {
+    const buf = buildDocxBuffer(docXml(['A rate of {interest_rate}% per annum']));
+    expect(
+      sanitizePercentValuesFromDocx({ interest_rate: '8% to 10' }, buf).interest_rate
+    ).toBe('8% to 10');
+  });
+
+  it('does not strip % from non-percent fields', () => {
+    const buf = buildDocxBuffer(docXml(['A rate of {interest_rate}% per annum']));
+    const result = sanitizePercentValuesFromDocx(
+      { interest_rate: '8%', share: '60%' },
+      buf
+    );
+    expect(result.interest_rate).toBe('8');
+    expect(result.share).toBe('60%'); // the source does not supply the sign here
+  });
+
+  it('does not strip % from non-string values', () => {
+    const buf = buildDocxBuffer(docXml(['A rate of {some_field}% per annum']));
+    const result = sanitizePercentValuesFromDocx({ some_field: true }, buf);
+    expect(result.some_field).toBe(true);
+  });
+
+  it('returns the same object when no percent fields are detected', () => {
+    const buf = buildDocxBuffer(docXml(['Hello {name}']));
+    const values = { name: '60%' };
+    expect(sanitizePercentValuesFromDocx(values, buf)).toBe(values);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Section 2: Template Verification
 // ---------------------------------------------------------------------------
 
@@ -240,6 +374,33 @@ describe('verifyTemplateFill', () => {
     const path = buildDocxFile(docXml(['Fee: $1,000', 'Cap: $5,000,000']));
     const result = verifyTemplateFill(path);
     const check = result.checks.find((c) => c.name === 'No double dollar signs');
+    expect(check?.passed).toBe(true);
+    rmSync(path.replace('/test.docx', ''), { recursive: true, force: true });
+  });
+
+  it('catches double percent signs in output', () => {
+    const path = buildDocxFile(docXml(['Holders of at least 60%% of the shares']));
+    const result = verifyTemplateFill(path);
+    expect(result.passed).toBe(false);
+    const check = result.checks.find((c) => c.name === 'No double percent signs');
+    expect(check?.passed).toBe(false);
+    expect(check?.details).toContain('60%%');
+    rmSync(path.replace('/test.docx', ''), { recursive: true, force: true });
+  });
+
+  it('catches % % with whitespace between', () => {
+    const path = buildDocxFile(docXml(['Holders of at least 60% % of the shares']));
+    const result = verifyTemplateFill(path);
+    expect(result.passed).toBe(false);
+    const check = result.checks.find((c) => c.name === 'No double percent signs');
+    expect(check?.passed).toBe(false);
+    rmSync(path.replace('/test.docx', ''), { recursive: true, force: true });
+  });
+
+  it('does not flag legitimate separate percentages', () => {
+    const path = buildDocxFile(docXml(['A rate of 8% rising to 10% per annum']));
+    const result = verifyTemplateFill(path);
+    const check = result.checks.find((c) => c.name === 'No double percent signs');
     expect(check?.passed).toBe(true);
     rmSync(path.replace('/test.docx', ''), { recursive: true, force: true });
   });
@@ -1181,6 +1342,52 @@ describe('Integration: template currency sanitization', () => {
     // Should contain $50,000 not $$50,000
     expect(outXml).toContain('50,000');
     expect(outXml).not.toContain('$$');
+  });
+});
+
+describe('Integration: template percentage sanitization (issue #719)', () => {
+  it('template fill with "8%" produces 8% not 8%%', async () => {
+    // Build a template DOCX whose source owns the sign — {interest_rate}%,
+    // the shape the NVCA certificate of incorporation lands for
+    // redemption_interest_rate ("aggregate per annum rate equal to > [12]%").
+    const xml =
+      '<?xml version="1.0" encoding="UTF-8"?>' +
+      `<w:document xmlns:w="${W_NS}"><w:body>` +
+      '<w:p><w:r><w:t>An aggregate per annum rate equal to {interest_rate}%.</w:t></w:r></w:p>' +
+      '</w:body></w:document>';
+    const buf = buildDocxBuffer(xml);
+
+    const result = await fillDocx({
+      templateBuffer: buf,
+      data: { interest_rate: '8%' },
+      stripParagraphPatterns: [],
+    });
+
+    const outText = docxBodyText(Buffer.from(result));
+
+    expect(outText).toContain('rate equal to 8%.');
+    expect(outText).not.toMatch(/%[\s\u00A0]*%/);
+  });
+
+  it('leaves the sign alone when the source does not supply it', async () => {
+    // The mirror case: the ROFR & co-sale replacement key absorbs the source %,
+    // so the value has to carry it and must survive the fill untouched.
+    const xml =
+      '<?xml version="1.0" encoding="UTF-8"?>' +
+      `<w:document xmlns:w="${W_NS}"><w:body>` +
+      '<w:p><w:r><w:t>Key Holders holding {specify_percentage} of the Transfer Stock.</w:t></w:r></w:p>' +
+      '</w:body></w:document>';
+    const buf = buildDocxBuffer(xml);
+
+    const result = await fillDocx({
+      templateBuffer: buf,
+      data: { specify_percentage: '60%' },
+      stripParagraphPatterns: [],
+    });
+
+    const outText = docxBodyText(Buffer.from(result));
+
+    expect(outText).toContain('holding 60% of the Transfer Stock.');
   });
 });
 

--- a/src/core/field-selector/ooxml-parts.ts
+++ b/src/core/field-selector/ooxml-parts.ts
@@ -43,6 +43,24 @@ export function getGeneralTextPartNames(parts: OoxmlTextParts): string[] {
 }
 
 /**
+ * Return every text part, footnotes included.
+ *
+ * `getGeneralTextPartNames()` excludes `word/footnotes.xml` because the
+ * *cleaner* has to special-case its separator / continuationSeparator
+ * paragraphs. That exclusion is about mutation. Read-only passes — detecting
+ * which fields the source owns a sigil for, and scanning rendered output for
+ * doubling artifacts — have no such constraint, and a document whose footnote
+ * renders `8%%` while the verifier reports success is worse than one that
+ * fails loudly. Use this list for inspection; use the general list for
+ * anything that rewrites parts.
+ */
+export function getAllTextPartNames(parts: OoxmlTextParts): string[] {
+  const names = getGeneralTextPartNames(parts);
+  if (parts.footnotes) names.push(parts.footnotes);
+  return names;
+}
+
+/**
  * Copy OPC parts from one zip to another, excluding directory entries.
  *
  * OOXML packages are a flat set of parts; directory entries such as `word/`

--- a/src/core/field-selector/verifier.test.ts
+++ b/src/core/field-selector/verifier.test.ts
@@ -304,6 +304,26 @@ describe('verifyOutput', () => {
     cleanupDocx(docxPath);
   });
 
+  it('flags a %% artifact inside a footnote (issue #719)', async () => {
+    // extractAllText() skips word/footnotes.xml, so the sigil checks read it
+    // separately: a corrupt footnote must not verify clean.
+    const docxPath = buildDocx(
+      '<?xml version="1.0" encoding="UTF-8"?>' +
+        `<w:document xmlns:w="${W_NS}"><w:body><w:p><w:r><w:t>Body is clean.</w:t></w:r></w:p></w:body></w:document>`,
+      {
+        'word/footnotes.xml':
+          '<?xml version="1.0" encoding="UTF-8"?>' +
+          `<w:footnotes xmlns:w="${W_NS}"><w:footnote w:id="1"><w:p><w:r><w:t xml:space="preserve">Rate 8%% per annum</w:t></w:r></w:p></w:footnote></w:footnotes>`,
+      }
+    );
+
+    const result = await verifyOutput(docxPath, {}, {});
+    const check = result.checks.find((c) => c.name === 'No double percent signs');
+    expect(check?.passed).toBe(false);
+    expect(check?.details).toContain('8%%');
+    cleanupDocx(docxPath);
+  });
+
   it('does not flag two separate legitimate percentages', async () => {
     const docxPath = buildTextDocx(['A rate of 8% rising to 10% per annum.']);
     const result = await verifyOutput(docxPath, {}, {});

--- a/src/core/field-selector/verifier.test.ts
+++ b/src/core/field-selector/verifier.test.ts
@@ -277,6 +277,40 @@ describe('verifyOutput', () => {
     rmSync(docxPath.replace('/test.docx', ''), { recursive: true, force: true });
   });
 
+  it('flags a %% artifact left by a sign-carrying percentage value (issue #719)', async () => {
+    // The trailing-sigil twin of the double-dollar check: the certificate of
+    // incorporation leaves the source % in place after {specify_percentage},
+    // so a value of "60%" doubles the sign.
+    const docxPath = buildTextDocx(['Holders of at least 60%% of the outstanding shares.']);
+
+    await allureParameter('case', 'double-percent');
+    const result = await verifyOutput(docxPath, {}, {});
+
+    const check = result.checks.find((c) => c.name === 'No double percent signs');
+    await allureStep('Assert the double-percent artifact is reported', () => {
+      expect(check?.passed).toBe(false);
+      expect(check?.details).toContain('60%%');
+      expect(result.passed).toBe(false);
+    });
+
+    cleanupDocx(docxPath);
+  });
+
+  it('flags a whitespace-separated % % artifact', async () => {
+    const docxPath = buildTextDocx(['Holders of at least 60% % of the outstanding shares.']);
+    const result = await verifyOutput(docxPath, {}, {});
+    const check = result.checks.find((c) => c.name === 'No double percent signs');
+    expect(check?.passed).toBe(false);
+    cleanupDocx(docxPath);
+  });
+
+  it('does not flag two separate legitimate percentages', async () => {
+    const docxPath = buildTextDocx(['A rate of 8% rising to 10% per annum.']);
+    const result = await verifyOutput(docxPath, {}, {});
+    const check = result.checks.find((c) => c.name === 'No double percent signs');
+    expect(check?.passed).toBe(true);
+    cleanupDocx(docxPath);
+  });
   it('reports zero new formatting anomalies when source and output have the same count', async () => {
     // Issue #609: runFieldSelector previously verified without the cleaned source,
     // so pre-existing source anomalies were all reported as fill-introduced.

--- a/src/core/field-selector/verifier.ts
+++ b/src/core/field-selector/verifier.ts
@@ -8,6 +8,7 @@ import { enumerateTextParts, getGeneralTextPartNames } from './ooxml-parts.js';
 import { isParagraphContentEmpty } from './cleaner.js';
 import { parseReplacementKey } from './replacement-keys.js';
 import { getTableRowContext, normalizeQuotes } from './patcher.js';
+import { DOUBLE_PERCENT_PATTERN } from '../fill-utils.js';
 import type { ReplacementValue } from './replacement-keys.js';
 
 const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
@@ -37,6 +38,8 @@ export function normalizeText(text: string): string {
  * - All context values appear in the document text
  * - No unrendered {template_tags} remain
  * - No leftover [bracketed placeholders] from the replacement map remain
+ * - No doubled currency or percent sigils from a value that already carried the
+ *   sign the source supplies
  * - Footnotes removed (if clean config specified)
  * - Drafting note paragraphs removed (if clean config specified)
  */
@@ -108,6 +111,23 @@ export async function verifyOutput(
     passed: doubleDollarLines.length === 0,
     details: doubleDollarLines.length > 0
       ? `Found ${doubleDollarLines.length} occurrence(s): "${doubleDollarLines[0].trim().slice(0, 80)}"`
+      : undefined,
+  });
+
+  // Check 5b: No double percent signs (%% or % %)
+  // The trailing-sigil twin of Check 5. Recipes disagree about which side of the
+  // seam owns the sign — the ROFR & co-sale replacement key "[specify percentage]%"
+  // absorbs the source %, while the certificate of incorporation and stock
+  // purchase agreement leave it in place — so a sign-carrying value that is
+  // correct for one template doubles the sign in another (issue #719).
+  const doublePercentLines = rawFullText
+    .split('\n')
+    .filter((line) => DOUBLE_PERCENT_PATTERN.test(line));
+  checks.push({
+    name: 'No double percent signs',
+    passed: doublePercentLines.length === 0,
+    details: doublePercentLines.length > 0
+      ? `Found ${doublePercentLines.length} occurrence(s): "${doublePercentLines[0].trim().slice(0, 80)}"`
       : undefined,
   });
 

--- a/src/core/field-selector/verifier.ts
+++ b/src/core/field-selector/verifier.ts
@@ -52,6 +52,11 @@ export async function verifyOutput(
 ): Promise<VerifyResult> {
   const checks: VerifyCheck[] = [];
   const rawFullText = extractAllText(outputPath);
+  // Footnotes are outside extractAllText()'s scope. They feed the sigil-doubling
+  // checks only: those read rather than rewrite, and every other check here
+  // keeps the part scope the patcher and cleaner actually operate on.
+  const footnoteText = extractFootnoteText(outputPath);
+  const sigilText = footnoteText ? `${rawFullText}\n${footnoteText}` : rawFullText;
   const normalizedFullText = normalizeText(rawFullText);
   const xml = extractDocumentXml(outputPath);
 
@@ -105,7 +110,7 @@ export async function verifyOutput(
   // This catches cases where the template already has a $ before a placeholder
   // and the user also included a $ in their value (e.g. "$1,000,000")
   const doubleDollarPattern = /\$[\s\u00A0\t]*\$/;
-  const doubleDollarLines = rawFullText.split('\n').filter((line) => doubleDollarPattern.test(line));
+  const doubleDollarLines = sigilText.split('\n').filter((line) => doubleDollarPattern.test(line));
   checks.push({
     name: 'No double dollar signs',
     passed: doubleDollarLines.length === 0,
@@ -120,7 +125,7 @@ export async function verifyOutput(
   // absorbs the source %, while the certificate of incorporation and stock
   // purchase agreement leave it in place — so a sign-carrying value that is
   // correct for one template doubles the sign in another (issue #719).
-  const doublePercentLines = rawFullText
+  const doublePercentLines = sigilText
     .split('\n')
     .filter((line) => DOUBLE_PERCENT_PATTERN.test(line));
   checks.push({
@@ -450,6 +455,36 @@ export function countFormattingAnomalies(docxPath: string): number {
 /**
  * Extract all text from general OOXML text parts (document, headers, footers, endnotes).
  */
+/**
+ * Extract footnote paragraph text, which `extractAllText()` deliberately omits.
+ *
+ * `getGeneralTextPartNames()` excludes `word/footnotes.xml` because the cleaner
+ * has to special-case its separator paragraphs. That constraint is about
+ * mutation; the sigil-doubling checks only read, and a footnote rendering
+ * `8%%` is a corrupt executed document that must not verify clean.
+ */
+export function extractFootnoteText(docxPath: string): string {
+  const zip = new AdmZip(docxPath);
+  const parts = enumerateTextParts(zip);
+  if (!parts.footnotes) return '';
+  const entry = zip.getEntry(parts.footnotes);
+  if (!entry) return '';
+
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(entry.getData().toString('utf-8'), 'text/xml');
+  const paragraphs: string[] = [];
+  const paras = doc.getElementsByTagNameNS(W_NS, 'p');
+  for (let i = 0; i < paras.length; i++) {
+    const tElements = paras[i].getElementsByTagNameNS(W_NS, 't');
+    const textParts: string[] = [];
+    for (let j = 0; j < tElements.length; j++) {
+      textParts.push(tElements[j].textContent ?? '');
+    }
+    if (textParts.length > 0) paragraphs.push(textParts.join(''));
+  }
+  return paragraphs.join('\n');
+}
+
 export function extractAllText(docxPath: string): string {
   const zip = new AdmZip(docxPath);
   const parser = new DOMParser();

--- a/src/core/fill-pipeline.ts
+++ b/src/core/fill-pipeline.ts
@@ -8,7 +8,11 @@ import AdmZip from 'adm-zip';
 import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
 import type { Document, Element, Node } from '@xmldom/xmldom';
 import { createReport } from 'docx-templates';
-import { sanitizeCurrencyValuesFromDocx, BLANK_PLACEHOLDER } from './fill-utils.js';
+import {
+  sanitizeCurrencyValuesFromDocx,
+  sanitizePercentValuesFromDocx,
+  BLANK_PLACEHOLDER,
+} from './fill-utils.js';
 import {
   copyEntriesSkippingDirs,
   enumerateTextParts,
@@ -768,7 +772,8 @@ function stripBlankPlaceholderOnRuledLines(docxBuffer: Buffer): Buffer {
  * Fill a DOCX template with prepared data:
  * 1. Strip drafting note paragraphs (configurable, on by default)
  * 2. Strip highlighting from runs with filled fields (unfilled keep their highlight)
- * 3. Sanitize currency values by scanning the template buffer for ${field} patterns
+ * 3. Sanitize currency and percentage values by scanning the template buffer for
+ *    ${field} and {field}% patterns
  * 4. Call docx-templates createReport() with standard delimiters
  * 5. Remove structurally empty table rows left by conditional rendering
  * 6. Suppress the blank-fill placeholder on lines that already carry a rule
@@ -799,8 +804,13 @@ export async function fillDocx(options: FillDocxOptions): Promise<Uint8Array> {
   }
   templateBuffer = stripFilledHighlighting(templateBuffer, filledFields);
 
-  // Step 3: Strip leading $ from values where the template has ${ before the tag
-  const sanitizedData = sanitizeCurrencyValuesFromDocx(data, templateBuffer);
+  // Step 3: Strip the redundant sigil from values where the template already
+  // carries it — a leading $ where the template has ${ before the tag, and a
+  // trailing % where the template has a % after the tag.
+  const sanitizedData = sanitizePercentValuesFromDocx(
+    sanitizeCurrencyValuesFromDocx(data, templateBuffer),
+    templateBuffer
+  );
 
   // Step 4: Fill template
   const filled = await createReport({

--- a/src/core/fill-utils.ts
+++ b/src/core/fill-utils.ts
@@ -81,9 +81,129 @@ export function sanitizeCurrencyValuesFromDocx(
 }
 
 /**
+ * Horizontal whitespace that can sit between a tag and a trailing `%`, or
+ * between a number and its `%` inside a user value. Deliberately excludes
+ * `\n` — a percent sign on the next line belongs to different prose.
+ */
+const H_SPACE = ' \\t\\u00A0\\u2007\\u202F';
+
+/** `{field}` immediately followed (modulo horizontal whitespace) by `%`. */
+const TAG_THEN_PERCENT = new RegExp(`\\{(\\w+)\\}[${H_SPACE}]*%`, 'g');
+
+/** Any `{field}` tag. */
+const ANY_TAG = /\{(\w+)\}/g;
+
+/** A trailing `%` on a user value, with any horizontal whitespace before it. */
+const TRAILING_PERCENT = new RegExp(`[${H_SPACE}]*%$`);
+
+/**
+ * A doubled percent sign (`%%` or `% %`) in rendered output — the artifact left
+ * when a sign-carrying value lands in a placeholder whose source already
+ * supplies the `%`. The trailing-sigil twin of the `doubleDollarPattern`.
+ *
+ * Shared with the fieldSelector verifier so both entry points flag the same
+ * shape. Not global: every caller only asks whether a line matches.
+ */
+export const DOUBLE_PERCENT_PATTERN = /%[\s\u00A0\t]*%/;
+
+/**
+ * Scan a DOCX template buffer for fields whose `{field_name}` tag is
+ * immediately followed by a literal `%` — the trailing-sigil mirror of
+ * {@link detectCurrencyFields}.
+ *
+ * A field is reported only when **every** occurrence of its tag carries the
+ * adjacent `%`. That asymmetry with the currency detector is deliberate and
+ * is the whole reason this is not a literal mirror: recipes disagree about
+ * which side of the seam owns the sign (`nvca-rofr-co-sale-agreement` maps the
+ * key `"[specify percentage]%"`, absorbing the source `%`, while the
+ * certificate of incorporation and stock purchase agreement map
+ * `"[specify percentage]"` and leave it in place), so one field can plausibly
+ * land in a document with the sign on some occurrences and not others. When
+ * the occurrences disagree there is no value that renders correctly
+ * everywhere, so we strip nothing and let the `%%` artifact surface loudly in
+ * the verifier rather than silently dropping the sign from the occurrence that
+ * needed it.
+ *
+ * Works by parsing OOXML text parts and concatenating `<w:t>` elements per
+ * paragraph, so a tag split across runs is still seen whole.
+ */
+export function detectPercentFields(docxBuffer: Buffer): Set<string> {
+  const zip = new AdmZip(docxBuffer);
+  const parser = new DOMParser();
+  const parts = enumerateTextParts(zip);
+  const partNames = getGeneralTextPartNames(parts);
+
+  const totalByField = new Map<string, number>();
+  const adjacentByField = new Map<string, number>();
+
+  for (const partName of partNames) {
+    const entry = zip.getEntry(partName);
+    if (!entry) continue;
+
+    const xml = entry.getData().toString('utf-8');
+    const doc = parser.parseFromString(xml, 'text/xml');
+
+    const paras = doc.getElementsByTagNameNS(W_NS, 'p');
+    for (let i = 0; i < paras.length; i++) {
+      const tElements = paras[i].getElementsByTagNameNS(W_NS, 't');
+      let fullText = '';
+      for (let j = 0; j < tElements.length; j++) {
+        fullText += tElements[j].textContent ?? '';
+      }
+      for (const m of fullText.matchAll(ANY_TAG)) {
+        totalByField.set(m[1], (totalByField.get(m[1]) ?? 0) + 1);
+      }
+      for (const m of fullText.matchAll(TAG_THEN_PERCENT)) {
+        adjacentByField.set(m[1], (adjacentByField.get(m[1]) ?? 0) + 1);
+      }
+    }
+  }
+
+  const percentFields = new Set<string>();
+  for (const [field, adjacent] of adjacentByField) {
+    if (adjacent > 0 && adjacent === totalByField.get(field)) {
+      percentFields.add(field);
+    }
+  }
+  return percentFields;
+}
+
+/**
+ * Strip a trailing `%` from user values where the DOCX template already has a
+ * literal `%` after the `{field_name}` tag. Prevents double-percent output
+ * like `60%%`.
+ *
+ * The mirror of {@link sanitizeCurrencyValuesFromDocx} is not literal: `$` is a
+ * leading sigil and `%` a trailing one, so this strips from the end, and it
+ * also absorbs any horizontal whitespace the user typed before the sign, a
+ * non-breaking or figure space included: "60%", "60 %", and a value with a
+ * U+00A0 before the sign all become "60". A value that is nothing but a
+ * percent sign is left alone rather than blanked.
+ */
+export function sanitizePercentValuesFromDocx(
+  values: Record<string, unknown>,
+  docxBuffer: Buffer
+): Record<string, unknown> {
+  const percentFields = detectPercentFields(docxBuffer);
+  if (percentFields.size === 0) return values;
+
+  const sanitized = { ...values };
+  for (const field of percentFields) {
+    const v = sanitized[field];
+    if (typeof v !== 'string') continue;
+    const stripped = v.replace(TRAILING_PERCENT, '');
+    if (stripped !== v && stripped.trim() !== '') {
+      sanitized[field] = stripped;
+    }
+  }
+  return sanitized;
+}
+
+/**
  * Verify a filled template DOCX output.
  * Runs a subset of checks that are safe for templates:
  * - No double dollar signs (catches currency sanitization failures)
+ * - No double percent signs (catches percentage sanitization failures)
  * - No unrendered {template_tags} (catches fill failures)
  *
  * Does NOT check: leftover brackets (templates don't use them),
@@ -129,7 +249,21 @@ export function verifyTemplateFill(outputPath: string): VerifyResult {
       : undefined,
   });
 
-  // Check 2: No unrendered {template_tags}
+  // Check 2: No double percent signs (%% or % %) — the trailing-sigil twin of
+  // Check 1. The template already carries the `%` after some placeholders, so a
+  // sign-carrying value doubles it.
+  const doublePercentLines = rawFullText
+    .split('\n')
+    .filter((line) => DOUBLE_PERCENT_PATTERN.test(line));
+  checks.push({
+    name: 'No double percent signs',
+    passed: doublePercentLines.length === 0,
+    details: doublePercentLines.length > 0
+      ? `Found ${doublePercentLines.length} occurrence(s): "${doublePercentLines[0].trim().slice(0, 80)}"`
+      : undefined,
+  });
+
+  // Check 3: No unrendered {template_tags}
   const unrenderedTags = rawFullText.match(/\{[a-z_][a-z0-9_]*\}/gi) ?? [];
   checks.push({
     name: 'No unrendered template tags',

--- a/src/core/fill-utils.ts
+++ b/src/core/fill-utils.ts
@@ -4,7 +4,11 @@
 
 import AdmZip from 'adm-zip';
 import { DOMParser } from '@xmldom/xmldom';
-import { enumerateTextParts, getGeneralTextPartNames } from './field-selector/ooxml-parts.js';
+import {
+  enumerateTextParts,
+  getGeneralTextPartNames,
+  getAllTextPartNames,
+} from './field-selector/ooxml-parts.js';
 import type { VerifyResult } from './field-selector/types.js';
 
 const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
@@ -131,7 +135,10 @@ export function detectPercentFields(docxBuffer: Buffer): Set<string> {
   const zip = new AdmZip(docxBuffer);
   const parser = new DOMParser();
   const parts = enumerateTextParts(zip);
-  const partNames = getGeneralTextPartNames(parts);
+  // Footnotes included: a percentage placeholder in a footnote owns its sign
+  // exactly as a body one does, and a footnote rendering `8%%` is a corrupt
+  // executed document.
+  const partNames = getAllTextPartNames(parts);
 
   const totalByField = new Map<string, number>();
   const adjacentByField = new Map<string, number>();
@@ -200,23 +207,12 @@ export function sanitizePercentValuesFromDocx(
 }
 
 /**
- * Verify a filled template DOCX output.
- * Runs a subset of checks that are safe for templates:
- * - No double dollar signs (catches currency sanitization failures)
- * - No double percent signs (catches percentage sanitization failures)
- * - No unrendered {template_tags} (catches fill failures)
- *
- * Does NOT check: leftover brackets (templates don't use them),
- * context values present (templates use {IF} conditionals that hide values),
- * drafting notes (stripped by fillDocx), footnotes (may be legitimate).
+ * Concatenate each paragraph's `<w:t>` runs into one string per paragraph,
+ * over the given OOXML part names. Cross-run splits disappear because the
+ * text is joined at the paragraph level.
  */
-export function verifyTemplateFill(outputPath: string): VerifyResult {
-  const zip = new AdmZip(outputPath);
-  const parser = new DOMParser();
-  const parts = enumerateTextParts(zip);
-  const partNames = getGeneralTextPartNames(parts);
-
-  const allParagraphs: string[] = [];
+function paragraphTexts(zip: AdmZip, parser: DOMParser, partNames: string[]): string[] {
+  const out: string[] = [];
   for (const partName of partNames) {
     const entry = zip.getEntry(partName);
     if (!entry) continue;
@@ -230,17 +226,48 @@ export function verifyTemplateFill(outputPath: string): VerifyResult {
         textParts.push(tElements[j].textContent ?? '');
       }
       if (textParts.length > 0) {
-        allParagraphs.push(textParts.join(''));
+        out.push(textParts.join(''));
       }
     }
   }
+  return out;
+}
+
+/**
+ * Verify a filled template DOCX output.
+ * Runs a subset of checks that are safe for templates:
+ * - No double dollar signs (catches currency sanitization failures)
+ * - No double percent signs (catches percentage sanitization failures)
+ * - No unrendered {template_tags} (catches fill failures)
+ *
+ * Does NOT check: leftover brackets (templates don't use them),
+ * context values present (templates use {IF} conditionals that hide values),
+ * drafting notes (stripped by fillDocx). Footnote text is read for the
+ * sigil-doubling checks only — the unrendered-tag check keeps body/header/
+ * footer/endnote scope, where a leftover footnote tag may be legitimate.
+ */
+export function verifyTemplateFill(outputPath: string): VerifyResult {
+  const zip = new AdmZip(outputPath);
+  const parser = new DOMParser();
+  const parts = enumerateTextParts(zip);
+  const partNames = getGeneralTextPartNames(parts);
+
+  const allParagraphs = paragraphTexts(zip, parser, partNames);
   const rawFullText = allParagraphs.join('\n');
+  // Footnotes sit outside the general part list (see `getAllTextPartNames`).
+  // They feed the sigil-doubling checks only: those are read-only and a corrupt
+  // footnote is still a corrupt document, while the unrendered-tag check keeps
+  // its existing scope.
+  const footnoteText = parts.footnotes
+    ? paragraphTexts(zip, parser, [parts.footnotes]).join('\n')
+    : '';
+  const sigilText = footnoteText ? `${rawFullText}\n${footnoteText}` : rawFullText;
 
   const checks: VerifyResult['checks'] = [];
 
   // Check 1: No double dollar signs ($$ or $ $)
   const doubleDollarPattern = /\$[\s\u00A0\t]*\$/;
-  const doubleDollarLines = rawFullText.split('\n').filter((line) => doubleDollarPattern.test(line));
+  const doubleDollarLines = sigilText.split('\n').filter((line) => doubleDollarPattern.test(line));
   checks.push({
     name: 'No double dollar signs',
     passed: doubleDollarLines.length === 0,
@@ -252,7 +279,7 @@ export function verifyTemplateFill(outputPath: string): VerifyResult {
   // Check 2: No double percent signs (%% or % %) — the trailing-sigil twin of
   // Check 1. The template already carries the `%` after some placeholders, so a
   // sign-carrying value doubles it.
-  const doublePercentLines = rawFullText
+  const doublePercentLines = sigilText
     .split('\n')
     .filter((line) => DOUBLE_PERCENT_PATTERN.test(line));
   checks.push({

--- a/src/core/selectors/manifest-schema.ts
+++ b/src/core/selectors/manifest-schema.ts
@@ -77,7 +77,12 @@ void _locatorTypeCheck;
 
 // ── Field selector manifest ─────────────────────────────────────────────
 
-export const POSTCONDITION_NAMES = ['no_unresolved_placeholder', 'all_occurrences_identical', 'no_double_dollar'] as const;
+export const POSTCONDITION_NAMES = [
+  'no_unresolved_placeholder',
+  'all_occurrences_identical',
+  'no_double_dollar',
+  'no_double_percent',
+] as const;
 export type PostconditionName = (typeof POSTCONDITION_NAMES)[number];
 
 export const FAILURE_BEHAVIORS = ['block_render_and_request_review', 'warn', 'skip'] as const;

--- a/src/core/selectors/postconditions.test.ts
+++ b/src/core/selectors/postconditions.test.ts
@@ -71,4 +71,36 @@ describe('evaluatePostconditions', () => {
     });
     expect(checks[0].passed).toBe(false);
   });
+
+  it('no_double_percent flags a %% artifact', () => {
+    const checks = evaluatePostconditions({
+      outputText: 'holders of at least 60%% of the shares',
+      manifests: [manifest(['no_double_percent'])],
+      fieldValues: {},
+      migratedAnchorsByField: {},
+    });
+    expect(checks).toHaveLength(1);
+    expect(checks[0].passed).toBe(false);
+    expect(checks[0].name).toBe('selector:company_name:no_double_percent');
+  });
+
+  it('no_double_percent flags whitespace-separated % % (locks the \\s* span)', () => {
+    const checks = evaluatePostconditions({
+      outputText: 'holders of at least 60% % of the shares',
+      manifests: [manifest(['no_double_percent'])],
+      fieldValues: {},
+      migratedAnchorsByField: {},
+    });
+    expect(checks[0].passed).toBe(false);
+  });
+
+  it('no_double_percent passes on two separate legitimate percentages', () => {
+    const checks = evaluatePostconditions({
+      outputText: 'a rate of 8% rising to 10% per annum',
+      manifests: [manifest(['no_double_percent'])],
+      fieldValues: {},
+      migratedAnchorsByField: {},
+    });
+    expect(checks[0].passed).toBe(true);
+  });
 });

--- a/src/core/selectors/postconditions.ts
+++ b/src/core/selectors/postconditions.ts
@@ -1,13 +1,24 @@
 /**
  * Selector postconditions, surfaced as fieldSelector `VerifyCheck` entries after fill.
  *
- * Phase 1 supports three:
+ * Phase 1 supports four:
  *  - `no_unresolved_placeholder` — the field's `{field_id}` tag did not survive
  *    to the output (every occurrence filled).
  *  - `all_occurrences_identical` — the field renders one value everywhere: its
  *    value is present and no selector-owned source anchor for the field remains
  *    (a remaining anchor means an occurrence rendered differently → divergence).
- *  - `no_double_dollar` — no `$$` / `$ $` artifact in the output.
+ *  - `no_double_dollar` — no doubled currency sigil in the output.
+ *  - `no_double_percent` — no doubled percent sigil in the output. The
+ *    trailing-sigil twin of `no_double_dollar`: recipes disagree about whether
+ *    the replacement key absorbs the source percent sign, so a sign-carrying
+ *    value that is correct for one template doubles the sign in another
+ *    (issue #719).
+ *
+ * `no_double_percent` is deliberately unwired in this repo: the
+ * `specify_percentage` manifests live under `templates/nvca-*`, which is
+ * replaced wholesale by the daily legal-explainer forward sync (see
+ * `.openagreements-managed-paths.json`), so setting it here would be reverted.
+ * The wiring is an upstream follow-up; the engine support lands first.
  */
 import type { VerifyCheck } from '../field-selector/types.js';
 import type { FieldSelectorManifest } from './manifest-schema.js';
@@ -23,6 +34,7 @@ export interface PostconditionInput {
 }
 
 const DOUBLE_DOLLAR = /\$\s*\$/;
+const DOUBLE_PERCENT = /%\s*%/;
 
 export function evaluatePostconditions(input: PostconditionInput): VerifyCheck[] {
   const { outputText, manifests, fieldValues, migratedAnchorsByField } = input;
@@ -65,6 +77,13 @@ export function evaluatePostconditions(input: PostconditionInput): VerifyCheck[]
           name: `selector:${fieldId}:no_double_dollar`,
           passed: lines.length === 0,
           details: lines.length > 0 ? `Double-dollar artifact on ${lines.length} line(s)` : undefined,
+        });
+      } else if (postcondition === 'no_double_percent') {
+        const lines = outputText.split('\n').filter((l) => DOUBLE_PERCENT.test(l));
+        checks.push({
+          name: `selector:${fieldId}:no_double_percent`,
+          passed: lines.length === 0,
+          details: lines.length > 0 ? `Double-percent artifact on ${lines.length} line(s)` : undefined,
         });
       }
     }


### PR DESCRIPTION
Closes #719

The `$` doubling trap has three layers of defense; the identical `%` trap had none. Feed a sign-carrying value into a placeholder whose source already supplies the sign and the executed document reads `60%%`, with nothing to catch it.

## What landed

| Layer | Location |
| --- | --- |
| Value sanitizer | `detectPercentFields()` / `sanitizePercentValuesFromDocx()` — `src/core/fill-utils.ts`, called from `fillDocx()` in `src/core/fill-pipeline.ts` alongside the currency sanitizer |
| Fill verifier check | "No double percent signs" — `verifyTemplateFill()`, `src/core/fill-utils.ts` |
| Pipeline verifier check | Check 5b — `verifyOutput()`, `src/core/field-selector/verifier.ts` |
| Per-field postcondition | `no_double_percent` — `src/core/selectors/postconditions.ts`, admitted by `POSTCONDITION_NAMES` in `manifest-schema.ts` |

Both verifier entry points share one exported `DOUBLE_PERCENT_PATTERN` so they flag the same shape.

## The sanitizer is not a literal mirror

Two asymmetries with `sanitizeCurrencyValuesFromDocx()`, both deliberate:

1. **`$` is a leading sigil, `%` is a trailing one.** The currency sanitizer does `v.startsWith('$') ? v.slice(1) : v`. This one strips from the end and absorbs any horizontal whitespace the user typed before the sign — ordinary space, non-breaking space (U+00A0), figure space (U+2007), narrow no-break space (U+202F) — so `60%`, `60 %` and `60 %` all become `60`. Newline is excluded from that class on purpose: a percent sign on the next line belongs to different prose. A value that is nothing but a percent sign is left alone rather than blanked.
2. **A field is only reported when *every* occurrence of its tag carries the adjacent `%`.** The recipes disagree about which side of the seam owns the sign — `nvca-rofr-co-sale-agreement/replacements.json` maps the key `"[specify percentage]%"`, absorbing the source `%`, while the certificate of incorporation and stock purchase agreement map `"[specify percentage]"` and leave it in place. A field whose occurrences disagree has no value that renders correctly everywhere. Stripping there would silently drop the sign from the occurrence that needed it; not stripping leaves a `%%` the verifier flags loudly. We chose the loud failure. Detection is driven entirely by what is actually adjacent in the patched DOCX, never by an assumption about the recipe.

## Deliberately unwired — please do not flag as dead code

`no_double_percent` is implemented in the engine but **not** set on `templates/nvca-*/fields/specify_percentage.json`. Everything under `templates/nvca-free-non-redistributable/*` is owned upstream and replaced wholesale by the daily 07:17 UTC forward sync from `legal-explainer` (see `.openagreements-managed-paths.json`), so any manifest edit here is reverted tomorrow and reads later as a mysterious regression. Wiring the postcondition onto those manifests is a legal-explainer-side follow-up; the engine support lands first so that follow-up has something to point at.

For the same reason the test that needs a manifest with `no_double_percent` set constructs it inline rather than editing a shipped template manifest.

## Verification against the real NVCA suite

Filled the three templates through the CLI, not just synthetic fixtures:

- **Certificate of incorporation**, `redemption_interest_rate` (source shape `{redemption_interest_rate}%`, from the replacement key `"aggregate per annum rate equal to > [12]%"`): renders `rate equal to 8%` from both `8` and `8%`. Before this change `8%` produced `8%%` — this is the live bug the sanitizer fixes.
- **ROFR & co-sale**, `specify_percentage` (source `%` absorbed by the replacement key): renders `holding 60% of the shares` from `60%`, untouched, as it must.
- Scanned all 187 tracked template DOCX files: **zero** paragraphs match `%\s*%` today, so the new verifier check introduces no pre-existing failures.

## Tests

- `integration-tests/fill-pipeline.test.ts` — `detectPercentFields` (adjacency, cross-run split, whitespace incl. U+00A0, headers/footers/endnotes, the mixed-occurrence abstention, no confusion with a leading-`$` currency field), `sanitizePercentValuesFromDocx` (strip, whitespace absorption, idempotence on an unsigned value, the bare-`%` guard, mid-string `%` left alone, non-percent fields, non-string values, same-object fast path), the `verifyTemplateFill` check, and two end-to-end `fillDocx` cases covering both sides of the seam.
- `src/core/field-selector/verifier.test.ts` — the `verifyOutput` check on `%%`, `% %`, and a clean two-percentage line.
- `src/core/selectors/postconditions.test.ts` — `no_double_percent` on `%%`, `% %`, and a clean line.

## Gates run locally

`npm run build`, `npx vitest run` (1226 passed, 6 skipped), `npm run lint`, `npm run check:derived`, `npm run check:allure-labels`, `npm run check:isolated-runtime` — all green.

https://claude.ai/code/session_01GqDeNuzVbMGy7GEtkbKGtY
