### PR TITLE
fix(selections): guard zero-match unselected options + CI-runnable clause-shape fixtures (#720, #721)

### DIFF
--- a/integration-tests/helpers/synthetic-docx.ts
+++ b/integration-tests/helpers/synthetic-docx.ts
@@ -1,0 +1,235 @@
+/**
+ * Generalized synthetic DOCX fixture builder (#721).
+ *
+ * The pre-existing synthetic builder in `nvca-spa-template.test.ts` emits each
+ * placeholder ALONE in its own paragraph (`Marker N: [placeholder]`). A whole
+ * class of rendering defects is invisible to that shape, because the defect is
+ * a property of the literal text AROUND the placeholder rather than of the
+ * placeholder itself:
+ *
+ *  - a binding key that absorbs a shared literal prefix (`District Court for
+ *    the District of [judicial district]`) so a full value does not double it
+ *    into `District of Northern District of California`;
+ *  - two adjacent bracketed alternatives in one sentence sharing that prefix,
+ *    where each must bind to its own key;
+ *  - a proper noun that must survive substitution with its capitalization
+ *    intact (`state courts of California`, not `state courts of california`).
+ *
+ * This builder therefore takes REAL paragraph prose with embedded placeholders,
+ * so a fixture can reproduce clause SHAPE, not just clause vocabulary.
+ *
+ * NOTE ON SOURCE TEXT: the NVCA forms these defects were found in are
+ * non-redistributable. Every fixture built on top of this helper must use
+ * PARAPHRASED prose that exercises the same binding mechanics — never copied
+ * source sentences.
+ *
+ * ## Run splitting
+ *
+ * Word routinely splits one sentence across many `<w:r>`/`<w:t>` runs
+ * (spell-check state, revision marks, formatting changes), and several of these
+ * defects only manifest when a placeholder spans runs. A fixture that puts each
+ * sentence in a single run is therefore too easy on the code, so the builder
+ * offers explicit strategies and callers should exercise more than one.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import AdmZip from 'adm-zip';
+
+export const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+const CONTENT_TYPES_XML =
+  '<?xml version="1.0" encoding="UTF-8"?>' +
+  '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">' +
+  '<Default Extension="xml" ContentType="application/xml"/>' +
+  '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+  '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+  '</Types>';
+
+const ROOT_RELS_XML =
+  '<?xml version="1.0" encoding="UTF-8"?>' +
+  '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+  '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>' +
+  '</Relationships>';
+
+const WORD_RELS_XML =
+  '<?xml version="1.0" encoding="UTF-8"?>' +
+  '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"/>';
+
+/**
+ * How a paragraph's text is distributed across `<w:r>`/`<w:t>` runs.
+ *
+ * - `single`    — one run for the whole paragraph. The easiest case; a defect
+ *                 that only appears cross-run will NOT reproduce here.
+ * - `words`     — one run per whitespace-delimited token. Realistic for a
+ *                 paragraph Word has edited in place.
+ * - `straddle`  — every `[…]` placeholder is deliberately cut in half, so each
+ *                 placeholder spans at least two runs. This is the shape that
+ *                 exercises the patcher's char-map cross-run replacement.
+ * - `{ chunkChars: n }` — fixed-size chunks of n characters, which slices
+ *                 through brackets and literal prefixes at arbitrary offsets.
+ */
+export type RunSplit = 'single' | 'words' | 'straddle' | { chunkChars: number };
+
+/** Every run-splitting strategy worth sweeping a rendering assertion across. */
+export const ALL_RUN_SPLITS: RunSplit[] = ['single', 'words', 'straddle', { chunkChars: 7 }];
+
+/** Short label for a run split, for use in test names and Allure parameters. */
+export function runSplitLabel(split: RunSplit): string {
+  return typeof split === 'string' ? split : `chunk-${split.chunkChars}`;
+}
+
+export interface SyntheticParagraph {
+  /** Literal paragraph text, placeholders included, exactly as Word would show it. */
+  text: string;
+  /** Overrides the document-level run split for this paragraph only. */
+  runSplit?: RunSplit;
+  /** Word auto-numbering level, when the fixture needs a numbered paragraph. */
+  numberingLevel?: number;
+}
+
+export type ParagraphSpec = string | SyntheticParagraph;
+
+export interface SyntheticDocxOptions {
+  /** Default run split for paragraphs that do not override it. Default: `single`. */
+  runSplit?: RunSplit;
+}
+
+function xmlEscape(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
+}
+
+/** Split `text` into the run-sized chunks the given strategy asks for. */
+export function splitIntoRuns(text: string, split: RunSplit): string[] {
+  if (text.length === 0) return [''];
+
+  if (typeof split === 'object') {
+    const size = Math.max(1, split.chunkChars);
+    const chunks: string[] = [];
+    for (let i = 0; i < text.length; i += size) chunks.push(text.slice(i, i + size));
+    return chunks;
+  }
+
+  if (split === 'single') return [text];
+
+  if (split === 'words') {
+    // Keep the delimiter with the preceding token so re-joining is lossless.
+    const chunks = text.match(/\S+\s*|\s+/g);
+    return chunks && chunks.length > 0 ? chunks : [text];
+  }
+
+  // 'straddle' — cut every bracketed placeholder in half, and cut once in the
+  // middle of each literal span between placeholders, so no placeholder and no
+  // surrounding literal prefix sits wholly inside a single run.
+  const boundaries = new Set<number>([0, text.length]);
+  for (const match of text.matchAll(/\[[^\]]*\]/g)) {
+    const start = match.index ?? 0;
+    const end = start + match[0].length;
+    boundaries.add(start);
+    boundaries.add(end);
+    if (end - start > 2) boundaries.add(start + Math.floor((end - start) / 2));
+  }
+  const sorted = [...boundaries].sort((a, b) => a - b);
+  // Add a midpoint cut inside each literal span between the placeholder cuts.
+  const withLiteralCuts = new Set(sorted);
+  for (let i = 0; i + 1 < sorted.length; i++) {
+    const span = sorted[i + 1] - sorted[i];
+    if (span > 8) withLiteralCuts.add(sorted[i] + Math.floor(span / 2));
+  }
+  const cuts = [...withLiteralCuts].sort((a, b) => a - b);
+  const runs: string[] = [];
+  for (let i = 0; i + 1 < cuts.length; i++) {
+    const chunk = text.slice(cuts[i], cuts[i + 1]);
+    if (chunk.length > 0) runs.push(chunk);
+  }
+  return runs.length > 0 ? runs : [text];
+}
+
+function paragraphXml(spec: ParagraphSpec, defaultSplit: RunSplit): string {
+  const paragraph: SyntheticParagraph = typeof spec === 'string' ? { text: spec } : spec;
+  const split = paragraph.runSplit ?? defaultSplit;
+  const runs = splitIntoRuns(paragraph.text, split)
+    .map((chunk) => `<w:r><w:t xml:space="preserve">${xmlEscape(chunk)}</w:t></w:r>`)
+    .join('');
+  const pPr =
+    paragraph.numberingLevel === undefined
+      ? ''
+      : `<w:pPr><w:numPr><w:ilvl w:val="${paragraph.numberingLevel}"/><w:numId w:val="1"/></w:numPr></w:pPr>`;
+  return `<w:p>${pPr}${runs}</w:p>`;
+}
+
+/** Build the raw bytes of a minimal, valid DOCX carrying the given paragraphs. */
+export function buildSyntheticDocxBuffer(
+  paragraphs: ParagraphSpec[],
+  options: SyntheticDocxOptions = {},
+): Buffer {
+  const defaultSplit = options.runSplit ?? 'single';
+  const bodyXml = paragraphs.map((p) => paragraphXml(p, defaultSplit)).join('');
+  const documentXml =
+    '<?xml version="1.0" encoding="UTF-8"?>' +
+    `<w:document xmlns:w="${W_NS}"><w:body>${bodyXml}</w:body></w:document>`;
+
+  const zip = new AdmZip();
+  zip.addFile('[Content_Types].xml', Buffer.from(CONTENT_TYPES_XML, 'utf-8'));
+  zip.addFile('_rels/.rels', Buffer.from(ROOT_RELS_XML, 'utf-8'));
+  zip.addFile('word/_rels/document.xml.rels', Buffer.from(WORD_RELS_XML, 'utf-8'));
+  zip.addFile('word/document.xml', Buffer.from(documentXml, 'utf-8'));
+  return zip.toBuffer();
+}
+
+export interface SyntheticDocxFixture {
+  tempDir: string;
+  /** The built source document. */
+  inputPath: string;
+  /** A path in the same temp dir for the pipeline to write to. */
+  outputPath: string;
+  /** Remove the temp dir. Safe to call more than once. */
+  cleanup: () => void;
+}
+
+/** Write a synthetic DOCX into a fresh temp dir and return its paths. */
+export function createSyntheticDocxFixture(
+  paragraphs: ParagraphSpec[],
+  options: SyntheticDocxOptions & { prefix?: string } = {},
+): SyntheticDocxFixture {
+  const tempDir = mkdtempSync(join(tmpdir(), options.prefix ?? 'synthetic-docx-'));
+  const inputPath = join(tempDir, 'source.docx');
+  const outputPath = join(tempDir, 'filled.docx');
+  writeFileSync(inputPath, buildSyntheticDocxBuffer(paragraphs, options));
+  return {
+    tempDir,
+    inputPath,
+    outputPath,
+    cleanup: () => rmSync(tempDir, { recursive: true, force: true }),
+  };
+}
+
+/** Concatenate every `<w:t>` in a DOCX's main document part. */
+export function extractDocxText(docxPath: string): string {
+  const zip = new AdmZip(docxPath);
+  const entry = zip.getEntry('word/document.xml');
+  if (!entry) return '';
+  const xml = entry.getData().toString('utf-8');
+  return [...xml.matchAll(/<w:t[^>]*>([^<]*)<\/w:t>/g)].map((m) => m[1]).join('');
+}
+
+/** Per-paragraph text of a DOCX's main document part, in document order. */
+export function extractDocxParagraphTexts(docxPath: string): string[] {
+  const zip = new AdmZip(docxPath);
+  const entry = zip.getEntry('word/document.xml');
+  if (!entry) return [];
+  const xml = entry.getData().toString('utf-8');
+  return [...xml.matchAll(/<w:p[ >][\s\S]*?<\/w:p>/g)].map((m) =>
+    [...m[0].matchAll(/<w:t[^>]*>([^<]*)<\/w:t>/g)].map((t) => t[1]).join(''),
+  );
+}
+
+/** Count non-overlapping occurrences of `needle` in `haystack`. */
+export function countOccurrences(haystack: string, needle: string): number {
+  if (!needle) return 0;
+  return haystack.split(needle).length - 1;
+}

--- a/integration-tests/selections-zero-match-guard.test.ts
+++ b/integration-tests/selections-zero-match-guard.test.ts
@@ -1,0 +1,172 @@
+/**
+ * End-to-end guard against a selections option that matches zero paragraphs (#720).
+ *
+ * `processMarkerlessGroup()` used to `continue` when an option's marker matched
+ * nothing. For an UNSELECTED option that inverts the intent: "remove this
+ * alternative" silently becomes "keep it", so the filled document ships BOTH
+ * alternatives. It renders cleanly, it fills cleanly, and every existing check
+ * passes — which is exactly what makes it dangerous.
+ *
+ * A marker only has to drift by one word for this to fire, and the markers are
+ * verbatim source prose from a form that is reissued periodically, so drift is
+ * expected rather than hypothetical.
+ *
+ * The fixtures below are built with the shared synthetic DOCX builder so the
+ * alternatives sit in real clause prose rather than in isolation, and none of
+ * the prose is copied from a non-redistributable source.
+ */
+
+import { describe, expect } from 'vitest';
+import { itAllure } from './helpers/allure-test.js';
+import { CleanConfigSchema, type FieldDefinition } from '../src/core/metadata.js';
+import { runFillPipeline } from '../src/core/unified-pipeline.js';
+import type { SelectionsConfig } from '../src/core/selector.js';
+import {
+  createSyntheticDocxFixture,
+  extractDocxText,
+  type RunSplit,
+} from './helpers/synthetic-docx.js';
+
+const it = itAllure.epic('FieldSelectors');
+
+// ---------------------------------------------------------------------------
+// Fixture — invented prose carrying two mutually-exclusive alternatives.
+// ---------------------------------------------------------------------------
+
+const HEADING_PARAGRAPH =
+  'Dispute Resolution. This Agreement is governed by the laws of the State of [state].';
+
+const ARBITRATION_PARAGRAPH =
+  'Any dispute, claim or controversy arising out of this Agreement shall be resolved by ' +
+  'binding arbitration before a single arbitrator sitting in the county in which the ' +
+  'Company maintains its principal executive offices.';
+
+const COURTS_PARAGRAPH =
+  'Each party irrevocably submits to the exclusive jurisdiction of the state courts of ' +
+  '[state] for the resolution of any dispute, claim or controversy arising out of this Agreement.';
+
+const REPLACEMENTS: Record<string, string> = {
+  'laws of the State of [state]': 'laws of the State of {forum_state}',
+  'state courts of [state]': 'state courts of {forum_state}',
+};
+
+const FIELDS: FieldDefinition[] = [
+  { name: 'forum_state', type: 'string', description: 'Forum state, as a proper noun.' },
+];
+
+const VALUES = { forum_state: 'Delaware' };
+
+/** The prose actually in the fixture. */
+const ACCURATE_ARBITRATION_MARKER = 'shall be resolved by binding arbitration before a single arbitrator';
+/** One word away from it — the upstream-drift shape this guard exists to catch. */
+const DRIFTED_ARBITRATION_MARKER = 'shall be resolved by arbitration before a single arbitrator';
+
+const COURTS_MARKER = 'irrevocably submits to the exclusive jurisdiction of the state courts of';
+
+function disputeConfig(arbitrationMarker: string): SelectionsConfig {
+  return {
+    groups: [{
+      id: 'dispute_resolution',
+      type: 'radio',
+      markerless: true,
+      options: [
+        {
+          marker: arbitrationMarker,
+          trigger: { field: 'dispute_resolution_mode', equals: 'arbitration' },
+        },
+        { marker: COURTS_MARKER, trigger: 'default' },
+      ],
+    }],
+  };
+}
+
+async function runFixture(
+  selectionsConfig: SelectionsConfig,
+  options: {
+    runSplit?: RunSplit;
+    paragraphs?: string[];
+    values?: Record<string, unknown>;
+    zeroMatchPolicy?: 'error' | 'warn';
+  } = {},
+) {
+  const fixture = createSyntheticDocxFixture(
+    options.paragraphs ?? [HEADING_PARAGRAPH, ARBITRATION_PARAGRAPH, COURTS_PARAGRAPH],
+    { runSplit: options.runSplit ?? 'single', prefix: 'zero-match-guard-' },
+  );
+  try {
+    const result = await runFillPipeline({
+      inputPath: fixture.inputPath,
+      outputPath: fixture.outputPath,
+      values: { ...VALUES, ...options.values },
+      fields: FIELDS,
+      cleanPatch: { cleanConfig: CleanConfigSchema.parse({}), replacements: REPLACEMENTS },
+      selectionsConfig,
+      selectionsZeroMatchPolicy: options.zeroMatchPolicy,
+      verify: () => ({ passed: true, checks: [] }),
+    });
+    return { result, text: extractDocxText(fixture.outputPath) };
+  } finally {
+    fixture.cleanup();
+  }
+}
+
+describe('selections zero-match guard (#720)', () => {
+  it('[OA-SEL-024] an accurate marker removes the unselected alternative and reports no anomaly', async () => {
+    const { result, text } = await runFixture(disputeConfig(ACCURATE_ARBITRATION_MARKER));
+
+    expect(text).not.toContain('binding arbitration');
+    expect(text).toContain('the state courts of Delaware');
+    expect(result.warnings).toEqual([]);
+  });
+
+  for (const runSplit of ['single', 'straddle'] as RunSplit[]) {
+    it(`[OA-SEL-025] a drifted marker on the UNSELECTED alternative is reported instead of passing silently (runs: ${String(runSplit)})`, async () => {
+      const { result, text } = await runFixture(disputeConfig(DRIFTED_ARBITRATION_MARKER), { runSplit });
+
+      // The document really does carry BOTH alternatives — this is the output
+      // the pre-fix code produced with `warnings: []` and no other signal.
+      expect(text).toContain('binding arbitration before a single arbitrator');
+      expect(text).toContain('the state courts of Delaware');
+
+      // What changed is that it is no longer silent.
+      const reported = result.warnings.filter((w) => w.includes('carries BOTH alternatives'));
+      expect(reported).toHaveLength(1);
+      expect(reported[0]).toContain('dispute_resolution[0]');
+    });
+
+    it(`[OA-SEL-028] the same drift rejects the fill outright under the 'error' policy (runs: ${String(runSplit)})`, async () => {
+      await expect(
+        runFixture(disputeConfig(DRIFTED_ARBITRATION_MARKER), { runSplit, zeroMatchPolicy: 'error' }),
+      ).rejects.toThrow(/unselected option\(s\) matched zero/);
+      await expect(
+        runFixture(disputeConfig(DRIFTED_ARBITRATION_MARKER), { runSplit, zeroMatchPolicy: 'error' }),
+      ).rejects.toThrow(/dispute_resolution\[0\]/);
+    });
+  }
+
+  it('[OA-SEL-026] a group that matches nothing at all warns rather than failing the fill', async () => {
+    // Neither alternative is in this document, so nothing was left half-removed:
+    // the group simply does not apply here. That must not block a fill, because
+    // partial fixtures and variant sources legitimately produce it.
+    const { result, text } = await runFixture(disputeConfig(ACCURATE_ARBITRATION_MARKER), {
+      paragraphs: [HEADING_PARAGRAPH],
+    });
+
+    expect(text).toContain('the laws of the State of Delaware');
+    // The unselected arbitration branch is the inert-group warning; the
+    // selected courts branch is separately reported as an absent kept clause.
+    expect(result.warnings.some((w) => w.includes('dispute_resolution[0]') && w.includes('does not apply'))).toBe(true);
+    expect(result.warnings.some((w) => w.includes('dispute_resolution[1]') && w.includes('meant to be kept is absent'))).toBe(true);
+  });
+
+  it('[OA-SEL-027] a SELECTED alternative that matches nothing warns that the kept clause is absent', async () => {
+    // The arbitration branch is chosen, but the document only carries the courts
+    // clause. The chosen alternative is missing — visible, so a warning.
+    const { result } = await runFixture(disputeConfig(ACCURATE_ARBITRATION_MARKER), {
+      paragraphs: [HEADING_PARAGRAPH, COURTS_PARAGRAPH],
+      values: { dispute_resolution_mode: 'arbitration' },
+    });
+
+    expect(result.warnings.some((w) => w.includes('dispute_resolution[0]') && w.includes('meant to be kept is absent'))).toBe(true);
+  });
+});

--- a/integration-tests/selections-zero-match-guard.test.ts
+++ b/integration-tests/selections-zero-match-guard.test.ts
@@ -132,12 +132,13 @@ describe('selections zero-match guard (#720)', () => {
       const reported = result.warnings.filter((w) => w.includes('carries BOTH alternatives'));
       expect(reported).toHaveLength(1);
       expect(reported[0]).toContain('dispute_resolution[0]');
+      expect(reported[0]).toContain('[matched 0, removed 0]');
     });
 
     it(`[OA-SEL-028] the same drift rejects the fill outright under the 'error' policy (runs: ${String(runSplit)})`, async () => {
       await expect(
         runFixture(disputeConfig(DRIFTED_ARBITRATION_MARKER), { runSplit, zeroMatchPolicy: 'error' }),
-      ).rejects.toThrow(/unselected option\(s\) matched zero/);
+      ).rejects.toThrow(/unselected option\(s\) were not removed/);
       await expect(
         runFixture(disputeConfig(DRIFTED_ARBITRATION_MARKER), { runSplit, zeroMatchPolicy: 'error' }),
       ).rejects.toThrow(/dispute_resolution\[0\]/);

--- a/integration-tests/selector-contracts.test.ts
+++ b/integration-tests/selector-contracts.test.ts
@@ -363,6 +363,12 @@ describeWithSource('SPA agreement date + dispute-resolution alternatives (#619)'
       });
 
       const text = textOf(outputPath);
+      // NOTE (#721): the three assertions below are the higher-fidelity, source-gated
+      // version of these checks and only run when a cached NVCA source is present. The
+      // same clause SHAPES — a shared `District of` literal prefix across two adjacent
+      // alternatives, and a proper noun that must survive substitution — are covered on
+      // every CI job by paraphrased synthetic fixtures in
+      // `integration-tests/synthetic-clause-shape-contracts.test.ts`.
       // The courts alternative is present and carries the supplied district.
       // Proper-noun forum state (#2391): "state courts of California", no longer lowercase.
       expect(text).toContain('irrevocably and unconditionally submit to the jurisdiction of the state courts of California');

--- a/integration-tests/synthetic-clause-shape-contracts.test.ts
+++ b/integration-tests/synthetic-clause-shape-contracts.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Synthetic clause-SHAPE rendering contracts (#721).
+ *
+ * open-agreements#707 added assertions for two real rendering defects found in a
+ * clean-room fill — a doubled `District of Northern District of California` and
+ * a lower-cased `state courts of california`. Those assertions live under
+ * `describeWithCoiSource` / `describeWithSource` in `selector-contracts.test.ts`,
+ * which resolve to `describe.skip` unless a cached NVCA source is on disk. The
+ * source is non-redistributable, so it is never on a CI runner and both
+ * regressions were effectively unguarded.
+ *
+ * The pre-existing synthetic builder could not cover them either: it emits every
+ * placeholder ALONE in its own paragraph, and both defects are properties of the
+ * literal text AROUND the placeholder.
+ *
+ * This file closes that gap with fixtures built from `helpers/synthetic-docx.ts`,
+ * which takes real paragraph prose with embedded placeholders. Everything here
+ * runs on every CI job. The source-gated assertions stay in place as the
+ * higher-fidelity check when a cached source exists; these are additive.
+ *
+ * ## The prose is paraphrased on purpose
+ *
+ * The NVCA forms are non-redistributable. Not one sentence below is copied from
+ * them. Each is an invented, equivalent-SHAPED sentence that exercises the same
+ * binding mechanics: a shared literal prefix across two adjacent bracketed
+ * alternatives, a context-anchored key, and a proper noun that has to survive
+ * substitution.
+ *
+ * ## Why these tests are load-bearing
+ *
+ * Each shape is asserted twice: once against the CORRECTED binding map (the
+ * shape upstream legal-explainer#2394 landed) and once against the LEGACY map
+ * that produced the defect. The legacy run asserts the defect REPRODUCES. A
+ * fixture that cannot produce the bug cannot guard against its return, so that
+ * proof is checked in rather than performed by hand once.
+ */
+
+import { describe, expect } from 'vitest';
+import { itAllure } from './helpers/allure-test.js';
+import { CleanConfigSchema, type FieldDefinition } from '../src/core/metadata.js';
+import { runFillPipeline } from '../src/core/unified-pipeline.js';
+import {
+  ALL_RUN_SPLITS,
+  countOccurrences,
+  createSyntheticDocxFixture,
+  extractDocxText,
+  runSplitLabel,
+  type RunSplit,
+} from './helpers/synthetic-docx.js';
+
+const it = itAllure.epic('FieldSelectors');
+
+// ---------------------------------------------------------------------------
+// Fixture prose — invented, NOT NVCA text. Shape-equivalent only.
+// ---------------------------------------------------------------------------
+
+/**
+ * Forum-selection clause. Carries two of the three shapes at once:
+ *
+ *  - a proper noun (`[state]`) inside a lower-case carrier phrase
+ *    ("…the state courts of [state]…"), which must render `California`, not
+ *    `california`;
+ *  - two ADJACENT bracketed alternatives that share the literal prefix
+ *    "District Court for the District of ", each of which must bind to its own
+ *    key and must absorb that prefix so a full district value does not double
+ *    it into "District of Northern District of California".
+ */
+const FORUM_PARAGRAPH =
+  'Governing Law and Forum. This Agreement is governed by the laws of the State of [state], ' +
+  'without regard to its conflict of laws principles. Each party irrevocably submits to the ' +
+  'exclusive jurisdiction of the state courts of [state] and, for any action that may properly ' +
+  'be brought in a federal forum, [to the U.S. District Court for the District of [_____]] ' +
+  '[to the United States District Court for the District of [judicial district]], in each case ' +
+  'sitting in that state.';
+
+/**
+ * Price-adjustment clause. Carries the third shape: a context-absorbing key
+ * (`"[or decrease] > [specify percentage]"`) that has to claim the SECOND of two
+ * identical placeholders without re-emitting — and so doubling — the `[or
+ * decrease]` literal it anchors on. A plain simple key then sweeps the first.
+ */
+const ADJUSTMENT_PARAGRAPH =
+  'Price Adjustment. No adjustment shall be made for any change of less than [specify percentage]. ' +
+  'The per share purchase price shall be proportionately adjusted for any increase [or decrease] ' +
+  'in the number of outstanding shares of [specify percentage] or more effected after the date of ' +
+  'this Agreement.';
+
+const FIXTURE_PARAGRAPHS = [FORUM_PARAGRAPH, ADJUSTMENT_PARAGRAPH];
+
+// ---------------------------------------------------------------------------
+// Binding maps
+// ---------------------------------------------------------------------------
+
+/**
+ * The corrected binding shape. Each key absorbs exactly the literal that its
+ * value re-emits, and the forum state binds to the proper-noun field.
+ */
+const CORRECTED_REPLACEMENTS: Record<string, string> = {
+  'laws of the State of [state]': 'laws of the State of {forum_state}',
+  'state courts of [state]': 'state courts of {forum_state}',
+  'U.S. District Court for the District of [_____]': 'U.S. District Court for the {judicial_district}',
+  'District Court for the District of [judicial district]': 'District Court for the {judicial_district}',
+  '[or decrease] > [specify percentage]': '{adjustment_threshold}',
+  '[specify percentage]': '{de_minimis_threshold}',
+};
+
+/**
+ * The binding shape BEFORE the upstream fix. Two defects, both invisible to a
+ * fixture that isolates its placeholders:
+ *
+ *  - `[state]` binds to the lower-cased audit field, so the proper noun is lost;
+ *  - `[judicial district]` binds bare, leaving the literal `District of ` in
+ *    front of a value that already begins with `Northern District of`.
+ */
+const LEGACY_REPLACEMENTS: Record<string, string> = {
+  'laws of the State of [state]': 'laws of the State of {forum_state}',
+  'state courts of [state]': 'state courts of {forum_state_lower}',
+  '[_____]': '{judicial_district}',
+  '[judicial district]': '{judicial_district}',
+  '[or decrease] > [specify percentage]': '{adjustment_threshold}',
+  '[specify percentage]': '{de_minimis_threshold}',
+};
+
+const FIELDS: FieldDefinition[] = [
+  { name: 'forum_state', type: 'string', description: 'Forum state, as a proper noun.' },
+  { name: 'forum_state_lower', type: 'string', description: 'Lower-cased forum state (audit input).' },
+  { name: 'judicial_district', type: 'string', description: 'Federal judicial district, full name.' },
+  { name: 'adjustment_threshold', type: 'string', description: 'Adjustment trigger threshold.' },
+  { name: 'de_minimis_threshold', type: 'string', description: 'De minimis change threshold.' },
+];
+
+const VALUES = {
+  forum_state: 'California',
+  forum_state_lower: 'california',
+  judicial_district: 'Northern District of California',
+  adjustment_threshold: 'five percent (5%)',
+  de_minimis_threshold: 'one percent (1%)',
+};
+
+/**
+ * Build the fixture at the given run split, push it through the real
+ * clean → patch → fill pipeline, and return the rendered text.
+ */
+async function renderFixture(
+  replacements: Record<string, string>,
+  runSplit: RunSplit,
+): Promise<string> {
+  const fixture = createSyntheticDocxFixture(FIXTURE_PARAGRAPHS, {
+    runSplit,
+    prefix: 'clause-shape-',
+  });
+  try {
+    await runFillPipeline({
+      inputPath: fixture.inputPath,
+      outputPath: fixture.outputPath,
+      values: VALUES,
+      fields: FIELDS,
+      cleanPatch: { cleanConfig: CleanConfigSchema.parse({}), replacements },
+      verify: () => ({ passed: true, checks: [] }),
+    });
+    return extractDocxText(fixture.outputPath);
+  } finally {
+    fixture.cleanup();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The corrected binding shape renders correctly — at every run split.
+// ---------------------------------------------------------------------------
+
+describe('synthetic clause-shape rendering contracts (#721)', () => {
+  for (const runSplit of ALL_RUN_SPLITS) {
+    const label = runSplitLabel(runSplit);
+
+    it(`[OA-SEL-030] a proper noun survives substitution into a lower-case carrier phrase (runs: ${label})`, async () => {
+      const text = await renderFixture(CORRECTED_REPLACEMENTS, runSplit);
+
+      expect(text).toContain('the state courts of California');
+      expect(text).not.toContain('state courts of california');
+      expect(text).toContain('the laws of the State of California');
+      expect(text).not.toContain('[state]');
+    });
+
+    it(`[OA-SEL-031] two adjacent alternatives sharing a literal prefix each absorb it exactly once (runs: ${label})`, async () => {
+      const text = await renderFixture(CORRECTED_REPLACEMENTS, runSplit);
+
+      // Both alternatives render their own full district name…
+      expect(text).toContain('U.S. District Court for the Northern District of California');
+      expect(text).toContain('United States District Court for the Northern District of California');
+      // …and neither doubles the shared `District of` prefix.
+      expect(text).not.toContain('District of Northern District');
+      expect(countOccurrences(text, 'Northern District of California')).toBe(2);
+      expect(countOccurrences(text, 'District of Northern District of California')).toBe(0);
+      // No source placeholder survives either alternative.
+      expect(text).not.toContain('[_____]');
+      expect(text).not.toContain('[judicial district]');
+    });
+
+    it(`[OA-SEL-032] a context-anchored key claims the right occurrence without doubling its anchor literal (runs: ${label})`, async () => {
+      const text = await renderFixture(CORRECTED_REPLACEMENTS, runSplit);
+
+      // The context key claimed the occurrence AFTER `[or decrease]`; the simple
+      // key swept the one before it. Neither claimed the other's target.
+      expect(text).toContain('any change of less than one percent (1%)');
+      expect(text).toContain('outstanding shares of five percent (5%) or more');
+      // The anchor literal is still present exactly once — it is absorbed for
+      // matching, not re-emitted alongside the value.
+      expect(countOccurrences(text, '[or decrease]')).toBe(1);
+      expect(text).not.toContain('[specify percentage]');
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// The fixture is load-bearing: the legacy binding shape still reproduces the
+// defects. A regression test that passes against the unfixed code is worthless,
+// so this proof is checked in rather than run by hand once.
+// ---------------------------------------------------------------------------
+
+describe('the synthetic fixture reproduces the pre-fix defect shape (#721)', () => {
+  it('[OA-SEL-033] the legacy `[state]` binding renders the lower-cased forum state the fixture must catch', async () => {
+    const text = await renderFixture(LEGACY_REPLACEMENTS, 'single');
+
+    expect(text).toContain('state courts of california');
+    expect(text).not.toContain('the state courts of California');
+  });
+
+  it('[OA-SEL-034] the legacy bare `[judicial district]` binding doubles the shared `District of` prefix', async () => {
+    const text = await renderFixture(LEGACY_REPLACEMENTS, 'single');
+
+    expect(text).toContain('District of Northern District of California');
+    expect(countOccurrences(text, 'District of Northern District of California')).toBeGreaterThan(0);
+  });
+
+  it('[OA-SEL-035] the defect also reproduces when the placeholder straddles runs', async () => {
+    const text = await renderFixture(LEGACY_REPLACEMENTS, 'straddle');
+
+    expect(text).toContain('state courts of california');
+    expect(text).toContain('District of Northern District of California');
+  });
+});

--- a/src/core/selector.test.ts
+++ b/src/core/selector.test.ts
@@ -7,7 +7,12 @@ import { join } from 'node:path';
 import { afterEach, describe, expect } from 'vitest';
 import AdmZip from 'adm-zip';
 import { DOMParser } from '@xmldom/xmldom';
-import { applySelections, SelectionsConfigSchema } from './selector.js';
+import {
+  applySelections,
+  classifySelectionMatches,
+  describeSelectionOption,
+  SelectionsConfigSchema,
+} from './selector.js';
 import type { SelectionsConfig } from './selector.js';
 import { itAllure } from '../../integration-tests/helpers/allure-test.js';
 
@@ -811,5 +816,193 @@ describe('replaceWith strips orphaned field constructs', () => {
     // Placeholder is not silently dropped despite there being no <w:t> left after stripping.
     expect(text).toContain('[Reserved]');
     expect(text).not.toContain('Exhibit A');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Zero-match reporting (#720)
+//
+// `processMarkerlessGroup()` used to `continue` when an option's marker matched
+// nothing. For an UNSELECTED option that inverts the intent: "remove this
+// alternative" silently becomes "keep it", and the filled document ships BOTH
+// alternatives — a legally wrong document that renders cleanly and passes every
+// other check. `applySelections()` now returns per-option match counts so the
+// caller can reject that outcome.
+// ---------------------------------------------------------------------------
+
+describe('selections zero-match reporting (#720)', () => {
+  /**
+   * Two mutually-exclusive dispute-resolution alternatives in one document.
+   * `driftedArbitrationMarker` reproduces upstream source drift: the config's
+   * marker for the arbitration alternative is one word away from the prose that
+   * is actually in the document.
+   */
+  function twoAlternativeDoc(): string {
+    return `
+      ${para('Governing Law. This Agreement is governed by the laws of the State of Delaware.')}
+      ${para('Any dispute arising under this Agreement shall be resolved by binding arbitration before a single arbitrator.')}
+      ${para('Each party irrevocably submits to the jurisdiction of the state courts of Delaware for any dispute arising under this Agreement.')}
+    `;
+  }
+
+  function disputeConfig(arbitrationMarker: string): SelectionsConfig {
+    return {
+      groups: [{
+        id: 'dispute_resolution',
+        type: 'radio',
+        markerless: true,
+        options: [
+          {
+            marker: arbitrationMarker,
+            trigger: { field: 'dispute_resolution_mode', equals: 'arbitration' },
+          },
+          {
+            marker: 'irrevocably submits to the jurisdiction of the state courts of',
+            trigger: 'default',
+          },
+        ],
+      }],
+    };
+  }
+
+  const ACCURATE_ARBITRATION_MARKER = 'shall be resolved by binding arbitration before a single arbitrator';
+  // One word drifted ("binding" dropped) — exactly how an NVCA reissue breaks a marker.
+  const DRIFTED_ARBITRATION_MARKER = 'shall be resolved by arbitration before a single arbitrator';
+
+  it('[OA-SEL-020] reports a per-option match count and selected flag for every option', async () => {
+    const inputPath = buildTestDocx(twoAlternativeDoc());
+    const outputPath = join(makeTempDir(), 'out.docx');
+
+    const result = await applySelections(
+      inputPath,
+      outputPath,
+      disputeConfig(ACCURATE_ARBITRATION_MARKER),
+      {},
+    );
+
+    expect(result.outputPath).toBe(outputPath);
+    expect(result.options).toHaveLength(2);
+    expect(result.options[0]).toMatchObject({
+      groupId: 'dispute_resolution',
+      optionIndex: 0,
+      selected: false,
+      matchCount: 1,
+    });
+    expect(result.options[1]).toMatchObject({
+      groupId: 'dispute_resolution',
+      optionIndex: 1,
+      selected: true,
+      matchCount: 1,
+    });
+    // Sanity: with an accurate marker the unselected alternative really is removed.
+    expect(extractText(outputPath)).not.toContain('binding arbitration');
+  });
+
+  it('[OA-SEL-021] a drifted marker on an UNSELECTED option reports zero matches and leaves BOTH alternatives in the document', async () => {
+    const inputPath = buildTestDocx(twoAlternativeDoc());
+    const outputPath = join(makeTempDir(), 'out.docx');
+
+    const result = await applySelections(
+      inputPath,
+      outputPath,
+      disputeConfig(DRIFTED_ARBITRATION_MARKER),
+      {},
+    );
+
+    // This is the silent failure the guard exists to catch: the arbitration
+    // alternative was meant to be deleted and is still there, alongside the
+    // courts alternative that was selected.
+    const text = extractText(outputPath);
+    expect(text).toContain('binding arbitration before a single arbitrator');
+    expect(text).toContain('state courts of Delaware');
+
+    // …and it is now visible in the returned result rather than silent.
+    expect(result.options[0]).toMatchObject({ optionIndex: 0, selected: false, matchCount: 0 });
+    expect(result.options[1]).toMatchObject({ optionIndex: 1, selected: true, matchCount: 1 });
+
+    const anomalies = classifySelectionMatches(result);
+    expect(anomalies.unselectedZeroMatchInEngagedGroup).toHaveLength(1);
+    expect(anomalies.unselectedZeroMatchInEngagedGroup[0].optionIndex).toBe(0);
+    expect(anomalies.unselectedZeroMatchInInertGroup).toHaveLength(0);
+    expect(anomalies.selectedZeroMatch).toHaveLength(0);
+    expect(describeSelectionOption(anomalies.unselectedZeroMatchInEngagedGroup[0]))
+      .toContain('dispute_resolution[0]');
+  });
+
+  it('[OA-SEL-022] a group where NO option matches is classified as inert, not as the dangerous case', async () => {
+    // A document that carries neither alternative — a partial fixture or a
+    // different source variant. Nothing was left half-removed.
+    const inputPath = buildTestDocx(`${para('Governing Law. This Agreement is governed by the laws of the State of Delaware.')}`);
+    const outputPath = join(makeTempDir(), 'out.docx');
+
+    const result = await applySelections(
+      inputPath,
+      outputPath,
+      disputeConfig(ACCURATE_ARBITRATION_MARKER),
+      { dispute_resolution_mode: 'arbitration' },
+    );
+
+    const anomalies = classifySelectionMatches(result);
+    expect(anomalies.unselectedZeroMatchInEngagedGroup).toHaveLength(0);
+    expect(anomalies.unselectedZeroMatchInInertGroup).toHaveLength(1);
+    expect(anomalies.unselectedZeroMatchInInertGroup[0].optionIndex).toBe(1);
+    // The SELECTED option also matched nothing — reported separately, because a
+    // missing kept-alternative fails visibly rather than silently.
+    expect(anomalies.selectedZeroMatch).toHaveLength(1);
+    expect(anomalies.selectedZeroMatch[0].optionIndex).toBe(0);
+  });
+
+  it('[OA-SEL-023] reports match counts for standalone and cell-based groups too', async () => {
+    const body = `
+      ${para('Additional Closings. The Company may sell additional shares after the Initial Closing.')}
+    `;
+    const inputPath = buildTestDocx(body);
+    const outputPath = join(makeTempDir(), 'out.docx');
+
+    const config: SelectionsConfig = {
+      groups: [
+        {
+          id: 'additional_closings',
+          type: 'checkbox',
+          markerless: true,
+          options: [{ marker: 'Additional Closings', trigger: { field: 'closing_type', equals: 'additional' } }],
+        },
+        {
+          // A cell-based group whose markers are nowhere in this document.
+          id: 'cell_based_group',
+          type: 'radio',
+          cellContext: 'Interest Rate',
+          options: [
+            { marker: 'Fixed rate', trigger: { field: 'rate_mode', equals: 'fixed' } },
+            { marker: 'Floating rate', trigger: 'default' },
+          ],
+        },
+        {
+          id: 'standalone_group',
+          type: 'checkbox',
+          standalone: true,
+          options: [{ marker: 'Optional covenant', trigger: { field: 'include_covenant', equals: true } }],
+        },
+      ],
+    };
+
+    const result = await applySelections(inputPath, outputPath, config, {});
+
+    // Every (group, option) pair is reported, in config order, even for groups
+    // that returned early without touching the document.
+    expect(result.options.map((o) => `${o.groupId}[${o.optionIndex}]`)).toEqual([
+      'additional_closings[0]',
+      'cell_based_group[0]',
+      'cell_based_group[1]',
+      'standalone_group[0]',
+    ]);
+    expect(result.options[0].matchCount).toBe(1);
+    expect(result.options[1].matchCount).toBe(0);
+    expect(result.options[2].matchCount).toBe(0);
+    expect(result.options[3].matchCount).toBe(0);
+
+    const anomalies = classifySelectionMatches(result);
+    // No group is both engaged and half-removed, so nothing is the dangerous case.
+    expect(anomalies.unselectedZeroMatchInEngagedGroup).toHaveLength(0);
   });
 });

--- a/src/core/selector.test.ts
+++ b/src/core/selector.test.ts
@@ -921,11 +921,11 @@ describe('selections zero-match reporting (#720)', () => {
     expect(result.options[1]).toMatchObject({ optionIndex: 1, selected: true, matchCount: 1 });
 
     const anomalies = classifySelectionMatches(result);
-    expect(anomalies.unselectedZeroMatchInEngagedGroup).toHaveLength(1);
-    expect(anomalies.unselectedZeroMatchInEngagedGroup[0].optionIndex).toBe(0);
-    expect(anomalies.unselectedZeroMatchInInertGroup).toHaveLength(0);
+    expect(anomalies.unremovedInEngagedGroup).toHaveLength(1);
+    expect(anomalies.unremovedInEngagedGroup[0].optionIndex).toBe(0);
+    expect(anomalies.unremovedInInertGroup).toHaveLength(0);
     expect(anomalies.selectedZeroMatch).toHaveLength(0);
-    expect(describeSelectionOption(anomalies.unselectedZeroMatchInEngagedGroup[0]))
+    expect(describeSelectionOption(anomalies.unremovedInEngagedGroup[0]))
       .toContain('dispute_resolution[0]');
   });
 
@@ -943,9 +943,9 @@ describe('selections zero-match reporting (#720)', () => {
     );
 
     const anomalies = classifySelectionMatches(result);
-    expect(anomalies.unselectedZeroMatchInEngagedGroup).toHaveLength(0);
-    expect(anomalies.unselectedZeroMatchInInertGroup).toHaveLength(1);
-    expect(anomalies.unselectedZeroMatchInInertGroup[0].optionIndex).toBe(1);
+    expect(anomalies.unremovedInEngagedGroup).toHaveLength(0);
+    expect(anomalies.unremovedInInertGroup).toHaveLength(1);
+    expect(anomalies.unremovedInInertGroup[0].optionIndex).toBe(1);
     // The SELECTED option also matched nothing — reported separately, because a
     // missing kept-alternative fails visibly rather than silently.
     expect(anomalies.selectedZeroMatch).toHaveLength(1);
@@ -1003,6 +1003,50 @@ describe('selections zero-match reporting (#720)', () => {
 
     const anomalies = classifySelectionMatches(result);
     // No group is both engaged and half-removed, so nothing is the dangerous case.
-    expect(anomalies.unselectedZeroMatchInEngagedGroup).toHaveLength(0);
+    expect(anomalies.unremovedInEngagedGroup).toHaveLength(0);
+  });
+
+  it('[OA-SEL-029] a cell-based group whose options live in DIFFERENT cells is caught even though both markers match', async () => {
+    // Found in peer review of #720. `processGroup()` needs every option of a
+    // cell-based group to appear in ONE table cell. When they are split across
+    // cells it resolves no qualifying cell, returns without touching anything,
+    // and BOTH alternatives survive — while every option still reports a
+    // non-zero match count. Keying the guard on matchCount alone would have
+    // reported nothing here, which is the exact silent-corruption shape #720
+    // exists to eliminate.
+    const body =
+      `<w:tbl xmlns:w="${W_NS}"><w:tr>` +
+      `<w:tc>${para('( ) Alternative A: the parties will arbitrate.')}</w:tc>` +
+      `<w:tc>${para('( ) Alternative B: the parties will litigate.')}</w:tc>` +
+      `</w:tr></w:tbl>`;
+    const inputPath = buildTestDocx(body);
+    const outputPath = join(makeTempDir(), 'out.docx');
+
+    const config: SelectionsConfig = {
+      groups: [{
+        id: 'split_cells',
+        type: 'radio',
+        options: [
+          { marker: 'Alternative A', trigger: { field: 'choice', equals: 'a' } },
+          { marker: 'Alternative B', trigger: 'default' },
+        ],
+      }],
+    };
+
+    const result = await applySelections(inputPath, outputPath, config, {});
+
+    // Nothing was removed: the document really does still carry both.
+    const text = extractText(outputPath);
+    expect(text).toContain('Alternative A');
+    expect(text).toContain('Alternative B');
+
+    // Both options matched, and neither was acted on.
+    expect(result.options[0]).toMatchObject({ optionIndex: 0, selected: false, matchCount: 1, appliedCount: 0 });
+    expect(result.options[1]).toMatchObject({ optionIndex: 1, selected: true, matchCount: 1, appliedCount: 0 });
+
+    const anomalies = classifySelectionMatches(result);
+    expect(anomalies.unremovedInEngagedGroup).toHaveLength(1);
+    expect(anomalies.unremovedInEngagedGroup[0].optionIndex).toBe(0);
+    expect(anomalies.selectedZeroMatch).toHaveLength(0);
   });
 });

--- a/src/core/selector.ts
+++ b/src/core/selector.ts
@@ -307,6 +307,25 @@ export interface SelectionOptionReport {
   selected: boolean;
   /** Paragraphs whose text contained the option marker, summed across parts. */
   matchCount: number;
+  /**
+   * Paragraphs this option's own removal / replacement / marking logic actually
+   * ACTED ON, summed across parts.
+   *
+   * This is not the same as `matchCount`, and the gap is where the silent
+   * failures live. An option can match paragraphs and still be acted on zero
+   * times: a cell-based group whose options turn out to live in DIFFERENT table
+   * cells resolves no qualifying cell, returns without touching anything, and
+   * leaves every alternative in place — with a non-zero match count for each.
+   * The inline markerless path can likewise match a paragraph and then fail to
+   * splice it. Both leave a document carrying both alternatives, so the
+   * classification below keys the dangerous case on this field, not on
+   * `matchCount`.
+   *
+   * A SELECTED option is normally acted on zero times in the markerless paths
+   * (it is kept as-is), so a zero here is only meaningful for an UNSELECTED
+   * option.
+   */
+  appliedCount: number;
 }
 
 export interface SelectionsResult {
@@ -326,18 +345,23 @@ export interface SelectionsResult {
 export interface SelectionAnomalies {
   /**
    * The dangerous case (#720). The option was NOT selected — the intent was
-   * "remove this alternative" — yet its marker matched nothing, while a sibling
-   * option in the same group did match. The group is present in the document,
-   * so this option's alternative is almost certainly still there under drifted
-   * marker text, and the filled document keeps BOTH alternatives.
+   * "remove this alternative" — yet nothing was removed for it, while a sibling
+   * option in the same group DID match. The group is demonstrably present in
+   * the document, so its alternative is still there and the filled document
+   * keeps BOTH alternatives.
+   *
+   * Two distinct faults land here: a marker that drifted away from source prose
+   * that is still present (zero matches), and a group that matched but resolved
+   * no location to act on (matches, zero applied — e.g. a cell-based group
+   * whose options sit in different table cells).
    */
-  unselectedZeroMatchInEngagedGroup: SelectionOptionReport[];
+  unremovedInEngagedGroup: SelectionOptionReport[];
   /**
-   * The whole group matched nothing. Either the group does not apply to this
+   * Nothing in the whole group matched. Either the group does not apply to this
    * document (partial fixtures, variant sources) or the entire clause moved.
    * Nothing was left half-removed, so this is advisory.
    */
-  unselectedZeroMatchInInertGroup: SelectionOptionReport[];
+  unremovedInInertGroup: SelectionOptionReport[];
   /**
    * The option WAS selected but matched nothing, so the alternative meant to be
    * kept is absent. Suspicious, but it fails visibly (a missing clause) rather
@@ -351,7 +375,7 @@ export function describeSelectionOption(o: SelectionOptionReport): string {
   return `${o.groupId}[${o.optionIndex}] "${o.marker}"`;
 }
 
-/** Split a selections run's per-option match counts into the three anomaly classes. */
+/** Split a selections run's per-option counts into the three anomaly classes. */
 export function classifySelectionMatches(result: SelectionsResult): SelectionAnomalies {
   const engagedGroups = new Set<string>();
   for (const o of result.options) {
@@ -359,19 +383,25 @@ export function classifySelectionMatches(result: SelectionsResult): SelectionAno
   }
 
   const anomalies: SelectionAnomalies = {
-    unselectedZeroMatchInEngagedGroup: [],
-    unselectedZeroMatchInInertGroup: [],
+    unremovedInEngagedGroup: [],
+    unremovedInInertGroup: [],
     selectedZeroMatch: [],
   };
 
   for (const o of result.options) {
-    if (o.matchCount > 0) continue;
     if (o.selected) {
-      anomalies.selectedZeroMatch.push(o);
-    } else if (engagedGroups.has(o.groupId)) {
-      anomalies.unselectedZeroMatchInEngagedGroup.push(o);
+      // A selected option is supposed to survive, so `appliedCount` says nothing
+      // about it in the markerless paths. Only its absence matters.
+      if (o.matchCount === 0) anomalies.selectedZeroMatch.push(o);
+      continue;
+    }
+    // An unselected option is supposed to DISAPPEAR. The question is therefore
+    // "was anything actually done about it", not "did its marker match".
+    if (o.appliedCount > 0) continue;
+    if (engagedGroups.has(o.groupId)) {
+      anomalies.unremovedInEngagedGroup.push(o);
     } else {
-      anomalies.unselectedZeroMatchInInertGroup.push(o);
+      anomalies.unremovedInInertGroup.push(o);
     }
   }
 
@@ -403,7 +433,25 @@ function recordOptionMatches(
       marker: group.options[oi].marker,
       selected: selectedIndices.has(oi),
       matchCount: counts[oi] ?? 0,
+      appliedCount: 0,
     });
+  }
+}
+
+/**
+ * Add to the "paragraphs actually acted on" tally. Split from
+ * `recordOptionMatches` because a processor learns its match counts up front —
+ * before the early returns that must not lose them — but only learns what it
+ * acted on at the end.
+ */
+function recordOptionApplied(
+  stats: OptionStats,
+  group: z.infer<typeof GroupSchema>,
+  applied: number[],
+): void {
+  for (let oi = 0; oi < group.options.length; oi++) {
+    const existing = stats.get(`${group.id}::${oi}`);
+    if (existing) existing.appliedCount += applied[oi] ?? 0;
   }
 }
 
@@ -513,6 +561,9 @@ function processGroup(
 
   // Record match counts before any early return or throw below (#720), so a
   // group that finds no qualifying cell still reports which options matched.
+  // `appliedCount` stays 0 on those paths, which is the point: a group that
+  // resolves no qualifying cell removes NOTHING while every option still
+  // reports a non-zero match count, and the document keeps both alternatives.
   recordOptionMatches(
     stats,
     group,
@@ -617,6 +668,7 @@ function processGroup(
   // Step 5 & 6: Remove unselected options + sub-clauses, mark selected as checked
   let madeChanges = false;
   const parasToRemove = new Set<Element>();
+  const appliedCounts: number[] = group.options.map(() => 0);
 
   for (const item of classified) {
     if (item.ownerOptionIndex === -1) continue; // header — always keep
@@ -625,16 +677,19 @@ function processGroup(
       // Selected: mark the option paragraph as checked
       if (item.isOption) {
         setChecked(item.para, group.type);
+        appliedCounts[item.ownerOptionIndex]++;
         madeChanges = true;
       }
     } else {
       // Unselected: collect for bookmark-aware removal
       parasToRemove.add(item.para);
+      appliedCounts[item.ownerOptionIndex]++;
       madeChanges = true;
     }
   }
 
   removeWithBookmarkCleanup(doc, parasToRemove);
+  recordOptionApplied(stats, group, appliedCounts);
 
   // Ensure at least one <w:p> remains in the cell (OOXML requirement)
   const remainingParas = cell.getElementsByTagNameNS(W_NS, 'p');
@@ -705,6 +760,7 @@ function processStandaloneGroup(
   const allParagraphs = doc.getElementsByTagNameNS(W_NS, 'p');
   const selectedIndices = evaluateTriggers(group, data);
   const matchCounts: number[] = group.options.map(() => 0);
+  const appliedCounts: number[] = group.options.map(() => 0);
   let madeChanges = false;
 
   for (let oi = 0; oi < group.options.length; oi++) {
@@ -759,9 +815,14 @@ function processStandaloneGroup(
       }
       madeChanges = true;
     }
+    // One paragraph is acted on per option here: the first match is marked or
+    // removed. `matchCount > appliedCount` therefore means duplicate marker
+    // matches survived untouched, which the caller can see.
+    appliedCounts[oi]++;
   }
 
   recordOptionMatches(stats, group, selectedIndices, matchCounts);
+  recordOptionApplied(stats, group, appliedCounts);
   return madeChanges;
 }
 
@@ -840,6 +901,7 @@ function processMarkerlessGroup(
 ): boolean {
   const selectedIndices = evaluateTriggers(group, data);
   const matchCounts: number[] = group.options.map(() => 0);
+  const appliedCounts: number[] = group.options.map(() => 0);
   let madeChanges = false;
   const parasToRemove = new Set<Element>();
 
@@ -879,12 +941,17 @@ function processMarkerlessGroup(
         const globalPara = markerPara as unknown as globalThis.Element;
         let text = normalizeQuotes(getParagraphText(globalPara));
         let safety = 0;
+        // Tracked separately from `madeChanges` so a paragraph that matched but
+        // could not be spliced (both the range edit and the fallback failed)
+        // is reported as unremoved rather than silently kept (#720).
+        let paraEdited = false;
         while (safety++ < 50) {
           const idx = text.indexOf(normalizedMarker);
           if (idx === -1) break;
           try {
             replaceParagraphTextRange(globalPara, idx, idx + normalizedMarker.length, replacement);
             madeChanges = true;
+            paraEdited = true;
           } catch (e) {
             if (e instanceof SafeDocxError) {
               // Fallback: formatting-destructive text splice via xmldom w:t elements
@@ -894,12 +961,14 @@ function processMarkerlessGroup(
                 const newText = rawText.slice(0, rawIdx) + replacement + rawText.slice(rawIdx + normalizedMarker.length);
                 replaceParagraphText(markerPara, newText);
                 madeChanges = true;
+                paraEdited = true;
               }
             }
             break;
           }
           text = normalizeQuotes(getParagraphText(globalPara));
         }
+        if (paraEdited) appliedCounts[oi]++;
       }
       continue;
     }
@@ -960,6 +1029,7 @@ function processMarkerlessGroup(
       for (const p of subClauses) {
         parasToRemove.add(p);
       }
+      appliedCounts[oi]++;
       madeChanges = true;
     }
   }
@@ -967,7 +1037,13 @@ function processMarkerlessGroup(
   // Deferred removal with bookmark cleanup
   removeWithBookmarkCleanup(doc, parasToRemove);
 
+  // NOTE on ordering: options are matched against the document as it stands
+  // when their turn comes, so an earlier option's replacement can change a
+  // later option's `matchCount`. That is deliberate — the counts describe what
+  // the processor actually saw, so `matchCount` and `appliedCount` stay
+  // consistent and cannot manufacture a phantom "matched but never removed".
   recordOptionMatches(stats, group, selectedIndices, matchCounts);
+  recordOptionApplied(stats, group, appliedCounts);
   return madeChanges;
 }
 

--- a/src/core/selector.ts
+++ b/src/core/selector.ts
@@ -290,6 +290,124 @@ function triggerFires(trigger: Trigger, data: Record<string, unknown>): boolean 
 }
 
 // ---------------------------------------------------------------------------
+// Match reporting (#720)
+// ---------------------------------------------------------------------------
+
+/**
+ * How many paragraphs one option's marker matched, and whether the option was
+ * selected. Counts are summed across every text part of the document
+ * (document.xml plus headers/footers), because an option legitimately lives in
+ * exactly one of them.
+ */
+export interface SelectionOptionReport {
+  groupId: string;
+  optionIndex: number;
+  marker: string;
+  /** True when the option's trigger fired (or it is the default fallback). */
+  selected: boolean;
+  /** Paragraphs whose text contained the option marker, summed across parts. */
+  matchCount: number;
+}
+
+export interface SelectionsResult {
+  outputPath: string;
+  /** One entry per (group, option), in config order. */
+  options: SelectionOptionReport[];
+}
+
+/**
+ * Classification of zero-match options.
+ *
+ * A group is "engaged" when at least one of its options matched at least one
+ * paragraph: the document demonstrably contains this group's alternatives.
+ * That distinction is what makes the dangerous case separable from the benign
+ * one — see `unselectedZeroMatchInEngagedGroup` below.
+ */
+export interface SelectionAnomalies {
+  /**
+   * The dangerous case (#720). The option was NOT selected — the intent was
+   * "remove this alternative" — yet its marker matched nothing, while a sibling
+   * option in the same group did match. The group is present in the document,
+   * so this option's alternative is almost certainly still there under drifted
+   * marker text, and the filled document keeps BOTH alternatives.
+   */
+  unselectedZeroMatchInEngagedGroup: SelectionOptionReport[];
+  /**
+   * The whole group matched nothing. Either the group does not apply to this
+   * document (partial fixtures, variant sources) or the entire clause moved.
+   * Nothing was left half-removed, so this is advisory.
+   */
+  unselectedZeroMatchInInertGroup: SelectionOptionReport[];
+  /**
+   * The option WAS selected but matched nothing, so the alternative meant to be
+   * kept is absent. Suspicious, but it fails visibly (a missing clause) rather
+   * than silently, so it is reported as a warning.
+   */
+  selectedZeroMatch: SelectionOptionReport[];
+}
+
+/** Human-readable identifier for one option in a diagnostic message. */
+export function describeSelectionOption(o: SelectionOptionReport): string {
+  return `${o.groupId}[${o.optionIndex}] "${o.marker}"`;
+}
+
+/** Split a selections run's per-option match counts into the three anomaly classes. */
+export function classifySelectionMatches(result: SelectionsResult): SelectionAnomalies {
+  const engagedGroups = new Set<string>();
+  for (const o of result.options) {
+    if (o.matchCount > 0) engagedGroups.add(o.groupId);
+  }
+
+  const anomalies: SelectionAnomalies = {
+    unselectedZeroMatchInEngagedGroup: [],
+    unselectedZeroMatchInInertGroup: [],
+    selectedZeroMatch: [],
+  };
+
+  for (const o of result.options) {
+    if (o.matchCount > 0) continue;
+    if (o.selected) {
+      anomalies.selectedZeroMatch.push(o);
+    } else if (engagedGroups.has(o.groupId)) {
+      anomalies.unselectedZeroMatchInEngagedGroup.push(o);
+    } else {
+      anomalies.unselectedZeroMatchInInertGroup.push(o);
+    }
+  }
+
+  return anomalies;
+}
+
+/**
+ * Accumulator threaded through the per-group processors so match counts survive
+ * every early return. Keyed by `${groupId}::${optionIndex}`.
+ */
+type OptionStats = Map<string, SelectionOptionReport>;
+
+function recordOptionMatches(
+  stats: OptionStats,
+  group: z.infer<typeof GroupSchema>,
+  selectedIndices: Set<number>,
+  counts: number[],
+): void {
+  for (let oi = 0; oi < group.options.length; oi++) {
+    const key = `${group.id}::${oi}`;
+    const existing = stats.get(key);
+    if (existing) {
+      existing.matchCount += counts[oi] ?? 0;
+      continue;
+    }
+    stats.set(key, {
+      groupId: group.id,
+      optionIndex: oi,
+      marker: group.options[oi].marker,
+      selected: selectedIndices.has(oi),
+      matchCount: counts[oi] ?? 0,
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Core algorithm
 // ---------------------------------------------------------------------------
 
@@ -309,13 +427,14 @@ export async function applySelections(
   outputPath: string,
   config: SelectionsConfig,
   data: Record<string, unknown>,
-): Promise<void> {
+): Promise<SelectionsResult> {
   const inputBuf = readFileSync(inputPath);
   const zip = new AdmZip(inputBuf);
   const parser = new DOMParser();
   const serializer = new XMLSerializer();
   const parts = enumerateTextParts(zip);
   const partNames = getGeneralTextPartNames(parts);
+  const stats: OptionStats = new Map();
 
   for (const partName of partNames) {
     const entry = zip.getEntry(partName);
@@ -326,7 +445,7 @@ export async function applySelections(
 
     let partModified = false;
     for (const group of config.groups) {
-      const result = processGroup(doc, group, data);
+      const result = processGroup(doc, group, data, stats);
       if (result) partModified = true;
     }
 
@@ -341,6 +460,17 @@ export async function applySelections(
   copyEntriesSkippingDirs(zip, outZip);
   const outBuf = outZip.toBuffer();
   writeFileSync(outputPath, outBuf);
+
+  // Report in config order so diagnostics read like the config file.
+  const options: SelectionOptionReport[] = [];
+  for (const group of config.groups) {
+    for (let oi = 0; oi < group.options.length; oi++) {
+      const entry = stats.get(`${group.id}::${oi}`);
+      if (entry) options.push(entry);
+    }
+  }
+
+  return { outputPath, options };
 }
 
 interface OptionMatch {
@@ -356,13 +486,14 @@ function processGroup(
   doc: Document,
   group: z.infer<typeof GroupSchema>,
   data: Record<string, unknown>,
+  stats: OptionStats,
 ): boolean {
   if (group.markerless) {
-    return processMarkerlessGroup(doc, group, data);
+    return processMarkerlessGroup(doc, group, data, stats);
   }
 
   if (group.standalone) {
-    return processStandaloneGroup(doc, group, data);
+    return processStandaloneGroup(doc, group, data, stats);
   }
 
   // Step 1: Find ALL candidate paragraphs for each option's marker
@@ -379,6 +510,15 @@ function processGroup(
       }
     }
   }
+
+  // Record match counts before any early return or throw below (#720), so a
+  // group that finds no qualifying cell still reports which options matched.
+  recordOptionMatches(
+    stats,
+    group,
+    evaluateTriggers(group, data),
+    candidatesPerOption.map((c) => c.length),
+  );
 
   // Step 2: Find a cell where ALL options have at least one candidate
   // Group candidates by their parent cell
@@ -560,22 +700,25 @@ function processStandaloneGroup(
   doc: Document,
   group: z.infer<typeof GroupSchema>,
   data: Record<string, unknown>,
+  stats: OptionStats,
 ): boolean {
   const allParagraphs = doc.getElementsByTagNameNS(W_NS, 'p');
   const selectedIndices = evaluateTriggers(group, data);
+  const matchCounts: number[] = group.options.map(() => 0);
   let madeChanges = false;
 
   for (let oi = 0; oi < group.options.length; oi++) {
     const option = group.options[oi];
 
-    // Find the marker paragraph
+    // Find the marker paragraph. Every match is counted (#720) even though only
+    // the first is acted on, so a drifted marker reports 0 rather than nothing.
     let markerPara: Element | null = null;
     for (let pi = 0; pi < allParagraphs.length; pi++) {
       const para = allParagraphs[pi];
       const text = extractParagraphText(para);
       if (text && hasOptionPrefix(text) && text.includes(option.marker)) {
-        markerPara = para;
-        break;
+        matchCounts[oi]++;
+        if (!markerPara) markerPara = para;
       }
     }
     if (!markerPara) continue;
@@ -618,6 +761,7 @@ function processStandaloneGroup(
     }
   }
 
+  recordOptionMatches(stats, group, selectedIndices, matchCounts);
   return madeChanges;
 }
 
@@ -692,8 +836,10 @@ function processMarkerlessGroup(
   doc: Document,
   group: z.infer<typeof GroupSchema>,
   data: Record<string, unknown>,
+  stats: OptionStats,
 ): boolean {
   const selectedIndices = evaluateTriggers(group, data);
+  const matchCounts: number[] = group.options.map(() => 0);
   let madeChanges = false;
   const parasToRemove = new Set<Element>();
 
@@ -712,6 +858,12 @@ function processMarkerlessGroup(
       }
     }
 
+    matchCounts[oi] += matchedParas.length;
+
+    // #720: a zero-match UNSELECTED option is not a benign no-op — the
+    // alternative it was meant to delete survives into the filled document.
+    // The count recorded above is what lets the caller reject that outcome
+    // instead of shipping a document carrying both alternatives.
     if (matchedParas.length === 0) continue;
 
     if (selectedIndices.has(oi)) {
@@ -815,6 +967,7 @@ function processMarkerlessGroup(
   // Deferred removal with bookmark cleanup
   removeWithBookmarkCleanup(doc, parasToRemove);
 
+  recordOptionMatches(stats, group, selectedIndices, matchCounts);
   return madeChanges;
 }
 

--- a/src/core/unified-pipeline.ts
+++ b/src/core/unified-pipeline.ts
@@ -294,11 +294,14 @@ export async function runFillPipeline(options: PipelineOptions): Promise<Pipelin
       const selectionsResult = await applySelections(preSelectPath, postSelectPath, selectionsConfig, data);
       templateBuf = readFileSync(postSelectPath);
 
-      // #720: a selections option that matched zero paragraphs is not a no-op.
-      // For an UNSELECTED option the intent is "delete this alternative", so a
-      // zero match means the alternative was never deleted and the filled
-      // document ships BOTH alternatives — legally wrong, and invisible to
-      // every other check because the result still renders cleanly.
+      // #720: an UNSELECTED selections option that was never actually removed is
+      // not a no-op. The intent is "delete this alternative", so nothing having
+      // been deleted means the filled document ships BOTH alternatives —
+      // legally wrong, and invisible to every other check because the result
+      // still renders cleanly. Two faults produce it: a marker that matched
+      // nothing (source drift), and a group that matched but resolved no
+      // location to act on. `appliedCount` catches both; `matchCount` alone
+      // catches only the first.
       //
       // The `engaged group` qualifier is what separates the dangerous case from
       // the benign one. A group whose OTHER options matched is demonstrably
@@ -323,22 +326,23 @@ export async function runFillPipeline(options: PipelineOptions): Promise<Pipelin
       // flip once the upstream configs are corrected.
       const anomalies = classifySelectionMatches(selectionsResult);
 
-      if (anomalies.unselectedZeroMatchInEngagedGroup.length > 0) {
-        const detail = anomalies.unselectedZeroMatchInEngagedGroup
-          .map((o) => describeSelectionOption(o))
+      if (anomalies.unremovedInEngagedGroup.length > 0) {
+        const detail = anomalies.unremovedInEngagedGroup
+          .map((o) => `${describeSelectionOption(o)} [matched ${o.matchCount}, removed ${o.appliedCount}]`)
           .join('; ');
         const message =
-          `selections: ${anomalies.unselectedZeroMatchInEngagedGroup.length} unselected option(s) matched zero ` +
-          `paragraphs while a sibling option in the same group did match. The alternative each was meant to remove ` +
-          `is still in the document, so the filled output carries BOTH alternatives. This usually means the ` +
-          `marker text drifted from the source. Offending option(s): ${detail}`;
+          `selections: ${anomalies.unremovedInEngagedGroup.length} unselected option(s) were not removed while a ` +
+          `sibling option in the same group did match. The alternative each was meant to remove is still in the ` +
+          `document, so the filled output carries BOTH alternatives. A zero match count means the marker text ` +
+          `drifted from the source; a non-zero match count with nothing removed means the group resolved no ` +
+          `location to act on (e.g. its options sit in different table cells). Offending option(s): ${detail}`;
         if (selectionsZeroMatchPolicy === 'error') {
           throw new Error(`[selections] ${message}`);
         }
         warnings.push(message);
       }
 
-      for (const o of anomalies.unselectedZeroMatchInInertGroup) {
+      for (const o of anomalies.unremovedInInertGroup) {
         warnings.push(
           `selections: unselected option ${describeSelectionOption(o)} matched zero paragraphs, and no option in ` +
           `that group matched either — the group does not apply to this document.`,

--- a/src/core/unified-pipeline.ts
+++ b/src/core/unified-pipeline.ts
@@ -19,7 +19,7 @@ import { prepareFillData, fillDocx, type ConfirmClauseDescriptor } from './fill-
 import { cleanDocument } from './field-selector/cleaner.js';
 import { patchDocument } from './field-selector/patcher.js';
 import { applySelectorContracts, type FieldSelectorManifest, type FieldResolution } from './selectors/index.js';
-import { applySelections } from './selector.js';
+import { applySelections, classifySelectionMatches, describeSelectionOption } from './selector.js';
 import { enumerateTextParts, getGeneralTextPartNames, rezipWithoutDirEntries } from './field-selector/ooxml-parts.js';
 import type { FieldDefinition, CleanConfig } from './metadata.js';
 import type { SelectionsConfig } from './selector.js';
@@ -50,6 +50,19 @@ export interface PipelineOptions {
 
   // Selections — omit to skip (only templates with selections.json)
   selectionsConfig?: SelectionsConfig;
+  /**
+   * What to do when an UNSELECTED selections option matches zero paragraphs
+   * inside a group whose other options DID match (#720): the alternative that
+   * was meant to be removed is still in the document, so the output carries
+   * both alternatives.
+   *
+   * `'warn'` (default) reports it in `PipelineResult.warnings`; `'error'`
+   * rejects the fill. The default is `'warn'` only because the bundled
+   * `templates/` corpus carries three pre-existing marker mismatches this repo
+   * cannot fix (see the note at the call site) — it is not a judgement that the
+   * condition is acceptable.
+   */
+  selectionsZeroMatchPolicy?: 'error' | 'warn';
 
   // prepareFillData options
   coerceBooleans?: boolean;             // default: false
@@ -158,6 +171,7 @@ export async function runFillPipeline(options: PipelineOptions): Promise<Pipelin
     selectorManifests,
     onSelectorResolved,
     selectionsConfig,
+    selectionsZeroMatchPolicy = 'warn',
     coerceBooleans = false,
     computeDisplayFields,
     fixSmartQuotes = false,
@@ -269,20 +283,78 @@ export async function runFillPipeline(options: PipelineOptions): Promise<Pipelin
       confirmClauses: options.confirmClauses,
     });
 
+    const warnings: string[] = [];
+
     // Step 5: Read current buffer; apply selections if configured
     let templateBuf: Buffer = readFileSync(currentPath);
     if (selectionsConfig) {
       const preSelectPath = join(tempDir, 'pre-select.docx');
       const postSelectPath = join(tempDir, 'post-select.docx');
       writeFileSync(preSelectPath, templateBuf);
-      await applySelections(preSelectPath, postSelectPath, selectionsConfig, data);
+      const selectionsResult = await applySelections(preSelectPath, postSelectPath, selectionsConfig, data);
       templateBuf = readFileSync(postSelectPath);
+
+      // #720: a selections option that matched zero paragraphs is not a no-op.
+      // For an UNSELECTED option the intent is "delete this alternative", so a
+      // zero match means the alternative was never deleted and the filled
+      // document ships BOTH alternatives — legally wrong, and invisible to
+      // every other check because the result still renders cleanly.
+      //
+      // The `engaged group` qualifier is what separates the dangerous case from
+      // the benign one. A group whose OTHER options matched is demonstrably
+      // present in this document, so a zero-match sibling means that option's
+      // marker drifted away from source prose that is still there. A group where
+      // NOTHING matched is a config/document mismatch (a partial fixture, a
+      // different source variant); nothing was left half-removed there.
+      //
+      // POLICY. The dangerous case is a warning by DEFAULT, not a hard failure,
+      // and that default is a deliberate concession to the bundled corpus rather
+      // than a judgement that the condition is tolerable. Turning this guard on
+      // surfaced three pre-existing marker/document mismatches in bundled
+      // Common Paper configs (an "Order Form" cover page whose marker says
+      // "Cover Page"; a straight-vs-curly apostrophe in the workers'-compensation
+      // insurance marker; a SOW-term marker naming `{term_duration_value}` where
+      // the patched text carries `{rejection_period_value}`). Those configs live
+      // under `templates/`, which this repo does not own — it is replaced
+      // wholesale by an upstream forward sync — so failing closed today would
+      // refuse to fill half a dozen shipped templates over defects that cannot
+      // be fixed here. Callers that own their configs can opt into failing
+      // closed with `selectionsZeroMatchPolicy: 'error'`, and the default should
+      // flip once the upstream configs are corrected.
+      const anomalies = classifySelectionMatches(selectionsResult);
+
+      if (anomalies.unselectedZeroMatchInEngagedGroup.length > 0) {
+        const detail = anomalies.unselectedZeroMatchInEngagedGroup
+          .map((o) => describeSelectionOption(o))
+          .join('; ');
+        const message =
+          `selections: ${anomalies.unselectedZeroMatchInEngagedGroup.length} unselected option(s) matched zero ` +
+          `paragraphs while a sibling option in the same group did match. The alternative each was meant to remove ` +
+          `is still in the document, so the filled output carries BOTH alternatives. This usually means the ` +
+          `marker text drifted from the source. Offending option(s): ${detail}`;
+        if (selectionsZeroMatchPolicy === 'error') {
+          throw new Error(`[selections] ${message}`);
+        }
+        warnings.push(message);
+      }
+
+      for (const o of anomalies.unselectedZeroMatchInInertGroup) {
+        warnings.push(
+          `selections: unselected option ${describeSelectionOption(o)} matched zero paragraphs, and no option in ` +
+          `that group matched either — the group does not apply to this document.`,
+        );
+      }
+      for (const o of anomalies.selectedZeroMatch) {
+        warnings.push(
+          `selections: selected option ${describeSelectionOption(o)} matched zero paragraphs — the alternative ` +
+          `meant to be kept is absent from the document.`,
+        );
+      }
     }
 
     // Step 5.5: Analyze fill commands on the exact buffer handed to fillDocx —
     // after clean → selector-contracts → patch → selections, so patch-injected
     // tokens (e.g. the yc-safe externals) are counted.
-    const warnings: string[] = [];
     const { commandCount, referencedIdentifiers } = await analyzeFillCommands(templateBuf);
     if (commandCount === 0) {
       warnings.push(


### PR DESCRIPTION
Ships #720 and #721 together. They were deliberately paired: both wanted the same design artifact — a synthetic DOCX fixture builder that preserves clause SHAPE — and shipping them separately would have meant one PR rebasing onto a builder it did not design.

Closes #720
Closes #721

---

## Part 1 — #720: selections zero-match guard (p1)

`processMarkerlessGroup()` did `if (matchedParas.length === 0) continue;`. For an **unselected** option that inverts the intent: "remove this alternative" silently became "keep it", so the filled document shipped BOTH alternatives — a legally wrong document that renders cleanly, fills cleanly, and passes every existing check. `applySelections()` returned `void`, so nothing upstream could see it.

**What changed**

- `applySelections()` returns `SelectionsResult` carrying per-group, per-option `matchCount` + `selected`, summed across every text part (document.xml plus headers/footers). All three group processors record counts — markerless, standalone, and cell-based — and they record *before* their early returns and throws, so a group that finds no qualifying cell still reports which of its options matched.
- Each report also carries `appliedCount` — the paragraphs an option's own removal / replacement / marking logic **actually acted on**. That is the field the guard keys on, because match counts alone miss a second route to the same corruption: a cell-based group whose options sit in different table cells resolves no qualifying cell, touches nothing, and leaves both alternatives in place while every option still reports a non-zero match count. Peer review found that path; `[OA-SEL-029]` covers it.
- `classifySelectionMatches()` splits the result into three classes. The discriminator is whether the group is **engaged** — whether any sibling option matched at least one paragraph:
  - **unselected + nothing removed, in an engaged group** — the dangerous case. The group is demonstrably present, so its alternative survives. Two faults land here: a marker that drifted away from prose that is still there (zero matches), and a group that matched but resolved no location to act on (matches, zero applied).
  - **unselected + nothing removed, in an inert group** — nothing in the group matched. The group does not apply to this document (a partial fixture, a different source variant). Nothing was left half-removed.
  - **selected + zero matches** — the alternative meant to be *kept* is absent. Suspicious, but it fails visibly (a missing clause) rather than silently, so a warning is the right severity, as the issue suggested.
- All three are surfaced in `PipelineResult.warnings`, which reaches CLI/API/MCP callers.

**Why the dangerous case warns by default instead of failing — and how to fail closed**

I implemented it as a hard failure first. Turning it on surfaced **three pre-existing marker/document mismatches in bundled Common Paper configs** (detailed below), which would have refused to fill six shipped templates. Those configs live under `templates/`, which this repo does not own — it is replaced wholesale by the upstream forward sync — so they cannot be fixed here. Blocking every Common Paper fill over defects that cannot be repaired in this repo is strictly worse than the status quo.

So the default is `selectionsZeroMatchPolicy: 'warn'`, with `'error'` available per call and covered by its own test (`[OA-SEL-028]`). The default should flip to `'error'` once the three upstream configs are corrected. The reasoning is recorded in a comment at the call site so it does not read as an accident.

### Three real defects this guard found in the bundled corpus

These are pre-existing and out of scope to fix here (`templates/` is upstream-owned), but each one currently produces a document carrying both alternatives:

1. **`common-paper-csa-*` / `effective_date[0]`** — the marker is `"Date of last signature on this Cover Page"`; `common-paper-csa-without-sla/template.docx` actually says `"Date of last signature on this **Order Form**"`. The group never fires, so a supplied `custom_effective_date` leaves the pre-checked default effective-date line in place alongside it.
2. **`common-paper-csa-* / insurance[1]`** — the marker is `"Workers’ compensation or employers’ liability insurance"` with a curly apostrophe in `employers’`; the document has a **straight** `employers'`. The cell-based `processGroup` matches raw (only `processMarkerlessGroup` runs `normalizeQuotes`), so the workers'-compensation line is never removed even when `insurance_workers_comp` is false. Fixing this by normalizing quotes in the cell-based path is a plausible one-line follow-up, deliberately left out of this PR as a behaviour change across the whole corpus.
3. **`common-paper-professional-services-agreement` / `sow_term[0]`** — the marker is `"{term_duration_value} {term_duration_unit} after the SOW Date"`; the patched document carries `"{rejection_period_value} {term_duration_unit} after the SOW Date"`. Both SOW-end alternatives survive, which leaves the SOW term genuinely ambiguous. The `{rejection_period_value}` binding in that slot looks like an upstream `replacements.json` defect in its own right.

---

## Part 2 — #721: fixtures that actually run in CI

The #707 assertions for the doubled `District of Northern District of California` and the lower-cased `state courts of california` sit under `describeWithCoiSource` / `describeWithSource`, which are `existsSync(cachedSourcePath()) ? describe : describe.skip`. The NVCA source is non-redistributable, so it is never on a runner and both regressions were unguarded.

`integration-tests/helpers/synthetic-docx.ts` generalizes the fixture builder: it takes real paragraph prose with embedded placeholders, so a fixture reproduces clause shape rather than isolated markers. It offers four run-splitting strategies — one run per paragraph, one run per word, placeholder-**straddling**, and fixed-size character chunks — because Word splits sentences across runs and several of these defects only manifest cross-run. Every rendering assertion is swept across all four.

`integration-tests/synthetic-clause-shape-contracts.test.ts` covers all three requested shapes, in **paraphrased, invented prose** — not one sentence is copied from an NVCA form:

1. two adjacent bracketed alternatives sharing the literal prefix `District Court for the District of `, each binding to its own key and absorbing the prefix exactly once;
2. a context-anchored key (`[or decrease] > [specify percentage]`) that claims the second of two identical placeholders without doubling its anchor literal, while a simple key sweeps the first;
3. a proper noun that survives substitution into a lower-case carrier phrase (`the state courts of California`).

The source-gated #707 assertions stay exactly where they are as the higher-fidelity check; a pointer comment next to them names the synthetic file. Edits to `selector-contracts.test.ts` are one additive comment block — no restructuring — so a concurrent stream's rebase stays tractable.

---

## Proof the new tests are load-bearing

**#720.** Reverted `src/core/selector.ts` and `src/core/unified-pipeline.ts` to the pre-fix versions and reran. **10 of the new tests failed** (`OA-SEL-020`–`023`, `OA-SEL-025` ×2, `OA-SEL-026`, `OA-SEL-027`, `OA-SEL-028` ×2), independently reproduced by the peer reviewer. Excerpt from the run:

```
× [OA-SEL-025] a drifted marker on the UNSELECTED alternative ... (runs: single)
  → promise resolved "{ result: { …(6) }, …(1) }" instead of rejecting
× [OA-SEL-021] ... TypeError: Cannot read properties of undefined (reading 'options')
× [OA-SEL-022] ... TypeError: (0 , classifySelectionMatches) is not a function
```

Direct evidence of the silent failure against the pre-fix pipeline — a one-word marker drift, `warnings: []`, no error, and both alternatives in the output:

```
RESOLVED (no error). warnings= []
OUTPUT:
Dispute Resolution. This Agreement is governed by the laws of the State of Delaware.
Any dispute, claim or controversy arising out of this Agreement shall be resolved by
binding arbitration before a single arbitrator ...
Each party irrevocably submits to the exclusive jurisdiction of the state courts of
Delaware for the resolution of any dispute ...
```

Post-fix, the same input reports:

```
[selections] 1 unselected option(s) matched zero paragraphs while a sibling option in
the same group did match. ... Offending option(s): dispute_resolution[0] "shall be
resolved by arbitration before a single arbitrator"
```

**#721.** Rather than proving this by hand once, the proof is **checked in**. `[OA-SEL-033]`–`[OA-SEL-035]` render the same fixture through the LEGACY (pre-legal-explainer#2394) binding map and assert the defect **reproduces**. Rendered output, same document, two binding maps:

```
CORRECTED: ... the state courts of California and, for any action ...,
           [to the U.S. District Court for the Northern District of California]
           [to the United States District Court for the Northern District of California] ...

LEGACY:    ... the state courts of california and, for any action ...,
           [to the U.S. District Court for the District of Northern District of California]
           [to the United States District Court for the District of Northern District of California] ...
```

A regression test that passes against the unfixed code is worthless, so this comparison runs on every CI job rather than living in a PR comment.

---

## Verification

Run in the worktree against the final tree:

- `npm run build` — clean
- `npx vitest run` — **1227 passed | 6 skipped (1233)**, 105 files passed / 3 skipped
- `npm run lint` — clean
- `npm run check:derived` — derived artifacts current (4 projections)
- `npm run check:allure-labels` — clean
- `npm run check:isolated-runtime` — PASS

Also verified against the real cached NVCA SPA source (not available in CI): a full `runFieldSelector` fill in both `dispute_resolution_mode=courts` and `=arbitration` reports **no anomalies and `warnings: []`**, so the guard is non-disruptive on the corpus it was written for.

New tests carry stable IDs `[OA-SEL-020]`–`[OA-SEL-029]` (#720) and `[OA-SEL-030]`–`[OA-SEL-035]` (#721), skipping 016–019 to leave room for a concurrent stream.

Peer-reviewed by Codex (verdict REQUEST CHANGES); the blocking finding is fixed in 9b8f5256 and the full adjudication is in a PR comment below.

https://claude.ai/code/session_01GqDeNuzVbMGy7GEtkbKGtY
