### PR TITLE
fix(selector): normalize punctuation removal seams

### DIFF
--- a/src/core/selector.test.ts
+++ b/src/core/selector.test.ts
@@ -598,6 +598,81 @@ describe('markerless selections', () => {
 // ---------------------------------------------------------------------------
 
 describe('inline selections', () => {
+  it('removes whitespace before punctuation at an empty inline-removal seam', async () => {
+    const body = `
+      ${para('Exhibit A [with respect to such Closing], at a purchase price per share [or other price], subject to adjustment.')}
+    `;
+    const inputPath = buildTestDocx(body);
+    const outputPath = join(makeTempDir(), 'out.docx');
+
+    const config: SelectionsConfig = {
+      groups: [{
+        id: 'closing_inline',
+        type: 'checkbox',
+        standalone: true,
+        markerless: true,
+        inline: true,
+        options: [
+          { marker: '[with respect to such Closing]', trigger: { field: 'keep_closing' }, replaceWith: '' },
+          { marker: '[or other price]', trigger: { field: 'keep_other_price' }, replaceWith: '' },
+        ],
+      }],
+    };
+
+    await applySelections(inputPath, outputPath, config, {});
+
+    const text = extractText(outputPath);
+    expect(text).toContain('Exhibit A, at a purchase price per share, subject to adjustment.');
+    expect(text).not.toMatch(/\s[,.;:!?]/);
+  });
+
+  it('normalizes an empty inline-removal seam split across Word runs', async () => {
+    const body = `
+      <w:p xmlns:w="${W_NS}">
+        <w:r><w:t xml:space="preserve">Exhibit A </w:t></w:r>
+        <w:r><w:t>[optional]</w:t></w:r>
+        <w:r><w:t xml:space="preserve">, at Closing.</w:t></w:r>
+      </w:p>
+    `;
+    const inputPath = buildTestDocx(body);
+    const outputPath = join(makeTempDir(), 'out.docx');
+
+    const config: SelectionsConfig = {
+      groups: [{
+        id: 'split_run_inline',
+        type: 'checkbox',
+        standalone: true,
+        markerless: true,
+        inline: true,
+        options: [{ marker: '[optional]', trigger: { field: 'keep_optional' }, replaceWith: '' }],
+      }],
+    };
+
+    await applySelections(inputPath, outputPath, config, {});
+
+    expect(extractText(outputPath)).toContain('Exhibit A, at Closing.');
+  });
+
+  it('does not rewrite unrelated source spacing away from the removal seam', async () => {
+    const body = `${para('Heading . Exhibit A [optional], at Closing.')}`;
+    const inputPath = buildTestDocx(body);
+    const outputPath = join(makeTempDir(), 'out.docx');
+    const config: SelectionsConfig = {
+      groups: [{
+        id: 'seam_only',
+        type: 'checkbox',
+        standalone: true,
+        markerless: true,
+        inline: true,
+        options: [{ marker: '[optional]', trigger: { field: 'keep_optional' }, replaceWith: '' }],
+      }],
+    };
+
+    await applySelections(inputPath, outputPath, config, {});
+
+    expect(extractText(outputPath)).toContain('Heading . Exhibit A, at Closing.');
+  });
+
   it('deletes inline marker text when trigger does not fire', async () => {
     const body = `
       ${para('Purchase at the Closing). , [Each Purchaser shall buy Tranche Shares.] The Company agrees.')}

--- a/src/core/selector.test.ts
+++ b/src/core/selector.test.ts
@@ -673,6 +673,46 @@ describe('inline selections', () => {
     expect(extractText(outputPath)).toContain('Heading . Exhibit A, at Closing.');
   });
 
+  it('preserves spacing when an inline option is replaced with text', async () => {
+    const body = `${para('Exhibit A [optional], at Closing.')}`;
+    const inputPath = buildTestDocx(body);
+    const outputPath = join(makeTempDir(), 'out.docx');
+    const config: SelectionsConfig = {
+      groups: [{
+        id: 'nonempty_replacement',
+        type: 'checkbox',
+        standalone: true,
+        markerless: true,
+        inline: true,
+        options: [{ marker: '[optional]', trigger: { field: 'keep_optional' }, replaceWith: 'Schedule 1' }],
+      }],
+    };
+
+    await applySelections(inputPath, outputPath, config, {});
+
+    expect(extractText(outputPath)).toContain('Exhibit A Schedule 1, at Closing.');
+  });
+
+  it('preserves ordinary word spacing when no punctuation follows the removal', async () => {
+    const body = `${para('Before [optional] after.')}`;
+    const inputPath = buildTestDocx(body);
+    const outputPath = join(makeTempDir(), 'out.docx');
+    const config: SelectionsConfig = {
+      groups: [{
+        id: 'word_seam',
+        type: 'checkbox',
+        standalone: true,
+        markerless: true,
+        inline: true,
+        options: [{ marker: '[optional]', trigger: { field: 'keep_optional' }, replaceWith: '' }],
+      }],
+    };
+
+    await applySelections(inputPath, outputPath, config, {});
+
+    expect(extractText(outputPath)).toContain('Before  after.');
+  });
+
   it('deletes inline marker text when trigger does not fire', async () => {
     const body = `
       ${para('Purchase at the Closing). , [Each Purchaser shall buy Tranche Shares.] The Company agrees.')}

--- a/src/core/selector.ts
+++ b/src/core/selector.ts
@@ -23,6 +23,32 @@ function normalizeQuotes(text: string): string {
     .replace(/[\u201C\u201D\u201A\u201E\u00AB\u00BB]/g, '"');
 }
 
+/**
+ * Keep punctuation attached when an inline option is removed.
+ *
+ * An option such as `Exhibit A [optional], at Closing` owns neither adjacent
+ * character. Deleting only the bracketed marker otherwise leaves `Exhibit A ,`.
+ * Expand the edit across whitespace on the left only when punctuation is the
+ * first surviving character on the right. This is deliberately seam-local:
+ * pre-existing spacing elsewhere in a licensed source is not rewritten.
+ */
+function normalizeEmptyInlineRemovalSeam(
+  paragraphText: string,
+  start: number,
+  end: number,
+  replacement: string,
+): { start: number; end: number; replacement: string } {
+  if (replacement !== '' || !/[,.;:!?]/.test(paragraphText[end] ?? '')) {
+    return { start, end, replacement };
+  }
+
+  let normalizedStart = start;
+  while (normalizedStart > 0 && /[ \t\u00a0]/.test(paragraphText[normalizedStart - 1])) {
+    normalizedStart--;
+  }
+  return { start: normalizedStart, end, replacement };
+}
+
 // ---------------------------------------------------------------------------
 // Schema
 // ---------------------------------------------------------------------------
@@ -948,8 +974,14 @@ function processMarkerlessGroup(
         while (safety++ < 50) {
           const idx = text.indexOf(normalizedMarker);
           if (idx === -1) break;
+          const edit = normalizeEmptyInlineRemovalSeam(
+            text,
+            idx,
+            idx + normalizedMarker.length,
+            replacement,
+          );
           try {
-            replaceParagraphTextRange(globalPara, idx, idx + normalizedMarker.length, replacement);
+            replaceParagraphTextRange(globalPara, edit.start, edit.end, edit.replacement);
             madeChanges = true;
             paraEdited = true;
           } catch (e) {
@@ -958,7 +990,13 @@ function processMarkerlessGroup(
               const rawText = extractParagraphText(markerPara);
               const rawIdx = normalizeQuotes(rawText).indexOf(normalizedMarker);
               if (rawIdx !== -1) {
-                const newText = rawText.slice(0, rawIdx) + replacement + rawText.slice(rawIdx + normalizedMarker.length);
+                const rawEdit = normalizeEmptyInlineRemovalSeam(
+                  rawText,
+                  rawIdx,
+                  rawIdx + normalizedMarker.length,
+                  replacement,
+                );
+                const newText = rawText.slice(0, rawEdit.start) + rawEdit.replacement + rawText.slice(rawEdit.end);
                 replaceParagraphText(markerPara, newText);
                 madeChanges = true;
                 paraEdited = true;

--- a/src/core/selector.ts
+++ b/src/core/selector.ts
@@ -990,13 +990,7 @@ function processMarkerlessGroup(
               const rawText = extractParagraphText(markerPara);
               const rawIdx = normalizeQuotes(rawText).indexOf(normalizedMarker);
               if (rawIdx !== -1) {
-                const rawEdit = normalizeEmptyInlineRemovalSeam(
-                  rawText,
-                  rawIdx,
-                  rawIdx + normalizedMarker.length,
-                  replacement,
-                );
-                const newText = rawText.slice(0, rawEdit.start) + rawEdit.replacement + rawText.slice(rawEdit.end);
+                const newText = rawText.slice(0, edit.start) + edit.replacement + rawText.slice(edit.end);
                 replaceParagraphText(markerPara, newText);
                 madeChanges = true;
                 paraEdited = true;


### PR DESCRIPTION
## Summary

- normalize whitespace only at an empty inline-option removal seam when punctuation is the next surviving character
- cover same-run and cross-run DOCX text
- prove unrelated pre-existing punctuation spacing is not rewritten

Closes #735.

## Reproduction and verification

- Before: the clean-room SPA rendered `Exhibit A , at a purchase price of $1.00 per share ,`.
- After: a fresh fill from the same values renders `per share, subject to adjustment` and contains neither prohibited string.
- `npx vitest run src/core/selector.test.ts` — 32 passed
- `npm run lint` — passed
- `npm run build` — passed
- `npm run validate` — passed with existing warnings
- `npm run test:run` — passed

## Safety boundary

This does not globally rewrite source punctuation. It expands only the active deletion range over adjacent left-side whitespace when the removed option is immediately followed by punctuation.
