### PR TITLE
feat(field-selector): fill repeatable DOCX table rows

### DIFF
--- a/src/core/field-selector/index.ts
+++ b/src/core/field-selector/index.ts
@@ -19,6 +19,7 @@ import { runFillPipeline } from '../unified-pipeline.js';
 import { formatDocumentDate } from '../fill-pipeline.js';
 import type { FieldSelectorRunOptions, FieldSelectorRunResult } from './types.js';
 import type { ComputedValueMap } from './computed.js';
+import { applyRepeatableTables, loadRepeatableTablesConfig, validateRepeatableTableFields } from './repeatable-tables.js';
 
 function toComputedValueMap(values: Record<string, unknown>): ComputedValueMap {
   const computedValues: ComputedValueMap = {};
@@ -45,6 +46,8 @@ export async function runFieldSelector(options: FieldSelectorRunOptions): Promis
   const metadata = loadFieldSelectorMetadata(fieldSelectorDir);
   const cleanConfig = loadCleanConfig(fieldSelectorDir);
   const normalizeConfig = loadNormalizeConfig(fieldSelectorDir);
+  const repeatableTablesConfig = loadRepeatableTablesConfig(fieldSelectorDir);
+  if (repeatableTablesConfig) validateRepeatableTableFields(repeatableTablesConfig, metadata.fields);
 
   // Load selectionsConfig if selections.json exists (mirrors engine.ts template path)
   const selectionsPath = join(fieldSelectorDir, 'selections.json');
@@ -139,12 +142,17 @@ export async function runFieldSelector(options: FieldSelectorRunOptions): Promis
     cleanPatch: { cleanConfig, replacements: patchReplacements },
     selectorManifests,
     selectionsConfig,
-    postProcess: shouldNormalizeBracketArtifacts
+    postProcess: repeatableTablesConfig || shouldNormalizeBracketArtifacts
       ? async (outputDocPath: string) => {
-        await normalizeBracketArtifacts(outputDocPath, outputDocPath, {
-          rules: normalizeConfig.paragraph_rules,
-          fieldValues: effectiveValues,
-        });
+        if (repeatableTablesConfig) {
+          applyRepeatableTables(outputDocPath, outputDocPath, repeatableTablesConfig, effectiveValues);
+        }
+        if (shouldNormalizeBracketArtifacts) {
+          await normalizeBracketArtifacts(outputDocPath, outputDocPath, {
+            rules: normalizeConfig.paragraph_rules,
+            fieldValues: effectiveValues,
+          });
+        }
       }
       : undefined,
     verify: async (p, cleanedSourcePath, referencedFields) => {
@@ -201,8 +209,17 @@ export async function runFieldSelector(options: FieldSelectorRunOptions): Promis
   return {
     outputPath: result.outputPath,
     metadata,
-    fieldsUsed: result.fieldsUsed,
-    providedFieldsUsed: result.providedFieldsUsed,
+    fieldsUsed: repeatableTablesConfig
+      ? [...new Set([...result.fieldsUsed, ...repeatableTablesConfig.tables.map((table) => table.rows_field)])]
+      : result.fieldsUsed,
+    providedFieldsUsed: repeatableTablesConfig
+      ? [...new Set([
+        ...result.providedFieldsUsed,
+        ...repeatableTablesConfig.tables
+          .map((table) => table.rows_field)
+          .filter((field) => Object.hasOwn(inputValues, field)),
+      ])]
+      : result.providedFieldsUsed,
     fillCommandCount: result.fillCommandCount,
     warnings: result.warnings,
     stages: result.stages!,
@@ -222,3 +239,5 @@ export { enumerateTextParts, getGeneralTextPartNames } from './ooxml-parts.js';
 export type { OoxmlTextParts } from './ooxml-parts.js';
 export type { FieldSelectorRunOptions, FieldSelectorRunResult, VerifyResult, VerifyCheck } from './types.js';
 export type { ComputedArtifact, ComputedProfile } from './computed.js';
+export { applyRepeatableTables, loadRepeatableTablesConfig, RepeatableTablesConfigSchema, validateRepeatableTableFields } from './repeatable-tables.js';
+export type { RepeatableTablesConfig } from './repeatable-tables.js';

--- a/src/core/field-selector/repeatable-tables.test.ts
+++ b/src/core/field-selector/repeatable-tables.test.ts
@@ -1,0 +1,142 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import AdmZip from 'adm-zip';
+import { afterEach, describe, expect, it } from 'vitest';
+import { applyRepeatableTables, RepeatableTablesConfigSchema, validateRepeatableTableFields } from './repeatable-tables.js';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const roots: string[] = [];
+
+function fixtureDocx(duplicate = false, postHeader: 'none' | 'blank' | 'nonblank' = 'none'): Buffer {
+  const zip = new AdmZip();
+  const header = `<w:tbl>` +
+    `<w:tr><w:trPr><w:tblHeader/></w:trPr><w:tc><w:tcPr><w:tcW w:w="3000"/><w:shd w:fill="AAAAAA"/></w:tcPr><w:p><w:pPr><w:jc w:val="left"/></w:pPr><w:r><w:t>Name</w:t></w:r></w:p></w:tc>` +
+    `<w:tc><w:tcPr><w:tcW w:w="1500"/></w:tcPr><w:p><w:pPr><w:jc w:val="right"/></w:pPr><w:r><w:t>Shares</w:t></w:r></w:p></w:tc>` +
+    `<w:tc><w:tcPr><w:tcW w:w="1500"/></w:tcPr><w:p><w:pPr><w:jc w:val="right"/></w:pPr><w:r><w:t>Price ($)</w:t></w:r></w:p></w:tc></w:tr>`;
+  const blankRow = `<w:tr><w:trPr><w:cantSplit/></w:trPr>` +
+    `<w:tc><w:tcPr><w:tcW w:w="3000"/></w:tcPr><w:p><w:pPr><w:jc w:val="left"/></w:pPr></w:p></w:tc>` +
+    `<w:tc><w:tcPr><w:tcW w:w="1500"/></w:tcPr><w:p><w:pPr><w:jc w:val="right"/></w:pPr></w:p></w:tc>` +
+    `<w:tc><w:tcPr><w:tcW w:w="1500"/></w:tcPr><w:p><w:pPr><w:jc w:val="right"/></w:pPr></w:p></w:tc>` +
+    `</w:tr>`;
+  const staleRow = blankRow.replace('</w:p></w:tc>', '<w:r><w:t>Stale purchaser</w:t></w:r></w:p></w:tc>');
+  const table = header + (postHeader === 'blank' ? blankRow : postHeader === 'nonblank' ? staleRow : '') + `</w:tbl>`;
+  zip.addFile('word/document.xml', Buffer.from(
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<w:document xmlns:w="${W}"><w:body>${table}${duplicate ? table : ''}</w:body></w:document>`,
+  ));
+  return zip.toBuffer();
+}
+
+const config = RepeatableTablesConfigSchema.parse({
+  schema_version: 1,
+  tables: [{
+    id: 'purchasers',
+    rows_field: 'purchasers',
+    header_cells: ['Name', 'Shares', 'Price ($)'],
+    columns: [
+      { field: 'name' },
+      { field: 'shares', format: 'integer' },
+      { field: 'price', format: 'currency' },
+    ],
+  }],
+});
+
+function render(
+  rows: unknown[],
+  duplicate = false,
+  postHeader: 'none' | 'blank' | 'nonblank' = 'none',
+  binding = config,
+): string {
+  const root = mkdtempSync(join(tmpdir(), 'repeatable-tables-'));
+  roots.push(root);
+  const input = join(root, 'in.docx');
+  const output = join(root, 'out.docx');
+  new AdmZip(fixtureDocx(duplicate, postHeader)).writeZip(input);
+  applyRepeatableTables(input, output, binding, { purchasers: rows });
+  const zip = new AdmZip(readFileSync(output));
+  return zip.readAsText('word/document.xml');
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('repeatable DOCX table bindings', () => {
+  it('leaves a genuine header-only table at one row when data is empty', () => {
+    const xml = render([]);
+    expect((xml.match(/<w:tr[ >]/g) ?? [])).toHaveLength(1);
+  });
+
+  it('removes blank post-header scaffolding deterministically', () => {
+    const xml = render([], false, 'blank');
+    expect((xml.match(/<w:tr[ >]/g) ?? [])).toHaveLength(1);
+    expect(xml).not.toContain('<w:cantSplit/>');
+  });
+
+  it('supports an explicitly selected prototype row', () => {
+    const explicit = RepeatableTablesConfigSchema.parse({
+      ...config,
+      tables: [{ ...config.tables[0], prototype_row_index: 1 }],
+    });
+    const xml = render([{ name: 'Alpha Fund', shares: 10, price: 20 }], false, 'blank', explicit);
+    expect(xml).toContain('Alpha Fund');
+    expect(xml).toContain('<w:cantSplit/>');
+  });
+
+  it('fills one row and preserves prototype formatting', () => {
+    const xml = render([{ name: 'Alpha Fund', shares: 1250000, price: 2500000 }]);
+    expect(xml).toContain('Alpha Fund');
+    expect(xml).toContain('1,250,000');
+    expect(xml).toContain('2,500,000.00');
+    expect((xml.match(/<w:tblHeader\/>/g) ?? [])).toHaveLength(1);
+    expect((xml.match(/<w:shd/g) ?? [])).toHaveLength(1);
+    expect(xml).toContain('w:w="3000"');
+    expect(xml).toContain('w:val="right"');
+  });
+
+  it('clones deterministic rows for multiple purchasers', () => {
+    const xml = render([
+      { name: 'Alpha Fund', shares: 100, price: 125 },
+      { name: 'Beta Fund', shares: 200, price: 250 },
+    ]);
+    expect((xml.match(/<w:tr[ >]/g) ?? [])).toHaveLength(3);
+    expect(xml.indexOf('Alpha Fund')).toBeLessThan(xml.indexOf('Beta Fund'));
+    expect(xml).toContain('125.00');
+    expect(xml).toContain('250.00');
+  });
+
+  it('fails closed when the configured header is absent or ambiguous', () => {
+    expect(() => render([{ name: 'Alpha Fund' }], true)).toThrow(/matched 2 tables/);
+    const bad = RepeatableTablesConfigSchema.parse({
+      schema_version: 1,
+      tables: [{ id: 'missing', rows_field: 'rows', header_cells: ['Unknown'], columns: [{ field: 'name' }] }],
+    });
+    const root = mkdtempSync(join(tmpdir(), 'repeatable-tables-'));
+    roots.push(root);
+    const input = join(root, 'in.docx');
+    new AdmZip(fixtureDocx()).writeZip(input);
+    expect(() => applyRepeatableTables(input, join(root, 'out.docx'), bad, { rows: [] })).toThrow(/matched 0 tables/);
+  });
+
+  it('fails closed on nonblank post-header data in synthesis mode', () => {
+    expect(() => render([{ name: 'New purchaser' }], false, 'nonblank')).toThrow(/nonblank post-header row/);
+  });
+
+  it('rejects malformed contracts before touching a document', () => {
+    expect(() => RepeatableTablesConfigSchema.parse({
+      schema_version: 1,
+      tables: [{ id: 'bad', rows_field: 'rows', header_cells: ['A', 'B'], columns: [{ field: 'only_one' }] }],
+    })).toThrow(/same length/);
+  });
+
+  it('requires the rows field and every column to be declared in metadata', () => {
+    expect(() => validateRepeatableTableFields(config, [])).toThrow(/must reference an array field/);
+    expect(() => validateRepeatableTableFields(config, [{
+      name: 'purchasers',
+      type: 'array',
+      description: 'Purchaser rows',
+      items: [{ name: 'name', type: 'string', description: 'Name' }],
+    }])).toThrow(/column field "shares" is not declared/);
+  });
+});

--- a/src/core/field-selector/repeatable-tables.ts
+++ b/src/core/field-selector/repeatable-tables.ts
@@ -1,0 +1,177 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import AdmZip from 'adm-zip';
+import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
+import type { Document as XmlDocument, Element as XmlElement } from '@xmldom/xmldom';
+import { z } from 'zod';
+import type { FieldDefinition } from '../metadata.js';
+
+const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+const ColumnSchema = z.object({
+  field: z.string().min(1),
+  format: z.enum(['text', 'integer', 'decimal', 'currency']).default('text'),
+}).strict();
+
+const TableSchema = z.object({
+  id: z.string().min(1),
+  rows_field: z.string().min(1),
+  header_cells: z.array(z.string()).min(1),
+  columns: z.array(ColumnSchema).min(1),
+  prototype_row_index: z.number().int().positive().optional(),
+}).strict().refine((table) => table.header_cells.length === table.columns.length, {
+  message: 'header_cells and columns must have the same length',
+});
+
+export const RepeatableTablesConfigSchema = z.object({
+  schema_version: z.literal(1),
+  tables: z.array(TableSchema).min(1),
+}).strict();
+
+export type RepeatableTablesConfig = z.infer<typeof RepeatableTablesConfigSchema>;
+
+export function loadRepeatableTablesConfig(templateDir: string): RepeatableTablesConfig | undefined {
+  const configPath = join(templateDir, 'repeatable-tables.json');
+  if (!existsSync(configPath)) return undefined;
+  return RepeatableTablesConfigSchema.parse(JSON.parse(readFileSync(configPath, 'utf8')));
+}
+
+export function validateRepeatableTableFields(config: RepeatableTablesConfig, fields: FieldDefinition[]): void {
+  const byName = new Map(fields.map((field) => [field.name, field]));
+  for (const table of config.tables) {
+    const rowsField = byName.get(table.rows_field);
+    if (!rowsField || rowsField.type !== 'array' || !rowsField.items) {
+      throw new Error(`repeatable table "${table.id}" rows_field "${table.rows_field}" must reference an array field with items`);
+    }
+    const itemNames = new Set(rowsField.items.map((item) => item.name));
+    for (const column of table.columns) {
+      if (!itemNames.has(column.field)) {
+        throw new Error(`repeatable table "${table.id}" column field "${column.field}" is not declared in ${table.rows_field}.items`);
+      }
+    }
+  }
+}
+
+function directChildren(element: XmlElement, localName: string): XmlElement[] {
+  return Array.from(element.childNodes).filter(
+    (node) => node.nodeType === 1 && (node as XmlElement).localName === localName,
+  ) as XmlElement[];
+}
+
+function textOf(element: XmlElement): string {
+  return Array.from(element.getElementsByTagNameNS(W_NS, 't'))
+    .map((node) => node.textContent ?? '')
+    .join('')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function formatValue(value: unknown, format: z.infer<typeof ColumnSchema>['format']): string {
+  if (value === null || value === undefined || value === '') return '';
+  if (format === 'text') return String(value);
+  const number = typeof value === 'number' ? value : Number(String(value).replace(/[$,]/g, ''));
+  if (!Number.isFinite(number)) throw new Error(`cannot format non-numeric repeatable-table value ${JSON.stringify(value)} as ${format}`);
+  if (format === 'integer') return new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 }).format(number);
+  if (format === 'currency') return new Intl.NumberFormat('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(number);
+  return new Intl.NumberFormat('en-US', { maximumFractionDigits: 8 }).format(number);
+}
+
+function setCellText(doc: XmlDocument, cell: XmlElement, value: string): void {
+  const paragraphs = directChildren(cell, 'p');
+  const paragraph = paragraphs[0] ?? doc.createElementNS(W_NS, 'w:p');
+  if (paragraph.parentNode === null) cell.appendChild(paragraph);
+  for (const child of Array.from(paragraph.childNodes)) {
+    if (child.nodeType === 1 && (child as XmlElement).localName !== 'pPr') paragraph.removeChild(child);
+  }
+  value.split('\n').forEach((line, index) => {
+    if (index > 0) {
+      const breakRun = doc.createElementNS(W_NS, 'w:r');
+      breakRun.appendChild(doc.createElementNS(W_NS, 'w:br'));
+      paragraph.appendChild(breakRun);
+    }
+    const run = doc.createElementNS(W_NS, 'w:r');
+    const text = doc.createElementNS(W_NS, 'w:t');
+    if (/^\s|\s$/.test(line)) text.setAttribute('xml:space', 'preserve');
+    text.appendChild(doc.createTextNode(line));
+    run.appendChild(text);
+    paragraph.appendChild(run);
+  });
+  for (const extra of paragraphs.slice(1)) cell.removeChild(extra);
+}
+
+function isBlankRow(row: XmlElement): boolean {
+  return directChildren(row, 'tc').every((cell) => textOf(cell) === '');
+}
+
+function stripHeaderSemantics(row: XmlElement): void {
+  for (const marker of Array.from(row.getElementsByTagNameNS(W_NS, 'tblHeader'))) {
+    marker.parentNode?.removeChild(marker);
+  }
+  for (const shading of Array.from(row.getElementsByTagNameNS(W_NS, 'shd'))) {
+    shading.parentNode?.removeChild(shading);
+  }
+}
+
+export function applyRepeatableTables(
+  inputPath: string,
+  outputPath: string,
+  config: RepeatableTablesConfig,
+  values: Record<string, unknown>,
+): void {
+  const zip = new AdmZip(inputPath);
+  const entry = zip.getEntry('word/document.xml');
+  if (!entry) throw new Error('repeatable tables require word/document.xml');
+  const doc = new DOMParser().parseFromString(entry.getData().toString('utf8'), 'text/xml');
+  const tables = Array.from(doc.getElementsByTagNameNS(W_NS, 'tbl')) as XmlElement[];
+
+  for (const binding of config.tables) {
+    const candidates = tables.filter((table) => {
+      const header = directChildren(table, 'tr')[0];
+      if (!header) return false;
+      return directChildren(header, 'tc').map(textOf).every((text, index) => text === binding.header_cells[index])
+        && directChildren(header, 'tc').length === binding.header_cells.length;
+    });
+    if (candidates.length !== 1) {
+      throw new Error(`repeatable table "${binding.id}" matched ${candidates.length} tables; expected exactly one`);
+    }
+    const table = candidates[0];
+    const rows = directChildren(table, 'tr');
+    if (binding.prototype_row_index === undefined) {
+      const nonblank = rows.slice(1).find((row) => !isBlankRow(row));
+      if (nonblank) {
+        throw new Error(`repeatable table "${binding.id}" has a nonblank post-header row; use an explicit prototype_row_index or remove stale data`);
+      }
+    }
+    const prototype = binding.prototype_row_index === undefined
+      ? rows[0].cloneNode(true) as XmlElement
+      : rows[binding.prototype_row_index];
+    if (!prototype) throw new Error(`repeatable table "${binding.id}" has no prototype row at index ${binding.prototype_row_index}`);
+    if (binding.prototype_row_index === undefined) stripHeaderSemantics(prototype);
+    const prototypeCells = directChildren(prototype, 'tc');
+    if (prototypeCells.length !== binding.columns.length) {
+      throw new Error(`repeatable table "${binding.id}" prototype has ${prototypeCells.length} cells; expected ${binding.columns.length}`);
+    }
+    const rawRows = values[binding.rows_field] ?? [];
+    if (!Array.isArray(rawRows)) throw new Error(`repeatable table field "${binding.rows_field}" must be an array`);
+    for (const [rowIndex, rawRow] of rawRows.entries()) {
+      if (!rawRow || typeof rawRow !== 'object' || Array.isArray(rawRow)) {
+        throw new Error(`repeatable table field "${binding.rows_field}" entry ${rowIndex} must be an object`);
+      }
+      const row = prototype.cloneNode(true) as XmlElement;
+      const cells = directChildren(row, 'tc');
+      for (let columnIndex = 0; columnIndex < binding.columns.length; columnIndex++) {
+        const column = binding.columns[columnIndex];
+        setCellText(doc, cells[columnIndex], formatValue((rawRow as Record<string, unknown>)[column.field], column.format));
+      }
+      table.appendChild(row);
+    }
+    for (const row of rows.slice(1)) {
+      if (binding.prototype_row_index === undefined ? isBlankRow(row) : row === prototype) {
+        table.removeChild(row);
+      }
+    }
+  }
+
+  zip.updateFile('word/document.xml', Buffer.from(new XMLSerializer().serializeToString(doc), 'utf8'));
+  zip.writeZip(outputPath);
+}


### PR DESCRIPTION
## Summary

- add a projection-friendly `repeatable-tables.json` contract for DOCX schedules
- support true header-only row synthesis and optional explicit prototype rows
- preserve cell widths, borders, and alignment while removing header-only semantics
- fail closed on missing/ambiguous headers, malformed data, and stale nonblank rows
- format text, integer, decimal, currency, and multiline address cells
- include repeatable row fields in field-usage reporting

## Verification

- focused repeatable-table and integration suites: 14 passed
- full test suite: 115 files passed (3 skipped), 1,315 tests passed (6 skipped)
- lint: passed
- build/TypeScript: passed
- actual hash-pinned SPA scratch-overlay fill: exit 0, valid DOCX archive
- populated two purchaser rows and one non-signing-holder row with the expected shares, prices, totals, and formatted values

The canonical SPA binding configuration remains upstream in `UseJunior/legal-explainer` and will be added in a dependent PR; no managed SPA recipe files are changed here.

Closes #733
