### PR TITLE
feat(field-selector): support prototype-only repeatable tables

### DIFF
--- a/integration-tests/repeatable-table-pipeline-ordering.test.ts
+++ b/integration-tests/repeatable-table-pipeline-ordering.test.ts
@@ -1,0 +1,100 @@
+import {mkdtempSync, readFileSync, rmSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import AdmZip from 'adm-zip';
+import {afterEach, describe, expect, it} from 'vitest';
+import {applyRepeatableTables, RepeatableTablesConfigSchema} from '../src/core/field-selector/repeatable-tables.js';
+import {runFillPipeline} from '../src/core/unified-pipeline.js';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const roots: string[] = [];
+
+function sourceDocx(): Buffer {
+  const zip = new AdmZip();
+  const row = `<w:tr><w:tc><w:p><w:r><w:t>Investor Name</w:t></w:r></w:p>` +
+    `<w:p><w:r><w:t>Address</w:t></w:r></w:p></w:tc></w:tr>`;
+  zip.addFile('[Content_Types].xml', Buffer.from(
+    '<?xml version="1.0" encoding="UTF-8"?>' +
+    '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">' +
+    '<Default Extension="xml" ContentType="application/xml"/>' +
+    '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+    '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+    '</Types>',
+  ));
+  zip.addFile('_rels/.rels', Buffer.from(
+    '<?xml version="1.0" encoding="UTF-8"?>' +
+    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+    '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>' +
+    '</Relationships>',
+  ));
+  zip.addFile('word/_rels/document.xml.rels', Buffer.from(
+    '<?xml version="1.0" encoding="UTF-8"?>' +
+    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"/>',
+  ));
+  zip.addFile('word/document.xml', Buffer.from(
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<w:document xmlns:w="${W}"><w:body><w:p><w:r><w:t>Lead: Investor Name</w:t></w:r></w:p>` +
+    `<w:tbl>${row}${row}${row}</w:tbl></w:body></w:document>`,
+  ));
+  return zip.toBuffer();
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, {recursive: true, force: true});
+});
+
+describe('repeatable-table full pipeline ordering', () => {
+  it('matches source prototypes before scalar replacement and preserves generated party values', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'repeatable-pipeline-'));
+    roots.push(root);
+    const inputPath = join(root, 'source.docx');
+    const outputPath = join(root, 'filled.docx');
+    new AdmZip(sourceDocx()).writeZip(inputPath);
+    const config = RepeatableTablesConfigSchema.parse({
+      schema_version: 1,
+      tables: [{
+        id: 'investor-signatures',
+        rows_field: 'investors',
+        prototype_cells: ['Investor NameAddress'],
+        columns: [{paragraphs: [{field: 'name'}, {field: 'address'}]}],
+      }],
+    });
+    const values = {
+      investor_name: 'Lead Fund, L.P.',
+      investors: [
+        {name: 'Alpha Ventures, L.P.', address: '1 Alpha Way'},
+        {name: 'Beta Capital, LLC', address: '2 Beta Road'},
+      ],
+    };
+
+    await runFillPipeline({
+      inputPath,
+      outputPath,
+      values,
+      fields: [
+        {name: 'investor_name', type: 'string', description: 'Lead investor'},
+        {name: 'investors', type: 'array', description: 'Investor rows', items: [
+          {name: 'name', type: 'string', description: 'Name'},
+          {name: 'address', type: 'string', description: 'Address'},
+        ]},
+      ],
+      cleanPatch: {
+        cleanConfig: {removeParagraphPatterns: [], removeRanges: []},
+        replacements: {'Investor Name': '{investor_name}'},
+      },
+      prePatchProcess: (source, destination) => applyRepeatableTables(source, destination, config, values),
+      verify: () => ({passed: true, checks: []}),
+    });
+
+    const xml = new AdmZip(readFileSync(outputPath)).readAsText('word/document.xml');
+    expect(xml).toContain('Lead: ');
+    expect(xml).toContain('Lead Fund, L.P.');
+    expect(xml).toContain('Alpha Ventures, L.P.');
+    expect(xml).toContain('Beta Capital, LLC');
+    expect(xml).toContain('1 Alpha Way');
+    expect(xml).toContain('2 Beta Road');
+    expect((xml.match(/<w:tr[ >]/g) ?? [])).toHaveLength(2);
+    expect(xml).not.toContain('Investor Name');
+    expect(xml.match(/Lead Fund, L.P./g)).toHaveLength(1);
+  });
+});

--- a/src/core/field-selector/index.ts
+++ b/src/core/field-selector/index.ts
@@ -142,11 +142,13 @@ export async function runFieldSelector(options: FieldSelectorRunOptions): Promis
     cleanPatch: { cleanConfig, replacements: patchReplacements },
     selectorManifests,
     selectionsConfig,
-    postProcess: repeatableTablesConfig || shouldNormalizeBracketArtifacts
+    prePatchProcess: repeatableTablesConfig
+      ? async (inputDocPath: string, outputDocPath: string) => {
+        applyRepeatableTables(inputDocPath, outputDocPath, repeatableTablesConfig, effectiveValues);
+      }
+      : undefined,
+    postProcess: shouldNormalizeBracketArtifacts
       ? async (outputDocPath: string) => {
-        if (repeatableTablesConfig) {
-          applyRepeatableTables(outputDocPath, outputDocPath, repeatableTablesConfig, effectiveValues);
-        }
         if (shouldNormalizeBracketArtifacts) {
           await normalizeBracketArtifacts(outputDocPath, outputDocPath, {
             rules: normalizeConfig.paragraph_rules,

--- a/src/core/field-selector/repeatable-tables.test.ts
+++ b/src/core/field-selector/repeatable-tables.test.ts
@@ -28,6 +28,20 @@ function fixtureDocx(duplicate = false, postHeader: 'none' | 'blank' | 'nonblank
   return zip.toBuffer();
 }
 
+function prototypeOnlyFixture(rowCount = 3, inconsistent = false, duplicate = false): Buffer {
+  const zip = new AdmZip();
+  const row = (index: number) => `<w:tr><w:trPr><w:cantSplit/></w:trPr><w:tc><w:tcPr><w:tcW w:w="6000"/><w:tcBorders><w:bottom w:val="single"/></w:tcBorders></w:tcPr>` +
+    `<w:p><w:pPr><w:jc w:val="left"/></w:pPr><w:r><w:rPr><w:b/></w:rPr><w:t>${inconsistent && index === 1 ? 'Unexpected Name' : 'Investor Name'}</w:t></w:r></w:p>` +
+    `<w:p><w:r><w:t>Address</w:t></w:r></w:p><w:p><w:r><w:t>Phone Number</w:t></w:r></w:p>` +
+    `<w:p><w:r><w:t>Email</w:t></w:r></w:p><w:p><w:r><w:t>[Counsel cc, if any]</w:t></w:r></w:p><w:p/></w:tc></w:tr>`;
+  const table = `<w:tbl>${Array.from({ length: rowCount }, (_, index) => row(index)).join('')}</w:tbl>`;
+  zip.addFile('word/document.xml', Buffer.from(
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<w:document xmlns:w="${W}"><w:body>${table}${duplicate ? table : ''}</w:body></w:document>`,
+  ));
+  return zip.toBuffer();
+}
+
 const config = RepeatableTablesConfigSchema.parse({
   schema_version: 1,
   tables: [{
@@ -138,5 +152,93 @@ describe('repeatable DOCX table bindings', () => {
       description: 'Purchaser rows',
       items: [{ name: 'name', type: 'string', description: 'Name' }],
     }])).toThrow(/column field "shares" is not declared/);
+  });
+
+  it.each([0, 1, 2, 4])('fills %i rows in a prototype-only signature table and removes unused rows', (count) => {
+    const root = mkdtempSync(join(tmpdir(), 'repeatable-prototype-'));
+    roots.push(root);
+    const input = join(root, 'in.docx');
+    const output = join(root, 'out.docx');
+    new AdmZip(prototypeOnlyFixture()).writeZip(input);
+    const binding = RepeatableTablesConfigSchema.parse({
+      schema_version: 1,
+      tables: [{
+        id: 'investor-signatures',
+        rows_field: 'investors',
+        prototype_cells: ['Investor NameAddressPhone NumberEmail[Counsel cc, if any]'],
+        columns: [{ paragraphs: [
+          { field: 'name' }, { field: 'address' }, { field: 'phone' }, { field: 'email' }, { field: 'counsel_cc' },
+        ] }],
+      }],
+    });
+    const investors = Array.from({ length: count }, (_, index) => ({
+      name: `Investor ${index + 1}`,
+      address: `${index + 1} Main Street`,
+      phone: `555-000${index}`,
+      email: `investor${index + 1}@example.com`,
+      counsel_cc: index === 0 ? 'Counsel One' : '',
+    }));
+    applyRepeatableTables(input, output, binding, { investors });
+    const xml = new AdmZip(readFileSync(output)).readAsText('word/document.xml');
+    expect((xml.match(/<w:tr[ >]/g) ?? [])).toHaveLength(count);
+    expect(xml).not.toContain('Investor Name');
+    expect(xml).not.toContain('[Counsel cc, if any]');
+    if (count > 0) {
+      expect(xml).toContain('Investor 1');
+      expect(xml).toContain('1 Main Street');
+      expect(xml).toContain('<w:cantSplit/>');
+      expect(xml).toContain('w:w="6000"');
+      expect(xml).toContain('<w:b/>');
+      expect(xml).toContain('<w:bottom w:val="single"/>');
+    }
+  });
+
+  it('fails closed when a prototype-only source table contains a divergent row', () => {
+    const root = mkdtempSync(join(tmpdir(), 'repeatable-prototype-'));
+    roots.push(root);
+    const input = join(root, 'in.docx');
+    new AdmZip(prototypeOnlyFixture(3, true)).writeZip(input);
+    const binding = RepeatableTablesConfigSchema.parse({
+      schema_version: 1,
+      tables: [{
+        id: 'investor-signatures', rows_field: 'investors',
+        prototype_cells: ['Investor NameAddressPhone NumberEmail[Counsel cc, if any]'],
+        columns: [{ paragraphs: [{ field: 'name' }] }],
+      }],
+    });
+    expect(() => applyRepeatableTables(input, join(root, 'out.docx'), binding, { investors: [] }))
+      .toThrow(/does not match prototype_cells/);
+  });
+
+  it('fails closed when a prototype-only selector is ambiguous', () => {
+    const root = mkdtempSync(join(tmpdir(), 'repeatable-prototype-'));
+    roots.push(root);
+    const input = join(root, 'in.docx');
+    new AdmZip(prototypeOnlyFixture(3, false, true)).writeZip(input);
+    const binding = RepeatableTablesConfigSchema.parse({
+      schema_version: 1,
+      tables: [{
+        id: 'investor-signatures', rows_field: 'investors',
+        prototype_cells: ['Investor NameAddressPhone NumberEmail[Counsel cc, if any]'],
+        columns: [{ paragraphs: [{ field: 'name' }] }],
+      }],
+    });
+    expect(() => applyRepeatableTables(input, join(root, 'out.docx'), binding, { investors: [] }))
+      .toThrow(/matched 2 tables/);
+  });
+
+  it('validates every paragraph mapping against array item metadata', () => {
+    const binding = RepeatableTablesConfigSchema.parse({
+      schema_version: 1,
+      tables: [{
+        id: 'investor-signatures', rows_field: 'investors',
+        prototype_cells: ['Investor NameAddress'],
+        columns: [{ paragraphs: [{ field: 'name' }, { field: 'address' }] }],
+      }],
+    });
+    expect(() => validateRepeatableTableFields(binding, [{
+      name: 'investors', type: 'array', description: 'Investor rows',
+      items: [{ name: 'name', type: 'string', description: 'Investor name' }],
+    }])).toThrow(/column field "address" is not declared/);
   });
 });

--- a/src/core/field-selector/repeatable-tables.ts
+++ b/src/core/field-selector/repeatable-tables.ts
@@ -8,20 +8,36 @@ import type { FieldDefinition } from '../metadata.js';
 
 const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 
-const ColumnSchema = z.object({
+const ValueSchema = z.object({
   field: z.string().min(1),
   format: z.enum(['text', 'integer', 'decimal', 'currency']).default('text'),
 }).strict();
 
-const TableSchema = z.object({
+const ColumnSchema = z.union([
+  ValueSchema,
+  z.object({ paragraphs: z.array(ValueSchema).min(1) }).strict(),
+]);
+
+const TableBaseSchema = z.object({
   id: z.string().min(1),
   rows_field: z.string().min(1),
-  header_cells: z.array(z.string()).min(1),
   columns: z.array(ColumnSchema).min(1),
+});
+
+const HeaderTableSchema = TableBaseSchema.extend({
+  header_cells: z.array(z.string()).min(1),
   prototype_row_index: z.number().int().positive().optional(),
 }).strict().refine((table) => table.header_cells.length === table.columns.length, {
   message: 'header_cells and columns must have the same length',
 });
+
+const PrototypeTableSchema = TableBaseSchema.extend({
+  prototype_cells: z.array(z.string()).min(1),
+}).strict().refine((table) => table.prototype_cells.length === table.columns.length, {
+  message: 'prototype_cells and columns must have the same length',
+});
+
+const TableSchema = z.union([HeaderTableSchema, PrototypeTableSchema]);
 
 export const RepeatableTablesConfigSchema = z.object({
   schema_version: z.literal(1),
@@ -45,8 +61,11 @@ export function validateRepeatableTableFields(config: RepeatableTablesConfig, fi
     }
     const itemNames = new Set(rowsField.items.map((item) => item.name));
     for (const column of table.columns) {
-      if (!itemNames.has(column.field)) {
-        throw new Error(`repeatable table "${table.id}" column field "${column.field}" is not declared in ${table.rows_field}.items`);
+      const values = 'paragraphs' in column ? column.paragraphs : [column];
+      for (const value of values) {
+        if (!itemNames.has(value.field)) {
+          throw new Error(`repeatable table "${table.id}" column field "${value.field}" is not declared in ${table.rows_field}.items`);
+        }
       }
     }
   }
@@ -66,7 +85,7 @@ function textOf(element: XmlElement): string {
     .trim();
 }
 
-function formatValue(value: unknown, format: z.infer<typeof ColumnSchema>['format']): string {
+function formatValue(value: unknown, format: z.infer<typeof ValueSchema>['format']): string {
   if (value === null || value === undefined || value === '') return '';
   if (format === 'text') return String(value);
   const number = typeof value === 'number' ? value : Number(String(value).replace(/[$,]/g, ''));
@@ -74,6 +93,20 @@ function formatValue(value: unknown, format: z.infer<typeof ColumnSchema>['forma
   if (format === 'integer') return new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 }).format(number);
   if (format === 'currency') return new Intl.NumberFormat('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(number);
   return new Intl.NumberFormat('en-US', { maximumFractionDigits: 8 }).format(number);
+}
+
+function setParagraphText(doc: XmlDocument, paragraph: XmlElement, value: string): void {
+  const runs = directChildren(paragraph, 'r');
+  const run = runs[0] ?? doc.createElementNS(W_NS, 'w:r');
+  if (run.parentNode === null) paragraph.appendChild(run);
+  for (const child of Array.from(run.childNodes)) {
+    if (child.nodeType === 1 && (child as XmlElement).localName !== 'rPr') run.removeChild(child);
+  }
+  const text = doc.createElementNS(W_NS, 'w:t');
+  if (/^\s|\s$/.test(value)) text.setAttribute('xml:space', 'preserve');
+  text.appendChild(doc.createTextNode(value));
+  run.appendChild(text);
+  for (const extra of runs.slice(1)) paragraph.removeChild(extra);
 }
 
 function setCellText(doc: XmlDocument, cell: XmlElement, value: string): void {
@@ -97,6 +130,23 @@ function setCellText(doc: XmlDocument, cell: XmlElement, value: string): void {
     paragraph.appendChild(run);
   });
   for (const extra of paragraphs.slice(1)) cell.removeChild(extra);
+}
+
+function setCellParagraphs(
+  doc: XmlDocument,
+  cell: XmlElement,
+  mappings: Array<z.infer<typeof ValueSchema>>,
+  row: Record<string, unknown>,
+  tableId: string,
+): void {
+  const paragraphs = directChildren(cell, 'p');
+  if (paragraphs.length < mappings.length) {
+    throw new Error(`repeatable table "${tableId}" prototype cell has ${paragraphs.length} paragraphs; expected at least ${mappings.length}`);
+  }
+  mappings.forEach((mapping, index) => {
+    setParagraphText(doc, paragraphs[index], formatValue(row[mapping.field], mapping.format));
+  });
+  for (const extra of paragraphs.slice(mappings.length)) cell.removeChild(extra);
 }
 
 function isBlankRow(row: XmlElement): boolean {
@@ -126,27 +176,38 @@ export function applyRepeatableTables(
 
   for (const binding of config.tables) {
     const candidates = tables.filter((table) => {
-      const header = directChildren(table, 'tr')[0];
-      if (!header) return false;
-      return directChildren(header, 'tc').map(textOf).every((text, index) => text === binding.header_cells[index])
-        && directChildren(header, 'tc').length === binding.header_cells.length;
+      const firstRow = directChildren(table, 'tr')[0];
+      if (!firstRow) return false;
+      const expected = 'header_cells' in binding ? binding.header_cells : binding.prototype_cells;
+      const cells = directChildren(firstRow, 'tc').map(textOf);
+      return cells.length === expected.length && cells.every((text, index) => text === expected[index]);
     });
     if (candidates.length !== 1) {
       throw new Error(`repeatable table "${binding.id}" matched ${candidates.length} tables; expected exactly one`);
     }
     const table = candidates[0];
     const rows = directChildren(table, 'tr');
-    if (binding.prototype_row_index === undefined) {
+    const isHeaderTable = 'header_cells' in binding;
+    if (isHeaderTable && binding.prototype_row_index === undefined) {
       const nonblank = rows.slice(1).find((row) => !isBlankRow(row));
       if (nonblank) {
         throw new Error(`repeatable table "${binding.id}" has a nonblank post-header row; use an explicit prototype_row_index or remove stale data`);
       }
     }
-    const prototype = binding.prototype_row_index === undefined
+    if (!isHeaderTable) {
+      const inconsistent = rows.find((row) => {
+        const cells = directChildren(row, 'tc').map(textOf);
+        return cells.length !== binding.prototype_cells.length
+          || cells.some((text, index) => text !== binding.prototype_cells[index]);
+      });
+      if (inconsistent) throw new Error(`repeatable table "${binding.id}" has a row that does not match prototype_cells`);
+    }
+    const explicitPrototypeIndex = isHeaderTable ? binding.prototype_row_index : undefined;
+    const prototype = isHeaderTable && explicitPrototypeIndex === undefined
       ? rows[0].cloneNode(true) as XmlElement
-      : rows[binding.prototype_row_index];
-    if (!prototype) throw new Error(`repeatable table "${binding.id}" has no prototype row at index ${binding.prototype_row_index}`);
-    if (binding.prototype_row_index === undefined) stripHeaderSemantics(prototype);
+      : rows[explicitPrototypeIndex ?? 0];
+    if (!prototype) throw new Error(`repeatable table "${binding.id}" has no prototype row at index ${explicitPrototypeIndex ?? 0}`);
+    if (isHeaderTable && explicitPrototypeIndex === undefined) stripHeaderSemantics(prototype);
     const prototypeCells = directChildren(prototype, 'tc');
     if (prototypeCells.length !== binding.columns.length) {
       throw new Error(`repeatable table "${binding.id}" prototype has ${prototypeCells.length} cells; expected ${binding.columns.length}`);
@@ -161,14 +222,17 @@ export function applyRepeatableTables(
       const cells = directChildren(row, 'tc');
       for (let columnIndex = 0; columnIndex < binding.columns.length; columnIndex++) {
         const column = binding.columns[columnIndex];
-        setCellText(doc, cells[columnIndex], formatValue((rawRow as Record<string, unknown>)[column.field], column.format));
+        if ('paragraphs' in column) {
+          setCellParagraphs(doc, cells[columnIndex], column.paragraphs, rawRow as Record<string, unknown>, binding.id);
+        } else {
+          setCellText(doc, cells[columnIndex], formatValue((rawRow as Record<string, unknown>)[column.field], column.format));
+        }
       }
       table.appendChild(row);
     }
-    for (const row of rows.slice(1)) {
-      if (binding.prototype_row_index === undefined ? isBlankRow(row) : row === prototype) {
-        table.removeChild(row);
-      }
+    const sourceRows = isHeaderTable ? rows.slice(1) : rows;
+    for (const row of sourceRows) {
+      if (!isHeaderTable || explicitPrototypeIndex === undefined ? (!isHeaderTable || isBlankRow(row)) : row === prototype) table.removeChild(row);
     }
   }
 

--- a/src/core/unified-pipeline.ts
+++ b/src/core/unified-pipeline.ts
@@ -86,6 +86,12 @@ export interface PipelineOptions {
     cleanedSourcePath?: string,
     referencedFields?: Set<string>,
   ) => VerifyResult | Promise<VerifyResult>;
+  /**
+   * Structural source transformation that must run after cleaning but before
+   * selector/legacy scalar patching. Generated content must contain no fill
+   * commands because command analysis and filling happen later.
+   */
+  prePatchProcess?: (inputPath: string, outputPath: string) => void | Promise<void>;
   postProcess?: (outputPath: string) => void | Promise<void>;
 
   // Debugging
@@ -176,6 +182,7 @@ export async function runFillPipeline(options: PipelineOptions): Promise<Pipelin
     computeDisplayFields,
     fixSmartQuotes = false,
     verify,
+    prePatchProcess,
     postProcess,
     keepIntermediate = false,
   } = options;
@@ -207,14 +214,21 @@ export async function runFillPipeline(options: PipelineOptions): Promise<Pipelin
       await cleanDocument(sourcePath, cleanedPath, cleanPatch.cleanConfig);
       cleanedSourcePath = cleanedPath;
 
+      let structuralInputPath = cleanedPath;
+      if (prePatchProcess) {
+        const structurallyProcessedPath = join(tempDir, 'structural.docx');
+        await prePatchProcess(cleanedPath, structurallyProcessedPath);
+        structuralInputPath = structurallyProcessedPath;
+      }
+
       // Selector-contract patch (deterministic locators) runs between clean and
       // the legacy patch. It rewrites resolved occurrences to {field_id} tags;
       // those fields' keys have already been removed from cleanPatch.replacements
       // (the declarative migrated_keys cutover) so each field is patched once.
-      let patchInputPath = cleanedPath;
+      let patchInputPath = structuralInputPath;
       if (selectorManifests && selectorManifests.length > 0) {
         const selectedPath = join(tempDir, 'selected.docx');
-        const selectorResult = await applySelectorContracts(cleanedPath, selectedPath, selectorManifests);
+        const selectorResult = await applySelectorContracts(structuralInputPath, selectedPath, selectorManifests);
         onSelectorResolved?.(selectorResult.fields);
         for (const warning of selectorResult.warnings) {
           console.warn(`Selector warning: ${warning}`);
@@ -249,6 +263,10 @@ export async function runFillPipeline(options: PipelineOptions): Promise<Pipelin
 
       currentPath = patchedPath;
       stages = { clean: cleanedPath, patch: patchedPath, fill: '' };
+    } else if (prePatchProcess) {
+      const structurallyProcessedPath = join(tempDir, 'structural.docx');
+      await prePatchProcess(sourcePath, structurallyProcessedPath);
+      currentPath = structurallyProcessedPath;
     }
 
     // Step 4: Prepare fill data.


### PR DESCRIPTION
## Summary

- extend repeatable-table bindings to prototype-only tables with exact `prototype_cells` matching
- support paragraph-level mappings inside a cell for party contact/signature schedules
- clone row, cell, paragraph, and run OOXML while preserving first-run formatting
- remove all unused prototype rows for zero, one, two, or multiple supplied parties
- fail closed on ambiguous tables or divergent source rows

## Verification

- focused repeatable-table suites: 16 passed
- actual pinned ROFR and Voting Agreement matrices: 0/0, 1/1, and 4/2 investor/key-holder rows
- no prototype schedule text remains in generated outputs
- every output parses as XML and passes DOCX archive validation
- lint, validation, and build: passed
- full suite: 115 test files passed (3 skipped), 1,322 tests passed (6 skipped)

Depends on #737; this PR is intentionally based on `fix/733-spa-repeatable-purchasers` because it extends that reusable runtime. Canonical ROFR and Voting bindings remain upstream and will be added in a dependent legal-explainer PR.

Closes #734
