### PR TITLE
fix(apap): restore current RI interoperability

### DIFF
--- a/.github/workflows/apap-interoperability.yml
+++ b/.github/workflows/apap-interoperability.yml
@@ -1,0 +1,75 @@
+name: APAP interoperability
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/apap-interoperability.yml'
+      - 'concerto/**'
+      - 'integration-tests/apap-server-roundtrip.test.ts'
+      - 'src/core/apap.ts'
+      - 'src/core/apap.test.ts'
+      - 'templates/openagreements-cc-by-4.0/openagreements-confidentiality-invention-assignment-agreement/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  current-reference-server:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:18
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - name: Check out OpenAgreements
+        uses: actions/checkout@v4
+
+      - name: Check out pinned APAP reference implementation
+        uses: actions/checkout@v4
+        with:
+          repository: accordproject/apap
+          ref: 6f0942cdd5aa05043df325c5fa26284085a09e0b
+          path: apap
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install OpenAgreements
+        run: npm ci
+
+      - name: Install and initialize APAP server
+        working-directory: apap/server
+        env:
+          POSTGRES_URL: postgresql://postgres:postgres@localhost:5432/postgres
+        run: |
+          npm ci
+          npx drizzle-kit push --force
+
+      - name: Start APAP server
+        working-directory: apap/server
+        env:
+          POSTGRES_URL: postgresql://postgres:postgres@localhost:5432/postgres
+        run: |
+          npm start > /tmp/apap-server.log 2>&1 &
+          for attempt in {1..60}; do
+            curl --fail --silent http://localhost:9000/templates && exit 0
+            sleep 1
+          done
+          cat /tmp/apap-server.log
+          exit 1
+
+      - name: Run APAP round-trip test
+        env:
+          APAP_BASE_URL: http://localhost:9000
+        run: npx vitest run integration-tests/apap-server-roundtrip.test.ts --reporter=verbose

--- a/docs/apap-interoperability.md
+++ b/docs/apap-interoperability.md
@@ -19,7 +19,10 @@ authoring.
 
 1. Call `get_apap_template` with the CIIAA template ID.
 2. Register the returned APAP Template with an APAP Agreement server.
-3. Create the APAP Agreement with Concerto data.
+3. Create the APAP Agreement with Concerto data. Set its `template`
+   relationship to the returned `template_relationship`, not the bare
+   `template.uri`. Package consumers can compute the same value with
+   `toApapTemplateRelationship(template)`.
 4. Pass that same data to `create_apap_agreement_docx`.
 5. Local MCP returns a local DOCX path. The hosted OpenAgreements MCP returns a
    signed, expiring download URL or MCP resource metadata.
@@ -27,6 +30,19 @@ authoring.
 The adapter removes APAP control properties (`$class`, `$identifier`, and
 `contractId`) before filling the canonical DOCX. It does not invent missing
 legal terms and fails closed on unsupported MDoc directives.
+
+The exported template declares Cicero `^2.0.0`, matching the current APAP
+reference implementation's Cicero 2 runtime. Its bundled Accord contract model
+and imports use the versioned `org.accordproject.contract@0.2.0` namespace
+required by current Concerto.
+
+The APAP template identifier is a stable `openagreements://templates/...`
+rather than the public `https:` page URL. The reference server treats HTTP(S)
+template identifiers as downloadable Cicero archives during agreement creation;
+the custom-scheme identifier makes it resolve the template registered in step 2
+instead. Its version segment uses hyphens because APAP template identifiers
+permit lowercase alphanumerics, underscores, and hyphens. The public canonical
+source remains in the template description.
 
 ## Repository boundaries
 

--- a/integration-tests/apap-server-roundtrip.test.ts
+++ b/integration-tests/apap-server-roundtrip.test.ts
@@ -1,0 +1,123 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import AdmZip from 'adm-zip';
+import { afterEach, describe, expect } from 'vitest';
+import { itAllure } from './helpers/allure-test.js';
+import { loadMetadata } from '../src/core/metadata.js';
+import {
+  exportTemplateToApap,
+  fillApapAgreementToDocx,
+  toApapAgreementData,
+  toApapTemplateRelationship,
+} from '../src/core/apap.js';
+
+const APAP_BASE_URL = process.env.APAP_BASE_URL?.replace(/\/$/, '');
+const ROOT = resolve(import.meta.dirname, '..');
+const TEMPLATE_ID = 'openagreements-confidentiality-invention-assignment-agreement';
+const TEMPLATE_DIR = join(ROOT, 'templates/openagreements-cc-by-4.0', TEMPLATE_ID);
+const MODEL_PATH = join(ROOT, 'concerto/openagreements-employee-ip-inventions-assignment.cto');
+const CONTRACT_MODEL_PATH = join(ROOT, 'concerto/deps/@models.accordproject.org.accordproject.contract.cto');
+const temporaryPaths: string[] = [];
+const createdResources: Array<{ kind: 'agreements' | 'templates'; id: number }> = [];
+const it = itAllure.epic('Platform & Distribution');
+
+async function requestJson(path: string, init?: RequestInit): Promise<Record<string, unknown>> {
+  const response = await fetch(`${APAP_BASE_URL}${path}`, {
+    ...init,
+    headers: { 'content-type': 'application/json', ...init?.headers },
+  });
+  const responseText = await response.text();
+  let body: Record<string, unknown>;
+  try {
+    body = JSON.parse(responseText) as Record<string, unknown>;
+  } catch {
+    throw new Error(
+      `APAP ${init?.method ?? 'GET'} ${path} returned non-JSON (${response.status}): ${responseText}`,
+    );
+  }
+  if (!response.ok) {
+    throw new Error(`APAP ${init?.method ?? 'GET'} ${path} failed (${response.status}): ${JSON.stringify(body)}`);
+  }
+  return body;
+}
+
+afterEach(async () => {
+  const cleanupFailures: string[] = [];
+  for (const resource of createdResources.reverse()) {
+    try {
+      const response = await fetch(`${APAP_BASE_URL}/${resource.kind}/${resource.id}`, { method: 'DELETE' });
+      if (!response.ok) cleanupFailures.push(`${resource.kind}/${resource.id}: HTTP ${response.status}`);
+    } catch (error) {
+      cleanupFailures.push(`${resource.kind}/${resource.id}: ${String(error)}`);
+    }
+  }
+  createdResources.length = 0;
+  for (const path of temporaryPaths) rmSync(path, { recursive: true, force: true });
+  temporaryPaths.length = 0;
+  if (cleanupFailures.length > 0) throw new Error(`APAP cleanup failed: ${cleanupFailures.join('; ')}`);
+});
+
+describe.skipIf(!APAP_BASE_URL)('APAP reference-server round trip', () => {
+  it('registers the CIIAA template, creates an agreement, and renders returned data', async () => {
+    const runId = randomUUID();
+    const template = exportTemplateToApap({
+      templateDir: TEMPLATE_DIR,
+      concertoModelPath: MODEL_PATH,
+      concertoDependencyPaths: [CONTRACT_MODEL_PATH],
+    });
+
+    const registeredTemplate = await requestJson('/templates', {
+      method: 'POST',
+      body: JSON.stringify(template),
+    });
+    createdResources.push({ kind: 'templates', id: Number(registeredTemplate.id) });
+
+    const agreementData = toApapAgreementData(template, loadMetadata(TEMPLATE_DIR), {
+      contractId: `oa-ciiaa-${runId}`,
+      values: {
+        company_name: 'Example Labs, Inc.',
+        company_signatory_name: 'Alex Smith',
+        company_signatory_title: 'President',
+        employee_name: 'Taylor Jones',
+        effective_date: '2026-09-04',
+        prior_inventions_disclosure: 'None',
+        excluded_inventions_statement: 'Personal projects listed on Schedule A are excluded.',
+        return_of_materials_timing: 'within five business days after termination',
+        post_termination_assistance: 'reasonable assistance on reasonable notice',
+        governing_law: 'New York',
+        venue: 'state and federal courts located in New York County, New York',
+      },
+    });
+    const createdAgreement = await requestJson('/agreements', {
+      method: 'POST',
+      body: JSON.stringify({
+        $class: 'org.accordproject.protocol@1.0.0.Agreement',
+        uri: `https://openagreements.org/apap-tests/agreements/${runId}`,
+        data: agreementData,
+        template: toApapTemplateRelationship(template),
+        agreementStatus: 'DRAFT',
+      }),
+    });
+    createdResources.push({ kind: 'agreements', id: Number(createdAgreement.id) });
+
+    expect(createdAgreement.template).toBe(toApapTemplateRelationship(template));
+    expect(createdAgreement.data).toEqual(agreementData);
+
+    const outputDir = mkdtempSync(join(tmpdir(), 'oa-apap-server-'));
+    temporaryPaths.push(outputDir);
+    const outputPath = join(outputDir, 'ciiaa.docx');
+    await fillApapAgreementToDocx({
+      templateDir: TEMPLATE_DIR,
+      agreementData: createdAgreement.data as Record<string, unknown>,
+      outputPath,
+    });
+
+    expect(readFileSync(outputPath).subarray(0, 2).toString()).toBe('PK');
+    const documentXml = new AdmZip(outputPath).readAsText('word/document.xml');
+    expect(documentXml).toContain('Example Labs, Inc.');
+    expect(documentXml).toContain('Taylor Jones');
+    expect(documentXml).not.toContain('{company_name}');
+  }, 30_000);
+});

--- a/packages/contract-templates-mcp/src/core/tools.ts
+++ b/packages/contract-templates-mcp/src/core/tools.ts
@@ -273,6 +273,7 @@ interface RepoModules {
     concertoModelPath: string;
     concertoDependencyPaths: string[];
   }) => Record<string, unknown>;
+  toApapTemplateRelationship: (template: { $class: string; uri: string }) => string;
   fillApapAgreementToDocx: (opts: {
     templateDir: string;
     agreementData: Record<string, unknown>;
@@ -322,6 +323,7 @@ async function importRepoModules(): Promise<RepoModules | null> {
         sourceName: listing.sourceName,
         mapFields: listing.mapFields,
         exportTemplateToApap: apap.exportTemplateToApap,
+        toApapTemplateRelationship: apap.toApapTemplateRelationship,
         fillApapAgreementToDocx: apap.fillApapAgreementToDocx,
         ...(content &&
         typeof content.listDocContentItems === 'function' &&
@@ -353,6 +355,7 @@ async function importRepoModules(): Promise<RepoModules | null> {
         sourceName: mod.sourceName ?? (() => null),
         mapFields: mod.mapFields ?? ((f: TemplateField[]) => f),
         exportTemplateToApap: mod.exportTemplateToApap,
+        toApapTemplateRelationship: mod.toApapTemplateRelationship,
         fillApapAgreementToDocx: mod.fillApapAgreementToDocx,
         ...(typeof mod.listDocContentItems === 'function' &&
         typeof mod.listDocContentTypesAvailable === 'function' &&
@@ -733,7 +736,7 @@ const tools: ToolDefinition[] = [
   {
     name: 'get_apap_template',
     description:
-      'Export an eligible OpenAgreements-authored template as an APAP Template payload, preserving canonical source, version, license, and attribution.',
+      'Export an eligible OpenAgreements-authored template as an APAP Template payload and its ready-to-use Agreement.template relationship, preserving canonical source, version, license, and attribution.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -750,8 +753,12 @@ const tools: ToolDefinition[] = [
       const dir = mod.findTemplateDir(input.template_id);
       if (!dir) return toolError('get_apap_template', 'TEMPLATE_NOT_FOUND', `Template not found: "${input.template_id}"`);
       try {
+        const template = mod.exportTemplateToApap(apapExportOptions(input.template_id, dir));
         return successResult('get_apap_template', {
-          template: mod.exportTemplateToApap(apapExportOptions(input.template_id, dir)),
+          template,
+          template_relationship: mod.toApapTemplateRelationship(
+            template as { $class: string; uri: string },
+          ),
         });
       } catch (error) {
         return toolError('get_apap_template', 'APAP_TEMPLATE_UNAVAILABLE', extractErrorMessage(error));

--- a/packages/contract-templates-mcp/tests/tools.test.ts
+++ b/packages/contract-templates-mcp/tests/tools.test.ts
@@ -387,6 +387,7 @@ describe('contract-templates-mcp tools', () => {
     expect(template.$class).toBe('org.accordproject.protocol@1.0.0.Template');
     expect(template.author).toBe('OpenAgreements contributors');
     expect(template.license).toBe('CC-BY-4.0');
+    expect(data.template_relationship).toBe(`resource:${template.$class}#${template.uri}`);
   });
 
   it('renders APAP CIIAA agreement data to a local DOCX without base64', async () => {

--- a/src/core/apap.test.ts
+++ b/src/core/apap.test.ts
@@ -9,6 +9,7 @@ import {
   canonicalMdocToApapTemplateMark,
   exportTemplateToApap,
   fillApapAgreementToDocx,
+  toApapTemplateRelationship,
   toApapAgreementData,
 } from './apap.js';
 
@@ -52,16 +53,26 @@ describe('APAP interoperability — OpenAgreements CIIAA pilot', () => {
     });
     const templateMetadata = loadMetadata(TEMPLATE_DIR);
     expect(templateMetadata.version).toMatch(/^\d+\.\d+(\.\d+)?$/);
-    expect(template.uri).toBe(`https://openagreements.org/templates/${TEMPLATE_ID}/v${templateMetadata.version}`);
+    expect(template.uri).toBe(
+      `openagreements://templates/${TEMPLATE_ID}-v${templateMetadata.version.replaceAll('.', '-')}`,
+    );
     expect(template.author).toBe('OpenAgreements contributors');
     expect(template.version).toBe(templateMetadata.version);
     expect(template.license).toBe('CC-BY-4.0');
+    expect(template.metadata.cicero).toBe('^2.0.0');
     expect(template.description).toContain('Authored by OpenAgreements contributors');
     expect(template.templateModel.model.ctoFiles).toHaveLength(2);
     const model = template.templateModel.model.ctoFiles[0].contents;
     expect(model).toContain('@template');
+    expect(model).toContain('import org.accordproject.contract@0.2.0.Contract');
     expect(model).not.toContain('company_name optional');
     expect(model).not.toContain('company_signatory_name optional');
+    expect(template.templateModel.model.ctoFiles[1].contents).toContain(
+      'namespace org.accordproject.contract@0.2.0',
+    );
+    expect(toApapTemplateRelationship(template)).toBe(
+      `resource:org.accordproject.protocol@1.0.0.Template#${template.uri}`,
+    );
   });
 
   it('round-trips APAP Concerto data into a filled DOCX', async () => {

--- a/src/core/apap.ts
+++ b/src/core/apap.ts
@@ -4,6 +4,7 @@ import { fillTemplate, type FillResult } from './engine.js';
 import { loadMetadata, type FieldDefinition, type TemplateMetadata } from './metadata.js';
 
 const APAP_NS = 'org.accordproject.protocol@1.0.0';
+const APAP_CICERO_RANGE = '^2.0.0';
 
 export interface ApapCtoFile {
   $class: `${typeof APAP_NS}.CtoFile`;
@@ -56,6 +57,15 @@ export interface FillApapAgreementOptions {
   templateDir: string;
   agreementData: Record<string, unknown>;
   outputPath: string;
+}
+
+/**
+ * Serialize an APAP Template as the Concerto relationship value required by
+ * Agreement.template. The template's URI is the relationship identifier; a
+ * bare URI is not a valid relationship value for the APAP protocol model.
+ */
+export function toApapTemplateRelationship(template: Pick<ApapTemplatePayload, '$class' | 'uri'>): string {
+  return `resource:${template.$class}#${template.uri}`;
 }
 
 function extractNamespaceAndType(cto: string): { namespace: string; typeName: string } {
@@ -178,7 +188,7 @@ function assertModelCoversCanonicalFields(cto: string, fields: FieldDefinition[]
 }
 
 function apapRequiredModel(cto: string, fields: FieldDefinition[]): string {
-  let result = cto;
+  let result = apapCompatibleCto(cto);
   if (!/^@template\s*$/m.test(result)) {
     result = result.replace(/^(asset\s+[^\n]+\s+extends\s+Contract\s*\{)/m, '@template\n$1');
   }
@@ -188,11 +198,30 @@ function apapRequiredModel(cto: string, fields: FieldDefinition[]): string {
   return result;
 }
 
+/**
+ * Normalize the legacy Accord contract model bundled by OpenAgreements to the
+ * versioned namespace required by current Concerto. Keep this transformation
+ * at the APAP export boundary: the source models are also consumed by the
+ * repository's Concerto 3 generation workflow and are not APAP projections.
+ */
+function apapCompatibleCto(cto: string): string {
+  return cto
+    .replace(
+      /\bimport org\.accordproject\.contract\.Contract from https:\/\/models\.accordproject\.org\/accordproject\/contract\.cto\b/,
+      'import org.accordproject.contract@0.2.0.Contract from https://models.accordproject.org/accordproject/contract@0.2.0.cto',
+    )
+    .replace(/^namespace org\.accordproject\.contract$/m, 'namespace org.accordproject.contract@0.2.0');
+}
+
 function apapSemver(version: string): string {
   if (/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(version)) return version;
   if (/^\d+\.\d+$/.test(version)) return `${version}.0`;
   if (/^\d+$/.test(version)) return `${version}.0.0`;
   throw new Error(`OpenAgreements version cannot be normalized to APAP semver: ${version}`);
+}
+
+function apapIdentifierVersion(version: string): string {
+  return apapSemver(version).toLowerCase().replace(/[^a-z0-9_-]+/g, '-');
 }
 
 export function exportTemplateToApap(options: ExportApapTemplateOptions): ApapTemplatePayload {
@@ -212,12 +241,12 @@ export function exportTemplateToApap(options: ExportApapTemplateOptions): ApapTe
   }, ...(options.concertoDependencyPaths ?? []).map((path) => ({
     $class: `${APAP_NS}.CtoFile` as const,
     filename: basename(path),
-    contents: readFileSync(path, 'utf8'),
+    contents: apapCompatibleCto(readFileSync(path, 'utf8')),
   }))];
 
   return {
     $class: `${APAP_NS}.Template`,
-    uri: options.templateUri ?? `https://openagreements.org/templates/${templateId}/v${metadata.version}`,
+    uri: options.templateUri ?? `openagreements://templates/${templateId}-v${apapIdentifierVersion(metadata.version)}`,
     author: 'OpenAgreements contributors',
     displayName: metadata.name,
     version: apapSemver(metadata.version),
@@ -231,7 +260,7 @@ export function exportTemplateToApap(options: ExportApapTemplateOptions): ApapTe
       $class: `${APAP_NS}.TemplateMetadata`,
       runtime: 'typescript',
       template: 'contract',
-      cicero: '0.25.x',
+      cicero: APAP_CICERO_RANGE,
     },
     templateModel: {
       $class: `${APAP_NS}.TemplateModel`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export { fillTemplate, type FillOptions, type FillResult } from './core/engine.j
 export {
   canonicalMdocToApapTemplateMark,
   exportTemplateToApap,
+  toApapTemplateRelationship,
   toApapAgreementData,
   fillApapAgreementToDocx,
   type ApapTemplatePayload,


### PR DESCRIPTION
## Summary

- update the APAP export to the current Cicero 2 / versioned Concerto contract model requirements
- serialize the required Concerto template relationship and return it directly from `get_apap_template`
- use a stable non-HTTP APAP template identifier so the RI resolves the registered template instead of fetching a `.cta`
- add a pinned APAP RI + PostgreSQL CI round trip and document the working flow

## Why this belongs here

This is an interoperability adapter fix in OpenAgreements. It does not change legal language, template fields, or content projected from `legal-explainer`, so no upstream content change is required.

## Verification

- `npm run preflight:ci` — 114 test files passed, 1,306 tests passed
- live disposable PostgreSQL + Accord Project APAP RI at `6f0942cdd5aa05043df325c5fa26284085a09e0b`
  - registered the exported CIIAA template
  - created a DRAFT agreement using returned Concerto data
  - rendered the server-returned data to DOCX
  - verified populated company/employee names and no remaining company-name placeholder
- focused MCP/APAP tests — 38 passed; real-server test skipped locally unless `APAP_BASE_URL` is set
- `npm run check:docs`
- `git diff --check`

## Review fixes incorporated

- return `template_relationship` to MCP-only callers
- exercise the exact production default identifier, including APAP's allowed-name characters
- report non-JSON server errors and cleanup failures
- run the real-server regression in CI rather than silently skipping it
