### PR TITLE
chore(release): v0.10.0

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "open-agreements",
   "displayName": "OpenAgreements",
   "description": "Open-source legal template automation for DOCX with MCP tooling.",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "author": {
     "name": "Open Agreements",
     "email": "steven@usejunior.com"

--- a/data/templates-snapshot.json
+++ b/data/templates-snapshot.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "cli_version": "0.9.0",
+  "cli_version": "0.10.0",
   "items": [
     {
       "name": "bonterms-mutual-nda",

--- a/docs/changelog-release-process.md
+++ b/docs/changelog-release-process.md
@@ -50,7 +50,12 @@ Allowed types include:
    - publish the npm package suite with trusted OIDC provenance, including both `open-agreements` and `@open-agreements/open-agreements`,
    - publish `server.json` to the official MCP registry (`io.github.open-agreements/open-agreements`) so the registry's `isLatest` tracks npm,
    - create a GitHub Release with auto-generated notes (if one does not exist),
-   - deploy production to Vercel.
+   - attach the versioned template snapshot tarball.
+
+> **Corrected 2026-09-04.** This page previously said the tag workflow deployed
+> production to Vercel. The current `release.yml` does not deploy Vercel. A
+> separate main-push workflow dispatches OpenAgreements updates to
+> `UseJunior/dev-website`.
 4. GitHub Releases is the public changelog surface for published notes:
    - `https://github.com/open-agreements/open-agreements/releases`
 
@@ -96,9 +101,19 @@ Before pushing a release tag, run a local Gemini extension install smoke test:
 1. Copy or symlink this repo checkout into `~/.gemini/extensions/open-agreements`.
 2. Verify `gemini-extension.json` is valid and includes:
    - `name`, `version`, `description`, `contextFileName`, `entrypoint`, `mcpServers`
-   - two local servers (`contracts-workspace-mcp`, `contract-templates-mcp`)
+   - the local servers declared by the manifest (currently
+     `contracts-workspace-mcp`, `contract-templates-mcp`, and `checklist-mcp`)
    - no `cwd` overrides
-3. Start Gemini and confirm both MCP servers initialize and respond.
+3. Run `gemini mcp list` and confirm every declared MCP server connects. Start
+   Gemini and confirm the servers respond to read-only calls. If Gemini's model
+   authentication is unavailable but `gemini mcp list` connects, directly
+   initialize and ping each locally built stdio server and record both results
+   in the release PR.
+
+> **Corrected 2026-09-04.** This gate previously hard-coded two servers even
+> after `checklist-mcp` was added, and it offered no auth-independent protocol
+> check. The manifest is now the source of truth; the fallback distinguishes an
+> MCP failure from a Gemini account-tier failure.
 
 Tagging is blocked until this gate passes.
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "open-agreements",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Local MCP extension for OpenAgreements workspace organization and contract template drafting.",
   "contextFileName": "AGENTS.md",
   "entrypoint": "AGENTS.md",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-agreements",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-agreements",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "bundleDependencies": [
         "@usejunior/docx-core"
       ],
@@ -8747,7 +8747,7 @@
     },
     "packages/checklist-mcp": {
       "name": "@open-agreements/checklist-mcp",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "open-agreements": ">=0.3.1",
@@ -8762,7 +8762,7 @@
     },
     "packages/contract-templates-mcp": {
       "name": "@open-agreements/contract-templates-mcp",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "open-agreements": ">=0.3.1",
@@ -8793,7 +8793,7 @@
     },
     "packages/contracts-workspace-mcp": {
       "name": "@open-agreements/contracts-workspace-mcp",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "js-yaml": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-agreements",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "workspaces": [
     "packages/allure-test-factory",
     "packages/contract-templates-mcp",

--- a/packages/checklist-mcp/package.json
+++ b/packages/checklist-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agreements/checklist-mcp",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Local stdio MCP server for OpenAgreements checklist memory operations",
   "type": "module",
   "bin": {

--- a/packages/contract-templates-mcp/package.json
+++ b/packages/contract-templates-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agreements/contract-templates-mcp",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "mcpName": "io.github.open-agreements/open-agreements",
   "description": "Local stdio MCP server for OpenAgreements template discovery and filling",
   "type": "module",

--- a/packages/contracts-workspace-mcp/package.json
+++ b/packages/contracts-workspace-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agreements/contracts-workspace-mcp",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Local stdio MCP server for contracts workspace operations",
   "type": "module",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -3,13 +3,13 @@
   "name": "io.github.open-agreements/open-agreements",
   "title": "Open Agreements",
   "description": "Fill standard legal agreement templates (NDAs, SAFEs, NVCA docs, employment) as DOCX files.",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "websiteUrl": "https://openagreements.org",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@open-agreements/contract-templates-mcp",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "transport": { "type": "stdio" },
       "runtimeHint": "npx",
       "environmentVariables": []


### PR DESCRIPTION
## Release

Bump the OpenAgreements package suite and distribution manifests from v0.9.0 to v0.10.0 after the APAP interoperability fix in #740.

## Included packages

- `open-agreements`
- `@open-agreements/open-agreements`
- `@open-agreements/contracts-workspace-mcp`
- `@open-agreements/contract-templates-mcp`
- `@open-agreements/checklist-mcp`
- Gemini/Cursor extension manifests and official MCP registry descriptor
- versioned template snapshot

## Release-gate evidence

- `node scripts/bump_version.mjs --check` — all 8 version fields at 0.10.0
- `npm run check:derived`
- `npm run check:templates-snapshot`
- `npm run preflight:ci` — 114 test files passed; 1,306 tests passed
- Gemini extension validation succeeded
- `gemini mcp list` connected all three manifest-declared MCP servers
- locally built `contracts-workspace-mcp`, `contract-templates-mcp`, and `checklist-mcp` each completed MCP initialize + ping
- Gemini model-driven tool calls were unavailable because Google reports the individual CLI tier as retired (`IneligibleTierError`); the corrected runbook now records the auth-independent protocol fallback

## Runbook corrections

The prior runbook had drifted from executable truth. It now records that:

- the release workflow publishes npm, MCP registry metadata, GitHub release notes, and the template tarball; it does not itself deploy Vercel
- the extension declares three MCP servers, not two
- an MCP-level initialize/ping is the fallback when Gemini model authentication is unavailable

Merging this PR should cause the auto-tag workflow to create `v0.10.0`, which triggers the release workflow.
