### PR TITLE
fix(ci): install schema probe dependencies

### DIFF
--- a/.github/workflows/published-schema-probe.yml
+++ b/.github/workflows/published-schema-probe.yml
@@ -39,6 +39,10 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Probe every published $schema reference
         run: npm run probe:published-schemas


### PR DESCRIPTION
## Summary

- install locked dependencies before running the published-schema probe
- enable the setup-node npm cache for that install

## Why

The probe imports the shared quality-card validator, which now depends on `ajv`. The scheduled/push workflow checked out source and invoked the probe without installing dependencies, so it failed with `ERR_MODULE_NOT_FOUND` before making any HTTP check.

## Validation

- workflow YAML parsed successfully
- `npm ci` completed from the committed lockfile
- `npm run probe:published-schemas` proceeds through dependency loading to the live endpoint check