### PR TITLE
fix(field-selector): harden production document fills

### DIFF
--- a/docs/adding-field-selectors.md
+++ b/docs/adding-field-selectors.md
@@ -212,6 +212,37 @@ point through the first subsequent `end` match (inclusive) are removed. Matching
 resumes from the next paragraph, so the same range pattern can match multiple occurrences
 in a single document.
 
+### Optional: replace prepopulated table rows
+
+Use `repeatable-tables.json` when an array field must replace rows in a source DOCX table.
+For a header table that already contains distinct model data, set
+`existing_data_row_count` to the exact number of post-header rows. The pipeline matches the
+table before scalar replacement, preserves its header, removes all asserted source data
+rows, and inserts one row per array item. `prototype_row_index` uses the table's zero-based
+row index (the header is row `0`, so the first data row is `1`) and selects the source row
+whose formatting is cloned;
+it defaults to the first data row in this mode.
+
+```json
+{
+  "schema_version": 1,
+  "tables": [{
+    "id": "existing-holders",
+    "rows_field": "holders",
+    "header_cells": ["Holder", "Shares"],
+    "existing_data_row_count": 7,
+    "prototype_row_index": 1,
+    "columns": [
+      { "field": "name" },
+      { "field": "shares", "format": "integer" }
+    ]
+  }]
+}
+```
+
+The asserted count is a source-drift guard: a different number of source rows fails closed.
+Omitting `existing_data_row_count` retains the prior header-only/prototype-row behavior.
+
 ## Step 6: Define fields in metadata.yaml
 
 Fields in `metadata.yaml` control default values for unfilled placeholders:

--- a/integration-tests/repeatable-table-pipeline-ordering.test.ts
+++ b/integration-tests/repeatable-table-pipeline-ordering.test.ts
@@ -2,12 +2,14 @@ import {mkdtempSync, readFileSync, rmSync} from 'node:fs';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import AdmZip from 'adm-zip';
-import {afterEach, describe, expect, it} from 'vitest';
+import {afterEach, describe, expect} from 'vitest';
+import {itAllure} from './helpers/allure-test.js';
 import {applyRepeatableTables, RepeatableTablesConfigSchema} from '../src/core/field-selector/repeatable-tables.js';
 import {runFillPipeline} from '../src/core/unified-pipeline.js';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const roots: string[] = [];
+const it = itAllure.epic('Filling & Rendering');
 
 function sourceDocx(): Buffer {
   const zip = new AdmZip();

--- a/integration-tests/repeatable-table-pipeline-ordering.test.ts
+++ b/integration-tests/repeatable-table-pipeline-ordering.test.ts
@@ -1,0 +1,100 @@
+import {mkdtempSync, readFileSync, rmSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import AdmZip from 'adm-zip';
+import {afterEach, describe, expect, it} from 'vitest';
+import {applyRepeatableTables, RepeatableTablesConfigSchema} from '../src/core/field-selector/repeatable-tables.js';
+import {runFillPipeline} from '../src/core/unified-pipeline.js';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const roots: string[] = [];
+
+function sourceDocx(): Buffer {
+  const zip = new AdmZip();
+  const row = `<w:tr><w:tc><w:p><w:r><w:t>Investor Name</w:t></w:r></w:p>` +
+    `<w:p><w:r><w:t>Address</w:t></w:r></w:p></w:tc></w:tr>`;
+  zip.addFile('[Content_Types].xml', Buffer.from(
+    '<?xml version="1.0" encoding="UTF-8"?>' +
+    '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">' +
+    '<Default Extension="xml" ContentType="application/xml"/>' +
+    '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+    '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+    '</Types>',
+  ));
+  zip.addFile('_rels/.rels', Buffer.from(
+    '<?xml version="1.0" encoding="UTF-8"?>' +
+    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+    '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>' +
+    '</Relationships>',
+  ));
+  zip.addFile('word/_rels/document.xml.rels', Buffer.from(
+    '<?xml version="1.0" encoding="UTF-8"?>' +
+    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"/>',
+  ));
+  zip.addFile('word/document.xml', Buffer.from(
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<w:document xmlns:w="${W}"><w:body><w:p><w:r><w:t>Lead: Investor Name</w:t></w:r></w:p>` +
+    `<w:tbl>${row}${row}${row}</w:tbl></w:body></w:document>`,
+  ));
+  return zip.toBuffer();
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, {recursive: true, force: true});
+});
+
+describe('repeatable-table full pipeline ordering', () => {
+  it('matches source prototypes before scalar replacement and preserves generated party values', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'repeatable-pipeline-'));
+    roots.push(root);
+    const inputPath = join(root, 'source.docx');
+    const outputPath = join(root, 'filled.docx');
+    new AdmZip(sourceDocx()).writeZip(inputPath);
+    const config = RepeatableTablesConfigSchema.parse({
+      schema_version: 1,
+      tables: [{
+        id: 'investor-signatures',
+        rows_field: 'investors',
+        prototype_cells: ['Investor NameAddress'],
+        columns: [{paragraphs: [{field: 'name'}, {field: 'address'}]}],
+      }],
+    });
+    const values = {
+      investor_name: 'Lead Fund, L.P.',
+      investors: [
+        {name: 'Alpha Ventures, L.P.', address: '1 Alpha Way'},
+        {name: 'Beta Capital, LLC', address: '2 Beta Road'},
+      ],
+    };
+
+    await runFillPipeline({
+      inputPath,
+      outputPath,
+      values,
+      fields: [
+        {name: 'investor_name', type: 'string', description: 'Lead investor'},
+        {name: 'investors', type: 'array', description: 'Investor rows', items: [
+          {name: 'name', type: 'string', description: 'Name'},
+          {name: 'address', type: 'string', description: 'Address'},
+        ]},
+      ],
+      cleanPatch: {
+        cleanConfig: {removeParagraphPatterns: [], removeRanges: []},
+        replacements: {'Investor Name': '{investor_name}'},
+      },
+      prePatchProcess: (source, destination) => applyRepeatableTables(source, destination, config, values),
+      verify: () => ({passed: true, checks: []}),
+    });
+
+    const xml = new AdmZip(readFileSync(outputPath)).readAsText('word/document.xml');
+    expect(xml).toContain('Lead: ');
+    expect(xml).toContain('Lead Fund, L.P.');
+    expect(xml).toContain('Alpha Ventures, L.P.');
+    expect(xml).toContain('Beta Capital, LLC');
+    expect(xml).toContain('1 Alpha Way');
+    expect(xml).toContain('2 Beta Road');
+    expect((xml.match(/<w:tr[ >]/g) ?? [])).toHaveLength(2);
+    expect(xml).not.toContain('Investor Name');
+    expect(xml.match(/Lead Fund, L.P./g)).toHaveLength(1);
+  });
+});

--- a/integration-tests/repeatable-table-pipeline-ordering.test.ts
+++ b/integration-tests/repeatable-table-pipeline-ordering.test.ts
@@ -39,6 +39,24 @@ function sourceDocx(): Buffer {
   return zip.toBuffer();
 }
 
+function prepopulatedSourceDocx(): Buffer {
+  const zip = new AdmZip(sourceDocx());
+  const header = '<w:tr><w:trPr><w:tblHeader/></w:trPr>' +
+    '<w:tc><w:p><w:r><w:t>Investor</w:t></w:r></w:p></w:tc>' +
+    '<w:tc><w:p><w:r><w:t>Commitment</w:t></w:r></w:p></w:tc></w:tr>';
+  const rows = Array.from({length: 7}, (_, index) =>
+    `<w:tr><w:trPr><w:cantSplit/><w:tblCellSpacing w:w="${index + 1}" w:type="dxa"/></w:trPr>` +
+    `<w:tc><w:p><w:r><w:t>Legacy Investor ${index + 1}</w:t></w:r></w:p></w:tc>` +
+    `<w:tc><w:p><w:r><w:t>Legacy Amount ${index + 1}</w:t></w:r></w:p></w:tc></w:tr>`,
+  ).join('');
+  zip.updateFile('word/document.xml', Buffer.from(
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<w:document xmlns:w="${W}"><w:body><w:p><w:r><w:t>Lead: Legacy Investor 1</w:t></w:r></w:p>` +
+    `<w:tbl>${header}${rows}</w:tbl></w:body></w:document>`,
+  ));
+  return zip.toBuffer();
+}
+
 afterEach(() => {
   for (const root of roots.splice(0)) rmSync(root, {recursive: true, force: true});
 });
@@ -96,5 +114,64 @@ describe('repeatable-table full pipeline ordering', () => {
     expect((xml.match(/<w:tr[ >]/g) ?? [])).toHaveLength(2);
     expect(xml).not.toContain('Investor Name');
     expect(xml.match(/Lead Fund, L.P./g)).toHaveLength(1);
+  });
+
+  it('replaces seven distinct source rows before overlapping scalar fill', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'repeatable-pipeline-prepopulated-'));
+    roots.push(root);
+    const inputPath = join(root, 'source.docx');
+    const outputPath = join(root, 'filled.docx');
+    new AdmZip(prepopulatedSourceDocx()).writeZip(inputPath);
+    const config = RepeatableTablesConfigSchema.parse({
+      schema_version: 1,
+      tables: [{
+        id: 'investor-commitments',
+        rows_field: 'investors',
+        header_cells: ['Investor', 'Commitment'],
+        existing_data_row_count: 7,
+        prototype_row_index: 3,
+        columns: [{field: 'name'}, {field: 'commitment', format: 'currency'}],
+      }],
+    });
+    const values = {
+      lead_investor: 'Lead Fund, L.P.',
+      investors: [
+        {name: 'Alpha Ventures, L.P.', commitment: 1000000},
+        {name: 'Beta Capital, LLC', commitment: 2500000},
+      ],
+    };
+
+    await runFillPipeline({
+      inputPath,
+      outputPath,
+      values,
+      fields: [
+        {name: 'lead_investor', type: 'string', description: 'Lead investor'},
+        {name: 'investors', type: 'array', description: 'Investor rows', items: [
+          {name: 'name', type: 'string', description: 'Name'},
+          {name: 'commitment', type: 'number', description: 'Commitment'},
+        ]},
+      ],
+      cleanPatch: {
+        cleanConfig: {removeParagraphPatterns: [], removeRanges: []},
+        replacements: {'Legacy Investor 1': '{lead_investor}'},
+      },
+      prePatchProcess: (source, destination) => applyRepeatableTables(source, destination, config, values),
+      verify: () => ({passed: true, checks: []}),
+    });
+
+    const outputZip = new AdmZip(readFileSync(outputPath));
+    expect(outputZip.getEntry('[Content_Types].xml')).not.toBeNull();
+    const xml = outputZip.readAsText('word/document.xml');
+    expect(xml).toContain('Lead: ');
+    expect(xml.match(/Lead Fund, L.P./g)).toHaveLength(1);
+    expect(xml).toContain('Alpha Ventures, L.P.');
+    expect(xml).toContain('1,000,000.00');
+    expect(xml).toContain('Beta Capital, LLC');
+    expect(xml).toContain('2,500,000.00');
+    expect((xml.match(/<w:tr[ >]/g) ?? [])).toHaveLength(3);
+    expect(xml).not.toContain('Legacy Investor');
+    expect(xml).not.toContain('Legacy Amount');
+    expect((xml.match(/w:tblCellSpacing w:w="3"/g) ?? [])).toHaveLength(2);
   });
 });

--- a/integration-tests/selections-zero-match-guard.test.ts
+++ b/integration-tests/selections-zero-match-guard.test.ts
@@ -170,4 +170,13 @@ describe('selections zero-match guard (#720)', () => {
 
     expect(result.warnings.some((w) => w.includes('dispute_resolution[0]') && w.includes('meant to be kept is absent'))).toBe(true);
   });
+
+  it('[OA-SEL-029] strict policy rejects a selected option that matches nothing', async () => {
+    await expect(runFixture(disputeConfig(ACCURATE_ARBITRATION_MARKER), {
+      paragraphs: [HEADING_PARAGRAPH, COURTS_PARAGRAPH],
+      values: { dispute_resolution_mode: 'arbitration' },
+      zeroMatchPolicy: 'error',
+    })).rejects.toThrow(/selected option\(s\) are absent.*dispute_resolution\[0\]/s);
+  });
+
 });

--- a/src/core/field-selector/index.test.ts
+++ b/src/core/field-selector/index.test.ts
@@ -18,7 +18,12 @@ afterEach(() => {
   vi.resetModules();
 });
 
-function createFieldSelectorFixture(options?: { computedProfile?: unknown; normalizeConfig?: unknown }) {
+function createFieldSelectorFixture(options?: {
+  computedProfile?: unknown;
+  normalizeConfig?: unknown;
+  fields?: string[];
+  replacements?: Record<string, string>;
+}) {
   const root = mkdtempSync(join(tmpdir(), 'oa-field-selector-index-'));
   tempDirs.push(root);
 
@@ -30,9 +35,11 @@ function createFieldSelectorFixture(options?: { computedProfile?: unknown; norma
       'source_version: "1.0"',
       'license_note: Example fieldSelector license',
       'fields:',
-      '  - name: company_name',
-      '    type: string',
-      '    description: Company name',
+      ...(options?.fields ?? [
+        '  - name: company_name',
+        '    type: string',
+        '    description: Company name',
+      ]),
       'priority_fields:',
       '  - company_name',
       '',
@@ -42,7 +49,7 @@ function createFieldSelectorFixture(options?: { computedProfile?: unknown; norma
 
   writeFileSync(
     join(root, 'replacements.json'),
-    JSON.stringify({ '[Company Name]': '{company_name}' }, null, 2),
+    JSON.stringify(options?.replacements ?? { '[Company Name]': '{company_name}' }, null, 2),
     'utf-8'
   );
 
@@ -214,6 +221,131 @@ describe('runFieldSelector', () => {
     });
     expect(Array.isArray(artifact.passes)).toBe(true);
     expect(result.computedOutPath).toBe(computedOutPath);
+  });
+
+  itFilling('formats declared dates before direct and chained computed interpolation', async () => {
+    const fieldSelectorDir = createFieldSelectorFixture({
+      fields: [
+        '  - name: company_name',
+        '    type: string',
+        '    description: Company name',
+        '  - name: checklist_delivery_date',
+        '    type: date',
+        '    description: Checklist delivery date',
+        '  - name: signer_text',
+        '    type: string',
+        '    description: Computed signer text',
+        '  - name: chained_text',
+        '    type: string',
+        '    description: Chained computed text',
+      ],
+      replacements: {
+        '[Company Name]': '{company_name}',
+        '[Delivery Date]': '{checklist_delivery_date}',
+        '[Signer Text]': '{signer_text}',
+        '[Chained Text]': '{chained_text}',
+      },
+      computedProfile: {
+        version: '1.0',
+        max_passes: 4,
+        rules: [
+          {
+            id: 'derive-signer-text',
+            when_all: [{ field: 'checklist_delivery_date', op: 'defined' }],
+            set_fill: { signer_text: 'delivered on ${checklist_delivery_date}' },
+          },
+          {
+            id: 'derive-chained-text',
+            when_all: [{ field: 'signer_text', op: 'defined' }],
+            set_fill: { chained_text: 'Signer materials were ${signer_text}.' },
+          },
+        ],
+      },
+    });
+    const runFillPipelineMock = vi.fn(async ({ outputPath }: { outputPath: string }) => ({
+      outputPath,
+      fieldsUsed: [],
+      providedFieldsUsed: [],
+      fillCommandCount: 1,
+      warnings: [],
+      stages: { cleaned: '/tmp/cleaned.docx', patched: '/tmp/patched.docx', filled: '/tmp/filled.docx' },
+    }));
+    vi.doMock('../../utils/paths.js', () => ({ resolveFieldSelectorDir: () => fieldSelectorDir }));
+    vi.doMock('../unified-pipeline.js', () => ({ runFillPipeline: runFillPipelineMock }));
+    const { runFieldSelector } = await import('./index.js');
+
+    await runFieldSelector({
+      fieldSelectorId: 'fixture-fieldSelector',
+      inputPath: '/tmp/input.docx',
+      outputPath: '/tmp/output.docx',
+      values: {
+        company_name: 'Acme Corp',
+        checklist_delivery_date: '2025-05-21',
+      },
+    });
+
+    const pipelineValues = runFillPipelineMock.mock.calls[0][0].values;
+    expect(pipelineValues).toMatchObject({
+      checklist_delivery_date: 'May 21, 2025',
+      signer_text: 'delivered on May 21, 2025',
+      chained_text: 'Signer materials were delivered on May 21, 2025.',
+    });
+    expect(JSON.stringify(pipelineValues)).not.toContain('2025-05-21');
+  });
+
+  itFilling('preserves display-ready dates and does not invent absent optional dates', async () => {
+    const fieldSelectorDir = createFieldSelectorFixture({
+      fields: [
+        '  - name: company_name',
+        '    type: string',
+        '    description: Company name',
+        '  - name: checklist_delivery_date',
+        '    type: date',
+        '    description: Optional checklist delivery date',
+        '  - name: reference_code',
+        '    type: string',
+        '    description: Non-date ISO-looking string',
+      ],
+      replacements: {
+        '[Company Name]': '{company_name}',
+        '[Delivery Date]': '{checklist_delivery_date}',
+        '[Reference]': '{reference_code}',
+      },
+      computedProfile: {
+        rules: [{
+          id: 'audit-only-to-enable-profile',
+          when_all: [{ field: 'checklist_delivery_date', op: 'defined' }],
+          set_audit: { has_delivery_date: true },
+        }],
+      },
+    });
+    const calls: Record<string, unknown>[] = [];
+    const runFillPipelineMock = vi.fn(async (args: Record<string, unknown>) => {
+      calls.push(args);
+      return {
+        outputPath: args.outputPath as string,
+        fieldsUsed: [], providedFieldsUsed: [], fillCommandCount: 1, warnings: [],
+        stages: { cleaned: '/tmp/cleaned.docx', patched: '/tmp/patched.docx', filled: '/tmp/filled.docx' },
+      };
+    });
+    vi.doMock('../../utils/paths.js', () => ({ resolveFieldSelectorDir: () => fieldSelectorDir }));
+    vi.doMock('../unified-pipeline.js', () => ({ runFillPipeline: runFillPipelineMock }));
+    const { runFieldSelector } = await import('./index.js');
+
+    await runFieldSelector({
+      fieldSelectorId: 'fixture-fieldSelector', inputPath: '/tmp/input.docx', outputPath: '/tmp/one.docx',
+      values: { company_name: 'Acme', checklist_delivery_date: 'May 21, 2025', reference_code: '2025-05-21' },
+    });
+    await runFieldSelector({
+      fieldSelectorId: 'fixture-fieldSelector', inputPath: '/tmp/input.docx', outputPath: '/tmp/two.docx',
+      values: { company_name: 'Acme', reference_code: '2025-05-21' },
+    });
+
+    expect((calls[0].values as Record<string, unknown>)).toMatchObject({
+      checklist_delivery_date: 'May 21, 2025',
+      reference_code: '2025-05-21',
+    });
+    expect(calls[1].values).toEqual({ company_name: 'Acme', reference_code: '2025-05-21' });
   });
 
   itFilling('uses downloader path when inputPath is omitted', async () => {

--- a/src/core/field-selector/index.test.ts
+++ b/src/core/field-selector/index.test.ts
@@ -97,6 +97,7 @@ describe('runFieldSelector', () => {
       inputPath: '/tmp/input.docx',
       outputPath: '/tmp/output.docx',
       values: { company_name: 'Acme Corp' },
+      selectionsZeroMatchPolicy: 'error',
     });
 
     await allureJsonAttachment('runFieldSelector-forwarding.json', {
@@ -110,6 +111,7 @@ describe('runFieldSelector', () => {
       outputPath: '/tmp/output.docx',
       priorityFieldNames: ['company_name'],
       values: { company_name: 'Acme Corp' },
+      selectionsZeroMatchPolicy: 'error',
     });
     expect(result.fieldsUsed).toEqual(['company_name']);
   });
@@ -432,4 +434,3 @@ describe('runFieldSelector', () => {
     expect(missingWarnings).toEqual([]);
   });
 });
-

--- a/src/core/field-selector/index.ts
+++ b/src/core/field-selector/index.ts
@@ -142,6 +142,7 @@ export async function runFieldSelector(options: FieldSelectorRunOptions): Promis
     cleanPatch: { cleanConfig, replacements: patchReplacements },
     selectorManifests,
     selectionsConfig,
+    selectionsZeroMatchPolicy: options.selectionsZeroMatchPolicy,
     prePatchProcess: repeatableTablesConfig
       ? async (inputDocPath: string, outputDocPath: string) => {
         applyRepeatableTables(inputDocPath, outputDocPath, repeatableTablesConfig, effectiveValues);

--- a/src/core/field-selector/index.ts
+++ b/src/core/field-selector/index.ts
@@ -19,6 +19,7 @@ import { runFillPipeline } from '../unified-pipeline.js';
 import { formatDocumentDate } from '../fill-pipeline.js';
 import type { FieldSelectorRunOptions, FieldSelectorRunResult } from './types.js';
 import type { ComputedValueMap } from './computed.js';
+import { applyRepeatableTables, loadRepeatableTablesConfig, validateRepeatableTableFields } from './repeatable-tables.js';
 
 function toComputedValueMap(values: Record<string, unknown>): ComputedValueMap {
   const computedValues: ComputedValueMap = {};
@@ -45,6 +46,8 @@ export async function runFieldSelector(options: FieldSelectorRunOptions): Promis
   const metadata = loadFieldSelectorMetadata(fieldSelectorDir);
   const cleanConfig = loadCleanConfig(fieldSelectorDir);
   const normalizeConfig = loadNormalizeConfig(fieldSelectorDir);
+  const repeatableTablesConfig = loadRepeatableTablesConfig(fieldSelectorDir);
+  if (repeatableTablesConfig) validateRepeatableTableFields(repeatableTablesConfig, metadata.fields);
 
   // Load selectionsConfig if selections.json exists (mirrors engine.ts template path)
   const selectionsPath = join(fieldSelectorDir, 'selections.json');
@@ -139,12 +142,17 @@ export async function runFieldSelector(options: FieldSelectorRunOptions): Promis
     cleanPatch: { cleanConfig, replacements: patchReplacements },
     selectorManifests,
     selectionsConfig,
-    postProcess: shouldNormalizeBracketArtifacts
+    postProcess: repeatableTablesConfig || shouldNormalizeBracketArtifacts
       ? async (outputDocPath: string) => {
-        await normalizeBracketArtifacts(outputDocPath, outputDocPath, {
-          rules: normalizeConfig.paragraph_rules,
-          fieldValues: effectiveValues,
-        });
+        if (repeatableTablesConfig) {
+          applyRepeatableTables(outputDocPath, outputDocPath, repeatableTablesConfig, effectiveValues);
+        }
+        if (shouldNormalizeBracketArtifacts) {
+          await normalizeBracketArtifacts(outputDocPath, outputDocPath, {
+            rules: normalizeConfig.paragraph_rules,
+            fieldValues: effectiveValues,
+          });
+        }
       }
       : undefined,
     verify: async (p, cleanedSourcePath, referencedFields) => {
@@ -201,8 +209,17 @@ export async function runFieldSelector(options: FieldSelectorRunOptions): Promis
   return {
     outputPath: result.outputPath,
     metadata,
-    fieldsUsed: result.fieldsUsed,
-    providedFieldsUsed: result.providedFieldsUsed,
+    fieldsUsed: repeatableTablesConfig
+      ? [...new Set([...result.fieldsUsed, ...repeatableTablesConfig.tables.map((table) => table.rows_field)])]
+      : result.fieldsUsed,
+    providedFieldsUsed: repeatableTablesConfig
+      ? [...new Set([
+        ...result.providedFieldsUsed,
+        ...repeatableTablesConfig.tables
+          .map((table) => table.rows_field)
+          .filter((field) => Object.hasOwn(inputValues, field)),
+      ])]
+      : result.providedFieldsUsed,
     fillCommandCount: result.fillCommandCount,
     warnings: result.warnings,
     stages: result.stages!,
@@ -222,3 +239,5 @@ export { enumerateTextParts, getGeneralTextPartNames } from './ooxml-parts.js';
 export type { OoxmlTextParts } from './ooxml-parts.js';
 export type { FieldSelectorRunOptions, FieldSelectorRunResult, VerifyResult, VerifyCheck } from './types.js';
 export type { ComputedArtifact, ComputedProfile } from './computed.js';
+export { applyRepeatableTables, loadRepeatableTablesConfig, RepeatableTablesConfigSchema, validateRepeatableTableFields } from './repeatable-tables.js';
+export type { RepeatableTablesConfig } from './repeatable-tables.js';

--- a/src/core/field-selector/index.ts
+++ b/src/core/field-selector/index.ts
@@ -142,11 +142,13 @@ export async function runFieldSelector(options: FieldSelectorRunOptions): Promis
     cleanPatch: { cleanConfig, replacements: patchReplacements },
     selectorManifests,
     selectionsConfig,
-    postProcess: repeatableTablesConfig || shouldNormalizeBracketArtifacts
+    prePatchProcess: repeatableTablesConfig
+      ? async (inputDocPath: string, outputDocPath: string) => {
+        applyRepeatableTables(inputDocPath, outputDocPath, repeatableTablesConfig, effectiveValues);
+      }
+      : undefined,
+    postProcess: shouldNormalizeBracketArtifacts
       ? async (outputDocPath: string) => {
-        if (repeatableTablesConfig) {
-          applyRepeatableTables(outputDocPath, outputDocPath, repeatableTablesConfig, effectiveValues);
-        }
         if (shouldNormalizeBracketArtifacts) {
           await normalizeBracketArtifacts(outputDocPath, outputDocPath, {
             rules: normalizeConfig.paragraph_rules,

--- a/src/core/field-selector/index.ts
+++ b/src/core/field-selector/index.ts
@@ -16,7 +16,7 @@ import {
 } from './computed.js';
 import { normalizeBracketArtifacts } from './bracket-normalizer.js';
 import { runFillPipeline } from '../unified-pipeline.js';
-import { formatDocumentDate } from '../fill-pipeline.js';
+import { formatDocumentDate, formatDocumentDateFields } from '../fill-pipeline.js';
 import type { FieldSelectorRunOptions, FieldSelectorRunResult } from './types.js';
 import type { ComputedValueMap } from './computed.js';
 import { applyRepeatableTables, loadRepeatableTablesConfig, validateRepeatableTableFields } from './repeatable-tables.js';
@@ -94,7 +94,10 @@ export async function runFieldSelector(options: FieldSelectorRunOptions): Promis
     (migratedAnchorsByField[fieldId] ??= []).push(extractSearchText(key));
   }
 
-  const inputValues = { ...values };
+  // Computed prose may interpolate source date fields. Normalize declared date
+  // values before computed evaluation so both direct tags and derived prose see
+  // the same display-ready value (and chained computed fields inherit it).
+  const inputValues = formatDocumentDateFields(values, metadata.fields);
   const computedInputValues = toComputedValueMap(inputValues);
   const computedProfile = loadComputedProfile(fieldSelectorDir);
   const computedEvaluation = computedProfile

--- a/src/core/field-selector/patcher.test.ts
+++ b/src/core/field-selector/patcher.test.ts
@@ -576,6 +576,94 @@ describe('patchDocument — formatting preservation (docx-core)', () => {
   });
 });
 
+describe('patchDocument — atomic complex-field range deletion', () => {
+  function field(bookmark: string, result: string): string {
+    return (
+      '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+      `<w:r><w:instrText xml:space="preserve"> REF ${bookmark} \\h </w:instrText></w:r>` +
+      '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+      `<w:r><w:t>${result}</w:t></w:r>` +
+      '<w:r><w:fldChar w:fldCharType="end"/></w:r>'
+    );
+  }
+
+  function outputXml(path: string): string {
+    return new AdmZip(path).getEntry('word/document.xml')!.getData().toString('utf-8');
+  }
+
+  it('removes every node of multiple REF fields intersected by a cross-run deletion', async () => {
+    const xml =
+      `<?xml version="1.0" encoding="UTF-8"?><w:document xmlns:w="${W_NS}"><w:body>` +
+      '<w:p><w:r><w:t xml:space="preserve">Base sentence. [Optional sentence refers to Section </w:t></w:r>' +
+      field('kept_target', '2.1') +
+      '<w:r><w:t xml:space="preserve"> and Section </w:t></w:r>' +
+      field('removed_target', '3.2') +
+      '<w:r><w:t xml:space="preserve">.] Tail sentence.</w:t></w:r></w:p>' +
+      '</w:body></w:document>';
+    const inputPath = buildMinimalDocx(xml);
+    const outputPath = inputPath.replace('test.docx', 'output.docx');
+
+    await patchDocument(inputPath, outputPath, {
+      '[Optional sentence refers to Section 2.1 and Section 3.2.]': '',
+    });
+
+    const out = outputXml(outputPath);
+    expect(extractText(outputPath)).toBe('Base sentence.  Tail sentence.');
+    expect(out).not.toContain('fldChar');
+    expect(out).not.toContain('instrText');
+    expect(out).not.toContain('kept_target');
+    expect(out).not.toContain('removed_target');
+    expect(new DOMParser().parseFromString(out, 'text/xml').getElementsByTagName('parsererror').length).toBe(0);
+    rmSync(inputPath.replace('/test.docx', ''), { recursive: true, force: true });
+  });
+
+  it('expands through nested fields but preserves a wholly outside REF field', async () => {
+    const nested =
+      '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+      '<w:r><w:instrText> IF </w:instrText></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+      field('nested_target', '4.1') +
+      '<w:r><w:fldChar w:fldCharType="end"/></w:r>';
+    const xml =
+      `<?xml version="1.0" encoding="UTF-8"?><w:document xmlns:w="${W_NS}"><w:body>` +
+      '<w:p>' + field('outside_target', '1.1') +
+      '<w:r><w:t xml:space="preserve"> Keep. [Drop </w:t></w:r>' + nested +
+      '<w:r><w:t xml:space="preserve"> now.] Tail.</w:t></w:r></w:p>' +
+      '</w:body></w:document>';
+    const inputPath = buildMinimalDocx(xml);
+    const outputPath = inputPath.replace('test.docx', 'output.docx');
+
+    await patchDocument(inputPath, outputPath, { '[Drop 4.1 now.]': '' });
+
+    const out = outputXml(outputPath);
+    expect(extractText(outputPath)).toBe('1.1 Keep.  Tail.');
+    expect(out).toContain('outside_target');
+    expect(out).not.toContain('nested_target');
+    expect((out.match(/fldCharType="begin"/g) ?? [])).toHaveLength(1);
+    expect((out.match(/fldCharType="end"/g) ?? [])).toHaveLength(1);
+    expect((out.match(/instrText/g) ?? [])).toHaveLength(2); // opening + closing XML tag
+    rmSync(inputPath.replace('/test.docx', ''), { recursive: true, force: true });
+  });
+
+  it('atomically removes a field when the matched text is only its cached result', async () => {
+    const xml =
+      `<?xml version="1.0" encoding="UTF-8"?><w:document xmlns:w="${W_NS}"><w:body><w:p>` +
+      '<w:r><w:t>Before </w:t></w:r>' + field('deleted_bookmark', 'BROKEN') +
+      '<w:r><w:t> after.</w:t></w:r></w:p></w:body></w:document>';
+    const inputPath = buildMinimalDocx(xml);
+    const outputPath = inputPath.replace('test.docx', 'output.docx');
+
+    await patchDocument(inputPath, outputPath, { BROKEN: '' });
+
+    const out = outputXml(outputPath);
+    expect(extractText(outputPath)).toBe('Before  after.');
+    expect(out).not.toContain('fldChar');
+    expect(out).not.toContain('instrText');
+    expect(out).not.toContain('deleted_bookmark');
+    rmSync(inputPath.replace('/test.docx', ''), { recursive: true, force: true });
+  });
+});
+
 describe('isRunSafeToRemove', () => {
   const parser = new DOMParser();
 

--- a/src/core/field-selector/patcher.ts
+++ b/src/core/field-selector/patcher.ts
@@ -393,6 +393,46 @@ function replaceAtPositionLegacy(
   const firstEntry = charMap[matchStart];
   const lastEntry = charMap[end - 1];
 
+  // A complex Word field is an atomic OOXML construct. Its instruction runs
+  // have no visible characters, while its cached-result runs do, so a
+  // character-range edit can otherwise clear only the result and leave
+  // begin/instr/separate/end behind. Word or LibreOffice will then regenerate
+  // the deleted result on refresh (or display a broken-reference error).
+  //
+  // Expand an intersecting edit to every enclosing field boundary. The loop is
+  // deliberate: expanding across one field can intersect an outer/nested field.
+  let expandedStart = firstEntry.runIndex;
+  let expandedEnd = lastEntry.runIndex;
+  const fieldRanges = getComplexFieldRunRanges(runs);
+  let expanded: boolean;
+  do {
+    expanded = false;
+    for (const field of fieldRanges) {
+      if (field.end < expandedStart || field.start > expandedEnd) continue;
+      const nextStart = Math.min(expandedStart, field.start);
+      const nextEnd = Math.max(expandedEnd, field.end);
+      if (nextStart !== expandedStart || nextEnd !== expandedEnd) {
+        expandedStart = nextStart;
+        expandedEnd = nextEnd;
+        expanded = true;
+      }
+    }
+  } while (expanded);
+
+  if (expandedStart !== firstEntry.runIndex || expandedEnd !== lastEntry.runIndex ||
+      fieldRanges.some(field => field.start <= expandedEnd && field.end >= expandedStart)) {
+    replaceExpandedAtomicRange(
+      runs,
+      firstEntry,
+      lastEntry,
+      expandedStart,
+      expandedEnd,
+      value,
+      replacementColor,
+    );
+    return;
+  }
+
   if (firstEntry.runIndex === lastEntry.runIndex) {
     const runText = getRunText(runs[firstEntry.runIndex]);
     setRunText(
@@ -418,6 +458,77 @@ function replaceAtPositionLegacy(
     if (getRunText(runs[i]) === '' && isRunSafeToRemove(runs[i])) {
       runs[i].parentNode?.removeChild(runs[i]);
     }
+  }
+}
+
+interface ComplexFieldRunRange {
+  start: number;
+  end: number;
+}
+
+/** Pair complex-field begin/end markers in run order, retaining nested pairs. */
+function getComplexFieldRunRanges(runs: Element[]): ComplexFieldRunRange[] {
+  const stack: number[] = [];
+  const ranges: ComplexFieldRunRange[] = [];
+  for (let i = 0; i < runs.length; i++) {
+    const chars = runs[i].getElementsByTagNameNS(W_NS, 'fldChar');
+    for (let j = 0; j < chars.length; j++) {
+      const type = chars[j].getAttributeNS(W_NS, 'fldCharType') || chars[j].getAttribute('w:fldCharType');
+      if (type === 'begin') {
+        stack.push(i);
+      } else if (type === 'end') {
+        const start = stack.pop();
+        if (start !== undefined) ranges.push({ start, end: i });
+      }
+    }
+  }
+  return ranges;
+}
+
+/**
+ * Replace an edit expanded across one or more complete field complexes.
+ * Boundary text outside the requested character span is retained, while every
+ * run in the expanded field-aware range is removed. A fresh ordinary text run
+ * is inserted at the original range location, so no instruction/result
+ * fragments can survive application field refresh.
+ */
+function replaceExpandedAtomicRange(
+  runs: Element[],
+  firstEntry: CharMapEntry,
+  lastEntry: CharMapEntry,
+  expandedStart: number,
+  expandedEnd: number,
+  value: string,
+  replacementColor?: string,
+): void {
+  const firstText = getRunText(runs[firstEntry.runIndex]);
+  const lastText = getRunText(runs[lastEntry.runIndex]);
+  const prefix = expandedStart === firstEntry.runIndex
+    ? firstText.slice(0, firstEntry.charOffset)
+    : '';
+  const suffix = expandedEnd === lastEntry.runIndex
+    ? lastText.slice(lastEntry.charOffset + 1)
+    : '';
+  const replacementText = prefix + value + suffix;
+
+  const anchor = runs[expandedStart];
+  const parent = anchor.parentNode;
+  if (!parent) return;
+  const doc = anchor.ownerDocument as Document;
+  if (replacementText !== '') {
+    const replacementRun = doc.createElementNS(W_NS, 'w:r');
+    const sourceRPr = runs[firstEntry.runIndex].getElementsByTagNameNS(W_NS, 'rPr')[0];
+    if (sourceRPr) replacementRun.appendChild(sourceRPr.cloneNode(true));
+    const text = doc.createElementNS(W_NS, 'w:t');
+    text.setAttribute('xml:space', 'preserve');
+    text.textContent = replacementText;
+    replacementRun.appendChild(text);
+    if (replacementColor) setRunColor(replacementRun, replacementColor);
+    parent.insertBefore(replacementRun, anchor);
+  }
+
+  for (let i = expandedEnd; i >= expandedStart; i--) {
+    runs[i].parentNode?.removeChild(runs[i]);
   }
 }
 

--- a/src/core/field-selector/repeatable-tables.test.ts
+++ b/src/core/field-selector/repeatable-tables.test.ts
@@ -28,6 +28,20 @@ function fixtureDocx(duplicate = false, postHeader: 'none' | 'blank' | 'nonblank
   return zip.toBuffer();
 }
 
+function prototypeOnlyFixture(rowCount = 3, inconsistent = false, duplicate = false): Buffer {
+  const zip = new AdmZip();
+  const row = (index: number) => `<w:tr><w:trPr><w:cantSplit/></w:trPr><w:tc><w:tcPr><w:tcW w:w="6000"/><w:tcBorders><w:bottom w:val="single"/></w:tcBorders></w:tcPr>` +
+    `<w:p><w:pPr><w:jc w:val="left"/></w:pPr><w:r><w:rPr><w:b/></w:rPr><w:t>${inconsistent && index === 1 ? 'Unexpected Name' : 'Investor Name'}</w:t></w:r></w:p>` +
+    `<w:p><w:r><w:t>Address</w:t></w:r></w:p><w:p><w:r><w:t>Phone Number</w:t></w:r></w:p>` +
+    `<w:p><w:r><w:t>Email</w:t></w:r></w:p><w:p><w:r><w:t>[Counsel cc, if any]</w:t></w:r></w:p><w:p/></w:tc></w:tr>`;
+  const table = `<w:tbl>${Array.from({ length: rowCount }, (_, index) => row(index)).join('')}</w:tbl>`;
+  zip.addFile('word/document.xml', Buffer.from(
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<w:document xmlns:w="${W}"><w:body>${table}${duplicate ? table : ''}</w:body></w:document>`,
+  ));
+  return zip.toBuffer();
+}
+
 const config = RepeatableTablesConfigSchema.parse({
   schema_version: 1,
   tables: [{
@@ -138,5 +152,93 @@ describe('repeatable DOCX table bindings', () => {
       description: 'Purchaser rows',
       items: [{ name: 'name', type: 'string', description: 'Name' }],
     }])).toThrow(/column field "shares" is not declared/);
+  });
+
+  it.each([0, 1, 2, 4])('fills %i rows in a prototype-only signature table and removes unused rows', (count) => {
+    const root = mkdtempSync(join(tmpdir(), 'repeatable-prototype-'));
+    roots.push(root);
+    const input = join(root, 'in.docx');
+    const output = join(root, 'out.docx');
+    new AdmZip(prototypeOnlyFixture()).writeZip(input);
+    const binding = RepeatableTablesConfigSchema.parse({
+      schema_version: 1,
+      tables: [{
+        id: 'investor-signatures',
+        rows_field: 'investors',
+        prototype_cells: ['Investor NameAddressPhone NumberEmail[Counsel cc, if any]'],
+        columns: [{ paragraphs: [
+          { field: 'name' }, { field: 'address' }, { field: 'phone' }, { field: 'email' }, { field: 'counsel_cc' },
+        ] }],
+      }],
+    });
+    const investors = Array.from({ length: count }, (_, index) => ({
+      name: `Investor ${index + 1}`,
+      address: `${index + 1} Main Street`,
+      phone: `555-000${index}`,
+      email: `investor${index + 1}@example.com`,
+      counsel_cc: index === 0 ? 'Counsel One' : '',
+    }));
+    applyRepeatableTables(input, output, binding, { investors });
+    const xml = new AdmZip(readFileSync(output)).readAsText('word/document.xml');
+    expect((xml.match(/<w:tr[ >]/g) ?? [])).toHaveLength(count);
+    expect(xml).not.toContain('Investor Name');
+    expect(xml).not.toContain('[Counsel cc, if any]');
+    if (count > 0) {
+      expect(xml).toContain('Investor 1');
+      expect(xml).toContain('1 Main Street');
+      expect(xml).toContain('<w:cantSplit/>');
+      expect(xml).toContain('w:w="6000"');
+      expect(xml).toContain('<w:b/>');
+      expect(xml).toContain('<w:bottom w:val="single"/>');
+    }
+  });
+
+  it('fails closed when a prototype-only source table contains a divergent row', () => {
+    const root = mkdtempSync(join(tmpdir(), 'repeatable-prototype-'));
+    roots.push(root);
+    const input = join(root, 'in.docx');
+    new AdmZip(prototypeOnlyFixture(3, true)).writeZip(input);
+    const binding = RepeatableTablesConfigSchema.parse({
+      schema_version: 1,
+      tables: [{
+        id: 'investor-signatures', rows_field: 'investors',
+        prototype_cells: ['Investor NameAddressPhone NumberEmail[Counsel cc, if any]'],
+        columns: [{ paragraphs: [{ field: 'name' }] }],
+      }],
+    });
+    expect(() => applyRepeatableTables(input, join(root, 'out.docx'), binding, { investors: [] }))
+      .toThrow(/does not match prototype_cells/);
+  });
+
+  it('fails closed when a prototype-only selector is ambiguous', () => {
+    const root = mkdtempSync(join(tmpdir(), 'repeatable-prototype-'));
+    roots.push(root);
+    const input = join(root, 'in.docx');
+    new AdmZip(prototypeOnlyFixture(3, false, true)).writeZip(input);
+    const binding = RepeatableTablesConfigSchema.parse({
+      schema_version: 1,
+      tables: [{
+        id: 'investor-signatures', rows_field: 'investors',
+        prototype_cells: ['Investor NameAddressPhone NumberEmail[Counsel cc, if any]'],
+        columns: [{ paragraphs: [{ field: 'name' }] }],
+      }],
+    });
+    expect(() => applyRepeatableTables(input, join(root, 'out.docx'), binding, { investors: [] }))
+      .toThrow(/matched 2 tables/);
+  });
+
+  it('validates every paragraph mapping against array item metadata', () => {
+    const binding = RepeatableTablesConfigSchema.parse({
+      schema_version: 1,
+      tables: [{
+        id: 'investor-signatures', rows_field: 'investors',
+        prototype_cells: ['Investor NameAddress'],
+        columns: [{ paragraphs: [{ field: 'name' }, { field: 'address' }] }],
+      }],
+    });
+    expect(() => validateRepeatableTableFields(binding, [{
+      name: 'investors', type: 'array', description: 'Investor rows',
+      items: [{ name: 'name', type: 'string', description: 'Investor name' }],
+    }])).toThrow(/column field "address" is not declared/);
   });
 });

--- a/src/core/field-selector/repeatable-tables.test.ts
+++ b/src/core/field-selector/repeatable-tables.test.ts
@@ -1,0 +1,142 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import AdmZip from 'adm-zip';
+import { afterEach, describe, expect, it } from 'vitest';
+import { applyRepeatableTables, RepeatableTablesConfigSchema, validateRepeatableTableFields } from './repeatable-tables.js';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const roots: string[] = [];
+
+function fixtureDocx(duplicate = false, postHeader: 'none' | 'blank' | 'nonblank' = 'none'): Buffer {
+  const zip = new AdmZip();
+  const header = `<w:tbl>` +
+    `<w:tr><w:trPr><w:tblHeader/></w:trPr><w:tc><w:tcPr><w:tcW w:w="3000"/><w:shd w:fill="AAAAAA"/></w:tcPr><w:p><w:pPr><w:jc w:val="left"/></w:pPr><w:r><w:t>Name</w:t></w:r></w:p></w:tc>` +
+    `<w:tc><w:tcPr><w:tcW w:w="1500"/></w:tcPr><w:p><w:pPr><w:jc w:val="right"/></w:pPr><w:r><w:t>Shares</w:t></w:r></w:p></w:tc>` +
+    `<w:tc><w:tcPr><w:tcW w:w="1500"/></w:tcPr><w:p><w:pPr><w:jc w:val="right"/></w:pPr><w:r><w:t>Price ($)</w:t></w:r></w:p></w:tc></w:tr>`;
+  const blankRow = `<w:tr><w:trPr><w:cantSplit/></w:trPr>` +
+    `<w:tc><w:tcPr><w:tcW w:w="3000"/></w:tcPr><w:p><w:pPr><w:jc w:val="left"/></w:pPr></w:p></w:tc>` +
+    `<w:tc><w:tcPr><w:tcW w:w="1500"/></w:tcPr><w:p><w:pPr><w:jc w:val="right"/></w:pPr></w:p></w:tc>` +
+    `<w:tc><w:tcPr><w:tcW w:w="1500"/></w:tcPr><w:p><w:pPr><w:jc w:val="right"/></w:pPr></w:p></w:tc>` +
+    `</w:tr>`;
+  const staleRow = blankRow.replace('</w:p></w:tc>', '<w:r><w:t>Stale purchaser</w:t></w:r></w:p></w:tc>');
+  const table = header + (postHeader === 'blank' ? blankRow : postHeader === 'nonblank' ? staleRow : '') + `</w:tbl>`;
+  zip.addFile('word/document.xml', Buffer.from(
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<w:document xmlns:w="${W}"><w:body>${table}${duplicate ? table : ''}</w:body></w:document>`,
+  ));
+  return zip.toBuffer();
+}
+
+const config = RepeatableTablesConfigSchema.parse({
+  schema_version: 1,
+  tables: [{
+    id: 'purchasers',
+    rows_field: 'purchasers',
+    header_cells: ['Name', 'Shares', 'Price ($)'],
+    columns: [
+      { field: 'name' },
+      { field: 'shares', format: 'integer' },
+      { field: 'price', format: 'currency' },
+    ],
+  }],
+});
+
+function render(
+  rows: unknown[],
+  duplicate = false,
+  postHeader: 'none' | 'blank' | 'nonblank' = 'none',
+  binding = config,
+): string {
+  const root = mkdtempSync(join(tmpdir(), 'repeatable-tables-'));
+  roots.push(root);
+  const input = join(root, 'in.docx');
+  const output = join(root, 'out.docx');
+  new AdmZip(fixtureDocx(duplicate, postHeader)).writeZip(input);
+  applyRepeatableTables(input, output, binding, { purchasers: rows });
+  const zip = new AdmZip(readFileSync(output));
+  return zip.readAsText('word/document.xml');
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('repeatable DOCX table bindings', () => {
+  it('leaves a genuine header-only table at one row when data is empty', () => {
+    const xml = render([]);
+    expect((xml.match(/<w:tr[ >]/g) ?? [])).toHaveLength(1);
+  });
+
+  it('removes blank post-header scaffolding deterministically', () => {
+    const xml = render([], false, 'blank');
+    expect((xml.match(/<w:tr[ >]/g) ?? [])).toHaveLength(1);
+    expect(xml).not.toContain('<w:cantSplit/>');
+  });
+
+  it('supports an explicitly selected prototype row', () => {
+    const explicit = RepeatableTablesConfigSchema.parse({
+      ...config,
+      tables: [{ ...config.tables[0], prototype_row_index: 1 }],
+    });
+    const xml = render([{ name: 'Alpha Fund', shares: 10, price: 20 }], false, 'blank', explicit);
+    expect(xml).toContain('Alpha Fund');
+    expect(xml).toContain('<w:cantSplit/>');
+  });
+
+  it('fills one row and preserves prototype formatting', () => {
+    const xml = render([{ name: 'Alpha Fund', shares: 1250000, price: 2500000 }]);
+    expect(xml).toContain('Alpha Fund');
+    expect(xml).toContain('1,250,000');
+    expect(xml).toContain('2,500,000.00');
+    expect((xml.match(/<w:tblHeader\/>/g) ?? [])).toHaveLength(1);
+    expect((xml.match(/<w:shd/g) ?? [])).toHaveLength(1);
+    expect(xml).toContain('w:w="3000"');
+    expect(xml).toContain('w:val="right"');
+  });
+
+  it('clones deterministic rows for multiple purchasers', () => {
+    const xml = render([
+      { name: 'Alpha Fund', shares: 100, price: 125 },
+      { name: 'Beta Fund', shares: 200, price: 250 },
+    ]);
+    expect((xml.match(/<w:tr[ >]/g) ?? [])).toHaveLength(3);
+    expect(xml.indexOf('Alpha Fund')).toBeLessThan(xml.indexOf('Beta Fund'));
+    expect(xml).toContain('125.00');
+    expect(xml).toContain('250.00');
+  });
+
+  it('fails closed when the configured header is absent or ambiguous', () => {
+    expect(() => render([{ name: 'Alpha Fund' }], true)).toThrow(/matched 2 tables/);
+    const bad = RepeatableTablesConfigSchema.parse({
+      schema_version: 1,
+      tables: [{ id: 'missing', rows_field: 'rows', header_cells: ['Unknown'], columns: [{ field: 'name' }] }],
+    });
+    const root = mkdtempSync(join(tmpdir(), 'repeatable-tables-'));
+    roots.push(root);
+    const input = join(root, 'in.docx');
+    new AdmZip(fixtureDocx()).writeZip(input);
+    expect(() => applyRepeatableTables(input, join(root, 'out.docx'), bad, { rows: [] })).toThrow(/matched 0 tables/);
+  });
+
+  it('fails closed on nonblank post-header data in synthesis mode', () => {
+    expect(() => render([{ name: 'New purchaser' }], false, 'nonblank')).toThrow(/nonblank post-header row/);
+  });
+
+  it('rejects malformed contracts before touching a document', () => {
+    expect(() => RepeatableTablesConfigSchema.parse({
+      schema_version: 1,
+      tables: [{ id: 'bad', rows_field: 'rows', header_cells: ['A', 'B'], columns: [{ field: 'only_one' }] }],
+    })).toThrow(/same length/);
+  });
+
+  it('requires the rows field and every column to be declared in metadata', () => {
+    expect(() => validateRepeatableTableFields(config, [])).toThrow(/must reference an array field/);
+    expect(() => validateRepeatableTableFields(config, [{
+      name: 'purchasers',
+      type: 'array',
+      description: 'Purchaser rows',
+      items: [{ name: 'name', type: 'string', description: 'Name' }],
+    }])).toThrow(/column field "shares" is not declared/);
+  });
+});

--- a/src/core/field-selector/repeatable-tables.test.ts
+++ b/src/core/field-selector/repeatable-tables.test.ts
@@ -3,11 +3,13 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import AdmZip from 'adm-zip';
 import { DOMParser } from '@xmldom/xmldom';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect } from 'vitest';
+import { itAllure } from '../../../integration-tests/helpers/allure-test.js';
 import { applyRepeatableTables, RepeatableTablesConfigSchema, validateRepeatableTableFields } from './repeatable-tables.js';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const roots: string[] = [];
+const it = itAllure.epic('Filling & Rendering');
 
 function fixtureDocx(duplicate = false, postHeader: 'none' | 'blank' | 'nonblank' = 'none'): Buffer {
   const zip = new AdmZip();

--- a/src/core/field-selector/repeatable-tables.test.ts
+++ b/src/core/field-selector/repeatable-tables.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import AdmZip from 'adm-zip';
+import { DOMParser } from '@xmldom/xmldom';
 import { afterEach, describe, expect, it } from 'vitest';
 import { applyRepeatableTables, RepeatableTablesConfigSchema, validateRepeatableTableFields } from './repeatable-tables.js';
 
@@ -38,6 +39,39 @@ function prototypeOnlyFixture(rowCount = 3, inconsistent = false, duplicate = fa
   zip.addFile('word/document.xml', Buffer.from(
     `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
     `<w:document xmlns:w="${W}"><w:body>${table}${duplicate ? table : ''}</w:body></w:document>`,
+  ));
+  return zip.toBuffer();
+}
+
+function prepopulatedHeaderFixture(): Buffer {
+  const zip = new AdmZip();
+  const row = (index: number) => `<w:tr><w:trPr><w:cantSplit/><w:tblCellSpacing w:w="${index + 1}" w:type="dxa"/></w:trPr>` +
+    `<w:tc><w:tcPr><w:tcW w:w="3000"/></w:tcPr><w:p><w:pPr><w:jc w:val="left"/></w:pPr><w:r><w:t>Old holder ${index + 1}</w:t></w:r></w:p></w:tc>` +
+    `<w:tc><w:tcPr><w:tcW w:w="3000"/></w:tcPr><w:p><w:pPr><w:jc w:val="right"/></w:pPr><w:r><w:t>Old amount ${index + 1}</w:t></w:r></w:p></w:tc></w:tr>`;
+  const header = `<w:tr><w:trPr><w:tblHeader/></w:trPr>` +
+    `<w:tc><w:p><w:r><w:t>Holder</w:t></w:r></w:p></w:tc>` +
+    `<w:tc><w:p><w:r><w:t>Amount</w:t></w:r></w:p></w:tc></w:tr>`;
+  zip.addFile('[Content_Types].xml', Buffer.from(
+    '<?xml version="1.0" encoding="UTF-8"?>' +
+    '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">' +
+    '<Default Extension="xml" ContentType="application/xml"/>' +
+    '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+    '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+    '</Types>',
+  ));
+  zip.addFile('_rels/.rels', Buffer.from(
+    '<?xml version="1.0" encoding="UTF-8"?>' +
+    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+    '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>' +
+    '</Relationships>',
+  ));
+  zip.addFile('word/_rels/document.xml.rels', Buffer.from(
+    '<?xml version="1.0" encoding="UTF-8"?>' +
+    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"/>',
+  ));
+  zip.addFile('word/document.xml', Buffer.from(
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<w:document xmlns:w="${W}"><w:body><w:tbl>${header}${Array.from({ length: 7 }, (_, index) => row(index)).join('')}</w:tbl></w:body></w:document>`,
   ));
   return zip.toBuffer();
 }
@@ -98,6 +132,64 @@ describe('repeatable DOCX table bindings', () => {
     expect(xml).toContain('<w:cantSplit/>');
   });
 
+  it('replaces an asserted set of heterogeneous prepopulated rows', () => {
+    const root = mkdtempSync(join(tmpdir(), 'repeatable-prepopulated-'));
+    roots.push(root);
+    const input = join(root, 'in.docx');
+    const output = join(root, 'out.docx');
+    new AdmZip(prepopulatedHeaderFixture()).writeZip(input);
+    const binding = RepeatableTablesConfigSchema.parse({
+      schema_version: 1,
+      tables: [{
+        id: 'existing-holders',
+        rows_field: 'holders',
+        header_cells: ['Holder', 'Amount'],
+        existing_data_row_count: 7,
+        prototype_row_index: 4,
+        columns: [{ field: 'name' }, { field: 'amount', format: 'integer' }],
+      }],
+    });
+
+    applyRepeatableTables(input, output, binding, {holders: [
+      {name: 'Alpha Fund', amount: 1200},
+      {name: 'Beta Fund', amount: 3400},
+    ]});
+
+    const outputZip = new AdmZip(readFileSync(output));
+    expect(outputZip.getEntry('[Content_Types].xml')).not.toBeNull();
+    expect(outputZip.getEntry('_rels/.rels')).not.toBeNull();
+    const xml = outputZip.readAsText('word/document.xml');
+    const parsed = new DOMParser().parseFromString(xml, 'text/xml');
+    expect(parsed.documentElement.localName).toBe('document');
+    expect((xml.match(/<w:tr[ >]/g) ?? [])).toHaveLength(3);
+    expect(xml).toContain('Alpha Fund');
+    expect(xml).toContain('1,200');
+    expect(xml).toContain('Beta Fund');
+    expect(xml).toContain('3,400');
+    expect(xml.indexOf('Alpha Fund')).toBeLessThan(xml.indexOf('Beta Fund'));
+    expect(xml).not.toContain('Old holder');
+    expect(xml).not.toContain('Old amount');
+    expect((xml.match(/<w:tblHeader\/>/g) ?? [])).toHaveLength(1);
+    expect((xml.match(/w:tblCellSpacing w:w="4"/g) ?? [])).toHaveLength(2);
+  });
+
+  it('fails closed when the asserted prepopulated row count drifts', () => {
+    const root = mkdtempSync(join(tmpdir(), 'repeatable-prepopulated-'));
+    roots.push(root);
+    const input = join(root, 'in.docx');
+    new AdmZip(prepopulatedHeaderFixture()).writeZip(input);
+    const binding = RepeatableTablesConfigSchema.parse({
+      schema_version: 1,
+      tables: [{
+        id: 'existing-holders', rows_field: 'holders',
+        header_cells: ['Holder', 'Amount'], existing_data_row_count: 6,
+        columns: [{field: 'name'}, {field: 'amount'}],
+      }],
+    });
+    expect(() => applyRepeatableTables(input, join(root, 'out.docx'), binding, {holders: []}))
+      .toThrow(/has 7 post-header rows; expected exactly 6/);
+  });
+
   it('fills one row and preserves prototype formatting', () => {
     const xml = render([{ name: 'Alpha Fund', shares: 1250000, price: 2500000 }]);
     expect(xml).toContain('Alpha Fund');
@@ -142,6 +234,13 @@ describe('repeatable DOCX table bindings', () => {
       schema_version: 1,
       tables: [{ id: 'bad', rows_field: 'rows', header_cells: ['A', 'B'], columns: [{ field: 'only_one' }] }],
     })).toThrow(/same length/);
+    expect(() => RepeatableTablesConfigSchema.parse({
+      schema_version: 1,
+      tables: [{
+        id: 'bad-index', rows_field: 'rows', header_cells: ['A'], columns: [{field: 'value'}],
+        existing_data_row_count: 2, prototype_row_index: 3,
+      }],
+    })).toThrow(/prototype_row_index must identify one of the existing data rows/);
   });
 
   it('requires the rows field and every column to be declared in metadata', () => {

--- a/src/core/field-selector/repeatable-tables.ts
+++ b/src/core/field-selector/repeatable-tables.ts
@@ -27,9 +27,17 @@ const TableBaseSchema = z.object({
 const HeaderTableSchema = TableBaseSchema.extend({
   header_cells: z.array(z.string()).min(1),
   prototype_row_index: z.number().int().positive().optional(),
-}).strict().refine((table) => table.header_cells.length === table.columns.length, {
-  message: 'header_cells and columns must have the same length',
-});
+  existing_data_row_count: z.number().int().positive().optional(),
+}).strict()
+  .refine((table) => table.header_cells.length === table.columns.length, {
+    message: 'header_cells and columns must have the same length',
+  })
+  .refine(
+    (table) => table.existing_data_row_count === undefined
+      || table.prototype_row_index === undefined
+      || table.prototype_row_index <= table.existing_data_row_count,
+    { message: 'prototype_row_index must identify one of the existing data rows' },
+  );
 
 const PrototypeTableSchema = TableBaseSchema.extend({
   prototype_cells: z.array(z.string()).min(1),
@@ -188,7 +196,13 @@ export function applyRepeatableTables(
     const table = candidates[0];
     const rows = directChildren(table, 'tr');
     const isHeaderTable = 'header_cells' in binding;
-    if (isHeaderTable && binding.prototype_row_index === undefined) {
+    const existingDataRowCount = isHeaderTable ? binding.existing_data_row_count : undefined;
+    if (isHeaderTable && existingDataRowCount !== undefined && rows.length !== existingDataRowCount + 1) {
+      throw new Error(
+        `repeatable table "${binding.id}" has ${rows.length - 1} post-header rows; expected exactly ${existingDataRowCount}`,
+      );
+    }
+    if (isHeaderTable && binding.prototype_row_index === undefined && existingDataRowCount === undefined) {
       const nonblank = rows.slice(1).find((row) => !isBlankRow(row));
       if (nonblank) {
         throw new Error(`repeatable table "${binding.id}" has a nonblank post-header row; use an explicit prototype_row_index or remove stale data`);
@@ -202,7 +216,9 @@ export function applyRepeatableTables(
       });
       if (inconsistent) throw new Error(`repeatable table "${binding.id}" has a row that does not match prototype_cells`);
     }
-    const explicitPrototypeIndex = isHeaderTable ? binding.prototype_row_index : undefined;
+    const explicitPrototypeIndex = isHeaderTable
+      ? (binding.prototype_row_index ?? (existingDataRowCount === undefined ? undefined : 1))
+      : undefined;
     const prototype = isHeaderTable && explicitPrototypeIndex === undefined
       ? rows[0].cloneNode(true) as XmlElement
       : rows[explicitPrototypeIndex ?? 0];
@@ -232,7 +248,10 @@ export function applyRepeatableTables(
     }
     const sourceRows = isHeaderTable ? rows.slice(1) : rows;
     for (const row of sourceRows) {
-      if (!isHeaderTable || explicitPrototypeIndex === undefined ? (!isHeaderTable || isBlankRow(row)) : row === prototype) table.removeChild(row);
+      const shouldRemove = !isHeaderTable
+        || existingDataRowCount !== undefined
+        || (explicitPrototypeIndex === undefined ? isBlankRow(row) : row === prototype);
+      if (shouldRemove) table.removeChild(row);
     }
   }
 

--- a/src/core/field-selector/repeatable-tables.ts
+++ b/src/core/field-selector/repeatable-tables.ts
@@ -1,0 +1,177 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import AdmZip from 'adm-zip';
+import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
+import type { Document as XmlDocument, Element as XmlElement } from '@xmldom/xmldom';
+import { z } from 'zod';
+import type { FieldDefinition } from '../metadata.js';
+
+const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+const ColumnSchema = z.object({
+  field: z.string().min(1),
+  format: z.enum(['text', 'integer', 'decimal', 'currency']).default('text'),
+}).strict();
+
+const TableSchema = z.object({
+  id: z.string().min(1),
+  rows_field: z.string().min(1),
+  header_cells: z.array(z.string()).min(1),
+  columns: z.array(ColumnSchema).min(1),
+  prototype_row_index: z.number().int().positive().optional(),
+}).strict().refine((table) => table.header_cells.length === table.columns.length, {
+  message: 'header_cells and columns must have the same length',
+});
+
+export const RepeatableTablesConfigSchema = z.object({
+  schema_version: z.literal(1),
+  tables: z.array(TableSchema).min(1),
+}).strict();
+
+export type RepeatableTablesConfig = z.infer<typeof RepeatableTablesConfigSchema>;
+
+export function loadRepeatableTablesConfig(templateDir: string): RepeatableTablesConfig | undefined {
+  const configPath = join(templateDir, 'repeatable-tables.json');
+  if (!existsSync(configPath)) return undefined;
+  return RepeatableTablesConfigSchema.parse(JSON.parse(readFileSync(configPath, 'utf8')));
+}
+
+export function validateRepeatableTableFields(config: RepeatableTablesConfig, fields: FieldDefinition[]): void {
+  const byName = new Map(fields.map((field) => [field.name, field]));
+  for (const table of config.tables) {
+    const rowsField = byName.get(table.rows_field);
+    if (!rowsField || rowsField.type !== 'array' || !rowsField.items) {
+      throw new Error(`repeatable table "${table.id}" rows_field "${table.rows_field}" must reference an array field with items`);
+    }
+    const itemNames = new Set(rowsField.items.map((item) => item.name));
+    for (const column of table.columns) {
+      if (!itemNames.has(column.field)) {
+        throw new Error(`repeatable table "${table.id}" column field "${column.field}" is not declared in ${table.rows_field}.items`);
+      }
+    }
+  }
+}
+
+function directChildren(element: XmlElement, localName: string): XmlElement[] {
+  return Array.from(element.childNodes).filter(
+    (node) => node.nodeType === 1 && (node as XmlElement).localName === localName,
+  ) as XmlElement[];
+}
+
+function textOf(element: XmlElement): string {
+  return Array.from(element.getElementsByTagNameNS(W_NS, 't'))
+    .map((node) => node.textContent ?? '')
+    .join('')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function formatValue(value: unknown, format: z.infer<typeof ColumnSchema>['format']): string {
+  if (value === null || value === undefined || value === '') return '';
+  if (format === 'text') return String(value);
+  const number = typeof value === 'number' ? value : Number(String(value).replace(/[$,]/g, ''));
+  if (!Number.isFinite(number)) throw new Error(`cannot format non-numeric repeatable-table value ${JSON.stringify(value)} as ${format}`);
+  if (format === 'integer') return new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 }).format(number);
+  if (format === 'currency') return new Intl.NumberFormat('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(number);
+  return new Intl.NumberFormat('en-US', { maximumFractionDigits: 8 }).format(number);
+}
+
+function setCellText(doc: XmlDocument, cell: XmlElement, value: string): void {
+  const paragraphs = directChildren(cell, 'p');
+  const paragraph = paragraphs[0] ?? doc.createElementNS(W_NS, 'w:p');
+  if (paragraph.parentNode === null) cell.appendChild(paragraph);
+  for (const child of Array.from(paragraph.childNodes)) {
+    if (child.nodeType === 1 && (child as XmlElement).localName !== 'pPr') paragraph.removeChild(child);
+  }
+  value.split('\n').forEach((line, index) => {
+    if (index > 0) {
+      const breakRun = doc.createElementNS(W_NS, 'w:r');
+      breakRun.appendChild(doc.createElementNS(W_NS, 'w:br'));
+      paragraph.appendChild(breakRun);
+    }
+    const run = doc.createElementNS(W_NS, 'w:r');
+    const text = doc.createElementNS(W_NS, 'w:t');
+    if (/^\s|\s$/.test(line)) text.setAttribute('xml:space', 'preserve');
+    text.appendChild(doc.createTextNode(line));
+    run.appendChild(text);
+    paragraph.appendChild(run);
+  });
+  for (const extra of paragraphs.slice(1)) cell.removeChild(extra);
+}
+
+function isBlankRow(row: XmlElement): boolean {
+  return directChildren(row, 'tc').every((cell) => textOf(cell) === '');
+}
+
+function stripHeaderSemantics(row: XmlElement): void {
+  for (const marker of Array.from(row.getElementsByTagNameNS(W_NS, 'tblHeader'))) {
+    marker.parentNode?.removeChild(marker);
+  }
+  for (const shading of Array.from(row.getElementsByTagNameNS(W_NS, 'shd'))) {
+    shading.parentNode?.removeChild(shading);
+  }
+}
+
+export function applyRepeatableTables(
+  inputPath: string,
+  outputPath: string,
+  config: RepeatableTablesConfig,
+  values: Record<string, unknown>,
+): void {
+  const zip = new AdmZip(inputPath);
+  const entry = zip.getEntry('word/document.xml');
+  if (!entry) throw new Error('repeatable tables require word/document.xml');
+  const doc = new DOMParser().parseFromString(entry.getData().toString('utf8'), 'text/xml');
+  const tables = Array.from(doc.getElementsByTagNameNS(W_NS, 'tbl')) as XmlElement[];
+
+  for (const binding of config.tables) {
+    const candidates = tables.filter((table) => {
+      const header = directChildren(table, 'tr')[0];
+      if (!header) return false;
+      return directChildren(header, 'tc').map(textOf).every((text, index) => text === binding.header_cells[index])
+        && directChildren(header, 'tc').length === binding.header_cells.length;
+    });
+    if (candidates.length !== 1) {
+      throw new Error(`repeatable table "${binding.id}" matched ${candidates.length} tables; expected exactly one`);
+    }
+    const table = candidates[0];
+    const rows = directChildren(table, 'tr');
+    if (binding.prototype_row_index === undefined) {
+      const nonblank = rows.slice(1).find((row) => !isBlankRow(row));
+      if (nonblank) {
+        throw new Error(`repeatable table "${binding.id}" has a nonblank post-header row; use an explicit prototype_row_index or remove stale data`);
+      }
+    }
+    const prototype = binding.prototype_row_index === undefined
+      ? rows[0].cloneNode(true) as XmlElement
+      : rows[binding.prototype_row_index];
+    if (!prototype) throw new Error(`repeatable table "${binding.id}" has no prototype row at index ${binding.prototype_row_index}`);
+    if (binding.prototype_row_index === undefined) stripHeaderSemantics(prototype);
+    const prototypeCells = directChildren(prototype, 'tc');
+    if (prototypeCells.length !== binding.columns.length) {
+      throw new Error(`repeatable table "${binding.id}" prototype has ${prototypeCells.length} cells; expected ${binding.columns.length}`);
+    }
+    const rawRows = values[binding.rows_field] ?? [];
+    if (!Array.isArray(rawRows)) throw new Error(`repeatable table field "${binding.rows_field}" must be an array`);
+    for (const [rowIndex, rawRow] of rawRows.entries()) {
+      if (!rawRow || typeof rawRow !== 'object' || Array.isArray(rawRow)) {
+        throw new Error(`repeatable table field "${binding.rows_field}" entry ${rowIndex} must be an object`);
+      }
+      const row = prototype.cloneNode(true) as XmlElement;
+      const cells = directChildren(row, 'tc');
+      for (let columnIndex = 0; columnIndex < binding.columns.length; columnIndex++) {
+        const column = binding.columns[columnIndex];
+        setCellText(doc, cells[columnIndex], formatValue((rawRow as Record<string, unknown>)[column.field], column.format));
+      }
+      table.appendChild(row);
+    }
+    for (const row of rows.slice(1)) {
+      if (binding.prototype_row_index === undefined ? isBlankRow(row) : row === prototype) {
+        table.removeChild(row);
+      }
+    }
+  }
+
+  zip.updateFile('word/document.xml', Buffer.from(new XMLSerializer().serializeToString(doc), 'utf8'));
+  zip.writeZip(outputPath);
+}

--- a/src/core/field-selector/repeatable-tables.ts
+++ b/src/core/field-selector/repeatable-tables.ts
@@ -8,20 +8,36 @@ import type { FieldDefinition } from '../metadata.js';
 
 const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 
-const ColumnSchema = z.object({
+const ValueSchema = z.object({
   field: z.string().min(1),
   format: z.enum(['text', 'integer', 'decimal', 'currency']).default('text'),
 }).strict();
 
-const TableSchema = z.object({
+const ColumnSchema = z.union([
+  ValueSchema,
+  z.object({ paragraphs: z.array(ValueSchema).min(1) }).strict(),
+]);
+
+const TableBaseSchema = z.object({
   id: z.string().min(1),
   rows_field: z.string().min(1),
-  header_cells: z.array(z.string()).min(1),
   columns: z.array(ColumnSchema).min(1),
+});
+
+const HeaderTableSchema = TableBaseSchema.extend({
+  header_cells: z.array(z.string()).min(1),
   prototype_row_index: z.number().int().positive().optional(),
 }).strict().refine((table) => table.header_cells.length === table.columns.length, {
   message: 'header_cells and columns must have the same length',
 });
+
+const PrototypeTableSchema = TableBaseSchema.extend({
+  prototype_cells: z.array(z.string()).min(1),
+}).strict().refine((table) => table.prototype_cells.length === table.columns.length, {
+  message: 'prototype_cells and columns must have the same length',
+});
+
+const TableSchema = z.union([HeaderTableSchema, PrototypeTableSchema]);
 
 export const RepeatableTablesConfigSchema = z.object({
   schema_version: z.literal(1),
@@ -45,8 +61,11 @@ export function validateRepeatableTableFields(config: RepeatableTablesConfig, fi
     }
     const itemNames = new Set(rowsField.items.map((item) => item.name));
     for (const column of table.columns) {
-      if (!itemNames.has(column.field)) {
-        throw new Error(`repeatable table "${table.id}" column field "${column.field}" is not declared in ${table.rows_field}.items`);
+      const values = 'paragraphs' in column ? column.paragraphs : [column];
+      for (const value of values) {
+        if (!itemNames.has(value.field)) {
+          throw new Error(`repeatable table "${table.id}" column field "${value.field}" is not declared in ${table.rows_field}.items`);
+        }
       }
     }
   }
@@ -66,7 +85,7 @@ function textOf(element: XmlElement): string {
     .trim();
 }
 
-function formatValue(value: unknown, format: z.infer<typeof ColumnSchema>['format']): string {
+function formatValue(value: unknown, format: z.infer<typeof ValueSchema>['format']): string {
   if (value === null || value === undefined || value === '') return '';
   if (format === 'text') return String(value);
   const number = typeof value === 'number' ? value : Number(String(value).replace(/[$,]/g, ''));
@@ -74,6 +93,20 @@ function formatValue(value: unknown, format: z.infer<typeof ColumnSchema>['forma
   if (format === 'integer') return new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 }).format(number);
   if (format === 'currency') return new Intl.NumberFormat('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(number);
   return new Intl.NumberFormat('en-US', { maximumFractionDigits: 8 }).format(number);
+}
+
+function setParagraphText(doc: XmlDocument, paragraph: XmlElement, value: string): void {
+  const runs = directChildren(paragraph, 'r');
+  const run = runs[0] ?? doc.createElementNS(W_NS, 'w:r');
+  if (run.parentNode === null) paragraph.appendChild(run);
+  for (const child of Array.from(run.childNodes)) {
+    if (child.nodeType === 1 && (child as XmlElement).localName !== 'rPr') run.removeChild(child);
+  }
+  const text = doc.createElementNS(W_NS, 'w:t');
+  if (/^\s|\s$/.test(value)) text.setAttribute('xml:space', 'preserve');
+  text.appendChild(doc.createTextNode(value));
+  run.appendChild(text);
+  for (const extra of runs.slice(1)) paragraph.removeChild(extra);
 }
 
 function setCellText(doc: XmlDocument, cell: XmlElement, value: string): void {
@@ -97,6 +130,23 @@ function setCellText(doc: XmlDocument, cell: XmlElement, value: string): void {
     paragraph.appendChild(run);
   });
   for (const extra of paragraphs.slice(1)) cell.removeChild(extra);
+}
+
+function setCellParagraphs(
+  doc: XmlDocument,
+  cell: XmlElement,
+  mappings: Array<z.infer<typeof ValueSchema>>,
+  row: Record<string, unknown>,
+  tableId: string,
+): void {
+  const paragraphs = directChildren(cell, 'p');
+  if (paragraphs.length < mappings.length) {
+    throw new Error(`repeatable table "${tableId}" prototype cell has ${paragraphs.length} paragraphs; expected at least ${mappings.length}`);
+  }
+  mappings.forEach((mapping, index) => {
+    setParagraphText(doc, paragraphs[index], formatValue(row[mapping.field], mapping.format));
+  });
+  for (const extra of paragraphs.slice(mappings.length)) cell.removeChild(extra);
 }
 
 function isBlankRow(row: XmlElement): boolean {
@@ -126,27 +176,38 @@ export function applyRepeatableTables(
 
   for (const binding of config.tables) {
     const candidates = tables.filter((table) => {
-      const header = directChildren(table, 'tr')[0];
-      if (!header) return false;
-      return directChildren(header, 'tc').map(textOf).every((text, index) => text === binding.header_cells[index])
-        && directChildren(header, 'tc').length === binding.header_cells.length;
+      const firstRow = directChildren(table, 'tr')[0];
+      if (!firstRow) return false;
+      const expected = 'header_cells' in binding ? binding.header_cells : binding.prototype_cells;
+      const cells = directChildren(firstRow, 'tc').map(textOf);
+      return cells.length === expected.length && cells.every((text, index) => text === expected[index]);
     });
     if (candidates.length !== 1) {
       throw new Error(`repeatable table "${binding.id}" matched ${candidates.length} tables; expected exactly one`);
     }
     const table = candidates[0];
     const rows = directChildren(table, 'tr');
-    if (binding.prototype_row_index === undefined) {
+    const isHeaderTable = 'header_cells' in binding;
+    if (isHeaderTable && binding.prototype_row_index === undefined) {
       const nonblank = rows.slice(1).find((row) => !isBlankRow(row));
       if (nonblank) {
         throw new Error(`repeatable table "${binding.id}" has a nonblank post-header row; use an explicit prototype_row_index or remove stale data`);
       }
     }
-    const prototype = binding.prototype_row_index === undefined
+    if (!isHeaderTable) {
+      const inconsistent = rows.find((row) => {
+        const cells = directChildren(row, 'tc').map(textOf);
+        return cells.length !== binding.prototype_cells.length
+          || cells.some((text, index) => text !== binding.prototype_cells[index]);
+      });
+      if (inconsistent) throw new Error(`repeatable table "${binding.id}" has a row that does not match prototype_cells`);
+    }
+    const explicitPrototypeIndex = isHeaderTable ? binding.prototype_row_index : undefined;
+    const prototype = isHeaderTable && explicitPrototypeIndex === undefined
       ? rows[0].cloneNode(true) as XmlElement
-      : rows[binding.prototype_row_index];
-    if (!prototype) throw new Error(`repeatable table "${binding.id}" has no prototype row at index ${binding.prototype_row_index}`);
-    if (binding.prototype_row_index === undefined) stripHeaderSemantics(prototype);
+      : rows[explicitPrototypeIndex ?? 0];
+    if (!prototype) throw new Error(`repeatable table "${binding.id}" has no prototype row at index ${explicitPrototypeIndex ?? 0}`);
+    if (isHeaderTable && explicitPrototypeIndex === undefined) stripHeaderSemantics(prototype);
     const prototypeCells = directChildren(prototype, 'tc');
     if (prototypeCells.length !== binding.columns.length) {
       throw new Error(`repeatable table "${binding.id}" prototype has ${prototypeCells.length} cells; expected ${binding.columns.length}`);
@@ -161,14 +222,17 @@ export function applyRepeatableTables(
       const cells = directChildren(row, 'tc');
       for (let columnIndex = 0; columnIndex < binding.columns.length; columnIndex++) {
         const column = binding.columns[columnIndex];
-        setCellText(doc, cells[columnIndex], formatValue((rawRow as Record<string, unknown>)[column.field], column.format));
+        if ('paragraphs' in column) {
+          setCellParagraphs(doc, cells[columnIndex], column.paragraphs, rawRow as Record<string, unknown>, binding.id);
+        } else {
+          setCellText(doc, cells[columnIndex], formatValue((rawRow as Record<string, unknown>)[column.field], column.format));
+        }
       }
       table.appendChild(row);
     }
-    for (const row of rows.slice(1)) {
-      if (binding.prototype_row_index === undefined ? isBlankRow(row) : row === prototype) {
-        table.removeChild(row);
-      }
+    const sourceRows = isHeaderTable ? rows.slice(1) : rows;
+    for (const row of sourceRows) {
+      if (!isHeaderTable || explicitPrototypeIndex === undefined ? (!isHeaderTable || isBlankRow(row)) : row === prototype) table.removeChild(row);
     }
   }
 

--- a/src/core/field-selector/types.ts
+++ b/src/core/field-selector/types.ts
@@ -9,6 +9,8 @@ export interface FieldSelectorRunOptions {
   keepIntermediate?: boolean;
   computedOutPath?: string;
   normalizeBracketArtifacts?: boolean;
+  /** Fail closed when a configured selected/unselected alternative cannot be resolved. */
+  selectionsZeroMatchPolicy?: 'error' | 'warn';
 }
 
 export interface FieldSelectorRunResult {

--- a/src/core/fill-pipeline.ts
+++ b/src/core/fill-pipeline.ts
@@ -155,6 +155,27 @@ export function formatDocumentDate(value: string): string {
 }
 
 /**
+ * Return a shallow copy with metadata-declared date fields normalized for
+ * document display. This is intentionally safe to call at more than one
+ * pipeline boundary: {@link formatDocumentDate} leaves display-ready and
+ * non-date strings unchanged.
+ */
+export function formatDocumentDateFields(
+  values: Record<string, unknown>,
+  fields: FieldDefinition[]
+): Record<string, unknown> {
+  const formatted = { ...values };
+  for (const field of fields) {
+    if (field.type !== 'date') continue;
+    const value = formatted[field.name];
+    if (typeof value === 'string') {
+      formatted[field.name] = formatDocumentDate(value);
+    }
+  }
+  return formatted;
+}
+
+/**
  * Prepare fill data with all normalization steps:
  * 1. Apply defaults for optional fields not provided
  * 2. Normalize multiselect fields and derive booleans (optional)
@@ -175,7 +196,7 @@ export function prepareFillData(options: PrepareFillDataOptions): Record<string,
 
   // Apply defaults for fields not provided
   const defaultValue = useBlankPlaceholder ? BLANK_PLACEHOLDER : '';
-  const data: Record<string, unknown> = { ...values };
+  let data: Record<string, unknown> = { ...values };
 
   for (const field of fields) {
     if (!(field.name in data)) {
@@ -195,13 +216,7 @@ export function prepareFillData(options: PrepareFillDataOptions): Record<string,
   // empty-but-non-null placeholders pass through unchanged, so fixtures that
   // supply "March 20, 2026" are unaffected. Deterministic and
   // timezone-independent — see formatDocumentDate.
-  for (const field of fields) {
-    if (field.type !== 'date') continue;
-    const value = data[field.name];
-    if (typeof value === 'string') {
-      data[field.name] = formatDocumentDate(value);
-    }
-  }
+  data = formatDocumentDateFields(data, fields);
 
   for (const field of fields) {
     if (field.type !== 'enum') continue;

--- a/src/core/selector.test.ts
+++ b/src/core/selector.test.ts
@@ -593,6 +593,98 @@ describe('markerless selections', () => {
   });
 });
 
+describe('bounded markerless removals', () => {
+  it('removes the exact alternate table and adjacent blank carriers as whole OOXML blocks', async () => {
+    const body = `
+      ${para('Purchase price is $1.00 per share.')}
+      ${para('')}
+      ${table(tableRow(tableCell(para('MANDATORY TRANCHE ALTERNATE TABLE'))))}
+      ${para('')}
+      ${para('The aggregate purchase price is $10,000,000.')}
+    `;
+    const inputPath = buildTestDocx(body);
+    const outputPath = join(makeTempDir(), 'out.docx');
+    const config: SelectionsConfig = { groups: [{
+      id: 'mandatory_tranche_table', type: 'checkbox', standalone: true, markerless: true,
+      options: [{
+        marker: 'MANDATORY TRANCHE ALTERNATE TABLE',
+        trigger: { field: 'use_mandatory_tranche', equals: true },
+        removal: { kind: 'table', anchor: 'MANDATORY TRANCHE ALTERNATE TABLE' },
+      }],
+    }] };
+
+    await applySelections(inputPath, outputPath, config, { use_mandatory_tranche: false });
+
+    const xml = readDocumentXml(outputPath);
+    const parsed = new DOMParser().parseFromString(xml, 'text/xml');
+    expect(extractText(outputPath)).toBe('Purchase price is $1.00 per share.The aggregate purchase price is $10,000,000.');
+    expect(parsed.getElementsByTagName('parsererror').length).toBe(0);
+    expect(parsed.getElementsByTagNameNS(W_NS, 'tbl').length).toBe(0);
+  });
+
+  it('removes only the declared section range and preserves following body text and punctuation', async () => {
+    const body = `
+      ${para('Representations follow:')}
+      ${para('SBIC Rights.')}
+      ${para('Optional SBIC representation.')}
+      ${table(tableRow(tableCell(para('Optional SBIC schedule.'))))}
+      ${para('Healthcare Matters.')}
+      ${para('The Company has complied with healthcare laws.')}
+      ${para('General Matters.')}
+      ${para('The Company is duly organized, validly existing, and in good standing.')}
+    `;
+    const inputPath = buildTestDocx(body);
+    const outputPath = join(makeTempDir(), 'out.docx');
+    const config: SelectionsConfig = { groups: [{
+      id: 'sbic_section', type: 'checkbox', standalone: true, markerless: true,
+      options: [{
+        marker: 'SBIC Rights.', trigger: { field: 'include_sbic', equals: true },
+        removal: { kind: 'section', startAnchor: 'SBIC Rights.', endAnchor: 'Healthcare Matters.' },
+      }],
+    }] };
+
+    await applySelections(inputPath, outputPath, config, {});
+
+    const text = extractText(outputPath);
+    expect(text).not.toContain('SBIC');
+    expect(text).not.toContain('Optional SBIC schedule');
+    expect(text).toContain('Healthcare Matters.The Company has complied with healthcare laws.');
+    expect(text).toContain('duly organized, validly existing, and in good standing.');
+  });
+
+  it.each([
+    ['missing end', para('SBIC Rights.')],
+    ['duplicate end', `${para('SBIC Rights.')}${para('Healthcare Matters.')}${para('Healthcare Matters.')}`],
+    ['end before start', `${para('Healthcare Matters.')}${para('SBIC Rights.')}`],
+  ])('fails closed for %s section boundaries', async (_name, body) => {
+    const inputPath = buildTestDocx(body);
+    const outputPath = join(makeTempDir(), 'out.docx');
+    const config: SelectionsConfig = { groups: [{
+      id: 'bounded_section', type: 'checkbox', standalone: true, markerless: true,
+      options: [{
+        marker: 'SBIC Rights.', trigger: { field: 'include_sbic', equals: true },
+        removal: { kind: 'section', startAnchor: 'SBIC Rights.', endAnchor: 'Healthcare Matters.' },
+      }],
+    }] };
+    await expect(applySelections(inputPath, outputPath, config, {})).rejects.toThrow(/section (boundaries|end boundary)/i);
+  });
+
+  it('fails closed when a table anchor is duplicated', async () => {
+    const inputPath = buildTestDocx(
+      `${table(tableRow(tableCell(para('ALTERNATE TABLE'))))}${table(tableRow(tableCell(para('ALTERNATE TABLE'))))}`,
+    );
+    const outputPath = join(makeTempDir(), 'out.docx');
+    const config: SelectionsConfig = { groups: [{
+      id: 'bounded_table', type: 'checkbox', standalone: true, markerless: true,
+      options: [{
+        marker: 'ALTERNATE TABLE', trigger: { field: 'keep', equals: true },
+        removal: { kind: 'table', anchor: 'ALTERNATE TABLE' },
+      }],
+    }] };
+    await expect(applySelections(inputPath, outputPath, config, {})).rejects.toThrow(/matched 2 paragraphs \(expected 1\)/);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Inline selections
 // ---------------------------------------------------------------------------

--- a/src/core/selector.ts
+++ b/src/core/selector.ts
@@ -38,6 +38,19 @@ const OptionSchema = z.object({
   marker: z.string(),
   trigger: TriggerSchema,
   replaceWith: z.string().optional(),
+  removal: z.discriminatedUnion('kind', [
+    z.object({
+      kind: z.literal('table'),
+      anchor: z.string().min(1),
+      removeAdjacentBlankParagraphs: z.boolean().optional(),
+    }).strict(),
+    z.object({
+      kind: z.literal('section'),
+      startAnchor: z.string().min(1),
+      endAnchor: z.string().min(1),
+      removeAdjacentBlankParagraphs: z.boolean().optional(),
+    }).strict(),
+  ]).optional(),
 });
 
 const GroupSchema = z
@@ -68,6 +81,10 @@ const GroupSchema = z
   .refine(
     (g) => !g.inline || g.markerless === true,
     { message: 'inline: true requires markerless: true' },
+  )
+  .refine(
+    (g) => g.options.every((o) => !o.removal || (g.markerless === true && !g.inline && o.replaceWith === undefined)),
+    { message: 'bounded removal requires markerless:true, inline:false, and no replaceWith' },
   );
 
 export const SelectionsConfigSchema = z.object({
@@ -155,6 +172,106 @@ function findAncestorElement(node: Node, localName: string): Element | null {
     current = current.parentNode;
   }
   return null;
+}
+
+function isWordElement(node: Node | null, localName?: string): node is Element {
+  if (!node || node.nodeType !== 1) return false;
+  const el = node as Element;
+  return el.namespaceURI === W_NS && (localName === undefined || el.localName === localName);
+}
+
+function elementChildren(parent: Node): Element[] {
+  const result: Element[] = [];
+  for (let i = 0; i < parent.childNodes.length; i++) {
+    const node = parent.childNodes[i];
+    if (node.nodeType === 1) result.push(node as Element);
+  }
+  return result;
+}
+
+function exactParagraphMatches(doc: Document, anchor: string): Element[] {
+  const expected = normalizeQuotes(anchor).trim();
+  const matches: Element[] = [];
+  const paragraphs = doc.getElementsByTagNameNS(W_NS, 'p');
+  for (let i = 0; i < paragraphs.length; i++) {
+    if (normalizeQuotes(extractParagraphText(paragraphs[i])).trim() === expected) matches.push(paragraphs[i]);
+  }
+  return matches;
+}
+
+function isBlankParagraph(node: Element): boolean {
+  return isWordElement(node, 'p') && extractParagraphText(node) === '';
+}
+
+/** Remove complete body blocks while also deleting bookmark counterparts outside them. */
+function removeBlockNodes(doc: Document, blocks: Set<Element>): void {
+  const doomedParas = new Set<Element>();
+  for (const block of blocks) {
+    if (isWordElement(block, 'p')) doomedParas.add(block);
+    const paras = block.getElementsByTagNameNS(W_NS, 'p');
+    for (let i = 0; i < paras.length; i++) doomedParas.add(paras[i]);
+  }
+
+  removeWithBookmarkCleanup(doc, doomedParas);
+  for (const block of blocks) block.parentNode?.removeChild(block);
+}
+
+type BoundedRemoval = NonNullable<z.infer<typeof OptionSchema>['removal']>;
+
+/**
+ * Execute an explicit, fail-closed block removal. Section end anchors are
+ * preserved and must be later siblings of the start anchor, preventing a
+ * missing/drifted boundary from consuming the rest of the agreement.
+ */
+function applyBoundedRemoval(doc: Document, groupId: string, removal: BoundedRemoval, remove: boolean): number {
+  if (removal.kind === 'table') {
+    const anchors = exactParagraphMatches(doc, removal.anchor);
+    if (anchors.length !== 1) {
+      throw new Error(`[selector] Group "${groupId}": table anchor "${removal.anchor}" matched ${anchors.length} paragraphs (expected 1).`);
+    }
+    const tables = new Set(anchors.map((p) => findAncestorElement(p, 'tbl')).filter((t): t is Element => t !== null));
+    if (tables.size !== 1) {
+      throw new Error(`[selector] Group "${groupId}": table anchor must resolve to exactly one table (resolved ${tables.size}).`);
+    }
+    const table = [...tables][0];
+    const parent = table.parentNode;
+    if (!parent) throw new Error(`[selector] Group "${groupId}": matched table has no parent.`);
+    const siblings = elementChildren(parent);
+    const index = siblings.indexOf(table);
+    const blocks = new Set<Element>([table]);
+    if (removal.removeAdjacentBlankParagraphs !== false) {
+      for (let i = index - 1; i >= 0 && isBlankParagraph(siblings[i]); i--) blocks.add(siblings[i]);
+      for (let i = index + 1; i < siblings.length && isBlankParagraph(siblings[i]); i++) blocks.add(siblings[i]);
+    }
+    if (remove) removeBlockNodes(doc, blocks);
+    return anchors.length;
+  }
+
+  const starts = exactParagraphMatches(doc, removal.startAnchor);
+  const ends = exactParagraphMatches(doc, removal.endAnchor);
+  if (starts.length !== 1 || ends.length !== 1) {
+    throw new Error(
+      `[selector] Group "${groupId}": section boundaries matched start=${starts.length} (expected 1), ` +
+      `end=${ends.length} (expected 1).`,
+    );
+  }
+  const start = starts[0];
+  const end = ends[0];
+  if (start.parentNode !== end.parentNode || !start.parentNode) {
+    throw new Error(`[selector] Group "${groupId}": section boundaries must be sibling body blocks.`);
+  }
+  const siblings = elementChildren(start.parentNode);
+  const startIndex = siblings.indexOf(start);
+  const endIndex = siblings.indexOf(end);
+  if (startIndex < 0 || endIndex <= startIndex) {
+    throw new Error(`[selector] Group "${groupId}": section end boundary must follow its start boundary.`);
+  }
+  const blocks = new Set<Element>(siblings.slice(startIndex, endIndex));
+  if (removal.removeAdjacentBlankParagraphs !== false) {
+    for (let i = startIndex - 1; i >= 0 && isBlankParagraph(siblings[i]); i--) blocks.add(siblings[i]);
+  }
+  if (remove) removeBlockNodes(doc, blocks);
+  return starts.length;
 }
 
 // ---------------------------------------------------------------------------
@@ -493,7 +610,7 @@ export async function applySelections(
 
     let partModified = false;
     for (const group of config.groups) {
-      const result = processGroup(doc, group, data, stats);
+      const result = processGroup(doc, group, data, stats, partName === 'word/document.xml');
       if (result) partModified = true;
     }
 
@@ -535,9 +652,10 @@ function processGroup(
   group: z.infer<typeof GroupSchema>,
   data: Record<string, unknown>,
   stats: OptionStats,
+  isMainDocument: boolean,
 ): boolean {
   if (group.markerless) {
-    return processMarkerlessGroup(doc, group, data, stats);
+    return processMarkerlessGroup(doc, group, data, stats, isMainDocument);
   }
 
   if (group.standalone) {
@@ -898,6 +1016,7 @@ function processMarkerlessGroup(
   group: z.infer<typeof GroupSchema>,
   data: Record<string, unknown>,
   stats: OptionStats,
+  isMainDocument: boolean,
 ): boolean {
   const selectedIndices = evaluateTriggers(group, data);
   const matchCounts: number[] = group.options.map(() => 0);
@@ -907,6 +1026,21 @@ function processMarkerlessGroup(
 
   for (let oi = 0; oi < group.options.length; oi++) {
     const option = group.options[oi];
+
+    if (option.removal) {
+      // Whole tables and sections are body-block concepts. Ignoring headers and
+      // footers also makes the exact-one assertion global for the only part in
+      // which bounded removal is valid.
+      if (!isMainDocument) continue;
+      const selected = selectedIndices.has(oi);
+      const count = applyBoundedRemoval(doc, group.id, option.removal, !selected);
+      matchCounts[oi] += count;
+      if (!selected) {
+        appliedCounts[oi]++;
+        madeChanges = true;
+      }
+      continue;
+    }
 
     // Snapshot all paragraphs before mutating to avoid live NodeList issues
     const allParagraphs = doc.getElementsByTagNameNS(W_NS, 'p');

--- a/src/core/unified-pipeline.ts
+++ b/src/core/unified-pipeline.ts
@@ -360,6 +360,16 @@ export async function runFillPipeline(options: PipelineOptions): Promise<Pipelin
         warnings.push(message);
       }
 
+      if (selectionsZeroMatchPolicy === 'error' && anomalies.selectedZeroMatch.length > 0) {
+        const detail = anomalies.selectedZeroMatch
+          .map((o) => `${describeSelectionOption(o)} [matched ${o.matchCount}]`)
+          .join('; ');
+        throw new Error(
+          `[selections] selected option(s) are absent from the document; refusing to emit a document that did ` +
+          `not implement the requested choice: ${detail}`,
+        );
+      }
+
       for (const o of anomalies.unremovedInInertGroup) {
         warnings.push(
           `selections: unselected option ${describeSelectionOption(o)} matched zero paragraphs, and no option in ` +

--- a/src/core/unified-pipeline.ts
+++ b/src/core/unified-pipeline.ts
@@ -86,6 +86,12 @@ export interface PipelineOptions {
     cleanedSourcePath?: string,
     referencedFields?: Set<string>,
   ) => VerifyResult | Promise<VerifyResult>;
+  /**
+   * Structural source transformation that must run after cleaning but before
+   * selector/legacy scalar patching. Generated content must contain no fill
+   * commands because command analysis and filling happen later.
+   */
+  prePatchProcess?: (inputPath: string, outputPath: string) => void | Promise<void>;
   postProcess?: (outputPath: string) => void | Promise<void>;
 
   // Debugging
@@ -176,6 +182,7 @@ export async function runFillPipeline(options: PipelineOptions): Promise<Pipelin
     computeDisplayFields,
     fixSmartQuotes = false,
     verify,
+    prePatchProcess,
     postProcess,
     keepIntermediate = false,
   } = options;
@@ -207,14 +214,21 @@ export async function runFillPipeline(options: PipelineOptions): Promise<Pipelin
       await cleanDocument(sourcePath, cleanedPath, cleanPatch.cleanConfig);
       cleanedSourcePath = cleanedPath;
 
+      let structuralInputPath = cleanedPath;
+      if (prePatchProcess) {
+        const structurallyProcessedPath = join(tempDir, 'structural.docx');
+        await prePatchProcess(cleanedPath, structurallyProcessedPath);
+        structuralInputPath = structurallyProcessedPath;
+      }
+
       // Selector-contract patch (deterministic locators) runs between clean and
       // the legacy patch. It rewrites resolved occurrences to {field_id} tags;
       // those fields' keys have already been removed from cleanPatch.replacements
       // (the declarative migrated_keys cutover) so each field is patched once.
-      let patchInputPath = cleanedPath;
+      let patchInputPath = structuralInputPath;
       if (selectorManifests && selectorManifests.length > 0) {
         const selectedPath = join(tempDir, 'selected.docx');
-        const selectorResult = await applySelectorContracts(cleanedPath, selectedPath, selectorManifests);
+        const selectorResult = await applySelectorContracts(structuralInputPath, selectedPath, selectorManifests);
         onSelectorResolved?.(selectorResult.fields);
         for (const warning of selectorResult.warnings) {
           console.warn(`Selector warning: ${warning}`);
@@ -249,6 +263,10 @@ export async function runFillPipeline(options: PipelineOptions): Promise<Pipelin
 
       currentPath = patchedPath;
       stages = { clean: cleanedPath, patch: patchedPath, fill: '' };
+    } else if (prePatchProcess) {
+      const structurallyProcessedPath = join(tempDir, 'structural.docx');
+      await prePatchProcess(sourcePath, structurallyProcessedPath);
+      currentPath = structurallyProcessedPath;
     }
 
     // Step 4: Prepare fill data.


### PR DESCRIPTION
## Summary
- support repeatable DOCX tables, including prototype-only and prepopulated rows
- add bounded conditional removal and fail closed on selected options with zero matches
- format ISO dates before computed-field interpolation
- delete intersecting complex Word fields atomically so stale REF instructions cannot revive

## Verification
- `npm run lint`
- `npm run build`
- `npm run test:run -- --silent`
- 117 test files passed, 4 skipped
- 1,351 tests passed, 7 skipped
- includes real hash-pinned NVCA source end-to-end tests for SPA, COI, IRA, Voting, ROFR, Indemnification Agreement, and Management Rights Letter

No legal recipe content is changed by this PR.