### PR TITLE
feat(field-selector): bind repeated labels within anchored blocks

### DIFF
--- a/src/core/field-selector/anchored-paragraph-bindings.test.ts
+++ b/src/core/field-selector/anchored-paragraph-bindings.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect } from 'vitest';
+import { itAllure } from '../../../integration-tests/helpers/allure-test.js';
 import AdmZip from 'adm-zip';
 import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
@@ -9,6 +10,7 @@ import {
 } from './anchored-paragraph-bindings.js';
 
 const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const it = itAllure.epic('Filling & Rendering');
 
 function p(inner: string): string { return `<w:p>${inner}</w:p>`; }
 function text(value: string): string { return `<w:r><w:t xml:space="preserve">${value}</w:t></w:r>`; }

--- a/src/core/field-selector/anchored-paragraph-bindings.test.ts
+++ b/src/core/field-selector/anchored-paragraph-bindings.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import AdmZip from 'adm-zip';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  bindAnchoredParagraphFields,
+  type AnchoredParagraphBindingsConfig,
+} from './anchored-paragraph-bindings.js';
+
+const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+function p(inner: string): string { return `<w:p>${inner}</w:p>`; }
+function text(value: string): string { return `<w:r><w:t xml:space="preserve">${value}</w:t></w:r>`; }
+function label(value: string): string {
+  return `<w:r><w:t xml:space="preserve">${value}</w:t><w:tab/></w:r><w:r><w:rPr><w:u w:val="single"/></w:rPr><w:tab/></w:r>`;
+}
+
+function build(body: string): { dir: string; input: string; output: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'anchored-bindings-'));
+  const input = join(dir, 'input.docx');
+  const zip = new AdmZip();
+  zip.addFile('word/document.xml', Buffer.from(
+    `<?xml version="1.0"?><w:document xmlns:w="${W_NS}"><w:body>${body}</w:body></w:document>`,
+  ));
+  zip.addFile('[Content_Types].xml', Buffer.from('<Types/>'));
+  zip.writeZip(input);
+  return { dir, input, output: join(dir, 'output.docx') };
+}
+
+const config: AnchoredParagraphBindingsConfig = {
+  groups: [
+    {
+      id: 'company',
+      start_anchor: 'COMPANY: [Insert Company Name]',
+      end_anchor: 'INVESTORS: [Insert Investor Name]',
+      expected_group_matches: 1,
+      bindings: [
+        { label: 'Name:', field: 'company_signatory_name', expected_matches: 1, insert_after_label: true, preserve_following_tabs: true },
+        { label: 'Title:', field: 'company_signatory_title', expected_matches: 1, insert_after_label: true, preserve_following_tabs: true },
+        { label: 'Address:', field: 'company_notice_address', expected_matches: 1, insert_after_label: true, preserve_following_tabs: true },
+        { label: 'Email:', field: 'company_notice_email', expected_matches: 1, insert_after_label: true, preserve_following_tabs: true },
+      ],
+    },
+    {
+      id: 'investor',
+      start_anchor: 'INVESTORS: [Insert Investor Name]',
+      end_anchor: 'KEY HOLDERS:',
+      expected_group_matches: 1,
+      bindings: [
+        { label: 'Name:', field: 'investor_signatory_name', expected_matches: 1, insert_after_label: true, preserve_following_tabs: true },
+        { label: 'Title:', field: 'investor_signatory_title', expected_matches: 1, insert_after_label: true, preserve_following_tabs: true },
+      ],
+    },
+  ],
+};
+
+const signatureBody =
+  p(text('OUTSIDE') + label('Name:')) +
+  p(text('COMPANY:') + '<w:r><w:tab/></w:r>' + text('[Insert Company Name]')) +
+  p(label('By:')) + p(label('Name:')) +
+  p(label('Title:') + '<w:r><w:br/><w:t xml:space="preserve">Address: </w:t><w:tab/><w:br/><w:tab/></w:r>') +
+  p(label('Email:')) +
+  p(text('INVESTORS:') + '<w:r><w:tab/></w:r>' + text('[Insert Investor Name]')) +
+  p(label('By:')) + p(label('Name:')) + p(label('Title:')) +
+  p(text('KEY HOLDERS:'));
+
+describe('anchor-scoped paragraph field binding', () => {
+  it('binds repeated labels to distinct fields inside their unique boundaries', () => {
+    const fixture = build(signatureBody);
+    const before = new AdmZip(fixture.input).getEntry('word/document.xml')!.getData().toString('utf-8');
+    bindAnchoredParagraphFields(fixture.input, fixture.output, config);
+    const xml = new AdmZip(fixture.output).getEntry('word/document.xml')!.getData().toString('utf-8');
+
+    for (const field of [
+      'company_signatory_name', 'company_signatory_title', 'company_notice_address',
+      'company_notice_email', 'investor_signatory_name', 'investor_signatory_title',
+    ]) expect(xml).toContain(`{${field}}`);
+    expect(xml).not.toContain('{outside');
+    expect(xml).not.toContain('{By');
+    expect((xml.match(/<w:tab/g) ?? []).length).toBe((before.match(/<w:tab/g) ?? []).length);
+    expect((xml.match(/<w:br/g) ?? []).length).toBe((before.match(/<w:br/g) ?? []).length);
+    expect((xml.match(/<w:u /g) ?? []).length).toBe((before.match(/<w:u /g) ?? []).length);
+    rmSync(fixture.dir, { recursive: true, force: true });
+  });
+
+  it('fails closed on a zero-match label without writing an output', () => {
+    const fixture = build(signatureBody.replace('Email:', 'E-mail:'));
+    expect(() => bindAnchoredParagraphFields(fixture.input, fixture.output, config))
+      .toThrow(/company.*Email:.*found 0/);
+    expect(existsSync(fixture.output)).toBe(false);
+    rmSync(fixture.dir, { recursive: true, force: true });
+  });
+
+  it('fails closed when a bounded label is ambiguous', () => {
+    const fixture = build(signatureBody.replace(p(label('Email:')), p(label('Name:')) + p(label('Email:'))));
+    expect(() => bindAnchoredParagraphFields(fixture.input, fixture.output, config))
+      .toThrow(/company.*Name:.*found 2/);
+    rmSync(fixture.dir, { recursive: true, force: true });
+  });
+
+  it('fails closed on duplicate or reversed boundary anchors', () => {
+    const duplicate = build(signatureBody + p(text('KEY HOLDERS:')));
+    expect(() => bindAnchoredParagraphFields(duplicate.input, duplicate.output, config))
+      .toThrow(/investor.*start=1, end=2/);
+    rmSync(duplicate.dir, { recursive: true, force: true });
+
+    const reversed = build(p(text('KEY HOLDERS:')) + signatureBody.replace(p(text('KEY HOLDERS:')), ''));
+    expect(() => bindAnchoredParagraphFields(reversed.input, reversed.output, config))
+      .toThrow(/end anchor does not follow start anchor/);
+    rmSync(reversed.dir, { recursive: true, force: true });
+  });
+});

--- a/src/core/field-selector/anchored-paragraph-bindings.ts
+++ b/src/core/field-selector/anchored-paragraph-bindings.ts
@@ -1,0 +1,130 @@
+import AdmZip from 'adm-zip';
+import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
+import type { Document, Element, Node } from '@xmldom/xmldom';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { z } from 'zod';
+import { copyEntriesSkippingDirs } from './ooxml-parts.js';
+
+const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+export const AnchoredParagraphBindingsConfigSchema = z.object({
+  groups: z.array(z.object({
+    id: z.string().min(1),
+    start_anchor: z.string().min(1),
+    end_anchor: z.string().min(1),
+    expected_group_matches: z.literal(1),
+    bindings: z.array(z.object({
+      label: z.string().min(1),
+      field: z.string().regex(/^[A-Za-z_][A-Za-z0-9_]*$/),
+      expected_matches: z.literal(1),
+      insert_after_label: z.literal(true),
+      preserve_following_tabs: z.literal(true),
+    }).strict()).min(1),
+  }).strict()).min(1),
+}).strict();
+
+export type AnchoredParagraphBindingsConfig = z.infer<typeof AnchoredParagraphBindingsConfigSchema>;
+
+function normalizedText(para: Element): string {
+  const chunks: string[] = [];
+  const walk = (node: Node): void => {
+    if (node.nodeType !== 1) return;
+    const el = node as Element;
+    if (el.namespaceURI === W_NS && el.localName === 't') chunks.push(el.textContent ?? '');
+    if (el.namespaceURI === W_NS && (el.localName === 'tab' || el.localName === 'br')) chunks.push(' ');
+    for (let i = 0; i < el.childNodes.length; i++) walk(el.childNodes[i]);
+  };
+  walk(para);
+  return chunks.join('').replace(/\s+/g, ' ').trim();
+}
+
+function directBodyParagraphs(doc: Document): Element[] {
+  const bodies = doc.getElementsByTagNameNS(W_NS, 'body');
+  if (bodies.length !== 1) throw new Error('anchored paragraph bindings: expected exactly one document body');
+  const result: Element[] = [];
+  const children = bodies[0].childNodes;
+  for (let i = 0; i < children.length; i++) {
+    const child = children[i] as Element;
+    if (child.nodeType === 1 && child.namespaceURI === W_NS && child.localName === 'p') result.push(child);
+  }
+  return result;
+}
+
+function exactAnchorIndices(paragraphs: Element[], anchor: string): number[] {
+  const expected = anchor.replace(/\s+/g, ' ').trim();
+  const matches: number[] = [];
+  for (let i = 0; i < paragraphs.length; i++) {
+    if (normalizedText(paragraphs[i]) === expected) matches.push(i);
+  }
+  return matches;
+}
+
+/** Bind fields after plain labels between unique sibling body-paragraph anchors. */
+export function bindAnchoredParagraphFields(
+  inputPath: string,
+  outputPath: string,
+  rawConfig: AnchoredParagraphBindingsConfig,
+): void {
+  const config = AnchoredParagraphBindingsConfigSchema.parse(rawConfig);
+  const zip = new AdmZip(inputPath);
+  const entry = zip.getEntry('word/document.xml');
+  if (!entry) throw new Error('anchored paragraph bindings: word/document.xml not found');
+  const doc = new DOMParser().parseFromString(entry.getData().toString('utf-8'), 'text/xml');
+  const paragraphs = directBodyParagraphs(doc);
+
+  // Validate the complete plan before mutation, so every failure is atomic.
+  const insertions: Array<{ textNode: Element; field: string; groupId: string }> = [];
+  for (const group of config.groups) {
+    const starts = exactAnchorIndices(paragraphs, group.start_anchor);
+    const ends = exactAnchorIndices(paragraphs, group.end_anchor);
+    if (starts.length !== group.expected_group_matches || ends.length !== group.expected_group_matches) {
+      throw new Error(
+        `anchored paragraph bindings '${group.id}': expected one unique start/end anchor; ` +
+        `found start=${starts.length}, end=${ends.length}`,
+      );
+    }
+    const start = starts[0];
+    const end = ends[0];
+    if (end <= start) throw new Error(`anchored paragraph bindings '${group.id}': end anchor does not follow start anchor`);
+
+    for (const binding of group.bindings) {
+      const matches: Element[] = [];
+      const expectedLabel = binding.label.replace(/\s+/g, ' ').trim();
+      for (let i = start + 1; i < end; i++) {
+        const texts = paragraphs[i].getElementsByTagNameNS(W_NS, 't');
+        for (let j = 0; j < texts.length; j++) {
+          if ((texts[j].textContent ?? '').replace(/\s+/g, ' ').trim() === expectedLabel) matches.push(texts[j]);
+        }
+      }
+      if (matches.length !== binding.expected_matches) {
+        throw new Error(
+          `anchored paragraph bindings '${group.id}' label '${binding.label}': ` +
+          `expected one match inside boundaries; found ${matches.length}`,
+        );
+      }
+      insertions.push({ textNode: matches[0], field: binding.field, groupId: group.id });
+    }
+  }
+
+  for (const insertion of insertions) {
+    const run = insertion.textNode.parentNode as Element | null;
+    if (!run || run.localName !== 'r' || run.namespaceURI !== W_NS) {
+      throw new Error(`anchored paragraph bindings '${insertion.groupId}': label is not directly inside a run`);
+    }
+    const tag = doc.createElementNS(W_NS, 'w:t');
+    tag.setAttribute('xml:space', 'preserve');
+    tag.textContent = `{${insertion.field}}`;
+    run.insertBefore(tag, insertion.textNode.nextSibling);
+  }
+
+  const serialized = new XMLSerializer().serializeToString(doc);
+  const outZip = new AdmZip();
+  copyEntriesSkippingDirs(zip, outZip, (name, data) =>
+    name === 'word/document.xml' ? Buffer.from(serialized, 'utf-8') : data,
+  );
+  writeFileSync(outputPath, outZip.toBuffer());
+}
+
+export function loadAnchoredParagraphBindingsConfig(path: string): AnchoredParagraphBindingsConfig {
+  return AnchoredParagraphBindingsConfigSchema.parse(JSON.parse(readFileSync(path, 'utf-8')));
+}

--- a/src/core/field-selector/index.ts
+++ b/src/core/field-selector/index.ts
@@ -20,6 +20,7 @@ import { formatDocumentDate, formatDocumentDateFields } from '../fill-pipeline.j
 import type { FieldSelectorRunOptions, FieldSelectorRunResult } from './types.js';
 import type { ComputedValueMap } from './computed.js';
 import { applyRepeatableTables, loadRepeatableTablesConfig, validateRepeatableTableFields } from './repeatable-tables.js';
+import { bindAnchoredParagraphFields, loadAnchoredParagraphBindingsConfig } from './anchored-paragraph-bindings.js';
 
 function toComputedValueMap(values: Record<string, unknown>): ComputedValueMap {
   const computedValues: ComputedValueMap = {};
@@ -48,6 +49,10 @@ export async function runFieldSelector(options: FieldSelectorRunOptions): Promis
   const normalizeConfig = loadNormalizeConfig(fieldSelectorDir);
   const repeatableTablesConfig = loadRepeatableTablesConfig(fieldSelectorDir);
   if (repeatableTablesConfig) validateRepeatableTableFields(repeatableTablesConfig, metadata.fields);
+  const anchoredBindingsPath = join(fieldSelectorDir, 'anchored-paragraph-bindings.json');
+  const anchoredParagraphBindingsConfig = existsSync(anchoredBindingsPath)
+    ? loadAnchoredParagraphBindingsConfig(anchoredBindingsPath)
+    : undefined;
 
   // Load selectionsConfig if selections.json exists (mirrors engine.ts template path)
   const selectionsPath = join(fieldSelectorDir, 'selections.json');
@@ -146,9 +151,17 @@ export async function runFieldSelector(options: FieldSelectorRunOptions): Promis
     selectorManifests,
     selectionsConfig,
     selectionsZeroMatchPolicy: options.selectionsZeroMatchPolicy,
-    prePatchProcess: repeatableTablesConfig
+    prePatchProcess: repeatableTablesConfig || anchoredParagraphBindingsConfig
       ? async (inputDocPath: string, outputDocPath: string) => {
-        applyRepeatableTables(inputDocPath, outputDocPath, repeatableTablesConfig, effectiveValues);
+        if (repeatableTablesConfig && anchoredParagraphBindingsConfig) {
+          const repeatablePath = `${outputDocPath}.repeatable.docx`;
+          applyRepeatableTables(inputDocPath, repeatablePath, repeatableTablesConfig, effectiveValues);
+          bindAnchoredParagraphFields(repeatablePath, outputDocPath, anchoredParagraphBindingsConfig);
+        } else if (repeatableTablesConfig) {
+          applyRepeatableTables(inputDocPath, outputDocPath, repeatableTablesConfig, effectiveValues);
+        } else if (anchoredParagraphBindingsConfig) {
+          bindAnchoredParagraphFields(inputDocPath, outputDocPath, anchoredParagraphBindingsConfig);
+        }
       }
       : undefined,
     postProcess: shouldNormalizeBracketArtifacts
@@ -247,3 +260,5 @@ export type { FieldSelectorRunOptions, FieldSelectorRunResult, VerifyResult, Ver
 export type { ComputedArtifact, ComputedProfile } from './computed.js';
 export { applyRepeatableTables, loadRepeatableTablesConfig, RepeatableTablesConfigSchema, validateRepeatableTableFields } from './repeatable-tables.js';
 export type { RepeatableTablesConfig } from './repeatable-tables.js';
+export { bindAnchoredParagraphFields, loadAnchoredParagraphBindingsConfig, AnchoredParagraphBindingsConfigSchema } from './anchored-paragraph-bindings.js';
+export type { AnchoredParagraphBindingsConfig } from './anchored-paragraph-bindings.js';


### PR DESCRIPTION
## Summary
- add optional anchored paragraph bindings for real DOCX blocks that repeat plain `Name:`, `Title:`, `Address:`, and `Email:` labels without source placeholders
- require unique start/end anchors and exactly one label match within each exclusive block
- validate the complete plan before mutation and preserve tabs, line breaks, underline runs, and handwritten `By:` lines

## Verification
- `npm run check:allure-labels`
- `npm run lint`
- `npm run build`
- full suite: 118 test files passed, 4 skipped; 1,355 tests passed, 7 skipped
- real pinned NVCA Investors’ Rights Agreement: distinct Company and Investor names/titles/addresses/emails filled without cross-block leakage; handwritten signature lines remained blank

No legal recipe content is changed by this PR.