### PR TITLE
fix(field-selector): normalize smart anchor punctuation

### DIFF
--- a/src/core/field-selector/anchored-paragraph-bindings.test.ts
+++ b/src/core/field-selector/anchored-paragraph-bindings.test.ts
@@ -112,4 +112,61 @@ describe('anchor-scoped paragraph field binding', () => {
       .toThrow(/end anchor does not follow start anchor/);
     rmSync(reversed.dir, { recursive: true, force: true });
   });
+
+  it('matches Word smart apostrophes, quotes, and en/em dashes to straight config punctuation', () => {
+    const fixture = build(
+      p(text('COMPANY’S “SIGNATURE” — START')) +
+      p(label('Officer’s “Name” –')) +
+      p(text('INVESTOR’S “SIGNATURE” — END')),
+    );
+    const smartConfig: AnchoredParagraphBindingsConfig = {
+      groups: [{
+        id: 'smart-punctuation',
+        start_anchor: 'COMPANY\'S "SIGNATURE" - START',
+        end_anchor: 'INVESTOR\'S "SIGNATURE" - END',
+        expected_group_matches: 1,
+        bindings: [{
+          label: 'Officer\'s "Name" -',
+          field: 'officer_name',
+          expected_matches: 1,
+          insert_after_label: true,
+          preserve_following_tabs: true,
+        }],
+      }],
+    };
+
+    bindAnchoredParagraphFields(fixture.input, fixture.output, smartConfig);
+    const xml = new AdmZip(fixture.output).getEntry('word/document.xml')!.getData().toString('utf-8');
+    expect(xml).toContain('{officer_name}');
+    expect(xml).toContain('COMPANY’S “SIGNATURE” — START');
+    rmSync(fixture.dir, { recursive: true, force: true });
+  });
+
+  it('does not case-fold or erase non-equivalent punctuation', () => {
+    const fixture = build(
+      p(text('Company’s Signature — Start')) +
+      p(label('Name;')) +
+      p(text('End')),
+    );
+    const strictConfig: AnchoredParagraphBindingsConfig = {
+      groups: [{
+        id: 'still-exact',
+        start_anchor: "COMPANY'S SIGNATURE - START",
+        end_anchor: 'End',
+        expected_group_matches: 1,
+        bindings: [{
+          label: 'Name:',
+          field: 'name',
+          expected_matches: 1,
+          insert_after_label: true,
+          preserve_following_tabs: true,
+        }],
+      }],
+    };
+
+    expect(() => bindAnchoredParagraphFields(fixture.input, fixture.output, strictConfig))
+      .toThrow(/still-exact.*start=0/);
+    expect(existsSync(fixture.output)).toBe(false);
+    rmSync(fixture.dir, { recursive: true, force: true });
+  });
 });

--- a/src/core/field-selector/anchored-paragraph-bindings.ts
+++ b/src/core/field-selector/anchored-paragraph-bindings.ts
@@ -25,6 +25,19 @@ export const AnchoredParagraphBindingsConfigSchema = z.object({
 
 export type AnchoredParagraphBindingsConfig = z.infer<typeof AnchoredParagraphBindingsConfigSchema>;
 
+/**
+ * Canonicalize only layout whitespace and Word's common smart-punctuation
+ * substitutions. Matching remains case- and punctuation-sensitive otherwise.
+ */
+function canonicalMatchText(value: string): string {
+  return value
+    .replace(/[\u2018\u2019]/g, "'")
+    .replace(/[\u201C\u201D]/g, '"')
+    .replace(/[\u2013\u2014]/g, '-')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
 function normalizedText(para: Element): string {
   const chunks: string[] = [];
   const walk = (node: Node): void => {
@@ -35,7 +48,7 @@ function normalizedText(para: Element): string {
     for (let i = 0; i < el.childNodes.length; i++) walk(el.childNodes[i]);
   };
   walk(para);
-  return chunks.join('').replace(/\s+/g, ' ').trim();
+  return canonicalMatchText(chunks.join(''));
 }
 
 function directBodyParagraphs(doc: Document): Element[] {
@@ -51,7 +64,7 @@ function directBodyParagraphs(doc: Document): Element[] {
 }
 
 function exactAnchorIndices(paragraphs: Element[], anchor: string): number[] {
-  const expected = anchor.replace(/\s+/g, ' ').trim();
+  const expected = canonicalMatchText(anchor);
   const matches: number[] = [];
   for (let i = 0; i < paragraphs.length; i++) {
     if (normalizedText(paragraphs[i]) === expected) matches.push(i);
@@ -89,11 +102,11 @@ export function bindAnchoredParagraphFields(
 
     for (const binding of group.bindings) {
       const matches: Element[] = [];
-      const expectedLabel = binding.label.replace(/\s+/g, ' ').trim();
+      const expectedLabel = canonicalMatchText(binding.label);
       for (let i = start + 1; i < end; i++) {
         const texts = paragraphs[i].getElementsByTagNameNS(W_NS, 't');
         for (let j = 0; j < texts.length; j++) {
-          if ((texts[j].textContent ?? '').replace(/\s+/g, ' ').trim() === expectedLabel) matches.push(texts[j]);
+          if (canonicalMatchText(texts[j].textContent ?? '') === expectedLabel) matches.push(texts[j]);
         }
       }
       if (matches.length !== binding.expected_matches) {


### PR DESCRIPTION
## Summary
- normalize smart/straight apostrophes and quotes plus en/em dashes for anchored-label matching
- keep matching case-sensitive and preserve non-equivalent punctuation
- add fail-closed controls to prevent over-normalization

## Verification
- Allure label gate, lint, build
- full suite: 118 files passed, 4 skipped; 1,357 tests passed, 7 skipped
- real bundled Common Paper CSA With SLA v2.1 DOCX: straight-punctuation config matched smart `Customer’s` / `Discloser’s` source anchors, inserted two distinct bounded values exactly once, preserved all original smart-punctuation occurrences, and passed ZIP integrity

No recipe content is changed.