### PR TITLE
feat(selector): remove uniquely anchored paragraphs safely

### DIFF
--- a/src/core/selector.test.ts
+++ b/src/core/selector.test.ts
@@ -594,6 +594,59 @@ describe('markerless selections', () => {
 });
 
 describe('bounded markerless removals', () => {
+  it('removes one uniquely contained paragraph without spilling into sibling paragraphs', async () => {
+    const inputPath = buildTestDocx(
+      para('Before.') +
+      '<w:p><w:bookmarkStart w:id="7" w:name="optional"/><w:r><w:t>Optional telecommunications text names the Federal Communications Commission.</w:t></w:r><w:bookmarkEnd w:id="7"/></w:p>' +
+      para('Outbound Investment Security Program remains.') +
+      para('DSP policies remain.'),
+    );
+    const outputPath = join(makeTempDir(), 'out.docx');
+    const config: SelectionsConfig = { groups: [{
+      id: 'telecom', type: 'checkbox', standalone: true, markerless: true,
+      options: [{
+        marker: 'Federal Communications Commission', trigger: { field: 'include_telecom', equals: true },
+        removal: { kind: 'paragraph', anchor: 'Federal Communications Commission', match: 'contains', expectedMatches: 1 },
+      }],
+    }] };
+
+    await applySelections(inputPath, outputPath, config, { include_telecom: false });
+    const xml = readDocumentXml(outputPath);
+    expect(extractText(outputPath)).toBe('Before.Outbound Investment Security Program remains.DSP policies remain.');
+    expect(xml).not.toContain('bookmarkStart');
+    expect(xml).not.toContain('bookmarkEnd');
+  });
+
+  it.each([
+    ['zero', para('No matching carrier.')],
+    ['ambiguous', para('Optional FCC carrier.') + para('Another FCC carrier.')],
+  ])('fails closed when a contains paragraph anchor is %s-match', async (_name, body) => {
+    const inputPath = buildTestDocx(body);
+    const outputPath = join(makeTempDir(), 'out.docx');
+    const config: SelectionsConfig = { groups: [{
+      id: 'fcc', type: 'checkbox', standalone: true, markerless: true,
+      options: [{ marker: 'FCC', trigger: { field: 'keep', equals: true }, removal: {
+        kind: 'paragraph', anchor: 'FCC', match: 'contains', expectedMatches: 1,
+      } }],
+    }] };
+    await expect(applySelections(inputPath, outputPath, config, {})).rejects.toThrow(/matched [02] paragraphs \(expected 1\)/);
+  });
+
+  it('fails closed rather than splitting a complex Word field across paragraphs', async () => {
+    const inputPath = buildTestDocx(
+      '<w:p><w:r><w:fldChar w:fldCharType="begin"/><w:t>REMOVE ME</w:t></w:r></w:p>' +
+      '<w:p><w:r><w:fldChar w:fldCharType="end"/><w:t>Keep field end.</w:t></w:r></w:p>',
+    );
+    const outputPath = join(makeTempDir(), 'out.docx');
+    const config: SelectionsConfig = { groups: [{
+      id: 'field_guard', type: 'checkbox', standalone: true, markerless: true,
+      options: [{ marker: 'REMOVE ME', trigger: { field: 'keep', equals: true }, removal: {
+        kind: 'paragraph', anchor: 'REMOVE ME', match: 'exact', expectedMatches: 1,
+      } }],
+    }] };
+    await expect(applySelections(inputPath, outputPath, config, {})).rejects.toThrow(/split a complex Word field/);
+  });
+
   it('removes the exact alternate table and adjacent blank carriers as whole OOXML blocks', async () => {
     const body = `
       ${para('Purchase price is $1.00 per share.')}

--- a/src/core/selector.ts
+++ b/src/core/selector.ts
@@ -50,6 +50,13 @@ const OptionSchema = z.object({
       endAnchor: z.string().min(1),
       removeAdjacentBlankParagraphs: z.boolean().optional(),
     }).strict(),
+    z.object({
+      kind: z.literal('paragraph'),
+      anchor: z.string().min(1),
+      match: z.enum(['exact', 'contains']).default('exact'),
+      expectedMatches: z.literal(1),
+      removeAdjacentBlankParagraphs: z.boolean().optional(),
+    }).strict(),
   ]).optional(),
 });
 
@@ -190,13 +197,42 @@ function elementChildren(parent: Node): Element[] {
 }
 
 function exactParagraphMatches(doc: Document, anchor: string): Element[] {
-  const expected = normalizeQuotes(anchor).trim();
+  const expected = normalizedParagraphText(anchor);
   const matches: Element[] = [];
   const paragraphs = doc.getElementsByTagNameNS(W_NS, 'p');
   for (let i = 0; i < paragraphs.length; i++) {
-    if (normalizeQuotes(extractParagraphText(paragraphs[i])).trim() === expected) matches.push(paragraphs[i]);
+    if (normalizedParagraphText(extractParagraphText(paragraphs[i])) === expected) matches.push(paragraphs[i]);
   }
   return matches;
+}
+
+function normalizedParagraphText(text: string): string {
+  return normalizeQuotes(text).replace(/\s+/g, ' ').trim();
+}
+
+function paragraphMatches(doc: Document, anchor: string, match: 'exact' | 'contains'): Element[] {
+  const expected = normalizedParagraphText(anchor);
+  const matches: Element[] = [];
+  const paragraphs = doc.getElementsByTagNameNS(W_NS, 'p');
+  for (let i = 0; i < paragraphs.length; i++) {
+    const actual = normalizedParagraphText(extractParagraphText(paragraphs[i]));
+    if (match === 'exact' ? actual === expected : actual.includes(expected)) matches.push(paragraphs[i]);
+  }
+  return matches;
+}
+
+function assertBalancedComplexFields(groupId: string, paragraph: Element): void {
+  const chars = paragraph.getElementsByTagNameNS(W_NS, 'fldChar');
+  let depth = 0;
+  for (let i = 0; i < chars.length; i++) {
+    const type = chars[i].getAttribute('w:fldCharType') ?? chars[i].getAttribute('fldCharType');
+    if (type === 'begin') depth++;
+    if (type === 'end') depth--;
+    if (depth < 0) break;
+  }
+  if (depth !== 0) {
+    throw new Error(`[selector] Group "${groupId}": paragraph removal would split a complex Word field.`);
+  }
 }
 
 function isBlankParagraph(node: Element): boolean {
@@ -224,6 +260,25 @@ type BoundedRemoval = NonNullable<z.infer<typeof OptionSchema>['removal']>;
  * missing/drifted boundary from consuming the rest of the agreement.
  */
 function applyBoundedRemoval(doc: Document, groupId: string, removal: BoundedRemoval, remove: boolean): number {
+  if (removal.kind === 'paragraph') {
+    const matches = paragraphMatches(doc, removal.anchor, removal.match);
+    if (matches.length !== removal.expectedMatches) {
+      throw new Error(`[selector] Group "${groupId}": paragraph anchor "${removal.anchor}" matched ${matches.length} paragraphs (expected 1).`);
+    }
+    const paragraph = matches[0];
+    if (remove) assertBalancedComplexFields(groupId, paragraph);
+    const parent = paragraph.parentNode;
+    if (!parent) throw new Error(`[selector] Group "${groupId}": matched paragraph has no parent.`);
+    const siblings = elementChildren(parent);
+    const index = siblings.indexOf(paragraph);
+    const blocks = new Set<Element>([paragraph]);
+    if (removal.removeAdjacentBlankParagraphs !== false) {
+      for (let i = index - 1; i >= 0 && isBlankParagraph(siblings[i]); i--) blocks.add(siblings[i]);
+      for (let i = index + 1; i < siblings.length && isBlankParagraph(siblings[i]); i++) blocks.add(siblings[i]);
+    }
+    if (remove) removeBlockNodes(doc, blocks);
+    return matches.length;
+  }
   if (removal.kind === 'table') {
     const anchors = exactParagraphMatches(doc, removal.anchor);
     if (anchors.length !== 1) {


### PR DESCRIPTION
## Summary
- add `removal.kind: paragraph` for exact or contains matching of one normalized body paragraph
- require literal `expectedMatches: 1` and fail closed on missing or ambiguous matches
- clean bookmarks, preserve sibling paragraphs, and refuse removal that would split a complex Word field

## Verification
- Allure label gate, lint, build
- full suite: 118 files passed, 4 skipped; 1,361 tests passed, 7 skipped
- selector-focused suite: 39/39 passed
- real pinned NVCA SPA: removed only the telecom/FCC paragraph; adjacent Outbound Investment and DSP provisions remained; strict warnings were empty

No recipe content is changed.