### PR TITLE
fix(field-selector): normalize selected list numbering

### DIFF
--- a/src/core/field-selector/index.test.ts
+++ b/src/core/field-selector/index.test.ts
@@ -415,6 +415,7 @@ describe('runFieldSelector', () => {
       normalizedParagraphs: 0,
       declarativeRuleApplications: 1,
     }));
+    const normalizeNumberingMock = vi.fn(() => ({ sections: 0, paragraphs: 0 }));
 
     const runFillPipelineMock = vi.fn(async ({ outputPath, postProcess }: { outputPath: string; postProcess?: (p: string) => Promise<void> }) => {
       if (postProcess) {
@@ -442,6 +443,10 @@ describe('runFieldSelector', () => {
       normalizeBracketArtifacts: normalizeMock,
     }));
 
+    vi.doMock('./numbering-normalizer.js', () => ({
+      normalizeNumberedHeadingSections: normalizeNumberingMock,
+    }));
+
     vi.doMock('../unified-pipeline.js', () => ({
       runFillPipeline: runFillPipelineMock,
     }));
@@ -457,6 +462,7 @@ describe('runFieldSelector', () => {
     });
 
     expect(normalizeMock).toHaveBeenCalledTimes(1);
+    expect(normalizeNumberingMock).toHaveBeenCalledWith('/tmp/output.docx', '/tmp/output.docx');
     expect(normalizeMock.mock.calls[0]).toEqual([
       '/tmp/output.docx',
       '/tmp/output.docx',

--- a/src/core/field-selector/index.ts
+++ b/src/core/field-selector/index.ts
@@ -21,6 +21,7 @@ import type { FieldSelectorRunOptions, FieldSelectorRunResult } from './types.js
 import type { ComputedValueMap } from './computed.js';
 import { applyRepeatableTables, loadRepeatableTablesConfig, validateRepeatableTableFields } from './repeatable-tables.js';
 import { bindAnchoredParagraphFields, loadAnchoredParagraphBindingsConfig } from './anchored-paragraph-bindings.js';
+import { normalizeNumberedHeadingSections } from './numbering-normalizer.js';
 
 function toComputedValueMap(values: Record<string, unknown>): ComputedValueMap {
   const computedValues: ComputedValueMap = {};
@@ -166,6 +167,7 @@ export async function runFieldSelector(options: FieldSelectorRunOptions): Promis
       : undefined,
     postProcess: shouldNormalizeBracketArtifacts
       ? async (outputDocPath: string) => {
+        normalizeNumberedHeadingSections(outputDocPath, outputDocPath);
         if (shouldNormalizeBracketArtifacts) {
           await normalizeBracketArtifacts(outputDocPath, outputDocPath, {
             rules: normalizeConfig.paragraph_rules,
@@ -260,5 +262,7 @@ export type { FieldSelectorRunOptions, FieldSelectorRunResult, VerifyResult, Ver
 export type { ComputedArtifact, ComputedProfile } from './computed.js';
 export { applyRepeatableTables, loadRepeatableTablesConfig, RepeatableTablesConfigSchema, validateRepeatableTableFields } from './repeatable-tables.js';
 export type { RepeatableTablesConfig } from './repeatable-tables.js';
+export { normalizeNumberedHeadingSections } from './numbering-normalizer.js';
+export type { NumberingNormalizationStats } from './numbering-normalizer.js';
 export { bindAnchoredParagraphFields, loadAnchoredParagraphBindingsConfig, AnchoredParagraphBindingsConfigSchema } from './anchored-paragraph-bindings.js';
 export type { AnchoredParagraphBindingsConfig } from './anchored-paragraph-bindings.js';

--- a/src/core/field-selector/numbering-normalizer.test.ts
+++ b/src/core/field-selector/numbering-normalizer.test.ts
@@ -1,0 +1,50 @@
+import AdmZip from 'adm-zip';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { describe, expect } from 'vitest';
+import { itAllure } from '../../../integration-tests/helpers/allure-test.js';
+import { normalizeNumberedHeadingSections } from './numbering-normalizer.js';
+
+const it = itAllure.epic('Filling & Rendering');
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+function fixture(ambiguous = false) {
+  const dir = mkdtempSync(join(tmpdir(), 'numbering-normalizer-'));
+  const input = join(dir, 'input.docx');
+  const output = join(dir, 'output.docx');
+  const p = (style: string, text: string) => `<w:p><w:pPr><w:pStyle w:val="${style}"/></w:pPr><w:r><w:t>${text}</w:t></w:r></w:p>`;
+  const zip = new AdmZip();
+  const ref = '<w:p><w:bookmarkStart w:id="7" w:name="_RefTarget"/><w:r><w:t>Target</w:t></w:r><w:bookmarkEnd w:id="7"/></w:p><w:p><w:r><w:fldChar w:fldCharType="begin"/></w:r><w:r><w:instrText> REF _RefTarget </w:instrText></w:r><w:r><w:fldChar w:fldCharType="separate"/></w:r><w:r><w:t>2.1</w:t></w:r><w:r><w:fldChar w:fldCharType="end"/></w:r></w:p>';
+  zip.addFile('word/document.xml', Buffer.from(`<w:document xmlns:w="${W}"><w:body>${p('H1','One')}${p('H2','One A')}${p('H1','Two')}${p('H2','Two A')}${p('H2','Two B')}${ref}${ambiguous ? p('Other','Other One') + p('Other','Other Two') : ''}</w:body></w:document>`));
+  zip.addFile('word/styles.xml', Buffer.from(`<w:styles xmlns:w="${W}"><w:style w:type="paragraph" w:styleId="H1"><w:pPr><w:numPr><w:numId w:val="1"/></w:numPr></w:pPr></w:style><w:style w:type="paragraph" w:styleId="H2"><w:pPr><w:numPr><w:ilvl w:val="1"/><w:numId w:val="1"/></w:numPr></w:pPr></w:style>${ambiguous ? '<w:style w:type="paragraph" w:styleId="Other"><w:pPr><w:numPr><w:numId w:val="2"/></w:numPr></w:pPr></w:style>' : ''}</w:styles>`));
+  const abstract = (id: number) => `<w:abstractNum w:abstractNumId="${id}"><w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="decimal"/><w:lvlText w:val="%1."/></w:lvl><w:lvl w:ilvl="1"><w:start w:val="1"/><w:numFmt w:val="decimal"/><w:lvlText w:val="%1.%2"/></w:lvl></w:abstractNum><w:num w:numId="${id + 1}"><w:abstractNumId w:val="${id}"/></w:num>`;
+  zip.addFile('word/numbering.xml', Buffer.from(`<w:numbering xmlns:w="${W}">${abstract(0)}${ambiguous ? abstract(1) : ''}</w:numbering>`));
+  zip.addFile('[Content_Types].xml', Buffer.from('<Types/>'));
+  zip.writeZip(input);
+  return { dir, input, output };
+}
+
+describe('post-selection numbered heading normalization', () => {
+  it('materializes deterministic starts without touching text, bookmarks, or cached REF results', () => {
+    const f = fixture();
+    expect(normalizeNumberedHeadingSections(f.input, f.output)).toEqual({ sections: 2, paragraphs: 5 });
+    const zip = new AdmZip(f.output);
+    const documentXml = zip.readAsText('word/document.xml');
+    const numberingXml = zip.readAsText('word/numbering.xml');
+    expect(documentXml).toContain('One A');
+    expect(documentXml).toContain('w:name="_RefTarget"');
+    expect(documentXml).toContain('REF _RefTarget');
+    expect(documentXml).toContain('<w:t>2.1</w:t>');
+    expect((documentXml.match(/<w:fldChar/g) ?? [])).toHaveLength(3);
+    expect(numberingXml).toContain('w:val="2"');
+    expect((documentXml.match(/<w:numId/g) ?? [])).toHaveLength(5);
+    rmSync(f.dir, { recursive: true, force: true });
+  });
+
+  it('fails closed when two hierarchical top-level numbering sequences are equally plausible', () => {
+    const f = fixture(true);
+    expect(() => normalizeNumberedHeadingSections(f.input, f.output)).toThrow(/ambiguous dominant/);
+    rmSync(f.dir, { recursive: true, force: true });
+  });
+});

--- a/src/core/field-selector/numbering-normalizer.ts
+++ b/src/core/field-selector/numbering-normalizer.ts
@@ -1,0 +1,134 @@
+import AdmZip from 'adm-zip';
+import { writeFileSync } from 'node:fs';
+import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
+import type { Element as XmlElement } from '@xmldom/xmldom';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+export interface NumberingNormalizationStats { sections: number; paragraphs: number }
+
+function attr(el: XmlElement, local: string): string | null {
+  return el.getAttributeNS(W, local) ?? el.getAttribute(`w:${local}`);
+}
+
+function direct(parent: XmlElement, local: string): XmlElement | null {
+  for (let node = parent.firstChild; node; node = node.nextSibling) {
+    if (node.nodeType === 1 && (node as XmlElement).localName === local) return node as XmlElement;
+  }
+  return null;
+}
+
+export function normalizeNumberedHeadingSections(inputPath: string, outputPath: string): NumberingNormalizationStats {
+  const zip = new AdmZip(inputPath);
+  const documentEntry = zip.getEntry('word/document.xml');
+  const stylesEntry = zip.getEntry('word/styles.xml');
+  const numberingEntry = zip.getEntry('word/numbering.xml');
+  if (!documentEntry || !stylesEntry || !numberingEntry) return { sections: 0, paragraphs: 0 };
+  const parser = new DOMParser();
+  const serializer = new XMLSerializer();
+  const document = parser.parseFromString(documentEntry.getData().toString('utf8'), 'text/xml');
+  const styles = parser.parseFromString(stylesEntry.getData().toString('utf8'), 'text/xml');
+  const numbering = parser.parseFromString(numberingEntry.getData().toString('utf8'), 'text/xml');
+
+  const styleLevels = new Map<string, { numId: string; ilvl: number }>();
+  for (const style of Array.from(styles.getElementsByTagNameNS(W, 'style'))) {
+    if (attr(style, 'type') !== 'paragraph') continue;
+    const styleId = attr(style, 'styleId');
+    const pPr = direct(style, 'pPr');
+    const numPr = pPr && direct(pPr, 'numPr');
+    const numId = numPr && direct(numPr, 'numId');
+    if (!styleId || !numId) continue;
+    const ilvl = numPr && direct(numPr, 'ilvl');
+    styleLevels.set(styleId, { numId: attr(numId, 'val')!, ilvl: Number(ilvl ? attr(ilvl, 'val') : 0) });
+  }
+  const numToAbstract = new Map<string, string>();
+  const hierarchicalAbstracts = new Set<string>();
+  const abstractElements = new Map<string, XmlElement>();
+  let maxAbstractNumId = 0;
+  for (const abstract of Array.from(numbering.getElementsByTagNameNS(W, 'abstractNum'))) {
+    const id = attr(abstract, 'abstractNumId');
+    if (id) { abstractElements.set(id, abstract); maxAbstractNumId = Math.max(maxAbstractNumId, Number(id)); }
+    const levels = Array.from(abstract.getElementsByTagNameNS(W, 'lvl'));
+    if (id && levels.some((level) => attr(level, 'ilvl') === '1')) hierarchicalAbstracts.add(id);
+  }
+  let maxNumId = 0;
+  for (const num of Array.from(numbering.getElementsByTagNameNS(W, 'num'))) {
+    const id = attr(num, 'numId');
+    const abstract = direct(num, 'abstractNumId');
+    if (id && abstract) numToAbstract.set(id, attr(abstract, 'val')!);
+    if (id) maxNumId = Math.max(maxNumId, Number(id));
+  }
+
+  const paragraphs = Array.from(document.getElementsByTagNameNS(W, 'p'));
+  const candidates = paragraphs.map((paragraph) => {
+    const pPr = direct(paragraph, 'pPr');
+    const pStyle = pPr && direct(pPr, 'pStyle');
+    const style = pStyle && styleLevels.get(attr(pStyle, 'val') ?? '');
+    return style ? { paragraph, pPr: pPr!, ...style } : null;
+  });
+  const roots = candidates.filter((item) => item?.ilvl === 0 && hierarchicalAbstracts.has(numToAbstract.get(item.numId) ?? ''));
+  if (roots.length < 2) return { sections: 0, paragraphs: 0 };
+  const counts = new Map<string, number>();
+  for (const root of roots) counts.set(root!.numId, (counts.get(root!.numId) ?? 0) + 1);
+  const ranked = [...counts.entries()].sort((a, b) => b[1] - a[1]);
+  if (ranked.length > 1 && ranked[0][1] === ranked[1][1]) {
+    throw new Error('numbering normalization: ambiguous dominant top-level numbering instance');
+  }
+  const sourceNumId = ranked[0][0];
+  const abstractNumId = numToAbstract.get(sourceNumId);
+  if (!abstractNumId) throw new Error(`numbering normalization: missing abstract numbering for numId ${sourceNumId}`);
+  const sourceAbstract = abstractElements.get(abstractNumId);
+  if (!sourceAbstract) throw new Error(`numbering normalization: missing abstractNum ${abstractNumId}`);
+
+  let section = 0;
+  let subsection = 0;
+  let rewritten = 0;
+  let activeNumId: string | null = null;
+  for (const item of candidates) {
+    if (!item || item.numId !== sourceNumId) continue;
+    if (item.ilvl === 0 || item.ilvl === 1) {
+      if (item.ilvl === 0) { section += 1; subsection = 0; }
+      else { subsection += 1; }
+      activeNumId = String(++maxNumId);
+      const sectionAbstract = sourceAbstract.cloneNode(true) as XmlElement;
+      const sectionAbstractId = String(++maxAbstractNumId);
+      sectionAbstract.setAttributeNS(W, 'w:abstractNumId', sectionAbstractId);
+      const levelZero = Array.from(sectionAbstract.getElementsByTagNameNS(W, 'lvl')).find((level) => attr(level, 'ilvl') === '0');
+      const levelStart = levelZero && direct(levelZero, 'start');
+      if (!levelStart) throw new Error('numbering normalization: level zero has no start value');
+      levelStart.setAttributeNS(W, 'w:val', String(section));
+      if (item.ilvl === 1) {
+        const levelOne = Array.from(sectionAbstract.getElementsByTagNameNS(W, 'lvl')).find((level) => attr(level, 'ilvl') === '1');
+        const levelOneStart = levelOne && direct(levelOne, 'start');
+        if (!levelOneStart) throw new Error('numbering normalization: level one has no start value');
+        levelOneStart.setAttributeNS(W, 'w:val', String(subsection));
+      }
+      if (!numbering.documentElement) throw new Error('numbering normalization: missing numbering root');
+      numbering.documentElement.appendChild(sectionAbstract);
+      const num = numbering.createElementNS(W, 'w:num');
+      num.setAttributeNS(W, 'w:numId', activeNumId);
+      const abstract = numbering.createElementNS(W, 'w:abstractNumId');
+      abstract.setAttributeNS(W, 'w:val', sectionAbstractId);
+      num.appendChild(abstract);
+      numbering.documentElement.appendChild(num);
+    }
+    if (!activeNumId) throw new Error('numbering normalization: subordinate heading precedes its top-level heading');
+    let numPr: XmlElement | null = direct(item.pPr, 'numPr');
+    if (!numPr) {
+      numPr = document.createElementNS(W, 'w:numPr');
+      item.pPr.appendChild(numPr);
+    }
+    const concreteNumPr = numPr;
+    let ilvl: XmlElement | null = direct(concreteNumPr, 'ilvl');
+    if (!ilvl) { ilvl = document.createElementNS(W, 'w:ilvl'); concreteNumPr.appendChild(ilvl); }
+    ilvl.setAttributeNS(W, 'w:val', String(item.ilvl));
+    let numId: XmlElement | null = direct(concreteNumPr, 'numId');
+    if (!numId) { numId = document.createElementNS(W, 'w:numId'); concreteNumPr.appendChild(numId); }
+    numId.setAttributeNS(W, 'w:val', activeNumId);
+    rewritten += 1;
+  }
+  zip.updateFile('word/document.xml', Buffer.from(serializer.serializeToString(document)));
+  zip.updateFile('word/numbering.xml', Buffer.from(serializer.serializeToString(numbering)));
+  writeFileSync(outputPath, zip.toBuffer());
+  return { sections: section, paragraphs: rewritten };
+}


### PR DESCRIPTION
## Summary
- derive hierarchical list semantics from OOXML after conditional selections
- materialize deterministic level-0 and level-1 starts without hard-coding agreement text
- preserve bookmark/REF XML and cached results; fail closed on tied numbering instances

## Verification
- Allure label gate, lint, build
- full suite: 119 files passed, 4 skipped; 1,363 tests passed, 7 skipped
- numbering-focused tests: 9/9 passed
- real pinned NVCA ROFR/Co-Sale rendered through LibreOffice: Sections 3, 4, 5, and 6 plus subsections 3.1–3.3, 5.1–5.3, and 6.1–6.17 number correctly

No recipe content is changed.