### PR TITLE
Fix namespace-safe xml:space writes

### DIFF
--- a/src/core/field-selector/anchored-paragraph-bindings.ts
+++ b/src/core/field-selector/anchored-paragraph-bindings.ts
@@ -3,7 +3,7 @@ import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
 import type { Document, Element, Node } from '@xmldom/xmldom';
 import { readFileSync, writeFileSync } from 'node:fs';
 import { z } from 'zod';
-import { copyEntriesSkippingDirs } from './ooxml-parts.js';
+import { copyEntriesSkippingDirs, preserveXmlSpace } from './ooxml-parts.js';
 
 const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 
@@ -125,7 +125,7 @@ export function bindAnchoredParagraphFields(
       throw new Error(`anchored paragraph bindings '${insertion.groupId}': label is not directly inside a run`);
     }
     const tag = doc.createElementNS(W_NS, 'w:t');
-    tag.setAttribute('xml:space', 'preserve');
+    preserveXmlSpace(tag);
     tag.textContent = `{${insertion.field}}`;
     run.insertBefore(tag, insertion.textNode.nextSibling);
   }

--- a/src/core/field-selector/bracket-normalizer.ts
+++ b/src/core/field-selector/bracket-normalizer.ts
@@ -3,7 +3,7 @@ import { writeFileSync } from 'node:fs';
 import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
 import type { Document, Element } from '@xmldom/xmldom';
 import { replaceParagraphTextRange } from '@usejunior/docx-core';
-import { copyEntriesSkippingDirs, enumerateTextParts, getGeneralTextPartNames } from './ooxml-parts.js';
+import { copyEntriesSkippingDirs, enumerateTextParts, getGeneralTextPartNames, preserveXmlSpace } from './ooxml-parts.js';
 import { BLANK_PLACEHOLDER } from '../fill-utils.js';
 
 const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
@@ -467,7 +467,7 @@ function setParagraphTextFallback(para: Element, text: string): void {
   if (tElements.length === 0) return;
   tElements[0].textContent = text;
   if (text.startsWith(' ') || text.endsWith(' ')) {
-    tElements[0].setAttribute('xml:space', 'preserve');
+    preserveXmlSpace(tElements[0]);
   }
   for (let i = 1; i < tElements.length; i++) {
     tElements[i].textContent = '';

--- a/src/core/field-selector/ooxml-parts.ts
+++ b/src/core/field-selector/ooxml-parts.ts
@@ -1,4 +1,19 @@
 import AdmZip from 'adm-zip';
+import type { Element } from '@xmldom/xmldom';
+
+const XML_NAMESPACE = 'http://www.w3.org/XML/1998/namespace';
+
+/** Set xml:space without duplicating a parsed namespaced attribute. */
+export function preserveXmlSpace(element: Element): void {
+  for (let index = element.attributes.length - 1; index >= 0; index--) {
+    const attribute = element.attributes.item(index);
+    if (attribute && (attribute.name === 'xml:space' ||
+      (attribute.namespaceURI === XML_NAMESPACE && attribute.localName === 'space'))) {
+      element.removeAttributeNode(attribute);
+    }
+  }
+  element.setAttributeNS(XML_NAMESPACE, 'xml:space', 'preserve');
+}
 
 export interface OoxmlTextParts {
   document: string | null;

--- a/src/core/field-selector/patcher.test.ts
+++ b/src/core/field-selector/patcher.test.ts
@@ -63,6 +63,33 @@ function extractText(docxPath: string): string {
 }
 
 describe('patchDocument', () => {
+  it('keeps xml:space namespaced and singular when rewriting a preserved text run', async () => {
+    const xml =
+      '<?xml version="1.0" encoding="UTF-8"?>' +
+      `<w:document xmlns:w="${W_NS}"><w:body>` +
+      '<w:p><w:r><w:t xml:space="preserve"> [Company Name] </w:t></w:r></w:p>' +
+      '</w:body></w:document>';
+    const inputPath = buildMinimalDocx(xml);
+    const outputPath = inputPath.replace('test.docx', 'output.docx');
+
+    await patchDocument(inputPath, outputPath, { '[Company Name]': '{company_name}' });
+
+    const outputXml = new AdmZip(outputPath).readAsText('word/document.xml');
+    const textTags = outputXml.match(/<w:t\b[^>]*>/g) ?? [];
+    expect(textTags.length).toBeGreaterThan(0);
+    expect(textTags.every((tag) => (tag.match(/xml:space=/g) ?? []).length <= 1)).toBe(true);
+    const parseErrors: string[] = [];
+    new DOMParser({
+      onError: (level, message) => {
+        if (level !== 'warning') parseErrors.push(message);
+      },
+    }).parseFromString(outputXml, 'text/xml');
+    expect(parseErrors).toEqual([]);
+    expect(extractText(outputPath)).toBe(' {company_name} ');
+
+    rmSync(inputPath.replace('/test.docx', ''), { recursive: true, force: true });
+  });
+
   it('replaces a placeholder within a single run', async () => {
     const xml =
       '<?xml version="1.0" encoding="UTF-8"?>' +

--- a/src/core/field-selector/patcher.ts
+++ b/src/core/field-selector/patcher.ts
@@ -7,7 +7,7 @@ import {
   getParagraphText,
   SafeDocxError,
 } from '@usejunior/docx-core';
-import { copyEntriesSkippingDirs, enumerateTextParts, getGeneralTextPartNames } from './ooxml-parts.js';
+import { copyEntriesSkippingDirs, enumerateTextParts, getGeneralTextPartNames, preserveXmlSpace } from './ooxml-parts.js';
 import { parseReplacementKey, resolveReplacementValue } from './replacement-keys.js';
 import type { ParsedKey, ReplacementValue } from './replacement-keys.js';
 
@@ -311,7 +311,7 @@ function setRunText(run: Element, text: string): void {
   if (tElements.length === 0) {
     const doc = run.ownerDocument as Document;
     const t = doc.createElementNS(W_NS, 'w:t');
-    t.setAttribute('xml:space', 'preserve');
+    preserveXmlSpace(t);
     t.textContent = text;
     run.appendChild(t);
     return;
@@ -319,7 +319,7 @@ function setRunText(run: Element, text: string): void {
 
   tElements[0].textContent = text;
   if (text.startsWith(' ') || text.endsWith(' ')) {
-    tElements[0].setAttribute('xml:space', 'preserve');
+    preserveXmlSpace(tElements[0]);
   }
   for (let i = 1; i < tElements.length; i++) {
     tElements[i].textContent = '';
@@ -520,7 +520,7 @@ function replaceExpandedAtomicRange(
     const sourceRPr = runs[firstEntry.runIndex].getElementsByTagNameNS(W_NS, 'rPr')[0];
     if (sourceRPr) replacementRun.appendChild(sourceRPr.cloneNode(true));
     const text = doc.createElementNS(W_NS, 'w:t');
-    text.setAttribute('xml:space', 'preserve');
+    preserveXmlSpace(text);
     text.textContent = replacementText;
     replacementRun.appendChild(text);
     if (replacementColor) setRunColor(replacementRun, replacementColor);

--- a/src/core/field-selector/repeatable-tables.ts
+++ b/src/core/field-selector/repeatable-tables.ts
@@ -5,6 +5,7 @@ import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
 import type { Document as XmlDocument, Element as XmlElement } from '@xmldom/xmldom';
 import { z } from 'zod';
 import type { FieldDefinition } from '../metadata.js';
+import { preserveXmlSpace } from './ooxml-parts.js';
 
 const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 
@@ -111,7 +112,7 @@ function setParagraphText(doc: XmlDocument, paragraph: XmlElement, value: string
     if (child.nodeType === 1 && (child as XmlElement).localName !== 'rPr') run.removeChild(child);
   }
   const text = doc.createElementNS(W_NS, 'w:t');
-  if (/^\s|\s$/.test(value)) text.setAttribute('xml:space', 'preserve');
+  if (/^\s|\s$/.test(value)) preserveXmlSpace(text);
   text.appendChild(doc.createTextNode(value));
   run.appendChild(text);
   for (const extra of runs.slice(1)) paragraph.removeChild(extra);
@@ -132,7 +133,7 @@ function setCellText(doc: XmlDocument, cell: XmlElement, value: string): void {
     }
     const run = doc.createElementNS(W_NS, 'w:r');
     const text = doc.createElementNS(W_NS, 'w:t');
-    if (/^\s|\s$/.test(line)) text.setAttribute('xml:space', 'preserve');
+    if (/^\s|\s$/.test(line)) preserveXmlSpace(text);
     text.appendChild(doc.createTextNode(line));
     run.appendChild(text);
     paragraph.appendChild(run);


### PR DESCRIPTION
## Summary
- centralize namespace-aware `xml:space="preserve"` handling
- update patching, anchored bindings, repeatable tables, and bracket normalization
- prevent duplicate attributes when rewriting parsed Word text nodes

## Verification
- lint and Allure label validation pass
- full suite: 1,364 passed, 7 skipped
- real pinned NVCA Investors Rights Agreement fill completes and emits valid DOCX/OOXML

## Regression
The new test starts with an existing namespaced `xml:space` attribute, rewrites that run, and verifies every text element has at most one `xml:space` attribute and the serialized OOXML reparses without errors.