### PR TITLE
fix(field-selector): preserve styled section structure

### DIFF
--- a/src/core/field-selector/anchored-paragraph-bindings.test.ts
+++ b/src/core/field-selector/anchored-paragraph-bindings.test.ts
@@ -77,7 +77,8 @@ describe('anchor-scoped paragraph field binding', () => {
     for (const field of [
       'company_signatory_name', 'company_signatory_title', 'company_notice_address',
       'company_notice_email', 'investor_signatory_name', 'investor_signatory_title',
-    ]) expect(xml).toContain(`{${field}}`);
+    ]) expect(xml).toContain(` {${field}}`);
+    expect(xml).toContain('Name:</w:t><w:t xml:space="preserve"> {company_signatory_name}</w:t>');
     expect(xml).not.toContain('{outside');
     expect(xml).not.toContain('{By');
     expect((xml.match(/<w:tab/g) ?? []).length).toBe((before.match(/<w:tab/g) ?? []).length);

--- a/src/core/field-selector/anchored-paragraph-bindings.ts
+++ b/src/core/field-selector/anchored-paragraph-bindings.ts
@@ -126,7 +126,11 @@ export function bindAnchoredParagraphFields(
     }
     const tag = doc.createElementNS(W_NS, 'w:t');
     preserveXmlSpace(tag);
-    tag.textContent = `{${insertion.field}}`;
+    // Labels such as "Name:" and "Title:" are authored without a trailing
+    // space in many signature blocks. The inserted value is a new semantic
+    // token, so keep a visible separator without disturbing the following tab
+    // and underline layout carriers.
+    tag.textContent = ` {${insertion.field}}`;
     run.insertBefore(tag, insertion.textNode.nextSibling);
   }
 

--- a/src/core/field-selector/bracket-normalizer.test.ts
+++ b/src/core/field-selector/bracket-normalizer.test.ts
@@ -372,8 +372,8 @@ describe('normalizeBracketArtifacts', () => {
     expect(stats.normalizedParagraphs).toBe(1);
   });
 
-  // #619 defect 3: edits at BOTH ends of a paragraph (leading ". " strip +
-  // trailing "]" trim) force the minimal CONTIGUOUS range to span the whole
+  // #619 defect 3: edits at separated positions in a paragraph can force the
+  // minimal CONTIGUOUS range to span nearly the whole
   // paragraph; when a Word field result sits inside, replaceParagraphTextRange
   // refuses and the normalizer previously fell back destructively (flattening
   // runs, emitting the "formatting-destructive fallback" warning). The hunked
@@ -459,7 +459,9 @@ describe('normalizeBracketArtifacts', () => {
     expect(text).toContain('The Purchasers shall have received from Cooley LLP, counsel for the Company');
     expect(text).not.toContain('[___________]');
     expect(text).not.toContain('Agreement.]');
-    expect(text).not.toMatch(/^\. The Purchasers/m);
+    // The leading period is the separator between the preceding split heading
+    // and its continuation paragraph; normalization must not erase it.
+    expect(text).toMatch(/^\. The Purchasers/m);
   });
 });
 

--- a/src/core/field-selector/bracket-normalizer.ts
+++ b/src/core/field-selector/bracket-normalizer.ts
@@ -385,7 +385,7 @@ function applyDeclarativeRulesToParagraph(params: {
     mutated = mutated
       .replace(/\s{2,}/g, ' ')
       .replace(/\s+\./g, '.')
-      .replace(/^\.\s*/, '')
+      .replace(/^\.\s*\.\s*/, '. ')
       .trim();
 
     break;

--- a/src/core/field-selector/numbering-normalizer.test.ts
+++ b/src/core/field-selector/numbering-normalizer.test.ts
@@ -17,7 +17,7 @@ function fixture(ambiguous = false) {
   const zip = new AdmZip();
   const ref = '<w:p><w:bookmarkStart w:id="7" w:name="_RefTarget"/><w:r><w:t>Target</w:t></w:r><w:bookmarkEnd w:id="7"/></w:p><w:p><w:r><w:fldChar w:fldCharType="begin"/></w:r><w:r><w:instrText> REF _RefTarget </w:instrText></w:r><w:r><w:fldChar w:fldCharType="separate"/></w:r><w:r><w:t>2.1</w:t></w:r><w:r><w:fldChar w:fldCharType="end"/></w:r></w:p>';
   zip.addFile('word/document.xml', Buffer.from(`<w:document xmlns:w="${W}"><w:body>${p('H1','One')}${p('H2','One A')}${p('H1','Two')}${p('H2','Two A')}${p('H2','Two B')}${ref}${ambiguous ? p('Other','Other One') + p('Other','Other Two') : ''}</w:body></w:document>`));
-  zip.addFile('word/styles.xml', Buffer.from(`<w:styles xmlns:w="${W}"><w:style w:type="paragraph" w:styleId="H1"><w:pPr><w:numPr><w:numId w:val="1"/></w:numPr></w:pPr></w:style><w:style w:type="paragraph" w:styleId="H2"><w:pPr><w:numPr><w:ilvl w:val="1"/><w:numId w:val="1"/></w:numPr></w:pPr></w:style>${ambiguous ? '<w:style w:type="paragraph" w:styleId="Other"><w:pPr><w:numPr><w:numId w:val="2"/></w:numPr></w:pPr></w:style>' : ''}</w:styles>`));
+  zip.addFile('word/styles.xml', Buffer.from(`<w:styles xmlns:w="${W}"><w:style w:type="paragraph" w:styleId="H1"><w:pPr><w:numPr><w:numId w:val="1"/></w:numPr><w:outlineLvl w:val="0"/></w:pPr></w:style><w:style w:type="paragraph" w:styleId="H2"><w:basedOn w:val="H1"/><w:pPr><w:numPr><w:ilvl w:val="1"/></w:numPr><w:outlineLvl w:val="1"/></w:pPr></w:style>${ambiguous ? '<w:style w:type="paragraph" w:styleId="Other"><w:pPr><w:numPr><w:numId w:val="2"/></w:numPr><w:outlineLvl w:val="0"/></w:pPr></w:style>' : ''}</w:styles>`));
   const abstract = (id: number) => `<w:abstractNum w:abstractNumId="${id}"><w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="decimal"/><w:lvlText w:val="%1."/></w:lvl><w:lvl w:ilvl="1"><w:start w:val="1"/><w:numFmt w:val="decimal"/><w:lvlText w:val="%1.%2"/></w:lvl></w:abstractNum><w:num w:numId="${id + 1}"><w:abstractNumId w:val="${id}"/></w:num>`;
   zip.addFile('word/numbering.xml', Buffer.from(`<w:numbering xmlns:w="${W}">${abstract(0)}${ambiguous ? abstract(1) : ''}</w:numbering>`));
   zip.addFile('[Content_Types].xml', Buffer.from('<Types/>'));
@@ -39,6 +39,11 @@ describe('post-selection numbered heading normalization', () => {
     expect((documentXml.match(/<w:fldChar/g) ?? [])).toHaveLength(3);
     expect(numberingXml).toContain('w:val="2"');
     expect((documentXml.match(/<w:numId/g) ?? [])).toHaveLength(5);
+    const paragraphNumIds = [...documentXml.matchAll(/<w:numId w:val="(\d+)"/g)].map((match) => match[1]);
+    expect(paragraphNumIds[0]).toBe(paragraphNumIds[1]);
+    expect(paragraphNumIds[2]).toBe(paragraphNumIds[3]);
+    expect(paragraphNumIds[3]).toBe(paragraphNumIds[4]);
+    expect(paragraphNumIds[0]).not.toBe(paragraphNumIds[2]);
     rmSync(f.dir, { recursive: true, force: true });
   });
 

--- a/src/core/field-selector/numbering-normalizer.ts
+++ b/src/core/field-selector/numbering-normalizer.ts
@@ -2,6 +2,7 @@ import AdmZip from 'adm-zip';
 import { writeFileSync } from 'node:fs';
 import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
 import type { Element as XmlElement } from '@xmldom/xmldom';
+import { createParagraphNumberingResolver } from './paragraph-numbering.js';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 
@@ -30,17 +31,7 @@ export function normalizeNumberedHeadingSections(inputPath: string, outputPath: 
   const styles = parser.parseFromString(stylesEntry.getData().toString('utf8'), 'text/xml');
   const numbering = parser.parseFromString(numberingEntry.getData().toString('utf8'), 'text/xml');
 
-  const styleLevels = new Map<string, { numId: string; ilvl: number }>();
-  for (const style of Array.from(styles.getElementsByTagNameNS(W, 'style'))) {
-    if (attr(style, 'type') !== 'paragraph') continue;
-    const styleId = attr(style, 'styleId');
-    const pPr = direct(style, 'pPr');
-    const numPr = pPr && direct(pPr, 'numPr');
-    const numId = numPr && direct(numPr, 'numId');
-    if (!styleId || !numId) continue;
-    const ilvl = numPr && direct(numPr, 'ilvl');
-    styleLevels.set(styleId, { numId: attr(numId, 'val')!, ilvl: Number(ilvl ? attr(ilvl, 'val') : 0) });
-  }
+  const resolveNumbering = createParagraphNumberingResolver(styles);
   const numToAbstract = new Map<string, string>();
   const hierarchicalAbstracts = new Set<string>();
   const abstractElements = new Map<string, XmlElement>();
@@ -62,9 +53,10 @@ export function normalizeNumberedHeadingSections(inputPath: string, outputPath: 
   const paragraphs = Array.from(document.getElementsByTagNameNS(W, 'p'));
   const candidates = paragraphs.map((paragraph) => {
     const pPr = direct(paragraph, 'pPr');
-    const pStyle = pPr && direct(pPr, 'pStyle');
-    const style = pStyle && styleLevels.get(attr(pStyle, 'val') ?? '');
-    return style ? { paragraph, pPr: pPr!, ...style } : null;
+    const resolved = resolveNumbering(paragraph);
+    return pPr && resolved && resolved.outlineLvl !== undefined
+      ? { paragraph, pPr, ...resolved }
+      : null;
   });
   const roots = candidates.filter((item) => item?.ilvl === 0 && hierarchicalAbstracts.has(numToAbstract.get(item.numId) ?? ''));
   if (roots.length < 2) return { sections: 0, paragraphs: 0 };
@@ -81,14 +73,12 @@ export function normalizeNumberedHeadingSections(inputPath: string, outputPath: 
   if (!sourceAbstract) throw new Error(`numbering normalization: missing abstractNum ${abstractNumId}`);
 
   let section = 0;
-  let subsection = 0;
   let rewritten = 0;
   let activeNumId: string | null = null;
   for (const item of candidates) {
     if (!item || item.numId !== sourceNumId) continue;
-    if (item.ilvl === 0 || item.ilvl === 1) {
-      if (item.ilvl === 0) { section += 1; subsection = 0; }
-      else { subsection += 1; }
+    if (item.ilvl === 0) {
+      section += 1;
       activeNumId = String(++maxNumId);
       const sectionAbstract = sourceAbstract.cloneNode(true) as XmlElement;
       const sectionAbstractId = String(++maxAbstractNumId);
@@ -97,12 +87,6 @@ export function normalizeNumberedHeadingSections(inputPath: string, outputPath: 
       const levelStart = levelZero && direct(levelZero, 'start');
       if (!levelStart) throw new Error('numbering normalization: level zero has no start value');
       levelStart.setAttributeNS(W, 'w:val', String(section));
-      if (item.ilvl === 1) {
-        const levelOne = Array.from(sectionAbstract.getElementsByTagNameNS(W, 'lvl')).find((level) => attr(level, 'ilvl') === '1');
-        const levelOneStart = levelOne && direct(levelOne, 'start');
-        if (!levelOneStart) throw new Error('numbering normalization: level one has no start value');
-        levelOneStart.setAttributeNS(W, 'w:val', String(subsection));
-      }
       if (!numbering.documentElement) throw new Error('numbering normalization: missing numbering root');
       numbering.documentElement.appendChild(sectionAbstract);
       const num = numbering.createElementNS(W, 'w:num');

--- a/src/core/field-selector/paragraph-numbering.ts
+++ b/src/core/field-selector/paragraph-numbering.ts
@@ -1,0 +1,95 @@
+import type { Document, Element } from '@xmldom/xmldom';
+
+const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+export interface ParagraphNumbering {
+  numId: string;
+  ilvl: number;
+  outlineLvl?: number;
+}
+
+interface StyleNumbering {
+  basedOn?: string;
+  numId?: string;
+  ilvl?: number;
+  outlineLvl?: number;
+}
+
+function attr(element: Element, localName: string): string | null {
+  return element.getAttributeNS(W_NS, localName) ?? element.getAttribute(`w:${localName}`);
+}
+
+function direct(parent: Element, localName: string): Element | null {
+  for (let node = parent.firstChild; node; node = node.nextSibling) {
+    if (node.nodeType === 1) {
+      const element = node as Element;
+      if (element.namespaceURI === W_NS && element.localName === localName) return element;
+    }
+  }
+  return null;
+}
+
+function numberingFromProperties(properties: Element | null): Partial<ParagraphNumbering> {
+  const numPr = properties && direct(properties, 'numPr');
+  if (!numPr) return {};
+  const numId = direct(numPr, 'numId');
+  const ilvl = direct(numPr, 'ilvl');
+  return {
+    ...(numId ? { numId: attr(numId, 'val') ?? undefined } : {}),
+    ...(ilvl ? { ilvl: Number(attr(ilvl, 'val') ?? 0) } : {}),
+  };
+}
+
+function outlineFromProperties(properties: Element | null): Pick<ParagraphNumbering, 'outlineLvl'> | Record<string, never> {
+  const outline = properties && direct(properties, 'outlineLvl');
+  return outline ? { outlineLvl: Number(attr(outline, 'val') ?? 0) } : {};
+}
+
+/** Resolve paragraph numbering through OOXML's basedOn style inheritance. */
+export function createParagraphNumberingResolver(styles: Document | undefined): (paragraph: Element) => ParagraphNumbering | null {
+  const definitions = new Map<string, StyleNumbering>();
+  if (styles) {
+    for (const style of Array.from(styles.getElementsByTagNameNS(W_NS, 'style'))) {
+      if (attr(style, 'type') !== 'paragraph') continue;
+      const styleId = attr(style, 'styleId');
+      if (!styleId) continue;
+      const basedOn = direct(style, 'basedOn');
+      const properties = direct(style, 'pPr');
+      definitions.set(styleId, {
+        ...(basedOn ? { basedOn: attr(basedOn, 'val') ?? undefined } : {}),
+        ...numberingFromProperties(properties),
+        ...outlineFromProperties(properties),
+      });
+    }
+  }
+
+  const cache = new Map<string, ParagraphNumbering | null>();
+  const resolving = new Set<string>();
+  const resolveStyle = (styleId: string): ParagraphNumbering | null => {
+    if (cache.has(styleId)) return cache.get(styleId) ?? null;
+    if (resolving.has(styleId)) return null;
+    resolving.add(styleId);
+    const definition = definitions.get(styleId);
+    const inherited = definition?.basedOn ? resolveStyle(definition.basedOn) : null;
+    const numId = definition?.numId ?? inherited?.numId;
+    const ilvl = definition?.ilvl ?? inherited?.ilvl ?? 0;
+    const outlineLvl = definition?.outlineLvl ?? inherited?.outlineLvl;
+    const result = numId ? { numId, ilvl, ...(outlineLvl !== undefined ? { outlineLvl } : {}) } : null;
+    resolving.delete(styleId);
+    cache.set(styleId, result);
+    return result;
+  };
+
+  return (paragraph: Element): ParagraphNumbering | null => {
+    const pPr = direct(paragraph, 'pPr');
+    if (!pPr) return null;
+    const pStyle = direct(pPr, 'pStyle');
+    const inherited = pStyle ? resolveStyle(attr(pStyle, 'val') ?? '') : null;
+    const directNumbering = numberingFromProperties(pPr);
+    const directOutline = direct(pPr, 'outlineLvl');
+    const numId = directNumbering.numId ?? inherited?.numId;
+    const ilvl = directNumbering.ilvl ?? inherited?.ilvl ?? 0;
+    const outlineLvl = directOutline ? Number(attr(directOutline, 'val') ?? 0) : inherited?.outlineLvl;
+    return numId ? { numId, ilvl, ...(outlineLvl !== undefined ? { outlineLvl } : {}) } : null;
+  };
+}

--- a/src/core/selector.test.ts
+++ b/src/core/selector.test.ts
@@ -38,7 +38,7 @@ function makeTempDir(): string {
  * Create a minimal DOCX with a single document.xml containing the given
  * <w:body> inner XML. Returns the path to the .docx file.
  */
-function buildTestDocx(bodyInnerXml: string): string {
+function buildTestDocx(bodyInnerXml: string, stylesXml?: string): string {
   const dir = makeTempDir();
   const docxPath = join(dir, 'test.docx');
 
@@ -64,6 +64,7 @@ function buildTestDocx(bodyInnerXml: string): string {
   zip.addFile('[Content_Types].xml', Buffer.from(contentTypes));
   zip.addFile('_rels/.rels', Buffer.from(rels));
   zip.addFile('word/document.xml', Buffer.from(documentXml));
+  if (stylesXml) zip.addFile('word/styles.xml', Buffer.from(stylesXml));
   zip.writeZip(docxPath);
   return docxPath;
 }
@@ -481,6 +482,43 @@ describe('cross-cell disambiguation', () => {
 // ---------------------------------------------------------------------------
 
 describe('markerless selections', () => {
+  it('stops before a numbered heading whose list metadata is inherited from its style', async () => {
+    const target =
+      '<w:p><w:pPr><w:pStyle w:val="Heading1"/></w:pPr>' +
+      '<w:bookmarkStart w:id="7" w:name="_RefNextArticle"/>' +
+      '<w:r><w:t>Additional Covenants</w:t></w:r>' +
+      '<w:bookmarkEnd w:id="7"/></w:p>';
+    const reference = paraWithComplexField('See ', '5')
+      .replaceAll('_Ref137575642', '_RefNextArticle');
+    const styles =
+      `<w:styles xmlns:w="${W_NS}">` +
+      '<w:style w:type="paragraph" w:styleId="Heading1"><w:pPr><w:numPr><w:numId w:val="2"/></w:numPr></w:pPr></w:style>' +
+      '</w:styles>';
+    const inputPath = buildTestDocx(
+      para('Optional Governance Program') + para('Optional program details.') + target + reference,
+      styles,
+    );
+    const outputPath = join(makeTempDir(), 'out.docx');
+    const config: SelectionsConfig = {
+      groups: [{
+        id: 'governance-program',
+        type: 'checkbox',
+        standalone: true,
+        markerless: true,
+        options: [{ marker: 'Optional Governance Program', trigger: { field: 'include_program' } }],
+      }],
+    };
+
+    await applySelections(inputPath, outputPath, config, {});
+
+    const xml = readDocumentXml(outputPath);
+    expect(xml).not.toContain('Optional Governance Program');
+    expect(xml).not.toContain('Optional program details.');
+    expect(xml).toContain('Additional Covenants');
+    expect(xml).toContain('w:name="_RefNextArticle"');
+    expect(xml).toContain('REF _RefNextArticle');
+  });
+
   it('removes paragraph when trigger does not fire', async () => {
     const body = `
       ${para('Section 1.2(a) Initial Closing.')}

--- a/src/core/selector.ts
+++ b/src/core/selector.ts
@@ -13,6 +13,7 @@ import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
 import type { Document, Element, Node } from '@xmldom/xmldom';
 import { getParagraphText, replaceParagraphTextRange, SafeDocxError } from '@usejunior/docx-core';
 import { copyEntriesSkippingDirs, enumerateTextParts, getGeneralTextPartNames } from './field-selector/ooxml-parts.js';
+import { createParagraphNumberingResolver, type ParagraphNumbering } from './field-selector/paragraph-numbering.js';
 
 const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 
@@ -655,6 +656,11 @@ export async function applySelections(
   const parts = enumerateTextParts(zip);
   const partNames = getGeneralTextPartNames(parts);
   const stats: OptionStats = new Map();
+  const stylesEntry = zip.getEntry('word/styles.xml');
+  const styles = stylesEntry
+    ? parser.parseFromString(stylesEntry.getData().toString('utf-8'), 'text/xml')
+    : undefined;
+  const resolveNumbering = createParagraphNumberingResolver(styles);
 
   for (const partName of partNames) {
     const entry = zip.getEntry(partName);
@@ -665,7 +671,7 @@ export async function applySelections(
 
     let partModified = false;
     for (const group of config.groups) {
-      const result = processGroup(doc, group, data, stats, partName === 'word/document.xml');
+      const result = processGroup(doc, group, data, stats, partName === 'word/document.xml', resolveNumbering);
       if (result) partModified = true;
     }
 
@@ -708,9 +714,10 @@ function processGroup(
   data: Record<string, unknown>,
   stats: OptionStats,
   isMainDocument: boolean,
+  resolveNumbering: (paragraph: Element) => ParagraphNumbering | null,
 ): boolean {
   if (group.markerless) {
-    return processMarkerlessGroup(doc, group, data, stats, isMainDocument);
+    return processMarkerlessGroup(doc, group, data, stats, isMainDocument, resolveNumbering);
   }
 
   if (group.standalone) {
@@ -1072,6 +1079,7 @@ function processMarkerlessGroup(
   data: Record<string, unknown>,
   stats: OptionStats,
   isMainDocument: boolean,
+  resolveNumbering: (paragraph: Element) => ParagraphNumbering | null,
 ): boolean {
   const selectedIndices = evaluateTriggers(group, data);
   const matchCounts: number[] = group.options.map(() => 0);
@@ -1188,13 +1196,13 @@ function processMarkerlessGroup(
         : null;
 
       // Get marker paragraph's numbering level for level-aware stop
-      const markerIlvl = getNumberingLevel(markerPara);
+      const markerIlvl = getNumberingLevel(markerPara, resolveNumbering);
 
       for (let si = markerIdx + 1; si < siblings.length; si++) {
         const p = siblings[si];
 
         // Stop at auto-numbered paragraphs at same or higher level
-        if (hasAutoNumbering(p, markerIlvl !== -1 ? markerIlvl : undefined)) break;
+        if (hasAutoNumbering(p, resolveNumbering, markerIlvl !== -1 ? markerIlvl : undefined)) break;
 
         const text = extractParagraphText(p);
         // Stop at next section heading or another option's marker
@@ -1237,36 +1245,21 @@ function processMarkerlessGroup(
 }
 
 /** Check if a paragraph has Word auto-numbering at or above the given level. */
-function hasAutoNumbering(para: Element, maxIlvl?: number): boolean {
-  for (let i = 0; i < para.childNodes.length; i++) {
-    const child = para.childNodes[i] as Element;
-    if (child.nodeType !== 1) continue;
-    if (child.localName === 'pPr' && child.namespaceURI === W_NS) {
-      const numPrs = child.getElementsByTagNameNS(W_NS, 'numPr');
-      if (numPrs.length === 0) return false;
-      if (maxIlvl === undefined) return true;
-      const ilvlEl = numPrs[0].getElementsByTagNameNS(W_NS, 'ilvl');
-      if (ilvlEl.length === 0) return true; // no level = top-level
-      const level = parseInt(ilvlEl[0].getAttribute('w:val') ?? '0', 10);
-      return level <= maxIlvl;
-    }
-  }
-  return false;
+function hasAutoNumbering(
+  para: Element,
+  resolveNumbering: (paragraph: Element) => ParagraphNumbering | null,
+  maxIlvl?: number,
+): boolean {
+  const numbering = resolveNumbering(para);
+  return numbering !== null && (maxIlvl === undefined || numbering.ilvl <= maxIlvl);
 }
 
 /** Get the numbering level (ilvl) of a paragraph, or -1 if not numbered. */
-function getNumberingLevel(para: Element): number {
-  for (let i = 0; i < para.childNodes.length; i++) {
-    const child = para.childNodes[i] as Element;
-    if (child.nodeType !== 1) continue;
-    if (child.localName === 'pPr' && child.namespaceURI === W_NS) {
-      const numPrs = child.getElementsByTagNameNS(W_NS, 'numPr');
-      if (numPrs.length === 0) return -1;
-      const ilvlEl = numPrs[0].getElementsByTagNameNS(W_NS, 'ilvl');
-      return parseInt(ilvlEl[0]?.getAttribute('w:val') ?? '0', 10);
-    }
-  }
-  return -1;
+function getNumberingLevel(
+  para: Element,
+  resolveNumbering: (paragraph: Element) => ParagraphNumbering | null,
+): number {
+  return resolveNumbering(para)?.ilvl ?? -1;
 }
 
 /** Walk up the DOM to find an ancestor with the given local name. */

--- a/src/core/unified-pipeline.test.ts
+++ b/src/core/unified-pipeline.test.ts
@@ -1,0 +1,39 @@
+import AdmZip from 'adm-zip';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect } from 'vitest';
+import { itAllure } from '../../integration-tests/helpers/allure-test.js';
+import { normalizeEmptyFillWhitespaceInDocx } from './unified-pipeline.js';
+
+const it = itAllure.epic('Filling & Rendering');
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+describe('empty-fill whitespace normalization', () => {
+  it('closes punctuation seams but leaves complex Word fields untouched', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'oa-empty-fill-whitespace-'));
+    const path = join(dir, 'fixture.docx');
+    const zip = new AdmZip();
+    zip.addFile('[Content_Types].xml', Buffer.from('<Types/>'));
+    zip.addFile('word/document.xml', Buffer.from(
+      `<w:document xmlns:w="${W}"><w:body>` +
+      '<w:p><w:r><w:t>United States </w:t></w:r><w:r><w:t>.</w:t></w:r></w:p>' +
+      '<w:p><w:r><w:t>Directors </w:t></w:r><w:r><w:t>;</w:t></w:r></w:p>' +
+      '<w:p><w:r><w:t xml:space="preserve">Section </w:t></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="begin"/></w:r><w:r><w:instrText> REF _Ref1 </w:instrText></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="separate"/></w:r><w:r><w:t>2.1</w:t></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="end"/></w:r><w:r><w:t xml:space="preserve"> , next</w:t></w:r></w:p>' +
+      '</w:body></w:document>',
+    ));
+    zip.writeZip(path);
+
+    await normalizeEmptyFillWhitespaceInDocx(path);
+
+    const xml = new AdmZip(path).readAsText('word/document.xml');
+    expect(xml).toContain('United States</w:t>');
+    expect(xml).toContain('Directors</w:t>');
+    expect(xml).toContain('REF _Ref1');
+    expect(xml).toContain('xml:space="preserve"> , next');
+    rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/src/core/unified-pipeline.ts
+++ b/src/core/unified-pipeline.ts
@@ -409,7 +409,7 @@ export async function runFillPipeline(options: PipelineOptions): Promise<Pipelin
     }
 
     // Collapse double spaces left by empty field substitutions (e.g. {initial_word_lower} → "")
-    await collapseDoubleSpacesInDocx(filledPath);
+    await normalizeEmptyFillWhitespaceInDocx(filledPath);
 
     // Step 7: Copy to output
     copyFileSync(filledPath, outputPath);
@@ -417,6 +417,10 @@ export async function runFillPipeline(options: PipelineOptions): Promise<Pipelin
     // Optional post-processing for field-selector-specific normalization.
     if (postProcess) {
       await postProcess(outputPath);
+      // Declarative post-processing can itself remove an optional carrier and
+      // expose the same empty-value whitespace seam, so normalize once more on
+      // the final artifact.
+      await normalizeEmptyFillWhitespaceInDocx(outputPath);
     }
 
     // Step 8: Verify — failures surface to callers via warnings (soft; no throw)
@@ -468,16 +472,15 @@ export async function runFillPipeline(options: PipelineOptions): Promise<Pipelin
 }
 
 /**
- * Collapse runs of 2+ spaces into a single space within all text paragraphs.
- * Fixes double spaces left when empty field substitutions (e.g. {initial_word_lower} → "")
- * leave adjacent spaces in the DOCX.
+ * Close whitespace seams left by empty substitutions within text paragraphs:
+ * collapse doubled spaces and remove whitespace immediately before punctuation.
  *
  * Paragraphs containing Word field characters (w:fldChar) are skipped because
  * getParagraphText treats field-code runs as empty, so "Page " + PAGE field +
  * " of " looks like "Page  of " and the replacement would delete the field run
  * that sits between the two space-bearing runs.
  */
-async function collapseDoubleSpacesInDocx(docxPath: string): Promise<void> {
+export async function normalizeEmptyFillWhitespaceInDocx(docxPath: string): Promise<void> {
   const zip = new AdmZip(docxPath);
   const parser = new DOMParser();
   const serializer = new XMLSerializer();
@@ -502,6 +505,15 @@ async function collapseDoubleSpacesInDocx(docxPath: string): Promise<void> {
       while ((match = / {2,}/.exec(text)) !== null) {
         try {
           replaceParagraphTextRange(para, match.index, match.index + match[0].length, ' ');
+          partModified = true;
+        } catch {
+          break;
+        }
+        text = getParagraphText(para);
+      }
+      while ((match = /[ \t\u00a0]+(?=[,.;:!?])/.exec(text)) !== null) {
+        try {
+          replaceParagraphTextRange(para, match.index, match.index + match[0].length, '');
           partModified = true;
         } catch {
           break;

--- a/src/core/validation/field-selector.test.ts
+++ b/src/core/validation/field-selector.test.ts
@@ -24,6 +24,8 @@ interface FixtureSpec {
   computed?: Record<string, unknown>;
   normalize?: Record<string, unknown>;
   selections?: Record<string, unknown>;
+  anchoredBindings?: Record<string, unknown>;
+  repeatableTables?: Record<string, unknown>;
   /** field ids to write minimal fields/<id>.json selector recipes for */
   recipes?: string[];
   templateManifest?: Record<string, unknown>;
@@ -79,6 +81,12 @@ function writeFixture(spec: FixtureSpec): string {
   }
   if (spec.selections) {
     writeFileSync(join(dir, 'selections.json'), JSON.stringify(spec.selections, null, 2));
+  }
+  if (spec.anchoredBindings) {
+    writeFileSync(join(dir, 'anchored-paragraph-bindings.json'), JSON.stringify(spec.anchoredBindings, null, 2));
+  }
+  if (spec.repeatableTables) {
+    writeFileSync(join(dir, 'repeatable-tables.json'), JSON.stringify(spec.repeatableTables, null, 2));
   }
   if (spec.recipes || spec.templateManifest) {
     mkdirSync(join(dir, 'fields'), { recursive: true });
@@ -170,6 +178,30 @@ describe('validateFieldSelector binding reachability', () => {
             options: [{ marker: '[ ]', trigger: { field: 'include_arbitration', equals: true } }],
           },
         ],
+      },
+    });
+    const result = validateFieldSelector(dir, 'fixture');
+    expect(result.errors).toEqual([]);
+    expect(result.valid).toBe(true);
+  });
+
+  it('passes fields bound through anchored labels and repeatable table rows', () => {
+    const dir = writeFixture({
+      fields: [{ name: 'company_name' }, { name: 'signatory_name' }, { name: 'investors', type: 'array' }],
+      replacements: { '[COMPANY]': '{company_name}' },
+      anchoredBindings: {
+        groups: [{
+          id: 'signature', start_anchor: 'COMPANY:', end_anchor: 'INVESTORS:', expected_group_matches: 1,
+          bindings: [{ label: 'Name:', field: 'signatory_name', expected_matches: 1, insert_after_label: true, preserve_following_tabs: true }],
+        }],
+      },
+      repeatableTables: {
+        schema_version: 1,
+        tables: [{
+          id: 'investors', rows_field: 'investors',
+          prototype_cells: ['[Investor Name]'],
+          columns: [{ field: 'name' }],
+        }],
       },
     });
     const result = validateFieldSelector(dir, 'fixture');

--- a/src/core/validation/field-selector.ts
+++ b/src/core/validation/field-selector.ts
@@ -8,6 +8,8 @@ import { ComputedProfileSchema, type ComputedProfile } from '../field-selector/c
 import type { NormalizeConfig } from '../metadata.js';
 import { SelectionsConfigSchema, type SelectionsConfig } from '../selector.js';
 import { loadSelectorContracts } from '../selectors/loader.js';
+import { AnchoredParagraphBindingsConfigSchema, type AnchoredParagraphBindingsConfig } from '../field-selector/anchored-paragraph-bindings.js';
+import { RepeatableTablesConfigSchema, type RepeatableTablesConfig } from '../field-selector/repeatable-tables.js';
 
 export interface FieldSelectorValidationResult {
   fieldSelectorId: string;
@@ -69,6 +71,8 @@ export function validateFieldSelector(
   let computedProfile: ComputedProfile | undefined;
   let normalizeConfig: NormalizeConfig | undefined;
   let selectionsConfig: SelectionsConfig | undefined;
+  let anchoredBindingsConfig: AnchoredParagraphBindingsConfig | undefined;
+  let repeatableTablesConfig: RepeatableTablesConfig | undefined;
   let replacementsRecord: Record<string, unknown> | undefined;
   /** Field names referenced by at least one {tag} in a replacements.json value. */
   const replacementBoundFields = new Set<string>();
@@ -227,6 +231,30 @@ export function validateFieldSelector(
     }
   }
 
+  const anchoredBindingsPath = join(fieldSelectorDir, 'anchored-paragraph-bindings.json');
+  if (existsSync(anchoredBindingsPath)) {
+    try {
+      anchoredBindingsConfig = AnchoredParagraphBindingsConfigSchema.parse(
+        JSON.parse(readFileSync(anchoredBindingsPath, 'utf-8')),
+      );
+    } catch {
+      errors.push('anchored-paragraph-bindings.json: invalid format');
+      reachabilityInputsOk = false;
+    }
+  }
+
+  const repeatableTablesPath = join(fieldSelectorDir, 'repeatable-tables.json');
+  if (existsSync(repeatableTablesPath)) {
+    try {
+      repeatableTablesConfig = RepeatableTablesConfigSchema.parse(
+        JSON.parse(readFileSync(repeatableTablesPath, 'utf-8')),
+      );
+    } catch {
+      errors.push('repeatable-tables.json: invalid format');
+      reachabilityInputsOk = false;
+    }
+  }
+
   // Load selector contracts (fields/*.json + template-manifest.json). The
   // loader schema already enforces that every recipe declares at least one
   // occurrence locator, so a loaded recipe is a nonempty selector manifest.
@@ -278,6 +306,12 @@ export function validateFieldSelector(
           }
         }
       }
+    }
+    for (const group of anchoredBindingsConfig?.groups ?? []) {
+      for (const binding of group.bindings) reachable.add(binding.field);
+    }
+    for (const table of repeatableTablesConfig?.tables ?? []) {
+      reachable.add(table.rows_field);
     }
 
     // Propagate reachability backwards through computed.json to a fixpoint.


### PR DESCRIPTION
## Summary
- resolve OOXML numbering through paragraph-style inheritance for selection boundaries and post-selection heading normalization
- preserve numbered bookmark targets so surviving REF fields do not point at deleted article headings
- preserve heading/body punctuation, normalize empty-fill punctuation seams, and separate anchored signature labels from values
- count anchored-label and repeatable-table bindings as document-affecting validator reachability

## Verification
- build and lint pass
- full suite: 1,367 passed, 7 skipped
- pinned NVCA IRA real-document render preserves every surviving REF target, eliminates the two runtime-introduced reference errors, and renders headings 2.4, 3.2, 3.4, 5, and 5.12 correctly
- punctuation-before-spacing findings fall from 26 to 24; the remaining findings are LibreOffice recalculation artifacts already present in the pristine source or canonical recipe-specific carriers
- signature labels render with spaces before supplied Name/Title values

The real source and generated licensed artifacts were used only locally and are not included.