### PR TITLE
Fix verification of staticized qualified REF fields

### DIFF
--- a/src/core/field-selector/verifier.test.ts
+++ b/src/core/field-selector/verifier.test.ts
@@ -4,6 +4,7 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import AdmZip from 'adm-zip';
 import { verifyOutput, normalizeText, findLeftoverPlaceholders } from './verifier.js';
+import { patchDocument } from './patcher.js';
 import {
   allureJsonAttachment,
   allureParameter,
@@ -463,6 +464,70 @@ describe('findLeftoverPlaceholders', () => {
 
     await allureStep('Assert retained occurrence is not reported', () => {
       expect(leftovers).toEqual([]);
+    });
+
+    cleanupDocx(sourcePath, outputPath);
+  });
+
+  it('accepts a context-qualified atomic REF replacement whose filled text equals its source result', async () => {
+    const prefix = 'rights under this Agreement are not assigned pursuant to ';
+    const sourcePath = buildDocx(
+      '<?xml version="1.0" encoding="UTF-8"?>' +
+        `<w:document xmlns:w="${W_NS}"><w:body><w:p>` +
+        `<w:r><w:t xml:space="preserve">${prefix}</w:t></w:r>` +
+        '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+        '<w:r><w:instrText xml:space="preserve"> REF _RefSuccessors \\h </w:instrText></w:r>' +
+        '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+        '<w:r><w:t>Section 6.1</w:t></w:r>' +
+        '<w:r><w:fldChar w:fldCharType="end"/></w:r>' +
+        '</w:p></w:body></w:document>'
+    );
+    const outputPath = sourcePath.replace('test.docx', 'output.docx');
+    const key = `${prefix.trim()} > Section 6.1`;
+
+    await patchDocument(sourcePath, outputPath, { [key]: 'Section 6.1' });
+
+    await allureParameter('case', 'qualified-ref-same-visible-result');
+    const leftovers = findLeftoverPlaceholders(
+      outputPath,
+      { [key]: 'Section {successors_assigns_section}' },
+      sourcePath
+    );
+
+    await allureStep('Assert the staticized REF is not a false leftover', () => {
+      expect(leftovers).toEqual([]);
+      const xml = new AdmZip(outputPath).readAsText('word/document.xml');
+      expect(xml).not.toContain('fldChar');
+    });
+
+    cleanupDocx(sourcePath, outputPath);
+  });
+
+  it('still reports a context-qualified REF when the live source field survives unchanged', async () => {
+    const prefix = 'rights under this Agreement are not assigned pursuant to ';
+    const fieldDocx = () => buildDocx(
+      '<?xml version="1.0" encoding="UTF-8"?>' +
+        `<w:document xmlns:w="${W_NS}"><w:body><w:p>` +
+        `<w:r><w:t xml:space="preserve">${prefix}</w:t></w:r>` +
+        '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+        '<w:r><w:instrText xml:space="preserve"> REF _RefSuccessors \\h </w:instrText></w:r>' +
+        '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+        '<w:r><w:t>Section 6.1</w:t></w:r>' +
+        '<w:r><w:fldChar w:fldCharType="end"/></w:r>' +
+        '</w:p></w:body></w:document>'
+    );
+    const sourcePath = fieldDocx();
+    const outputPath = fieldDocx();
+    const key = `${prefix.trim()} > Section 6.1`;
+
+    const leftovers = findLeftoverPlaceholders(
+      outputPath,
+      { [key]: 'Section {successors_assigns_section}' },
+      sourcePath
+    );
+
+    await allureStep('Assert the unmodified live REF remains a true positive', () => {
+      expect(leftovers).toContain(key);
     });
 
     cleanupDocx(sourcePath, outputPath);

--- a/src/core/field-selector/verifier.ts
+++ b/src/core/field-selector/verifier.ts
@@ -227,6 +227,34 @@ export function isFirstBodyParagraphEmpty(docxPath: string): boolean {
 interface ParagraphInfo {
   text: string;
   rowContext: string | null;
+  fieldResultText: string;
+}
+
+/** Visible cached text carried by complex Word fields in a paragraph. */
+function getComplexFieldResultText(para: Element): string {
+  const states: Array<'instruction' | 'result'> = [];
+  let result = '';
+
+  const visit = (node: Node): void => {
+    if (node.nodeType === 1) {
+      const el = node as unknown as Element;
+      if (el.namespaceURI === W_NS && el.localName === 'fldChar') {
+        const type = el.getAttributeNS(W_NS, 'fldCharType') || el.getAttribute('w:fldCharType');
+        if (type === 'begin') states.push('instruction');
+        else if (type === 'separate' && states.length > 0) states[states.length - 1] = 'result';
+        else if (type === 'end' && states.length > 0) states.pop();
+        return;
+      }
+      if (el.namespaceURI === W_NS && el.localName === 't' && states.includes('result')) {
+        result += el.textContent ?? '';
+        return;
+      }
+    }
+    for (let child = node.firstChild; child; child = child.nextSibling) visit(child);
+  };
+
+  visit(para as unknown as Node);
+  return normalizeQuotes(result);
 }
 
 /**
@@ -251,6 +279,7 @@ function extractParagraphInfos(docxPath: string): ParagraphInfo[] {
       infos.push({
         text: normalizeQuotes(paraText),
         rowContext: rowContext !== null ? normalizeQuotes(rowContext) : null,
+        fieldResultText: getComplexFieldResultText(para),
       });
     }
   }
@@ -297,6 +326,18 @@ function hasQualifiedLeftover(
     }
   }
   return false;
+}
+
+/** Whether the qualified token is still the cached result of a live Word field. */
+function hasQualifiedFieldResult(
+  paragraphs: ParagraphInfo[],
+  context: string,
+  searchText: string,
+): boolean {
+  return paragraphs.some(({ text, rowContext, fieldResultText }) => {
+    if (!fieldResultText.includes(searchText)) return false;
+    return rowContext !== null ? rowContext.includes(context) : text.includes(context);
+  });
 }
 
 /**
@@ -377,6 +418,8 @@ export function findLeftoverPlaceholders(
   if (contextKeys.length > 0) {
     if (cleanedSourcePath) {
       const sourceFullText = normalizeQuotes(extractAllText(cleanedSourcePath));
+      const sourceParagraphs = extractParagraphInfos(cleanedSourcePath);
+      const outputParagraphs = extractParagraphInfos(docxPath);
       for (const ck of contextKeys) {
         const srcCount = countOccurrences(sourceFullText, ck.searchText);
         if (srcCount === 0) continue; // key does not apply to this document
@@ -384,7 +427,18 @@ export function findLeftoverPlaceholders(
         // Nothing filled for this placeholder → the mapping was entirely
         // unhandled. A partial reduction leaves only intentionally-retained /
         // selector-verified occurrences behind, which are not reported.
-        if (outCount >= srcCount) leftovers.add(ck.label);
+        if (outCount >= srcCount) {
+          // A context-qualified replacement may intentionally render the same
+          // visible text as the source (for example, staticizing an atomic REF
+          // field from "Section 6.1" to "Section {section}" and then filling
+          // the tag with "6.1"). Text counts cannot prove that replacement.
+          // In that narrow case, the structural transition from a cached field
+          // result to ordinary text does: do not report the full qualified key
+          // as a leftover once the field at that qualified location is gone.
+          const sourceWasField = hasQualifiedFieldResult(sourceParagraphs, ck.context, ck.searchText);
+          const outputIsField = hasQualifiedFieldResult(outputParagraphs, ck.context, ck.searchText);
+          if (!sourceWasField || outputIsField) leftovers.add(ck.label);
+        }
       }
     } else {
       const outputParagraphs = extractParagraphInfos(docxPath);


### PR DESCRIPTION
## Summary
- recognize context-qualified replacements that staticize a complex Word REF field even when the filled visible text equals the cached source result
- preserve true-positive reporting when the live REF field survives unchanged
- add the exact Section 6.1 regression shape

## Verification
- focused verifier suite: 32 passed
- full suite: 120 passed, 4 skipped files; 1,369 passed, 7 skipped tests
- build and lint pass