### PR TITLE
Normalize detached heading punctuation and signature tails

### DIFF
--- a/src/core/field-selector/anchored-paragraph-bindings.test.ts
+++ b/src/core/field-selector/anchored-paragraph-bindings.test.ts
@@ -87,6 +87,37 @@ describe('anchor-scoped paragraph field binding', () => {
     rmSync(fixture.dir, { recursive: true, force: true });
   });
 
+  it('optionally consumes only residual underlined tab tails after a bound value', () => {
+    const fixture = build(
+      p(text('START')) +
+      p('<w:r><w:t>Name:</w:t></w:r><w:r><w:tab/></w:r><w:r><w:rPr><w:u w:val="single"/></w:rPr><w:tab/></w:r>') +
+      p(text('END')),
+    );
+    const tailConfig: AnchoredParagraphBindingsConfig = {
+      groups: [{
+        id: 'signature-tail',
+        start_anchor: 'START',
+        end_anchor: 'END',
+        expected_group_matches: 1,
+        bindings: [{
+          label: 'Name:',
+          field: 'signatory_name',
+          expected_matches: 1,
+          insert_after_label: true,
+          preserve_following_tabs: true,
+          consume_following_underlined_tabs: true,
+        }],
+      }],
+    };
+
+    bindAnchoredParagraphFields(fixture.input, fixture.output, tailConfig);
+    const xml = new AdmZip(fixture.output).readAsText('word/document.xml');
+    expect(xml).toContain('Name:</w:t><w:t xml:space="preserve"> {signatory_name}</w:t>');
+    expect((xml.match(/<w:tab/g) ?? [])).toHaveLength(1);
+    expect(xml).not.toContain('<w:u');
+    rmSync(fixture.dir, { recursive: true, force: true });
+  });
+
   it('fails closed on a zero-match label without writing an output', () => {
     const fixture = build(signatureBody.replace('Email:', 'E-mail:'));
     expect(() => bindAnchoredParagraphFields(fixture.input, fixture.output, config))

--- a/src/core/field-selector/anchored-paragraph-bindings.ts
+++ b/src/core/field-selector/anchored-paragraph-bindings.ts
@@ -19,6 +19,8 @@ export const AnchoredParagraphBindingsConfigSchema = z.object({
       expected_matches: z.literal(1),
       insert_after_label: z.literal(true),
       preserve_following_tabs: z.literal(true),
+      /** Opt in only when following underlined tab-only runs are blank form tails. */
+      consume_following_underlined_tabs: z.literal(true).optional(),
     }).strict()).min(1),
   }).strict()).min(1),
 }).strict();
@@ -86,7 +88,12 @@ export function bindAnchoredParagraphFields(
   const paragraphs = directBodyParagraphs(doc);
 
   // Validate the complete plan before mutation, so every failure is atomic.
-  const insertions: Array<{ textNode: Element; field: string; groupId: string }> = [];
+  const insertions: Array<{
+    textNode: Element;
+    field: string;
+    groupId: string;
+    consumeFollowingUnderlinedTabs: boolean;
+  }> = [];
   for (const group of config.groups) {
     const starts = exactAnchorIndices(paragraphs, group.start_anchor);
     const ends = exactAnchorIndices(paragraphs, group.end_anchor);
@@ -115,7 +122,12 @@ export function bindAnchoredParagraphFields(
           `expected one match inside boundaries; found ${matches.length}`,
         );
       }
-      insertions.push({ textNode: matches[0], field: binding.field, groupId: group.id });
+      insertions.push({
+        textNode: matches[0],
+        field: binding.field,
+        groupId: group.id,
+        consumeFollowingUnderlinedTabs: binding.consume_following_underlined_tabs === true,
+      });
     }
   }
 
@@ -132,6 +144,10 @@ export function bindAnchoredParagraphFields(
     // and underline layout carriers.
     tag.textContent = ` {${insertion.field}}`;
     run.insertBefore(tag, insertion.textNode.nextSibling);
+
+    if (insertion.consumeFollowingUnderlinedTabs) {
+      removeFollowingUnderlinedTabTails(run);
+    }
   }
 
   const serialized = new XMLSerializer().serializeToString(doc);
@@ -140,6 +156,37 @@ export function bindAnchoredParagraphFields(
     name === 'word/document.xml' ? Buffer.from(serialized, 'utf-8') : data,
   );
   writeFileSync(outputPath, outZip.toBuffer());
+}
+
+/**
+ * Remove only underlined, textless tab runs following an anchored label/value.
+ * Non-underlined layout tabs remain, and visible text, fields, breaks, drawings,
+ * or any other semantic run content ends the scan.
+ */
+function removeFollowingUnderlinedTabTails(labelRun: Element): void {
+  let sibling = labelRun.nextSibling;
+  while (sibling) {
+    const next = sibling.nextSibling;
+    if (sibling.nodeType !== 1) {
+      sibling = next;
+      continue;
+    }
+    const run = sibling as Element;
+    if (run.namespaceURI !== W_NS || run.localName !== 'r') break;
+
+    const texts = run.getElementsByTagNameNS(W_NS, 't');
+    const hasVisibleText = Array.from(texts).some((text) => (text.textContent ?? '').length > 0);
+    const tabs = run.getElementsByTagNameNS(W_NS, 'tab');
+    const breaks = run.getElementsByTagNameNS(W_NS, 'br');
+    const fields = run.getElementsByTagNameNS(W_NS, 'fldChar');
+    const underlines = run.getElementsByTagNameNS(W_NS, 'u');
+    if (hasVisibleText || breaks.length > 0 || fields.length > 0) break;
+
+    if (tabs.length > 0 && underlines.length > 0) {
+      run.parentNode?.removeChild(run);
+    }
+    sibling = next;
+  }
 }
 
 export function loadAnchoredParagraphBindingsConfig(path: string): AnchoredParagraphBindingsConfig {

--- a/src/core/field-selector/heading-punctuation-normalizer.test.ts
+++ b/src/core/field-selector/heading-punctuation-normalizer.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect } from 'vitest';
+import { itAllure } from '../../../integration-tests/helpers/allure-test.js';
+import AdmZip from 'adm-zip';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { normalizeDetachedHeadingPunctuation } from './heading-punctuation-normalizer.js';
+
+const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const it = itAllure.epic('Filling & Rendering');
+
+function fixture(body: string): { dir: string; input: string; output: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'heading-punctuation-'));
+  const input = join(dir, 'input.docx');
+  const output = join(dir, 'output.docx');
+  const zip = new AdmZip();
+  zip.addFile('word/document.xml', Buffer.from(
+    `<?xml version="1.0"?><w:document xmlns:w="${W_NS}"><w:body>${body}</w:body></w:document>`,
+  ));
+  zip.addFile('[Content_Types].xml', Buffer.from('<Types/>'));
+  zip.writeZip(input);
+  return { dir, input, output };
+}
+
+describe('detached heading punctuation normalization', () => {
+  it('joins an isolated punctuation continuation to its matching heading and preserves bookmarks', () => {
+    const f = fixture(
+      '<w:p><w:pPr><w:pStyle w:val="Heading2"/></w:pPr><w:r><w:t>Sale of the Company</w:t></w:r></w:p>' +
+      '<w:p><w:pPr><w:pStyle w:val="HeadingPara2"/></w:pPr><w:r><w:t>.</w:t></w:r>' +
+      '<w:bookmarkStart w:id="9" w:name="_RefTail"/><w:bookmarkEnd w:id="9"/>' +
+      '<w:r><w:t xml:space="preserve"> </w:t></w:r></w:p>' +
+      '<w:p><w:r><w:t>Following text.</w:t></w:r></w:p>',
+    );
+
+    expect(normalizeDetachedHeadingPunctuation(f.input, f.output)).toBe(1);
+    const xml = new AdmZip(f.output).readAsText('word/document.xml');
+    expect(xml).toContain('Sale of the Company</w:t></w:r><w:r><w:t>.</w:t></w:r>');
+    expect(xml).toContain('w:name="_RefTail"');
+    expect(xml).not.toContain('HeadingPara2');
+    rmSync(f.dir, { recursive: true, force: true });
+  });
+
+  it('leaves substantive continuations and mismatched heading levels unchanged', () => {
+    const f = fixture(
+      '<w:p><w:pPr><w:pStyle w:val="Heading2"/></w:pPr><w:r><w:t>Heading</w:t></w:r></w:p>' +
+      '<w:p><w:pPr><w:pStyle w:val="HeadingPara2"/></w:pPr><w:r><w:t>. Body</w:t></w:r></w:p>' +
+      '<w:p><w:pPr><w:pStyle w:val="HeadingPara3"/></w:pPr><w:r><w:t>.</w:t></w:r></w:p>',
+    );
+
+    expect(normalizeDetachedHeadingPunctuation(f.input, f.output)).toBe(0);
+    const xml = new AdmZip(f.output).readAsText('word/document.xml');
+    expect(xml).toContain('. Body');
+    expect(xml).toContain('HeadingPara3');
+    rmSync(f.dir, { recursive: true, force: true });
+  });
+
+  it('fails closed on punctuation paragraphs carrying semantic references', () => {
+    const f = fixture(
+      '<w:p><w:pPr><w:pStyle w:val="Heading2"/></w:pPr><w:r><w:t>Heading</w:t></w:r></w:p>' +
+      '<w:p><w:pPr><w:pStyle w:val="HeadingPara2"/></w:pPr><w:r><w:t>.</w:t>' +
+      '<w:footnoteReference w:id="48"/></w:r></w:p>',
+    );
+
+    expect(normalizeDetachedHeadingPunctuation(f.input, f.output)).toBe(0);
+    const xml = new AdmZip(f.output).readAsText('word/document.xml');
+    expect(xml).toContain('footnoteReference');
+    expect(xml).toContain('HeadingPara2');
+    rmSync(f.dir, { recursive: true, force: true });
+  });
+});

--- a/src/core/field-selector/heading-punctuation-normalizer.ts
+++ b/src/core/field-selector/heading-punctuation-normalizer.ts
@@ -1,0 +1,73 @@
+import AdmZip from 'adm-zip';
+import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
+import type { Element, Node } from '@xmldom/xmldom';
+import { writeFileSync } from 'node:fs';
+import { getParagraphText } from '@usejunior/docx-core';
+import { copyEntriesSkippingDirs } from './ooxml-parts.js';
+
+const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+function paragraphStyle(para: Element): string | null {
+  const styles = para.getElementsByTagNameNS(W_NS, 'pStyle');
+  if (styles.length === 0) return null;
+  return styles[0].getAttributeNS(W_NS, 'val') || styles[0].getAttribute('w:val');
+}
+
+function matchingSplitHeadingStyles(heading: Element, continuation: Element): boolean {
+  const headingMatch = /^Heading(\d+)$/.exec(paragraphStyle(heading) ?? '');
+  const continuationMatch = /^HeadingPara(\d+)$/.exec(paragraphStyle(continuation) ?? '');
+  return headingMatch !== null && continuationMatch !== null && headingMatch[1] === continuationMatch[1];
+}
+
+function directElementChildren(node: Element): Element[] {
+  const result: Element[] = [];
+  for (let i = 0; i < node.childNodes.length; i++) {
+    const child = node.childNodes[i] as Node;
+    if (child.nodeType === 1) result.push(child as Element);
+  }
+  return result;
+}
+
+/** Join an isolated punctuation continuation back to its matching split heading. */
+export function normalizeDetachedHeadingPunctuation(inputPath: string, outputPath: string): number {
+  const zip = new AdmZip(inputPath);
+  const entry = zip.getEntry('word/document.xml');
+  if (!entry) throw new Error('heading punctuation normalizer: word/document.xml not found');
+  const doc = new DOMParser().parseFromString(entry.getData().toString('utf-8'), 'text/xml');
+  const paragraphs = Array.from(doc.getElementsByTagNameNS(W_NS, 'p')) as Element[];
+  let normalized = 0;
+
+  for (const continuation of paragraphs) {
+    if (!/^[.,;:!?]\s*$/.test(getParagraphText(continuation as unknown as globalThis.Element))) continue;
+    if (['fldChar', 'drawing', 'pict', 'object', 'footnoteReference', 'endnoteReference', 'br']
+      .some((name) => continuation.getElementsByTagNameNS(W_NS, name).length > 0)) continue;
+
+    let previous = continuation.previousSibling;
+    while (previous && previous.nodeType !== 1) previous = previous.previousSibling;
+    if (!previous) continue;
+    const heading = previous as Element;
+    if (heading.localName !== 'p' || heading.namespaceURI !== W_NS ||
+        !matchingSplitHeadingStyles(heading, continuation)) continue;
+
+    for (const child of directElementChildren(continuation)) {
+      if (child.localName === 'pPr' && child.namespaceURI === W_NS) continue;
+      if (child.localName === 'r' && child.namespaceURI === W_NS) {
+        const text = getParagraphText(continuation as unknown as globalThis.Element);
+        const runText = Array.from(child.getElementsByTagNameNS(W_NS, 't'))
+          .map((node) => node.textContent ?? '').join('');
+        if (runText.trim().length === 0 && text.trim().length > 0) continue;
+      }
+      heading.appendChild(child);
+    }
+    continuation.parentNode?.removeChild(continuation);
+    normalized++;
+  }
+
+  const serialized = new XMLSerializer().serializeToString(doc);
+  const outZip = new AdmZip();
+  copyEntriesSkippingDirs(zip, outZip, (name, data) =>
+    name === 'word/document.xml' ? Buffer.from(serialized, 'utf-8') : data,
+  );
+  writeFileSync(outputPath, outZip.toBuffer());
+  return normalized;
+}

--- a/src/core/field-selector/index.test.ts
+++ b/src/core/field-selector/index.test.ts
@@ -416,6 +416,7 @@ describe('runFieldSelector', () => {
       declarativeRuleApplications: 1,
     }));
     const normalizeNumberingMock = vi.fn(() => ({ sections: 0, paragraphs: 0 }));
+    const normalizeHeadingPunctuationMock = vi.fn(() => 0);
 
     const runFillPipelineMock = vi.fn(async ({ outputPath, postProcess }: { outputPath: string; postProcess?: (p: string) => Promise<void> }) => {
       if (postProcess) {
@@ -447,6 +448,10 @@ describe('runFieldSelector', () => {
       normalizeNumberedHeadingSections: normalizeNumberingMock,
     }));
 
+    vi.doMock('./heading-punctuation-normalizer.js', () => ({
+      normalizeDetachedHeadingPunctuation: normalizeHeadingPunctuationMock,
+    }));
+
     vi.doMock('../unified-pipeline.js', () => ({
       runFillPipeline: runFillPipelineMock,
     }));
@@ -463,6 +468,7 @@ describe('runFieldSelector', () => {
 
     expect(normalizeMock).toHaveBeenCalledTimes(1);
     expect(normalizeNumberingMock).toHaveBeenCalledWith('/tmp/output.docx', '/tmp/output.docx');
+    expect(normalizeHeadingPunctuationMock).toHaveBeenCalledWith('/tmp/output.docx', '/tmp/output.docx');
     expect(normalizeMock.mock.calls[0]).toEqual([
       '/tmp/output.docx',
       '/tmp/output.docx',

--- a/src/core/field-selector/index.ts
+++ b/src/core/field-selector/index.ts
@@ -15,6 +15,7 @@ import {
   writeComputedArtifact,
 } from './computed.js';
 import { normalizeBracketArtifacts } from './bracket-normalizer.js';
+import { normalizeDetachedHeadingPunctuation } from './heading-punctuation-normalizer.js';
 import { runFillPipeline } from '../unified-pipeline.js';
 import { formatDocumentDate, formatDocumentDateFields } from '../fill-pipeline.js';
 import type { FieldSelectorRunOptions, FieldSelectorRunResult } from './types.js';
@@ -174,6 +175,7 @@ export async function runFieldSelector(options: FieldSelectorRunOptions): Promis
             fieldValues: effectiveValues,
           });
         }
+        normalizeDetachedHeadingPunctuation(outputDocPath, outputDocPath);
       }
       : undefined,
     verify: async (p, cleanedSourcePath, referencedFields) => {
@@ -265,4 +267,5 @@ export type { RepeatableTablesConfig } from './repeatable-tables.js';
 export { normalizeNumberedHeadingSections } from './numbering-normalizer.js';
 export type { NumberingNormalizationStats } from './numbering-normalizer.js';
 export { bindAnchoredParagraphFields, loadAnchoredParagraphBindingsConfig, AnchoredParagraphBindingsConfigSchema } from './anchored-paragraph-bindings.js';
+export { normalizeDetachedHeadingPunctuation } from './heading-punctuation-normalizer.js';
 export type { AnchoredParagraphBindingsConfig } from './anchored-paragraph-bindings.js';


### PR DESCRIPTION
## Summary
- join isolated punctuation-only `HeadingParaN` continuations back to their matching `HeadingN` paragraph while preserving bookmarks
- add an opt-in anchored-binding primitive that removes only following underlined tab-only form tails
- preserve non-underlined layout tabs and fail closed around fields, references, breaks, drawings, substantive continuations, and mismatched heading levels

## Real-document proof
- the final IRA artifact contained six matching detached heading punctuation paragraphs, including the expenses heading; all six normalized structurally
- the pinned IRA source bound four Company/Investor Name/Title labels with zero targeted underline tails after enabling the new option

## Verification
- focused suites: 17 passed
- full suite: 121 passed, 4 skipped files; 1,375 passed, 7 skipped tests
- build and lint pass
