### PR TITLE
fix(validation): allow literal recipe replacements

### DIFF
--- a/integration-tests/field-selector-validation-negative.test.ts
+++ b/integration-tests/field-selector-validation-negative.test.ts
@@ -125,7 +125,7 @@ describe('validateFieldSelector negative scenarios', () => {
     expect(result.errors.join(' ')).toContain('replacements.json must be a JSON object');
   });
 
-  it('rejects replacement value shape and infinite loop patterns', () => {
+  it('rejects invalid replacement shapes and loops while allowing literals', () => {
     const fieldSelectorDir = mkdtempSync(join(tmpdir(), 'oa-field-selector-replacement-shape-'));
     tempDirs.push(fieldSelectorDir);
 
@@ -149,7 +149,7 @@ describe('validateFieldSelector negative scenarios', () => {
 
     expect(result.valid).toBe(false);
     expect(result.errors.join(' ')).toContain('value for "[Not String]" must be a string');
-    expect(result.errors.join(' ')).toContain('must contain at least one {identifier} tag');
+    expect(result.errors.join(' ')).not.toContain('value for "[No Tags]"');
     expect(result.errors.join(' ')).toContain('contains the key itself');
     expect(result.errors.join(' ')).toContain('contains the search text');
   });

--- a/src/core/validation/field-selector.test.ts
+++ b/src/core/validation/field-selector.test.ts
@@ -133,6 +133,21 @@ function writeFixture(spec: FixtureSpec): string {
 // Binding reachability (issue #621)
 // ---------------------------------------------------------------------------
 
+describe('validateFieldSelector replacement values', () => {
+  it('accepts literal and empty cleanup replacements alongside field tags', () => {
+    const dir = writeFixture({
+      fields: [{ name: 'company_name' }],
+      replacements: {
+        '[COMPANY]': '{company_name}',
+        '[and]': 'and',
+        '[DELETE THIS NOTE]': '',
+      },
+    });
+    const result = validateFieldSelector(dir, 'fixture');
+    expect(result.errors).toEqual([]);
+  });
+});
+
 describe('validateFieldSelector binding reachability', () => {
   it('fails a metadata field bound by nothing, naming the field', () => {
     const dir = writeFixture({

--- a/src/core/validation/field-selector.ts
+++ b/src/core/validation/field-selector.ts
@@ -31,7 +31,8 @@ const SAFE_TAG_RE = /^\{[a-z_][a-z0-9_]*\}$/;
  * - No .docx files (copyrighted content must not be committed)
  * - metadata.yaml validates against schema
  * - For non-scaffold fieldSelectors: replacements.json present and valid
- * - Replacement values must be valid {identifier} tags
+ * - Replacement values may be literal text, empty cleanup replacements, or
+ *   valid {identifier} tags
  * - In strict mode: scaffolds are errors, all files required
  */
 export function validateFieldSelector(
@@ -145,14 +146,6 @@ export function validateFieldSelector(
         } else {
           errors.push(`replacements.json: value for "${key}" must be a string or { value: string, format?: object }`);
           continue;
-        }
-
-        // Value must contain at least one {identifier} tag
-        const tags = value.match(TAG_RE);
-        if (!tags || tags.length === 0) {
-          errors.push(
-            `replacements.json: value for "${key}" must contain at least one {identifier} tag, got "${value}"`
-          );
         }
 
         // All curly-brace tokens in value must be safe identifiers (no control tags)
@@ -392,7 +385,9 @@ export function validateFieldSelector(
           : undefined);
       if (value === undefined) continue; // malformed value already reported above
       const tagFields = (value.match(TAG_RE) ?? []).map((tag) => tag.slice(1, -1));
-      if (tagFields.length === 0) continue; // tagless value already reported above
+      // Literal and empty replacements are handled by the legacy patcher and
+      // therefore have no selector field whose ownership can be checked.
+      if (tagFields.length === 0) continue;
       const missingRecipes = tagFields.filter((f) => !selectorRecipeFields.has(f));
       for (const fieldName of missingRecipes) {
         errors.push(


### PR DESCRIPTION
## Summary
- accept literal text and empty cleanup values in field-selector replacement maps
- continue validating every brace token as a safe field identifier
- retain migrated-key ownership checks for tag-backed selector fields

This is a generic runtime-validator fix required by canonical recipes that normalize editorial alternatives or delete drafting notes without introducing a field.

## Verification
- field-selector validator: 24/24 tests passed
- TypeScript build passed
- ESLint passed