### PR TITLE
feat(selector): add fail-closed bounded paragraph removal

### DIFF
--- a/src/core/selector.test.ts
+++ b/src/core/selector.test.ts
@@ -632,6 +632,105 @@ describe('markerless selections', () => {
 });
 
 describe('bounded markerless removals', () => {
+  it('scopes a duplicated paragraph to unique containing boundaries and preserves those boundaries', async () => {
+    const inputPath = buildTestDocx(
+      para('First section starts here.') +
+      para('Certificate surrender mechanics.') +
+      para('First section ends here.') +
+      para('Second section starts here.') +
+      para('Certificate surrender mechanics.') +
+      para('Second section ends here.'),
+    );
+    const outputPath = join(makeTempDir(), 'out.docx');
+    const config = { groups: [{
+      id: 'second_certificate_surrender', type: 'checkbox', standalone: true, markerless: true,
+      options: [{
+        marker: 'Certificate surrender mechanics.', trigger: { field: 'keep_second', equals: true },
+        removal: {
+          kind: 'paragraph', anchor: 'Certificate surrender', match: 'contains', expectedMatches: 1,
+          within: {
+            startAnchor: 'Second section starts', endAnchor: 'Second section ends',
+            match: 'contains', expectedMatches: 1,
+          },
+        },
+      }],
+    }] } as SelectionsConfig;
+
+    await applySelections(inputPath, outputPath, config, { keep_second: false });
+
+    const text = extractText(outputPath);
+    expect(text).toContain('First section starts here.Certificate surrender mechanics.First section ends here.');
+    expect(text).toContain('Second section starts here.Second section ends here.');
+    expect(text.match(/Certificate surrender mechanics\./g)).toHaveLength(1);
+  });
+
+  it.each([
+    ['missing start', para('Target.') + para('Scope ends.')],
+    ['duplicate start', para('Scope starts.') + para('Scope starts.') + para('Target.') + para('Scope ends.')],
+    ['missing end', para('Scope starts.') + para('Target.')],
+    ['duplicate end', para('Scope starts.') + para('Target.') + para('Scope ends.') + para('Scope ends.')],
+    ['end before start', para('Scope ends.') + para('Scope starts.') + para('Target.')],
+    ['target outside scope', para('Target.') + para('Scope starts.') + para('Inside.') + para('Scope ends.')],
+  ])('fails closed for bounded paragraph scope with %s', async (_name, body) => {
+    const inputPath = buildTestDocx(body);
+    const outputPath = join(makeTempDir(), 'out.docx');
+    const config = { groups: [{
+      id: 'scoped_target', type: 'checkbox', standalone: true, markerless: true,
+      options: [{
+        marker: 'Target.', trigger: { field: 'keep', equals: true },
+        removal: {
+          kind: 'paragraph', anchor: 'Target.', match: 'exact', expectedMatches: 1,
+          within: {
+            startAnchor: 'Scope starts.', endAnchor: 'Scope ends.',
+            match: 'exact', expectedMatches: 1,
+          },
+        },
+      }],
+    }] } as SelectionsConfig;
+
+    await expect(applySelections(inputPath, outputPath, config, { keep: false })).rejects.toThrow(/paragraph scope|within scope/i);
+  });
+
+  it('validates an ambiguous bounded paragraph target even when its option is selected', async () => {
+    const inputPath = buildTestDocx(
+      para('Scope starts.') + para('Target one.') + para('Target two.') + para('Scope ends.'),
+    );
+    const outputPath = join(makeTempDir(), 'out.docx');
+    const config = { groups: [{
+      id: 'selected_scoped_target', type: 'checkbox', standalone: true, markerless: true,
+      options: [{
+        marker: 'Target', trigger: { field: 'keep', equals: true },
+        removal: {
+          kind: 'paragraph', anchor: 'Target', match: 'contains', expectedMatches: 1,
+          within: {
+            startAnchor: 'Scope starts.', endAnchor: 'Scope ends.',
+            match: 'exact', expectedMatches: 1,
+          },
+        },
+      }],
+    }] } as SelectionsConfig;
+
+    await expect(applySelections(inputPath, outputPath, config, { keep: true })).rejects.toThrow(/within scope matched 2 paragraphs/i);
+  });
+
+  it('requires explicit single-match accounting for a paragraph scope', () => {
+    const parsed = SelectionsConfigSchema.safeParse({ groups: [{
+      id: 'scoped_target', type: 'checkbox', standalone: true, markerless: true,
+      options: [{
+        marker: 'Target.', trigger: { field: 'keep', equals: true },
+        removal: {
+          kind: 'paragraph', anchor: 'Target.', match: 'exact', expectedMatches: 1,
+          within: {
+            startAnchor: 'Scope starts.', endAnchor: 'Scope ends.',
+            match: 'exact', expectedMatches: 2,
+          },
+        },
+      }],
+    }] });
+
+    expect(parsed.success).toBe(false);
+  });
+
   it('removes one uniquely contained paragraph without spilling into sibling paragraphs', async () => {
     const inputPath = buildTestDocx(
       para('Before.') +

--- a/src/core/selector.ts
+++ b/src/core/selector.ts
@@ -56,6 +56,12 @@ const OptionSchema = z.object({
       anchor: z.string().min(1),
       match: z.enum(['exact', 'contains']).default('exact'),
       expectedMatches: z.literal(1),
+      within: z.object({
+        startAnchor: z.string().min(1),
+        endAnchor: z.string().min(1),
+        match: z.enum(['exact', 'contains']).default('exact'),
+        expectedMatches: z.literal(1),
+      }).strict().optional(),
       removeAdjacentBlankParagraphs: z.boolean().optional(),
     }).strict(),
   ]).optional(),
@@ -211,15 +217,62 @@ function normalizedParagraphText(text: string): string {
   return normalizeQuotes(text).replace(/\s+/g, ' ').trim();
 }
 
-function paragraphMatches(doc: Document, anchor: string, match: 'exact' | 'contains'): Element[] {
+function matchingParagraphs(paragraphs: Iterable<Element>, anchor: string, match: 'exact' | 'contains'): Element[] {
   const expected = normalizedParagraphText(anchor);
   const matches: Element[] = [];
-  const paragraphs = doc.getElementsByTagNameNS(W_NS, 'p');
-  for (let i = 0; i < paragraphs.length; i++) {
-    const actual = normalizedParagraphText(extractParagraphText(paragraphs[i]));
-    if (match === 'exact' ? actual === expected : actual.includes(expected)) matches.push(paragraphs[i]);
+  for (const paragraph of paragraphs) {
+    const actual = normalizedParagraphText(extractParagraphText(paragraph));
+    if (match === 'exact' ? actual === expected : actual.includes(expected)) matches.push(paragraph);
   }
   return matches;
+}
+
+function allParagraphs(doc: Document): Element[] {
+  return Array.from(doc.getElementsByTagNameNS(W_NS, 'p'));
+}
+
+function paragraphMatches(doc: Document, anchor: string, match: 'exact' | 'contains'): Element[] {
+  return matchingParagraphs(allParagraphs(doc), anchor, match);
+}
+
+/**
+ * Resolve the body blocks strictly between an unambiguous pair of paragraph
+ * boundaries. The boundaries themselves are deliberately excluded so callers
+ * can mutate only content inside the declared region.
+ */
+function paragraphsWithinScope(
+  doc: Document,
+  groupId: string,
+  scope: NonNullable<Extract<BoundedRemoval, { kind: 'paragraph' }>['within']>,
+): Element[] {
+  const starts = paragraphMatches(doc, scope.startAnchor, scope.match);
+  const ends = paragraphMatches(doc, scope.endAnchor, scope.match);
+  if (starts.length !== scope.expectedMatches || ends.length !== scope.expectedMatches) {
+    throw new Error(
+      `[selector] Group "${groupId}": paragraph scope boundaries matched start=${starts.length} (expected 1), ` +
+      `end=${ends.length} (expected 1).`,
+    );
+  }
+
+  const start = starts[0];
+  const end = ends[0];
+  if (start.parentNode !== end.parentNode || !start.parentNode) {
+    throw new Error(`[selector] Group "${groupId}": paragraph scope boundaries must be sibling blocks.`);
+  }
+  const siblings = elementChildren(start.parentNode);
+  const startIndex = siblings.indexOf(start);
+  const endIndex = siblings.indexOf(end);
+  if (startIndex < 0 || endIndex <= startIndex) {
+    throw new Error(`[selector] Group "${groupId}": paragraph scope end boundary must follow its start boundary.`);
+  }
+
+  const paragraphs: Element[] = [];
+  for (const block of siblings.slice(startIndex + 1, endIndex)) {
+    if (isWordElement(block, 'p')) paragraphs.push(block);
+    const descendants = block.getElementsByTagNameNS(W_NS, 'p');
+    for (let i = 0; i < descendants.length; i++) paragraphs.push(descendants[i]);
+  }
+  return paragraphs;
 }
 
 function assertBalancedComplexFields(groupId: string, paragraph: Element): void {
@@ -262,9 +315,11 @@ type BoundedRemoval = NonNullable<z.infer<typeof OptionSchema>['removal']>;
  */
 function applyBoundedRemoval(doc: Document, groupId: string, removal: BoundedRemoval, remove: boolean): number {
   if (removal.kind === 'paragraph') {
-    const matches = paragraphMatches(doc, removal.anchor, removal.match);
+    const candidates = removal.within ? paragraphsWithinScope(doc, groupId, removal.within) : allParagraphs(doc);
+    const matches = matchingParagraphs(candidates, removal.anchor, removal.match);
     if (matches.length !== removal.expectedMatches) {
-      throw new Error(`[selector] Group "${groupId}": paragraph anchor "${removal.anchor}" matched ${matches.length} paragraphs (expected 1).`);
+      const scopeLabel = removal.within ? ' within scope' : '';
+      throw new Error(`[selector] Group "${groupId}": paragraph anchor "${removal.anchor}"${scopeLabel} matched ${matches.length} paragraphs (expected 1).`);
     }
     const paragraph = matches[0];
     if (remove) assertBalancedComplexFields(groupId, paragraph);


### PR DESCRIPTION
## Summary

- add an optional `within` scope to markerless paragraph removals
- resolve scope boundaries and the in-scope target with explicit single-match accounting
- fail closed for missing, duplicated, non-sibling, reversed, or out-of-scope anchors
- preserve both scope boundaries and validate scopes even when the option is selected

Closes #760.

## Usage

```json
{
  "kind": "paragraph",
  "anchor": "target text",
  "match": "contains",
  "expectedMatches": 1,
  "within": {
    "startAnchor": "section start context",
    "endAnchor": "section end context",
    "match": "contains",
    "expectedMatches": 1
  }
}
```

The start and end anchors must each resolve to exactly one sibling block, in that order. The target must resolve exactly once strictly between them. The boundary paragraphs are not removed.

## Verification

- red-before: 8 new focused cases failed against the prior runtime
- `npm run build`
- `npx vitest run src/core/selector.test.ts` (49 passed)
- `npm run lint -- --quiet`
- `npm run test:run` (121 files passed, 4 skipped; 1,385 tests passed, 7 skipped)
