### PR TITLE
fix(normalizer): preserve REF fields across disjoint deletions

### DIFF
--- a/src/core/field-selector/bracket-normalizer.test.ts
+++ b/src/core/field-selector/bracket-normalizer.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import AdmZip from 'adm-zip';
 import { afterEach, describe, expect } from 'vitest';
-import { computeEditHunks, normalizeBracketArtifacts } from './bracket-normalizer.js';
+import { computeDeletionHunks, computeEditHunks, normalizeBracketArtifacts } from './bracket-normalizer.js';
 import { itAllure } from '../../../integration-tests/helpers/allure-test.js';
 
 const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
@@ -463,6 +463,54 @@ describe('normalizeBracketArtifacts', () => {
     // and its continuation paragraph; normalization must not erase it.
     expect(text).toMatch(/^\. The Purchasers/m);
   });
+
+  it('unwraps a carrier with several short deletions around a REF field without flattening runs', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'oa-bracket-normalizer-ref-carrier-'));
+    tempDirs.push(dir);
+
+    const input = join(dir, 'input.docx');
+    const output = join(dir, 'output.docx');
+    const fieldParagraphXml =
+      '<w:p>' +
+      '<w:r><w:rPr><w:b/></w:rPr><w:t xml:space="preserve">. The covenants set forth in Sections 3.1, 3.2 and 3.3 shall terminate [or (iv) upon the closing of a Deemed Liquidation Event comparable to those set forth in Section </w:t></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+      '<w:r><w:instrText xml:space="preserve"> REF _Ref301 \\h </w:instrText></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+      '<w:r><w:rPr><w:u w:val="single"/></w:rPr><w:t>3.1</w:t></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="end"/></w:r>' +
+      '<w:r><w:rPr><w:i/></w:rPr><w:t>].</w:t></w:r>' +
+      '</w:p>';
+    const documentXml =
+      '<?xml version="1.0" encoding="UTF-8"?>' +
+      `<w:document xmlns:w="${W_NS}"><w:body>${fieldParagraphXml}</w:body></w:document>`;
+    const zip = new AdmZip(buildDocx([]));
+    zip.updateFile('word/document.xml', Buffer.from(documentXml, 'utf-8'));
+    writeFileSync(input, zip.toBuffer());
+
+    const stats = await normalizeBracketArtifacts(input, output, {
+      rules: [{
+        id: 'unwrap-carrier',
+        section_heading: '',
+        ignore_heading: true,
+        paragraph_contains: 'upon the closing of a Deemed Liquidation Event',
+        replacements: { '[or (iv)': 'or (iv)', ']': '' },
+        expected_min_matches: 1,
+      }],
+    });
+
+    expect(stats.formattingFallbackCount).toBe(0);
+    expect(stats.declarativeRuleMatchCounts['unwrap-carrier']).toBe(1);
+    expect(stats.declarativeRuleMutationCounts['unwrap-carrier']).toBe(1);
+    const paragraphXml = readParagraphXml(output)[0];
+    expect(paragraphXml).toContain('fldChar');
+    expect(paragraphXml).toContain('instrText');
+    expect(paragraphXml).toContain('<w:b');
+    expect(paragraphXml).toContain('<w:u');
+    expect(paragraphXml).toContain('<w:i');
+    expect(readParagraphs(output)[0]).toBe(
+      '. The covenants set forth in Sections 3.1, 3.2 and 3.3 shall terminate or (iv) upon the closing of a Deemed Liquidation Event comparable to those set forth in Section 3.1.'
+    );
+  });
 });
 
 describe('computeEditHunks', () => {
@@ -502,5 +550,22 @@ describe('computeEditHunks', () => {
       replay = replay.slice(0, hunks[i].start) + hunks[i].replacement + replay.slice(hunks[i].end);
     }
     expect(replay).toBe(newText);
+  });
+
+  it('returns exact ordered deletions for repeated short punctuation', () => {
+    const oldText = '3.1[,][and] 3.2 [and 3.3] [or (iv) REF].';
+    const newText = '3.1[,[and 3.2 [and 3.3 or (iv) REF.';
+    const hunks = computeDeletionHunks(oldText, newText);
+    expect(hunks).not.toBeNull();
+    let replay = oldText;
+    for (let i = hunks!.length - 1; i >= 0; i--) {
+      replay = replay.slice(0, hunks![i].start) + replay.slice(hunks![i].end);
+    }
+    expect(replay).toBe(newText);
+  });
+
+  it('fails closed when the requested output is not deletion-only', () => {
+    expect(computeDeletionHunks('abc', 'axc')).toBeNull();
+    expect(computeDeletionHunks('abc', 'abcd')).toBeNull();
   });
 });

--- a/src/core/field-selector/bracket-normalizer.ts
+++ b/src/core/field-selector/bracket-normalizer.ts
@@ -1,7 +1,7 @@
 import AdmZip from 'adm-zip';
 import { writeFileSync } from 'node:fs';
 import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
-import type { Document, Element } from '@xmldom/xmldom';
+import type { Document, Element, Node } from '@xmldom/xmldom';
 import { replaceParagraphTextRange } from '@usejunior/docx-core';
 import { copyEntriesSkippingDirs, enumerateTextParts, getGeneralTextPartNames, preserveXmlSpace } from './ooxml-parts.js';
 import { BLANK_PLACEHOLDER } from '../fill-utils.js';
@@ -215,6 +215,43 @@ export interface EditHunk {
   replacement: string;
 }
 
+/**
+ * Return exact deletion hunks when `newText` is a subsequence of `oldText`.
+ * The leftmost embedding is deterministic and, unlike a wide replacement,
+ * never crosses text that survives the transformation (including REF field
+ * results). The caller still verifies the reconstructed text before mutation.
+ */
+export function computeDeletionHunks(
+  oldText: string,
+  newText: string,
+  offset = 0,
+): EditHunk[] | null {
+  if (newText.length >= oldText.length) return null;
+
+  const left: number[] = [];
+  let oldIndex = 0;
+  for (let i = 0; i < newText.length; i++) {
+    const char = newText[i];
+    const found = oldText.indexOf(char, oldIndex);
+    if (found < 0) return null;
+    left.push(found);
+    oldIndex = found + 1;
+  }
+
+  const retained = new Set(left);
+  const hunks: EditHunk[] = [];
+  let start = -1;
+  for (let i = 0; i <= oldText.length; i++) {
+    if (i < oldText.length && !retained.has(i)) {
+      if (start < 0) start = i;
+    } else if (start >= 0) {
+      hunks.push({ start: offset + start, end: offset + i, replacement: '' });
+      start = -1;
+    }
+  }
+  return hunks;
+}
+
 /** Minimum anchor length for hunk splitting — short anchors over-fragment. */
 const MIN_HUNK_ANCHOR_LENGTH = 12;
 /** Recursion cap for hunk splitting (2^6 = 64 hunks is far beyond real use). */
@@ -262,6 +299,9 @@ export function computeEditHunks(
   offset = 0,
   depth = 0,
 ): EditHunk[] {
+  const deletionHunks = computeDeletionHunks(oldText, newText, offset);
+  if (deletionHunks) return deletionHunks;
+
   let start = 0;
   const minLen = Math.min(oldText.length, newText.length);
   while (start < minLen && oldText[start] === newText[start]) start++;
@@ -319,8 +359,59 @@ function applyEditHunks(para: Element, original: string, finalText: string): boo
         hunk.replacement,
       );
     } catch {
-      return false;
+      if (!replaceRangeInSingleSafeTextNode(para, hunk)) return false;
     }
+  }
+  return true;
+}
+
+/**
+ * Safe narrow fallback for a range wholly contained in one ordinary w:t node.
+ * Safe-docx intentionally rejects a boundary that it maps to the preceding
+ * field-result run; direct mutation is nevertheless safe when the requested
+ * characters are demonstrably in the following non-field text node. This
+ * preserves the run, its rPr, and all REF field machinery.
+ */
+function replaceRangeInSingleSafeTextNode(para: Element, hunk: EditHunk): boolean {
+  if (hunk.end <= hunk.start) return false;
+  const textNodes: Array<{ node: Element; start: number; end: number; isFieldResult: boolean }> = [];
+  let visibleOffset = 0;
+  const fieldPhases: Array<'instruction' | 'result'> = [];
+
+  const visit = (node: Node): void => {
+    if (node.nodeType !== 1) return;
+    const element = node as unknown as Element;
+    if (element.namespaceURI === W_NS && element.localName === 'fldChar') {
+      const type = element.getAttributeNS(W_NS, 'fldCharType') || element.getAttribute('w:fldCharType');
+      if (type === 'begin') fieldPhases.push('instruction');
+      else if (type === 'separate' && fieldPhases.length > 0) fieldPhases[fieldPhases.length - 1] = 'result';
+      else if (type === 'end') fieldPhases.pop();
+      return;
+    }
+    if (element.namespaceURI === W_NS && element.localName === 't') {
+      if (fieldPhases.at(-1) === 'instruction') return;
+      const text = element.textContent ?? '';
+      textNodes.push({
+        node: element,
+        start: visibleOffset,
+        end: visibleOffset + text.length,
+        isFieldResult: fieldPhases.at(-1) === 'result',
+      });
+      visibleOffset += text.length;
+      return;
+    }
+    for (let child = element.firstChild; child; child = child.nextSibling) visit(child);
+  };
+  visit(para as unknown as Node);
+
+  const target = textNodes.find(({ start, end }) => hunk.start >= start && hunk.end <= end);
+  if (!target || target.isFieldResult) return false;
+  const text = target.node.textContent ?? '';
+  const localStart = hunk.start - target.start;
+  const localEnd = hunk.end - target.start;
+  target.node.textContent = text.slice(0, localStart) + hunk.replacement + text.slice(localEnd);
+  if ((target.node.textContent ?? '').startsWith(' ') || (target.node.textContent ?? '').endsWith(' ')) {
+    preserveXmlSpace(target.node);
   }
   return true;
 }


### PR DESCRIPTION
Closes #763.

## What changed

- detects deletion-only normalization as exact ordered hunks, avoiding wide replacements across surviving REF field text
- adds a narrowly proven single-`w:t` fallback for Safe-DOCX boundary ambiguity immediately after a field result
- refuses that narrow fallback for field-result text and cross-node ranges
- preserves run properties, field instructions, and declarative match accounting

## Regression proof

The new real-shape OOXML fixture failed before the runtime change with `formattingFallbackCount: 1`. It now completes with zero destructive fallbacks while retaining the complete REF field and bold/underline/italic run properties.

## Verification

- `npm run build`
- `npm run lint`
- `npx vitest run src/core/field-selector/bracket-normalizer.test.ts` — 13 passed
- `npm run test:run` — 121 files passed, 4 skipped; 1,388 tests passed, 7 skipped
