### PR TITLE
Remove orphaned inline note references during DOCX cleanup

### DIFF
--- a/src/core/field-selector/cleaner.test.ts
+++ b/src/core/field-selector/cleaner.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os';
 import AdmZip from 'adm-zip';
 import { DOMParser } from '@xmldom/xmldom';
 import { cleanDocument } from './cleaner.js';
+import { scanDocxBrackets } from '../../commands/scan.js';
 import type { CleanConfig } from '../metadata.js';
 import { itAllure } from '../../../integration-tests/helpers/allure-test.js';
 
@@ -65,6 +66,49 @@ function extractDocXml(docxPath: string): string {
   const entry = zip.getEntry('word/document.xml');
   return entry ? entry.getData().toString('utf-8') : '';
 }
+
+describe('cleanDocument removeFootnotes inline references', () => {
+  it('removes footnote and endnote reference-only runs and leaves scan/render views consistent', async () => {
+    const inputPath = buildTestDocxRaw([
+      '<w:p><w:r><w:t>Before</w:t></w:r>',
+      '<w:r><w:rPr><w:rStyle w:val="FootnoteReference"/></w:rPr><w:footnoteReference w:id="1"/></w:r>',
+      '<w:r><w:t> and after</w:t></w:r>',
+      '<w:r><w:rPr><w:rStyle w:val="EndnoteReference"/></w:rPr><w:endnoteReference w:id="2"/></w:r></w:p>',
+    ].join(''));
+    const outputPath = inputPath.replace('input.docx', 'output.docx');
+
+    await cleanDocument(inputPath, outputPath, makeConfig({ removeFootnotes: true }));
+
+    const xml = extractDocXml(outputPath);
+    expect(xml).not.toContain('footnoteReference');
+    expect(xml).not.toContain('endnoteReference');
+    expect(xml).not.toContain('FootnoteReference');
+    expect(xml).not.toContain('EndnoteReference');
+    expect(extractParaTexts(outputPath)).toEqual(['Before and after']);
+    expect(scanDocxBrackets(outputPath).footnoteCount).toBe(0);
+
+    rmSync(inputPath.replace('/input.docx', ''), { recursive: true, force: true });
+  });
+
+  it('preserves text, formatting, and non-reference content in mixed-content runs', async () => {
+    const inputPath = buildTestDocxRaw([
+      '<w:p><w:r><w:rPr><w:b/></w:rPr><w:t>Kept</w:t>',
+      '<w:footnoteReference w:id="1"/><w:tab/><w:endnoteReference w:id="2"/>',
+      '<w:t> text</w:t></w:r></w:p>',
+    ].join(''));
+    const outputPath = inputPath.replace('input.docx', 'output.docx');
+
+    await cleanDocument(inputPath, outputPath, makeConfig({ removeFootnotes: true }));
+
+    const xml = extractDocXml(outputPath);
+    expect(xml).not.toMatch(/(?:footnote|endnote)Reference/);
+    expect(xml).toContain('<w:b/>');
+    expect(xml).toContain('<w:tab/>');
+    expect(extractParaTexts(outputPath)).toEqual(['Kept text']);
+
+    rmSync(inputPath.replace('/input.docx', ''), { recursive: true, force: true });
+  });
+});
 
 describe('cleanDocument removeBeforePattern', () => {
   it('removes paragraphs before the anchor pattern', async () => {

--- a/src/core/field-selector/cleaner.ts
+++ b/src/core/field-selector/cleaner.ts
@@ -129,7 +129,7 @@ export async function cleanDocument(
     }
 
     if (config.removeFootnotes) {
-      removeFootnoteReferences(doc);
+      removeNoteReferences(doc);
       modified = true;
     }
 
@@ -256,26 +256,51 @@ function clearPartContent(doc: Document): void {
   root.appendChild(p);
 }
 
-function removeFootnoteReferences(doc: Document): void {
-  const refs = doc.getElementsByTagNameNS(W_NS, 'footnoteReference');
-  const runsToRemove: Element[] = [];
+/**
+ * Remove inline note markers without discarding other content that happens to
+ * share their run. Word commonly gives a reference its own styled run, but
+ * producers are allowed to place text and a reference in the same run.
+ */
+function removeNoteReferences(doc: Document): void {
+  const refs: Element[] = [];
+  for (const localName of ['footnoteReference', 'endnoteReference']) {
+    const matches = doc.getElementsByTagNameNS(W_NS, localName);
+    for (let i = 0; i < matches.length; i++) refs.push(matches[i]);
+  }
 
-  for (let i = 0; i < refs.length; i++) {
-    let node: Node | null = refs[i];
+  const affectedRuns = new Set<Element>();
+  for (const ref of refs) {
+    let node: Node | null = ref.parentNode;
     while (node) {
       if (node.nodeType === 1) {
         const element = node as Element;
         if (element.localName === 'r' && element.namespaceURI === W_NS) {
-          runsToRemove.push(element);
+          affectedRuns.add(element);
           break;
         }
       }
       node = node.parentNode;
     }
+    ref.parentNode?.removeChild(ref);
   }
 
-  for (const run of runsToRemove) {
-    run.parentNode?.removeChild(run);
+  // A reference-only run now contains, at most, its run properties. Drop that
+  // structural shell; preserve runs with text, tabs, drawings, or other OOXML.
+  for (const run of affectedRuns) {
+    let hasContent = false;
+    for (let child = run.firstChild; child; child = child.nextSibling) {
+      if (child.nodeType === 1) {
+        const element = child as Element;
+        if (!(element.namespaceURI === W_NS && element.localName === 'rPr')) {
+          hasContent = true;
+          break;
+        }
+      } else if (child.nodeType === 3 && (child.nodeValue ?? '').trim() !== '') {
+        hasContent = true;
+        break;
+      }
+    }
+    if (!hasContent) run.parentNode?.removeChild(run);
   }
 }
 

--- a/src/core/field-selector/verifier.test.ts
+++ b/src/core/field-selector/verifier.test.ts
@@ -122,6 +122,30 @@ describe('normalizeText', () => {
   });
 });
 
+describe('verifyOutput note-reference cleanup', () => {
+  it('fails removeFootnotes verification for either inline reference type', async () => {
+    const config = {
+      removeFootnotes: true,
+      removeParagraphPatterns: [],
+      removeRanges: [],
+      clearParts: [],
+    };
+
+    for (const reference of ['footnoteReference', 'endnoteReference']) {
+      const docxPath = buildDocx(
+        '<?xml version="1.0" encoding="UTF-8"?>' +
+          `<w:document xmlns:w="${W_NS}"><w:body><w:p><w:r>` +
+          `<w:${reference} w:id="1"/>` +
+          '</w:r></w:p></w:body></w:document>'
+      );
+      const result = await verifyOutput(docxPath, {}, {}, config);
+      const check = result.checks.find((item) => item.name === 'Footnotes removed');
+      expect(check?.passed, reference).toBe(false);
+      cleanupDocx(docxPath);
+    }
+  });
+});
+
 describe('verifyOutput', () => {
   it('skips empty string values', async () => {
     const xml =

--- a/src/core/field-selector/verifier.ts
+++ b/src/core/field-selector/verifier.ts
@@ -98,11 +98,11 @@ export async function verifyOutput(
 
   // Check 4: No footnote references (if removeFootnotes was set)
   if (cleanConfig?.removeFootnotes) {
-    const footnoteRefs = (xml.match(/footnoteReference/g) ?? []).length;
+    const footnoteRefs = (xml.match(/(?:footnote|endnote)Reference/g) ?? []).length;
     checks.push({
       name: 'Footnotes removed',
       passed: footnoteRefs === 0,
-      details: footnoteRefs > 0 ? `${footnoteRefs} footnote reference(s) remain` : undefined,
+      details: footnoteRefs > 0 ? `${footnoteRefs} note reference(s) remain` : undefined,
     });
   }
 


### PR DESCRIPTION
Closes #765.

## What changed

- removes both inline `w:footnoteReference` and `w:endnoteReference` elements when `removeFootnotes` is enabled
- removes only reference-only runs that become empty, while preserving mixed-content text, styling, tabs, drawings, and other OOXML
- makes verification fail on either orphaned inline note-reference type
- adds regression coverage for footnotes, endnotes, mixed-content runs, empty-run cleanup, and scanner/rendered-text consistency

## Verification

- `npm run build`
- `npx vitest run src/core/field-selector/cleaner.test.ts src/core/field-selector/verifier.test.ts`
- `npm run test:run -- --reporter=dot` — 121 files passed, 4 skipped; 1,391 tests passed, 7 skipped
