### PR TITLE
fix(cleaner): remove rendered legacy note markers

### DIFF
--- a/src/core/field-selector/cleaner.test.ts
+++ b/src/core/field-selector/cleaner.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os';
 import AdmZip from 'adm-zip';
 import { DOMParser } from '@xmldom/xmldom';
 import { cleanDocument } from './cleaner.js';
+import { normalizeBracketArtifacts } from './bracket-normalizer.js';
 import { scanDocxBrackets } from '../../commands/scan.js';
 import type { CleanConfig } from '../metadata.js';
 import { itAllure } from '../../../integration-tests/helpers/allure-test.js';
@@ -67,6 +68,17 @@ function extractDocXml(docxPath: string): string {
   return entry ? entry.getData().toString('utf-8') : '';
 }
 
+function addNotesPart(docxPath: string, kind: 'footnote' | 'endnote', ids: number[]): void {
+  const zip = new AdmZip(docxPath);
+  const plural = `${kind}s`;
+  const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:${plural} xmlns:w="${W_NS}">${ids.map((id) =>
+    `<w:${kind} w:id="${id}"><w:p><w:r><w:t>Note ${id}</w:t></w:r></w:p></w:${kind}>`,
+  ).join('')}</w:${plural}>`;
+  zip.addFile(`word/${plural}.xml`, Buffer.from(xml, 'utf-8'));
+  zip.writeZip(docxPath);
+}
+
 describe('cleanDocument removeFootnotes inline references', () => {
   it('removes footnote and endnote reference-only runs and leaves scan/render views consistent', async () => {
     const inputPath = buildTestDocxRaw([
@@ -106,6 +118,85 @@ describe('cleanDocument removeFootnotes inline references', () => {
     expect(xml).toContain('<w:tab/>');
     expect(extractParaTexts(outputPath)).toEqual(['Kept text']);
 
+    rmSync(inputPath.replace('/input.docx', ''), { recursive: true, force: true });
+  });
+
+  it('removes a legacy bookmark-backed superscript note marker before paragraph normalization (#765)', async () => {
+    const inputPath = buildTestDocxRaw([
+      '<w:p><w:pPr><w:jc w:val="both"/></w:pPr>',
+      '<w:r><w:rPr><w:b/></w:rPr><w:t>[such time after consummation of an IPO as Rule 144 permits sale without registration;]</w:t></w:r>',
+      '<w:r><w:t xml:space="preserve"> [and]</w:t></w:r>',
+      '<w:bookmarkStart w:id="246" w:name="_Ref42252623"/>',
+      '<w:r><w:rPr><w:vertAlign w:val="superscript"/></w:rPr><w:t>36</w:t></w:r>',
+      '<w:bookmarkEnd w:id="246"/></w:p>',
+    ].join(''));
+    addNotesPart(inputPath, 'footnote', [36]);
+    const outputPath = inputPath.replace('input.docx', 'output.docx');
+    const normalizedPath = inputPath.replace('input.docx', 'normalized.docx');
+
+    await cleanDocument(inputPath, outputPath, makeConfig({ removeFootnotes: true }));
+    await normalizeBracketArtifacts(outputPath, normalizedPath, {
+      rules: [{
+        id: 'unwrap-registration-termination-rule-144',
+        section_heading: '',
+        ignore_heading: true,
+        paragraph_contains: 'such time after consummation of an IPO',
+        replacements: { '[': '', ']': '' },
+        expected_min_matches: 1,
+      }],
+    });
+
+    const xml = extractDocXml(normalizedPath);
+    expect(xml).not.toMatch(/<w:t[^>]*>36<\/w:t>/);
+    expect(xml).toContain('<w:jc w:val="both"/>');
+    expect(xml).toContain('<w:b/>');
+    expect(extractParaTexts(normalizedPath)).toEqual([
+      'such time after consummation of an IPO as Rule 144 permits sale without registration; and',
+    ]);
+    rmSync(inputPath.replace('/input.docx', ''), { recursive: true, force: true });
+  });
+
+  it('preserves superscript numbers without a matching note identity or reference bookmark', async () => {
+    const inputPath = buildTestDocxRaw([
+      '<w:p><w:bookmarkStart w:id="8" w:name="_RefExponent"/>',
+      '<w:r><w:rPr><w:vertAlign w:val="superscript"/></w:rPr><w:t>2</w:t></w:r>',
+      '<w:bookmarkEnd w:id="8"/>',
+      '<w:r><w:t xml:space="preserve"> plus </w:t></w:r>',
+      '<w:r><w:rPr><w:vertAlign w:val="superscript"/></w:rPr><w:t>36</w:t></w:r></w:p>',
+    ].join(''));
+    addNotesPart(inputPath, 'footnote', [36]);
+    const outputPath = inputPath.replace('input.docx', 'output.docx');
+
+    await cleanDocument(inputPath, outputPath, makeConfig({ removeFootnotes: true }));
+
+    expect(extractParaTexts(outputPath)).toEqual(['2 plus 36']);
+    rmSync(inputPath.replace('/input.docx', ''), { recursive: true, force: true });
+  });
+
+  it('preserves mixed-content superscript runs and field results', async () => {
+    const inputPath = buildTestDocxRaw([
+      '<w:p><w:bookmarkStart w:id="9" w:name="_RefMixed"/>',
+      '<w:r><w:rPr><w:i/><w:vertAlign w:val="superscript"/></w:rPr><w:t>note 36</w:t></w:r>',
+      '<w:bookmarkEnd w:id="9"/>',
+      '<w:bookmarkStart w:id="10" w:name="_RefField"/>',
+      '<w:r><w:rPr><w:vertAlign w:val="superscript"/></w:rPr><w:fldChar w:fldCharType="begin"/></w:r>',
+      '<w:r><w:instrText> REF _Ref36 </w:instrText></w:r>',
+      '<w:r><w:fldChar w:fldCharType="separate"/></w:r>',
+      '<w:r><w:rPr><w:vertAlign w:val="superscript"/></w:rPr><w:t>36</w:t></w:r>',
+      '<w:r><w:fldChar w:fldCharType="end"/></w:r>',
+      '<w:bookmarkEnd w:id="10"/></w:p>',
+    ].join(''));
+    addNotesPart(inputPath, 'endnote', [36]);
+    const outputPath = inputPath.replace('input.docx', 'output.docx');
+
+    await cleanDocument(inputPath, outputPath, makeConfig({ removeFootnotes: true }));
+
+    const xml = extractDocXml(outputPath);
+    expect(xml).toContain('<w:i/>');
+    expect(xml).toContain('note 36');
+    expect(xml).toContain('fldChar');
+    expect(xml).toContain('instrText');
+    expect(xml).toMatch(/<w:t>36<\/w:t>/);
     rmSync(inputPath.replace('/input.docx', ''), { recursive: true, force: true });
   });
 });

--- a/src/core/field-selector/cleaner.ts
+++ b/src/core/field-selector/cleaner.ts
@@ -9,6 +9,7 @@ import { copyEntriesSkippingDirs, enumerateTextParts, getGeneralTextPartNames } 
 const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const R_NS = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
 const PKG_REL_NS = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const EMPTY_NOTE_IDS: ReadonlySet<string> = new Set();
 
 /**
  * Default size threshold for removeHeaderFooterDrawings, in bytes.
@@ -63,6 +64,9 @@ export async function cleanDocument(
 
   const parts = enumerateTextParts(zip);
   const generalParts = getGeneralTextPartNames(parts);
+  const normalNoteIds = config.removeFootnotes
+    ? collectNormalNoteIds(zip, parser, [parts.footnotes, parts.endnotes])
+    : new Set<string>();
 
   const extract = options?.extractGuidance ?? false;
   const entries: GuidanceEntry[] = [];
@@ -129,7 +133,10 @@ export async function cleanDocument(
     }
 
     if (config.removeFootnotes) {
-      removeNoteReferences(doc);
+      removeNoteReferences(
+        doc,
+        partName === 'word/document.xml' ? normalNoteIds : EMPTY_NOTE_IDS,
+      );
       modified = true;
     }
 
@@ -261,7 +268,7 @@ function clearPartContent(doc: Document): void {
  * share their run. Word commonly gives a reference its own styled run, but
  * producers are allowed to place text and a reference in the same run.
  */
-function removeNoteReferences(doc: Document): void {
+function removeNoteReferences(doc: Document, normalNoteIds: ReadonlySet<string>): void {
   const refs: Element[] = [];
   for (const localName of ['footnoteReference', 'endnoteReference']) {
     const matches = doc.getElementsByTagNameNS(W_NS, localName);
@@ -302,6 +309,73 @@ function removeNoteReferences(doc: Document): void {
     }
     if (!hasContent) run.parentNode?.removeChild(run);
   }
+
+  removeLegacyRenderedNoteReferences(doc, normalNoteIds);
+}
+
+/**
+ * Some DOCX producers materialize a note marker as superscript text wrapped by
+ * a `_Ref…` bookmark instead of emitting w:footnoteReference. Treat that as a
+ * note reference only when all three independent signals agree: the run is
+ * numeric-only superscript text, its number identifies a real footnote/endnote
+ * part entry, and a reference bookmark starts immediately before the run.
+ * This deliberately leaves ordinary superscript numbers and mixed-content runs
+ * untouched.
+ */
+function removeLegacyRenderedNoteReferences(
+  doc: Document,
+  normalNoteIds: ReadonlySet<string>,
+): void {
+  if (normalNoteIds.size === 0) return;
+  const runs = doc.getElementsByTagNameNS(W_NS, 'r');
+  const candidates: Element[] = [];
+  for (let i = 0; i < runs.length; i++) {
+    const run = runs[i];
+    const texts = run.getElementsByTagNameNS(W_NS, 't');
+    if (texts.length !== 1) continue;
+    const marker = (texts[0].textContent ?? '').trim();
+    if (!/^\d+$/.test(marker) || !normalNoteIds.has(marker)) continue;
+    const verticalAlign = run.getElementsByTagNameNS(W_NS, 'vertAlign');
+    if (verticalAlign.length !== 1) continue;
+    const align = verticalAlign[0].getAttributeNS(W_NS, 'val') || verticalAlign[0].getAttribute('w:val');
+    if (align !== 'superscript') continue;
+    if (run.getElementsByTagNameNS(W_NS, 'fldChar').length > 0 ||
+        run.getElementsByTagNameNS(W_NS, 'instrText').length > 0) continue;
+
+    let previous = run.previousSibling;
+    while (previous?.nodeType === 3 && (previous.nodeValue ?? '').trim() === '') {
+      previous = previous.previousSibling;
+    }
+    if (!previous || previous.nodeType !== 1) continue;
+    const bookmark = previous as Element;
+    if (bookmark.namespaceURI !== W_NS || bookmark.localName !== 'bookmarkStart') continue;
+    const name = bookmark.getAttributeNS(W_NS, 'name') || bookmark.getAttribute('w:name') || '';
+    if (!name.startsWith('_Ref')) continue;
+    candidates.push(run);
+  }
+  for (const run of candidates) run.parentNode?.removeChild(run);
+}
+
+function collectNormalNoteIds(
+  zip: AdmZip,
+  parser: DOMParser,
+  partNames: Array<string | null | undefined>,
+): Set<string> {
+  const ids = new Set<string>();
+  for (const partName of partNames) {
+    if (!partName) continue;
+    const entry = zip.getEntry(partName);
+    if (!entry) continue;
+    const doc = parser.parseFromString(entry.getData().toString('utf-8'), 'text/xml');
+    for (const localName of ['footnote', 'endnote']) {
+      const notes = doc.getElementsByTagNameNS(W_NS, localName);
+      for (let i = 0; i < notes.length; i++) {
+        const id = notes[i].getAttributeNS(W_NS, 'id') || notes[i].getAttribute('w:id');
+        if (id && !id.startsWith('-')) ids.add(id);
+      }
+    }
+  }
+  return ids;
 }
 
 function removeNormalFootnotes(doc: Document): void {


### PR DESCRIPTION
## Summary
- recognize producer-rendered legacy note markers only when numeric superscript text, a real note-part ID, and an adjacent `_Ref…` bookmark all agree
- remove the marker before normalization can preserve it as visible `and36` text
- preserve ordinary superscripts, mixed-content styled runs, REF fields, and paragraph formatting

## Verification
- `npm run build`
- `npm test -- --run` — 121 files passed, 4 skipped; 1,394 tests passed, 7 skipped
- real pinned NVCA IRA source + current Legal Explainer fixture: no `<w:t>36</w:t>`, note-reference nodes, `and36`, or `and³⁶`

Fixes the reopened follow-up in #765.