### PR TITLE
Add declarative atomic REF-to-literal conversion

### DIFF
--- a/docs/adding-field-selectors.md
+++ b/docs/adding-field-selectors.md
@@ -200,6 +200,33 @@ Rule behavior:
 
 This keeps cleanup declarative and versionable, instead of relying on brittle ad hoc parsing scripts.
 
+### Optional: reference-fields.json for atomic REF conversion
+
+Use `reference-fields.json` when cleaning an optional branch removes a bookmark
+target but a retained clause must show a fixed reference. The runtime converts
+the complete Word REF field (complex or `fldSimple`) to ordinary text before
+scalar patching and before missing-target verification.
+
+```json
+{
+  "version": 1,
+  "actions": [{
+    "target": "_DV_M84",
+    "strategy": "literalize",
+    "literal": "2.1",
+    "expected_cached_result": "2.1",
+    "expected_matches": 1,
+    "expected_target_count": 0
+  }]
+}
+```
+
+Every assertion is exact and is checked before any field is changed.
+`expected_target_count` describes bookmark targets in the post-clean document;
+`expected_matches` describes REF fields with that target. A stale cached result,
+zero or ambiguous field match, or unexpected bookmark count rejects the fill.
+Unrelated fields and bookmarks remain live.
+
 ### Range deletion
 
 `removeRanges` is useful for multi-paragraph blocks where individual patterns would be

--- a/src/core/field-selector/index.ts
+++ b/src/core/field-selector/index.ts
@@ -23,6 +23,7 @@ import type { ComputedValueMap } from './computed.js';
 import { applyRepeatableTables, loadRepeatableTablesConfig, validateRepeatableTableFields } from './repeatable-tables.js';
 import { bindAnchoredParagraphFields, loadAnchoredParagraphBindingsConfig } from './anchored-paragraph-bindings.js';
 import { normalizeNumberedHeadingSections } from './numbering-normalizer.js';
+import { loadReferenceFieldsConfig } from './reference-fields.js';
 
 function toComputedValueMap(values: Record<string, unknown>): ComputedValueMap {
   const computedValues: ComputedValueMap = {};
@@ -55,6 +56,7 @@ export async function runFieldSelector(options: FieldSelectorRunOptions): Promis
   const anchoredParagraphBindingsConfig = existsSync(anchoredBindingsPath)
     ? loadAnchoredParagraphBindingsConfig(anchoredBindingsPath)
     : undefined;
+  const referenceFieldsConfig = loadReferenceFieldsConfig(join(fieldSelectorDir, 'reference-fields.json'));
 
   // Load selectionsConfig if selections.json exists (mirrors engine.ts template path)
   const selectionsPath = join(fieldSelectorDir, 'selections.json');
@@ -166,6 +168,7 @@ export async function runFieldSelector(options: FieldSelectorRunOptions): Promis
         }
       }
       : undefined,
+    referenceFieldsConfig,
     postProcess: shouldNormalizeBracketArtifacts
       ? async (outputDocPath: string) => {
         normalizeNumberedHeadingSections(outputDocPath, outputDocPath);
@@ -269,3 +272,5 @@ export type { NumberingNormalizationStats } from './numbering-normalizer.js';
 export { bindAnchoredParagraphFields, loadAnchoredParagraphBindingsConfig, AnchoredParagraphBindingsConfigSchema } from './anchored-paragraph-bindings.js';
 export { normalizeDetachedHeadingPunctuation } from './heading-punctuation-normalizer.js';
 export type { AnchoredParagraphBindingsConfig } from './anchored-paragraph-bindings.js';
+export { applyReferenceFieldActions, loadReferenceFieldsConfig, ReferenceFieldsConfigSchema } from './reference-fields.js';
+export type { ReferenceFieldsConfig } from './reference-fields.js';

--- a/src/core/field-selector/reference-fields.test.ts
+++ b/src/core/field-selector/reference-fields.test.ts
@@ -2,11 +2,13 @@ import AdmZip from 'adm-zip';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect } from 'vitest';
+import { itAllure } from '../../../integration-tests/helpers/allure-test.js';
 import { applyReferenceFieldActions, ReferenceFieldsConfigSchema } from './reference-fields.js';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const dirs: string[] = [];
+const it = itAllure.epic('FieldSelectors');
 
 function fixture(body: string): string {
   const dir = mkdtempSync(join(tmpdir(), 'oa-reference-fields-'));

--- a/src/core/field-selector/reference-fields.test.ts
+++ b/src/core/field-selector/reference-fields.test.ts
@@ -1,0 +1,84 @@
+import AdmZip from 'adm-zip';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { applyReferenceFieldActions, ReferenceFieldsConfigSchema } from './reference-fields.js';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const dirs: string[] = [];
+
+function fixture(body: string): string {
+  const dir = mkdtempSync(join(tmpdir(), 'oa-reference-fields-'));
+  dirs.push(dir);
+  const path = join(dir, 'input.docx');
+  const zip = new AdmZip();
+  zip.addFile('[Content_Types].xml', Buffer.from('<Types/>'));
+  zip.addFile('word/document.xml', Buffer.from(`<w:document xmlns:w="${W}"><w:body>${body}</w:body></w:document>`));
+  zip.writeZip(path);
+  return path;
+}
+
+const action = {
+  target: '_DV_M84',
+  strategy: 'literalize' as const,
+  literal: '2.1',
+  expected_cached_result: '2.1',
+  expected_matches: 1,
+  expected_target_count: 0,
+};
+
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('declarative REF-field actions', () => {
+  it('literalizes a split complex REF atomically and preserves result formatting and unrelated fields', () => {
+    const input = fixture(
+      '<w:p><w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+      '<w:r><w:instrText> RE</w:instrText></w:r><w:r><w:instrText>F _DV_M84 \\h </w:instrText></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+      '<w:r><w:rPr><w:b/></w:rPr><w:t>2.</w:t></w:r><w:r><w:t>1</w:t></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="end"/></w:r></w:p>' +
+      '<w:p><w:bookmarkStart w:id="7" w:name="_Keep"/><w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+      '<w:r><w:instrText> REF _Keep \\h </w:instrText></w:r><w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+      '<w:r><w:t>9.9</w:t></w:r><w:r><w:fldChar w:fldCharType="end"/></w:r></w:p>',
+    );
+    const output = join(input, '..', 'output.docx');
+    applyReferenceFieldActions(input, output, { version: 1, actions: [action] });
+    const xml = new AdmZip(output).readAsText('word/document.xml');
+    expect(xml).not.toContain('_DV_M84');
+    expect(xml).toContain('<w:b/>');
+    expect(xml).toContain('>2.1</w:t>');
+    expect(xml).toContain('REF _Keep');
+    expect(xml).toContain('w:name="_Keep"');
+  });
+
+  it('literalizes an atomic fldSimple REF and preserves its result style', () => {
+    const input = fixture('<w:p><w:fldSimple w:instr=" REF _DV_M84 \\h "><w:r><w:rPr><w:i/></w:rPr><w:t>2.1</w:t></w:r></w:fldSimple></w:p>');
+    const output = join(input, '..', 'output.docx');
+    applyReferenceFieldActions(input, output, { version: 1, actions: [action] });
+    const xml = new AdmZip(output).readAsText('word/document.xml');
+    expect(xml).not.toContain('fldSimple');
+    expect(xml).not.toContain('_DV_M84');
+    expect(xml).toContain('<w:i/>');
+    expect(xml).toContain('>2.1</w:t>');
+  });
+
+  it.each([
+    ['absent REF', '<w:p><w:r><w:t>ordinary</w:t></w:r></w:p>', /expected 1 REF field match\(es\), found 0/],
+    ['ambiguous REF', '<w:p><w:fldSimple w:instr=" REF _DV_M84 "><w:r><w:t>2.1</w:t></w:r></w:fldSimple><w:fldSimple w:instr=" REF _DV_M84 "><w:r><w:t>2.1</w:t></w:r></w:fldSimple></w:p>', /expected 1 REF field match\(es\), found 2/],
+    ['stale cache', '<w:p><w:fldSimple w:instr=" REF _DV_M84 "><w:r><w:t>2.2</w:t></w:r></w:fldSimple></w:p>', /expected cached result "2.1", found "2.2"/],
+    ['unexpected live target', '<w:p><w:bookmarkStart w:id="1" w:name="_DV_M84"/><w:fldSimple w:instr=" REF _DV_M84 "><w:r><w:t>2.1</w:t></w:r></w:fldSimple></w:p>', /expected 0 bookmark target\(s\), found 1/],
+  ])('fails closed without writing output for %s', (_name, body, error) => {
+    const input = fixture(body);
+    const output = join(input, '..', 'output.docx');
+    expect(() => applyReferenceFieldActions(input, output, { version: 1, actions: [action] })).toThrow(error);
+    expect(() => new AdmZip(output)).toThrow();
+  });
+
+  it('rejects duplicate targets and incomplete declarations', () => {
+    expect(() => ReferenceFieldsConfigSchema.parse({ version: 1, actions: [action, action] })).toThrow(/duplicate target/);
+    expect(() => ReferenceFieldsConfigSchema.parse({ version: 1, actions: [{ target: '_DV_M84' }] })).toThrow();
+  });
+});

--- a/src/core/field-selector/reference-fields.ts
+++ b/src/core/field-selector/reference-fields.ts
@@ -1,0 +1,211 @@
+import { existsSync, readFileSync } from 'node:fs';
+import AdmZip from 'adm-zip';
+import { DOMParser, XMLSerializer, type Document, type Element, type Node } from '@xmldom/xmldom';
+import { z } from 'zod';
+import { enumerateTextParts, getAllTextPartNames, preserveXmlSpace, rezipWithoutDirEntries } from './ooxml-parts.js';
+
+const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const REF_INSTRUCTION_RE = /^\s*REF\s+(?:"([^"]+)"|'([^']+)'|([^\s\\]+))(?:\s|\\|$)/i;
+
+export const ReferenceFieldActionSchema = z.object({
+  target: z.string().min(1),
+  strategy: z.literal('literalize'),
+  literal: z.string(),
+  expected_cached_result: z.string(),
+  expected_matches: z.number().int().nonnegative(),
+  expected_target_count: z.number().int().nonnegative(),
+}).strict();
+
+export const ReferenceFieldsConfigSchema = z.object({
+  version: z.literal(1),
+  actions: z.array(ReferenceFieldActionSchema).min(1),
+}).strict().superRefine((config, ctx) => {
+  const seen = new Set<string>();
+  for (const action of config.actions) {
+    if (seen.has(action.target)) {
+      ctx.addIssue({ code: 'custom', message: `duplicate target "${action.target}"` });
+    }
+    seen.add(action.target);
+  }
+});
+
+export type ReferenceFieldsConfig = z.infer<typeof ReferenceFieldsConfigSchema>;
+
+export function loadReferenceFieldsConfig(path: string): ReferenceFieldsConfig | undefined {
+  if (!existsSync(path)) return undefined;
+  return ReferenceFieldsConfigSchema.parse(JSON.parse(readFileSync(path, 'utf-8')));
+}
+
+interface FieldMatch {
+  partName: string;
+  target: string;
+  cachedResult: string;
+  replace: (literal: string) => void;
+}
+
+function attr(element: Element, localName: string): string {
+  return element.getAttributeNS(W_NS, localName) || element.getAttribute(`w:${localName}`) || '';
+}
+
+function fieldTarget(instruction: string): string | undefined {
+  const match = instruction.match(REF_INSTRUCTION_RE);
+  return match?.[1] ?? match?.[2] ?? match?.[3];
+}
+
+function textOf(node: Node): string {
+  const texts = (node as Element).getElementsByTagNameNS(W_NS, 't');
+  let text = '';
+  for (let i = 0; i < texts.length; i++) text += texts[i].textContent ?? '';
+  return text;
+}
+
+function ordinaryRun(doc: Document, styleSource: Element | undefined, literal: string): Element {
+  const run = doc.createElementNS(W_NS, 'w:r') as unknown as Element;
+  const rPr = styleSource?.getElementsByTagNameNS(W_NS, 'rPr')[0];
+  if (rPr) run.appendChild(rPr.cloneNode(true));
+  const text = doc.createElementNS(W_NS, 'w:t') as unknown as Element;
+  preserveXmlSpace(text);
+  text.textContent = literal;
+  run.appendChild(text);
+  return run;
+}
+
+function findFields(doc: Document, partName: string): FieldMatch[] {
+  const matches: FieldMatch[] = [];
+
+  // Atomic fields are self-contained and may carry split result runs.
+  const simple = Array.from(doc.getElementsByTagNameNS(W_NS, 'fldSimple')) as unknown as Element[];
+  for (const field of simple) {
+    const instruction = attr(field, 'instr');
+    const target = fieldTarget(instruction);
+    if (!target) continue;
+    const cachedResult = textOf(field);
+    matches.push({
+      partName,
+      target,
+      cachedResult,
+      replace: (literal) => {
+        const parent = field.parentNode;
+        if (!parent) throw new Error(`${partName}: REF ${target} has no parent`);
+        const styleRun = field.getElementsByTagNameNS(W_NS, 'r')[0] as unknown as Element | undefined;
+        parent.replaceChild(ordinaryRun(doc, styleRun, literal), field);
+      },
+    });
+  }
+
+  // Complex fields are sibling run triplets. Pair begin/end with a stack so
+  // nested fields remain atomic; concatenate split instrText and result text.
+  const paragraphs = Array.from(doc.getElementsByTagNameNS(W_NS, 'p')) as unknown as Element[];
+  for (const paragraph of paragraphs) {
+    const runs = Array.from(paragraph.getElementsByTagNameNS(W_NS, 'r')) as unknown as Element[];
+    const stack: Array<{ start: number; separate?: number }> = [];
+    for (let i = 0; i < runs.length; i++) {
+      const chars = runs[i].getElementsByTagNameNS(W_NS, 'fldChar');
+      for (let c = 0; c < chars.length; c++) {
+        const type = attr(chars[c] as unknown as Element, 'fldCharType');
+        if (type === 'begin') stack.push({ start: i });
+        else if (type === 'separate' && stack.length > 0) stack[stack.length - 1].separate = i;
+        else if (type === 'end' && stack.length > 0) {
+          const range = stack.pop()!;
+          const separate = range.separate;
+          if (separate === undefined) continue;
+          let instruction = '';
+          for (let j = range.start; j < separate; j++) {
+            const nodes = runs[j].getElementsByTagNameNS(W_NS, 'instrText');
+            for (let k = 0; k < nodes.length; k++) instruction += nodes[k].textContent ?? '';
+          }
+          const target = fieldTarget(instruction);
+          if (!target) continue;
+          let cachedResult = '';
+          let styleRun: Element | undefined;
+          for (let j = separate + 1; j < i; j++) {
+            const value = textOf(runs[j]);
+            cachedResult += value;
+            if (!styleRun && value.length > 0) styleRun = runs[j];
+          }
+          const start = range.start;
+          const end = i;
+          matches.push({
+            partName,
+            target,
+            cachedResult,
+            replace: (literal) => {
+              const anchor = runs[start];
+              const parent = anchor.parentNode;
+              if (!parent) throw new Error(`${partName}: REF ${target} has no parent`);
+              parent.insertBefore(ordinaryRun(doc, styleRun, literal), anchor);
+              for (let j = end; j >= start; j--) runs[j].parentNode?.removeChild(runs[j]);
+            },
+          });
+        }
+      }
+    }
+  }
+  return matches;
+}
+
+/**
+ * Structurally literalize declared REF fields. All assertions are evaluated
+ * before any mutation, so a stale recipe cannot partially rewrite a document.
+ */
+export function applyReferenceFieldActions(
+  inputPath: string,
+  outputPath: string,
+  config: ReferenceFieldsConfig,
+): void {
+  const source = new AdmZip(inputPath);
+  const partNames = getAllTextPartNames(enumerateTextParts(source));
+  const parser = new DOMParser();
+  const serializer = new XMLSerializer();
+  const docs = new Map<string, Document>();
+  const fields: FieldMatch[] = [];
+  const targetCounts = new Map<string, number>();
+
+  for (const partName of partNames) {
+    const entry = source.getEntry(partName);
+    if (!entry) continue;
+    const doc = parser.parseFromString(entry.getData().toString('utf-8'), 'text/xml');
+    docs.set(partName, doc);
+    fields.push(...findFields(doc, partName));
+    const bookmarks = doc.getElementsByTagNameNS(W_NS, 'bookmarkStart');
+    for (let i = 0; i < bookmarks.length; i++) {
+      const name = attr(bookmarks[i] as unknown as Element, 'name');
+      targetCounts.set(name, (targetCounts.get(name) ?? 0) + 1);
+    }
+  }
+
+  const selected: Array<{ action: ReferenceFieldsConfig['actions'][number]; fields: FieldMatch[] }> = [];
+  for (const action of config.actions) {
+    const actionFields = fields.filter((field) => field.target === action.target);
+    const actualTargetCount = targetCounts.get(action.target) ?? 0;
+    if (actualTargetCount !== action.expected_target_count) {
+      throw new Error(
+        `reference-fields.json: target "${action.target}" expected ${action.expected_target_count} bookmark target(s), found ${actualTargetCount}`,
+      );
+    }
+    if (actionFields.length !== action.expected_matches) {
+      throw new Error(
+        `reference-fields.json: target "${action.target}" expected ${action.expected_matches} REF field match(es), found ${actionFields.length}`,
+      );
+    }
+    for (const field of actionFields) {
+      if (field.cachedResult !== action.expected_cached_result) {
+        throw new Error(
+          `reference-fields.json: ${field.partName} REF "${action.target}" expected cached result ` +
+          `"${action.expected_cached_result}", found "${field.cachedResult}"`,
+        );
+      }
+    }
+    selected.push({ action, fields: actionFields });
+  }
+
+  for (const { action, fields: actionFields } of selected) {
+    for (const field of actionFields) field.replace(action.literal);
+  }
+
+  const output = rezipWithoutDirEntries(source);
+  for (const [partName, doc] of docs) {
+    output.updateFile(partName, Buffer.from(serializer.serializeToString(doc)));
+  }
+  output.writeZip(outputPath);
+}

--- a/src/core/unified-pipeline.ts
+++ b/src/core/unified-pipeline.ts
@@ -24,6 +24,7 @@ import { enumerateTextParts, getGeneralTextPartNames, rezipWithoutDirEntries } f
 import type { FieldDefinition, CleanConfig } from './metadata.js';
 import type { SelectionsConfig } from './selector.js';
 import type { VerifyResult } from './field-selector/types.js';
+import { applyReferenceFieldActions, type ReferenceFieldsConfig } from './field-selector/reference-fields.js';
 
 const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 
@@ -92,6 +93,8 @@ export interface PipelineOptions {
    * commands because command analysis and filling happen later.
    */
   prePatchProcess?: (inputPath: string, outputPath: string) => void | Promise<void>;
+  /** Target-driven, assertion-guarded REF-field structural actions. */
+  referenceFieldsConfig?: ReferenceFieldsConfig;
   postProcess?: (outputPath: string) => void | Promise<void>;
 
   // Debugging
@@ -183,6 +186,7 @@ export async function runFillPipeline(options: PipelineOptions): Promise<Pipelin
     fixSmartQuotes = false,
     verify,
     prePatchProcess,
+    referenceFieldsConfig,
     postProcess,
     keepIntermediate = false,
   } = options;
@@ -219,6 +223,12 @@ export async function runFillPipeline(options: PipelineOptions): Promise<Pipelin
         const structurallyProcessedPath = join(tempDir, 'structural.docx');
         await prePatchProcess(cleanedPath, structurallyProcessedPath);
         structuralInputPath = structurallyProcessedPath;
+      }
+
+      if (referenceFieldsConfig) {
+        const referenceFieldsPath = join(tempDir, 'reference-fields.docx');
+        applyReferenceFieldActions(structuralInputPath, referenceFieldsPath, referenceFieldsConfig);
+        structuralInputPath = referenceFieldsPath;
       }
 
       // Selector-contract patch (deterministic locators) runs between clean and

--- a/src/core/validation/field-selector.test.ts
+++ b/src/core/validation/field-selector.test.ts
@@ -26,6 +26,7 @@ interface FixtureSpec {
   selections?: Record<string, unknown>;
   anchoredBindings?: Record<string, unknown>;
   repeatableTables?: Record<string, unknown>;
+  referenceFields?: Record<string, unknown>;
   /** field ids to write minimal fields/<id>.json selector recipes for */
   recipes?: string[];
   templateManifest?: Record<string, unknown>;
@@ -88,6 +89,9 @@ function writeFixture(spec: FixtureSpec): string {
   if (spec.repeatableTables) {
     writeFileSync(join(dir, 'repeatable-tables.json'), JSON.stringify(spec.repeatableTables, null, 2));
   }
+  if (spec.referenceFields) {
+    writeFileSync(join(dir, 'reference-fields.json'), JSON.stringify(spec.referenceFields, null, 2));
+  }
   if (spec.recipes || spec.templateManifest) {
     mkdirSync(join(dir, 'fields'), { recursive: true });
   }
@@ -145,6 +149,28 @@ describe('validateFieldSelector replacement values', () => {
     });
     const result = validateFieldSelector(dir, 'fixture');
     expect(result.errors).toEqual([]);
+  });
+
+  it('validates the reference-fields.json fail-closed declaration', () => {
+    const valid = writeFixture({
+      fields: [{ name: 'company_name' }],
+      replacements: { '[COMPANY]': '{company_name}' },
+      referenceFields: {
+        version: 1,
+        actions: [{
+          target: '_DV_M84', strategy: 'literalize', literal: '2.1',
+          expected_cached_result: '2.1', expected_matches: 1, expected_target_count: 0,
+        }],
+      },
+    });
+    expect(validateFieldSelector(valid, 'valid').errors).toEqual([]);
+
+    const invalid = writeFixture({
+      fields: [{ name: 'company_name' }],
+      replacements: { '[COMPANY]': '{company_name}' },
+      referenceFields: { version: 1, actions: [{ target: '_DV_M84' }] },
+    });
+    expect(validateFieldSelector(invalid, 'invalid').errors.some((e) => e.startsWith('reference-fields.json:'))).toBe(true);
   });
 });
 

--- a/src/core/validation/field-selector.ts
+++ b/src/core/validation/field-selector.ts
@@ -10,6 +10,7 @@ import { SelectionsConfigSchema, type SelectionsConfig } from '../selector.js';
 import { loadSelectorContracts } from '../selectors/loader.js';
 import { AnchoredParagraphBindingsConfigSchema, type AnchoredParagraphBindingsConfig } from '../field-selector/anchored-paragraph-bindings.js';
 import { RepeatableTablesConfigSchema, type RepeatableTablesConfig } from '../field-selector/repeatable-tables.js';
+import { ReferenceFieldsConfigSchema } from '../field-selector/reference-fields.js';
 
 export interface FieldSelectorValidationResult {
   fieldSelectorId: string;
@@ -186,6 +187,16 @@ export function validateFieldSelector(
   } catch (err) {
     errors.push(`replacements.json: ${(err as Error).message}`);
     reachabilityInputsOk = false;
+  }
+
+  // Validate clean.json if present
+  const referenceFieldsPath = join(fieldSelectorDir, 'reference-fields.json');
+  if (existsSync(referenceFieldsPath)) {
+    try {
+      ReferenceFieldsConfigSchema.parse(JSON.parse(readFileSync(referenceFieldsPath, 'utf-8')));
+    } catch (err) {
+      errors.push(`reference-fields.json: ${err instanceof Error ? err.message : 'invalid format'}`);
+    }
   }
 
   // Validate clean.json if present

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,6 +106,10 @@ export {
   type FieldSelectorRunResult,
   type VerifyResult,
   type VerifyCheck,
+  applyReferenceFieldActions,
+  loadReferenceFieldsConfig,
+  ReferenceFieldsConfigSchema,
+  type ReferenceFieldsConfig,
 } from './core/field-selector/index.js';
 
 // Closing checklist


### PR DESCRIPTION
## Summary

- add validated `reference-fields.json` v1 actions keyed by REF bookmark target
- assert exact post-clean bookmark counts, REF match counts, and cached results before any mutation
- atomically replace complex and `fldSimple` fields with styled ordinary text while preserving unrelated fields
- run the action before scalar patching and delivery verification

## Tests

- `npm run test:run` — 122 files passed, 4 skipped; 1,417 tests passed, 7 skipped
- `npm run lint`
- synthetic coverage: split complex fields, atomic fields, stale cache, absent/ambiguous targets, bookmark-count drift, unrelated REF preservation

Closes #769
