### PR TITLE
feat: support grouped REF literalization actions

### DIFF
--- a/src/core/field-selector/reference-fields.test.ts
+++ b/src/core/field-selector/reference-fields.test.ts
@@ -1,5 +1,5 @@
 import AdmZip from 'adm-zip';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect } from 'vitest';
@@ -29,6 +29,28 @@ const action = {
   expected_matches: 1,
   expected_target_count: 0,
 };
+
+const groupedAction = {
+  target: '_Ref137784392',
+  strategy: 'literalize' as const,
+  expected_matches: 3,
+  expected_target_count: 0,
+  groups: [
+    { expected_cached_result: '2.3.2(b)', literal: '2.3.2(b)', expected_matches: 1 },
+    { expected_cached_result: '(b)', literal: '(b)', expected_matches: 2 },
+  ],
+};
+
+const simpleField = (target: string, result: string, style = '') =>
+  `<w:fldSimple w:instr=" REF ${target} \\h "><w:r>${style}<w:t>${result}</w:t></w:r></w:fldSimple>`;
+
+const complexField = (target: string, resultRuns: string, splitInstruction = false) =>
+  '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+  (splitInstruction
+    ? `<w:r><w:instrText> RE</w:instrText></w:r><w:r><w:instrText>F ${target} \\h </w:instrText></w:r>`
+    : `<w:r><w:instrText> REF ${target} \\h </w:instrText></w:r>`) +
+  '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' + resultRuns +
+  '<w:r><w:fldChar w:fldCharType="end"/></w:r>';
 
 afterEach(() => {
   for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
@@ -67,6 +89,63 @@ describe('declarative REF-field actions', () => {
     expect(xml).toContain('>2.1</w:t>');
   });
 
+  it('literalizes one target transactionally by cached-result groups across atomic, complex, and split fields', () => {
+    const input = fixture(
+      `<w:p>${simpleField('_Ref137784392', '2.3.2(b)', '<w:rPr><w:b/></w:rPr>')}</w:p>` +
+      `<w:p>${complexField('_Ref137784392', '<w:r><w:rPr><w:i/></w:rPr><w:t>(b)</w:t></w:r>')}</w:p>` +
+      `<w:p>${complexField('_Ref137784392', '<w:r><w:t>(</w:t></w:r><w:r><w:t>b)</w:t></w:r>', true)}</w:p>` +
+      `<w:p>${simpleField('_Keep', '9.9')}</w:p>`,
+    );
+    const output = join(input, '..', 'output.docx');
+    applyReferenceFieldActions(input, output, { version: 1, actions: [groupedAction] });
+    const xml = new AdmZip(output).readAsText('word/document.xml');
+    expect(xml).not.toContain('_Ref137784392');
+    expect(xml.match(/>2\.3\.2\(b\)<\/w:t>/g)).toHaveLength(1);
+    expect(xml.match(/>\(b\)<\/w:t>/g)).toHaveLength(2);
+    expect(xml).toContain('<w:b/>');
+    expect(xml).toContain('<w:i/>');
+    expect(xml).toContain('REF _Keep');
+    expect(xml).toContain('>9.9</w:t>');
+  });
+
+  it.each([
+    [
+      'undeclared cached result',
+      `<w:p>${simpleField('_Ref137784392', '2.3.2(b)')}</w:p>` +
+        `<w:p>${simpleField('_Ref137784392', '(b)')}</w:p>` +
+        `<w:p>${simpleField('_Ref137784392', '(c)')}</w:p>`,
+      /undeclared cached result "\(c\)"/,
+    ],
+    [
+      'mismatched group count',
+      `<w:p>${simpleField('_Ref137784392', '2.3.2(b)')}</w:p>` +
+        `<w:p>${simpleField('_Ref137784392', '2.3.2(b)')}</w:p>` +
+        `<w:p>${simpleField('_Ref137784392', '(b)')}</w:p>`,
+      /cached-result group "2\.3\.2\(b\)" expected 1 REF field match\(es\), found 2/,
+    ],
+  ])('fails closed for grouped action with %s', (_name, body, error) => {
+    const input = fixture(body);
+    const output = join(input, '..', 'output.docx');
+    expect(() => applyReferenceFieldActions(input, output, { version: 1, actions: [groupedAction] })).toThrow(error);
+    expect(() => new AdmZip(output)).toThrow();
+  });
+
+  it('validates every action before mutation and preserves a pre-existing output on rollback', () => {
+    const input = fixture(
+      `<w:p>${simpleField('_DV_M84', '2.1')}</w:p>` +
+      `<w:p>${simpleField('_Ref137784392', '2.3.2(b)')}</w:p>` +
+      `<w:p>${simpleField('_Ref137784392', '(b)')}</w:p>` +
+      `<w:p>${simpleField('_Ref137784392', '(c)')}</w:p>`,
+    );
+    const output = join(input, '..', 'output.docx');
+    const sentinel = Buffer.from('pre-existing-output');
+    writeFileSync(output, sentinel);
+    expect(() => applyReferenceFieldActions(input, output, { version: 1, actions: [action, groupedAction] }))
+      .toThrow(/undeclared cached result "\(c\)"/);
+    expect(readFileSync(output)).toEqual(sentinel);
+    expect(new AdmZip(input).readAsText('word/document.xml')).toContain('_DV_M84');
+  });
+
   it.each([
     ['absent REF', '<w:p><w:r><w:t>ordinary</w:t></w:r></w:p>', /expected 1 REF field match\(es\), found 0/],
     ['ambiguous REF', '<w:p><w:fldSimple w:instr=" REF _DV_M84 "><w:r><w:t>2.1</w:t></w:r></w:fldSimple><w:fldSimple w:instr=" REF _DV_M84 "><w:r><w:t>2.1</w:t></w:r></w:fldSimple></w:p>', /expected 1 REF field match\(es\), found 2/],
@@ -82,5 +161,16 @@ describe('declarative REF-field actions', () => {
   it('rejects duplicate targets and incomplete declarations', () => {
     expect(() => ReferenceFieldsConfigSchema.parse({ version: 1, actions: [action, action] })).toThrow(/duplicate target/);
     expect(() => ReferenceFieldsConfigSchema.parse({ version: 1, actions: [{ target: '_DV_M84' }] })).toThrow();
+  });
+
+  it('rejects duplicate groups and partial group partitions in the schema', () => {
+    expect(() => ReferenceFieldsConfigSchema.parse({
+      version: 1,
+      actions: [{ ...groupedAction, groups: [...groupedAction.groups, groupedAction.groups[0]] }],
+    })).toThrow(/duplicate cached-result group/);
+    expect(() => ReferenceFieldsConfigSchema.parse({
+      version: 1,
+      actions: [{ ...groupedAction, groups: [groupedAction.groups[0]] }],
+    })).toThrow(/group expected_matches sum 1 does not equal action expected_matches 3/);
   });
 });

--- a/src/core/field-selector/reference-fields.ts
+++ b/src/core/field-selector/reference-fields.ts
@@ -7,14 +7,46 @@ import { enumerateTextParts, getAllTextPartNames, preserveXmlSpace, rezipWithout
 const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const REF_INSTRUCTION_RE = /^\s*REF\s+(?:"([^"]+)"|'([^']+)'|([^\s\\]+))(?:\s|\\|$)/i;
 
-export const ReferenceFieldActionSchema = z.object({
+const ReferenceFieldActionBaseSchema = z.object({
   target: z.string().min(1),
   strategy: z.literal('literalize'),
-  literal: z.string(),
-  expected_cached_result: z.string(),
   expected_matches: z.number().int().nonnegative(),
   expected_target_count: z.number().int().nonnegative(),
+});
+
+const SimpleReferenceFieldActionSchema = ReferenceFieldActionBaseSchema.extend({
+  literal: z.string(),
+  expected_cached_result: z.string(),
 }).strict();
+
+const GroupedReferenceFieldActionSchema = ReferenceFieldActionBaseSchema.extend({
+  groups: z.array(z.object({
+    expected_cached_result: z.string(),
+    literal: z.string(),
+    expected_matches: z.number().int().positive(),
+  }).strict()).min(1),
+}).strict().superRefine((action, ctx) => {
+  const seen = new Set<string>();
+  let sum = 0;
+  for (const group of action.groups) {
+    if (seen.has(group.expected_cached_result)) {
+      ctx.addIssue({ code: 'custom', message: `duplicate cached-result group "${group.expected_cached_result}"` });
+    }
+    seen.add(group.expected_cached_result);
+    sum += group.expected_matches;
+  }
+  if (sum !== action.expected_matches) {
+    ctx.addIssue({
+      code: 'custom',
+      message: `group expected_matches sum ${sum} does not equal action expected_matches ${action.expected_matches}`,
+    });
+  }
+});
+
+export const ReferenceFieldActionSchema = z.union([
+  SimpleReferenceFieldActionSchema,
+  GroupedReferenceFieldActionSchema,
+]);
 
 export const ReferenceFieldsConfigSchema = z.object({
   version: z.literal(1),
@@ -174,7 +206,7 @@ export function applyReferenceFieldActions(
     }
   }
 
-  const selected: Array<{ action: ReferenceFieldsConfig['actions'][number]; fields: FieldMatch[] }> = [];
+  const selected: Array<{ literal: string; field: FieldMatch }> = [];
   for (const action of config.actions) {
     const actionFields = fields.filter((field) => field.target === action.target);
     const actualTargetCount = targetCounts.get(action.target) ?? 0;
@@ -188,20 +220,44 @@ export function applyReferenceFieldActions(
         `reference-fields.json: target "${action.target}" expected ${action.expected_matches} REF field match(es), found ${actionFields.length}`,
       );
     }
-    for (const field of actionFields) {
-      if (field.cachedResult !== action.expected_cached_result) {
-        throw new Error(
-          `reference-fields.json: ${field.partName} REF "${action.target}" expected cached result ` +
-          `"${action.expected_cached_result}", found "${field.cachedResult}"`,
-        );
+    if ('groups' in action) {
+      const groupsByCache = new Map(action.groups.map((group) => [group.expected_cached_result, group]));
+      const actualByCache = new Map<string, FieldMatch[]>();
+      for (const field of actionFields) {
+        const group = groupsByCache.get(field.cachedResult);
+        if (!group) {
+          throw new Error(
+            `reference-fields.json: ${field.partName} REF "${action.target}" has undeclared cached result "${field.cachedResult}"`,
+          );
+        }
+        const groupFields = actualByCache.get(field.cachedResult) ?? [];
+        groupFields.push(field);
+        actualByCache.set(field.cachedResult, groupFields);
+      }
+      for (const group of action.groups) {
+        const groupFields = actualByCache.get(group.expected_cached_result) ?? [];
+        if (groupFields.length !== group.expected_matches) {
+          throw new Error(
+            `reference-fields.json: target "${action.target}" cached-result group ` +
+            `"${group.expected_cached_result}" expected ${group.expected_matches} REF field match(es), found ${groupFields.length}`,
+          );
+        }
+        for (const field of groupFields) selected.push({ field, literal: group.literal });
+      }
+    } else {
+      for (const field of actionFields) {
+        if (field.cachedResult !== action.expected_cached_result) {
+          throw new Error(
+            `reference-fields.json: ${field.partName} REF "${action.target}" expected cached result ` +
+            `"${action.expected_cached_result}", found "${field.cachedResult}"`,
+          );
+        }
+        selected.push({ field, literal: action.literal });
       }
     }
-    selected.push({ action, fields: actionFields });
   }
 
-  for (const { action, fields: actionFields } of selected) {
-    for (const field of actionFields) field.replace(action.literal);
-  }
+  for (const { field, literal } of selected) field.replace(literal);
 
   const output = rezipWithoutDirEntries(source);
   for (const [partName, doc] of docs) {


### PR DESCRIPTION
Closes #771.

Adds a backwards-compatible grouped form of the v1 `reference-fields.json` action. One authoritative REF target can partition surviving fields by cached result and assign a distinct literal/count to each group. The schema rejects duplicate cached-result groups and incomplete count partitions. Runtime validation checks target count, total REF count, every declared group count, and undeclared cached results before any mutation.

Tests cover the `_Ref137784392` shape (one `2.3.2(b)`, two `(b)`) across atomic, complex, and split fields; duplicate target/group declarations; incomplete partitions; transaction rollback; and unrelated field preservation.

Verification: focused 12/12; full suite 122 passed + 4 skipped files, 1,422 passed + 7 skipped tests; build and lint pass.
