### PR TITLE
Fix ordinary cross-reference placeholder false positives

### DIFF
--- a/integration-tests/nvca-ira-drafting-choice-coverage.test.ts
+++ b/integration-tests/nvca-ira-drafting-choice-coverage.test.ts
@@ -3,6 +3,7 @@ import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect } from 'vitest';
 import { extractAllText, runFieldSelector } from '../src/core/field-selector/index.js';
+import { findLeftoverPlaceholders } from '../src/core/field-selector/verifier.js';
 import { itAllure } from './helpers/allure-test.js';
 
 const it = itAllure.epic('NVCA Forms').withLabels({ feature: 'Investor and Governance Agreements' });
@@ -31,6 +32,19 @@ async function fill(values: Record<string, unknown>, allowVerifyWarnings = false
 }
 
 describeWithSource('NVCA IRA drafting-choice coverage', () => {
+  it('does not classify the pinned source\'s operative Section 2.8 prose as a placeholder', () => {
+    const text = extractAllText(SOURCE);
+    expect(text.match(/this Section 2\.8/g)?.length).toBeGreaterThan(1);
+
+    const leftovers = findLeftoverPlaceholders(
+      SOURCE,
+      { 'this Section 2.8': 'this Section {indemnification_section}' },
+      SOURCE,
+    );
+
+    expect(leftovers).toEqual([]);
+  });
+
   it('fills the Major Investor and board-observer thresholds with contextual bindings', async () => {
     const text = await fill(FIXTURE);
 

--- a/src/core/field-selector/verifier.test.ts
+++ b/src/core/field-selector/verifier.test.ts
@@ -570,6 +570,32 @@ describe('findLeftoverPlaceholders', () => {
 
     cleanupDocx(docxPath);
   });
+
+  it('distinguishes ordinary section prose from a genuine unresolved source placeholder', async () => {
+    // Issue #772 red/green control: both keys survive, but only the bracketed
+    // drafting placeholder is signer-facing residue. The ordinary cross-reference
+    // may render to the same visible text after parameterization.
+    const sourcePath = buildTextDocx([
+      'A claim under this Section 2.8 survives termination.',
+      'Company: [Company Name]',
+    ]);
+    const outputPath = buildTextDocx([
+      'A claim under this Section 2.8 survives termination.',
+      'Company: [Company Name]',
+    ]);
+
+    const leftovers = findLeftoverPlaceholders(
+      outputPath,
+      {
+        'this Section 2.8': 'this Section {indemnification_section}',
+        '[Company Name]': '{company_name}',
+      },
+      sourcePath,
+    );
+
+    expect(leftovers).toEqual(['[Company Name]']);
+    cleanupDocx(sourcePath, outputPath);
+  });
 });
 
 describe('verifyOutput first-body-paragraph guard (issue #605)', () => {

--- a/src/core/field-selector/verifier.ts
+++ b/src/core/field-selector/verifier.ts
@@ -433,6 +433,26 @@ function countOccurrences(haystack: string, needle: string): number {
 }
 
 /**
+ * Whether replacement search text is itself a signer-facing source artifact.
+ *
+ * A replacement map can also carry ordinary prose in order to parameterize a
+ * value that may render back to the same visible text (for example, the IRA's
+ * repeated `this Section 2.8` cross-references).  Treating every replacement
+ * key as a placeholder makes that valid source-carried prose a false positive.
+ * Keep this check deliberately syntactic: brackets, blank lines, and explicit
+ * merge-token delimiters are artifacts; ordinary legal prose is not.
+ */
+function isSourcePlaceholderText(text: string): boolean {
+  return (
+    /\[[^\]]*\]/.test(text) ||
+    /_{2,}/.test(text) ||
+    /\{[a-z_][a-z0-9_]*\}/i.test(text) ||
+    /<<[^<>]+>>/.test(text) ||
+    /«[^»]+»/.test(text)
+  );
+}
+
+/**
  * Whether a context key has an unfilled placeholder at its qualified location,
  * mirroring how the patcher targets them:
  *  - Table-row context: a `searchText` survives in a paragraph whose row label
@@ -546,9 +566,11 @@ export function findLeftoverPlaceholders(
   const leftovers = new Set<string>();
   const outputFullText = normalizeQuotes(extractAllText(docxPath));
 
-  // Simple keys: whole-document search (any surviving occurrence is a leftover).
+  // Simple keys: whole-document search for actual placeholder-shaped source
+  // artifacts. Ordinary prose replacement keys are not placeholders and can
+  // legitimately render back to the same visible text.
   for (const text of simpleSearchTexts) {
-    if (outputFullText.includes(normalizeQuotes(text))) leftovers.add(text);
+    if (isSourcePlaceholderText(text) && outputFullText.includes(normalizeQuotes(text))) leftovers.add(text);
   }
 
   // Context keys: count baseline against the cleaned source, else qualified location.
@@ -558,6 +580,13 @@ export function findLeftoverPlaceholders(
       const sourceParagraphs = extractParagraphInfos(cleanedSourcePath);
       const outputParagraphs = extractParagraphInfos(docxPath);
       for (const ck of contextKeys) {
+        // An ordinary cross-reference can be a legitimate source-carried value.
+        // Preserve structural checking for Word REF results, which really must
+        // transition to ordinary text when declared for replacement.
+        if (!isSourcePlaceholderText(ck.searchText) &&
+            !hasQualifiedFieldBackedOccurrence(sourceParagraphs, ck.context, ck.searchText)) {
+          continue;
+        }
         const srcCount = countOccurrences(sourceFullText, ck.searchText);
         if (srcCount === 0) continue; // key does not apply to this document
         const outCount = countOccurrences(outputFullText, ck.searchText);
@@ -580,7 +609,8 @@ export function findLeftoverPlaceholders(
     } else {
       const outputParagraphs = extractParagraphInfos(docxPath);
       for (const ck of contextKeys) {
-        if (hasQualifiedLeftover(outputParagraphs, ck.context, ck.searchText)) {
+        if (isSourcePlaceholderText(ck.searchText) &&
+            hasQualifiedLeftover(outputParagraphs, ck.context, ck.searchText)) {
           leftovers.add(ck.label);
         }
       }


### PR DESCRIPTION
Closes #772.

## What changed
- limit leftover-source-placeholder detection to syntactic source artifacts (brackets, blank underscores, and explicit merge tokens)
- retain structural fail-closed detection for live Word REF fields
- add a red/green synthetic control with ordinary `this Section 2.8` prose beside a genuine unresolved placeholder
- add a regression against the hash-pinned NVCA Investors’ Rights Agreement source

## Verification
- `npm run lint`
- focused verifier + IRA tests: 58 passed
- full suite: 122 files passed, 4 skipped; 1,424 tests passed, 7 skipped