### PR TITLE
fix(verifier): block delivery of unresolved REF fields

### DIFF
--- a/integration-tests/nvca-round-date-series.test.ts
+++ b/integration-tests/nvca-round-date-series.test.ts
@@ -16,7 +16,7 @@
  * already appear in each template's replacements.json — the NVCA source
  * documents are not redistributable and are never embedded here.
  */
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import AdmZip from 'adm-zip';
@@ -111,7 +111,26 @@ async function fillFixture(
   const inputPath = join(tempDir, 'source.docx');
   const outputPath = join(tempDir, 'filled.docx');
   writeFileSync(inputPath, buildDocx(paragraphs));
-  await runFieldSelector({ fieldSelectorId, inputPath, outputPath, values });
+  // These deliberately tiny anchor fixtures test scalar date/round filling,
+  // not whole-source structural contracts. Give them a purpose-built recipe
+  // copy without full-source-only REF actions; faking all of the pinned NVCA
+  // bookmark targets here would make this test assert on invented structure.
+  const sourceRecipe = resolveFieldSelectorDir(fieldSelectorId);
+  const fixtureRoot = join(tempDir, 'fixture-content');
+  const fixtureRecipe = join(fixtureRoot, 'templates', 'test-fixtures', fieldSelectorId);
+  mkdirSync(fixtureRecipe, { recursive: true });
+  cpSync(sourceRecipe, fixtureRecipe, {
+    recursive: true,
+    filter: (source) => !source.endsWith('/reference-fields.json'),
+  });
+  const previousRoots = process.env.OPEN_AGREEMENTS_CONTENT_ROOTS;
+  process.env.OPEN_AGREEMENTS_CONTENT_ROOTS = fixtureRoot;
+  try {
+    await runFieldSelector({ fieldSelectorId, inputPath, outputPath, values });
+  } finally {
+    if (previousRoots === undefined) delete process.env.OPEN_AGREEMENTS_CONTENT_ROOTS;
+    else process.env.OPEN_AGREEMENTS_CONTENT_ROOTS = previousRoots;
+  }
   return readText(outputPath);
 }
 

--- a/src/core/field-selector/index.ts
+++ b/src/core/field-selector/index.ts
@@ -258,7 +258,7 @@ export { cleanDocument } from './cleaner.js';
 export type { CleanResult, CleanOptions } from './cleaner.js';
 export { patchDocument } from './patcher.js';
 export type { PatchResult } from './patcher.js';
-export { verifyOutput, normalizeText, extractAllText, countFormattingAnomalies } from './verifier.js';
+export { verifyOutput, validateWordFields, normalizeText, extractAllText, countFormattingAnomalies } from './verifier.js';
 export { ensureSourceDocx } from './downloader.js';
 export { checkFieldSelectorSourceDrift, checkSelectorDrift, computeSourceStructureSignature } from './source-drift.js';
 export { enumerateTextParts, getGeneralTextPartNames } from './ooxml-parts.js';

--- a/src/core/field-selector/types.ts
+++ b/src/core/field-selector/types.ts
@@ -42,4 +42,6 @@ export interface VerifyCheck {
   name: string;
   passed: boolean;
   details?: string;
+  /** A failed check that makes the artifact unsafe to deliver. */
+  fatal?: boolean;
 }

--- a/src/core/field-selector/verifier.test.ts
+++ b/src/core/field-selector/verifier.test.ts
@@ -3,7 +3,13 @@ import { join } from 'node:path';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import AdmZip from 'adm-zip';
-import { verifyOutput, normalizeText, findLeftoverPlaceholders, findRenderedTextArtifacts } from './verifier.js';
+import {
+  verifyOutput,
+  normalizeText,
+  findLeftoverPlaceholders,
+  findRenderedTextArtifacts,
+  validateWordFields,
+} from './verifier.js';
 import { patchDocument } from './patcher.js';
 import {
   allureJsonAttachment,
@@ -147,6 +153,93 @@ describe('verifyOutput note-reference cleanup', () => {
 });
 
 describe('verifyOutput', () => {
+  it('fails a REF whose target bookmark is absent with an actionable diagnostic', async () => {
+    const docxPath = buildDocx(
+      '<?xml version="1.0" encoding="UTF-8"?>' +
+      `<w:document xmlns:w="${W_NS}"><w:body><w:p>` +
+      '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+      '<w:r><w:instrText xml:space="preserve"> REF MissingSection \\h </w:instrText></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+      '<w:r><w:t>Section 6.1</w:t></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="end"/></w:r>' +
+      '</w:p></w:body></w:document>',
+    );
+
+    const result = await verifyOutput(docxPath, {}, {});
+    const check = result.checks.find((c) => c.name === 'Word REF fields resolve');
+    expect(check).toMatchObject({ passed: false, fatal: true });
+    expect(check?.details).toContain('word/document.xml');
+    expect(check?.details).toContain('MissingSection');
+    expect(check?.details).toContain('REF MissingSection');
+    cleanupDocx(docxPath);
+  });
+
+  it('accepts a valid REF and its cached visible result', async () => {
+    const docxPath = buildDocx(
+      '<?xml version="1.0" encoding="UTF-8"?>' +
+      `<w:document xmlns:w="${W_NS}"><w:body>` +
+      '<w:p><w:bookmarkStart w:id="0" w:name="Section_6_1"/><w:r><w:t>6.1</w:t></w:r><w:bookmarkEnd w:id="0"/></w:p>' +
+      '<w:p><w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+      '<w:r><w:instrText xml:space="preserve"> REF Section_6_1 \\h </w:instrText></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+      '<w:r><w:t>Section 6.1 (cached)</w:t></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="end"/></w:r></w:p>' +
+      '</w:body></w:document>',
+    );
+
+    expect(validateWordFields(docxPath)).toEqual([]);
+    const result = await verifyOutput(docxPath, {}, {});
+    expect(result.checks.find((c) => c.name === 'Word REF fields resolve')?.passed).toBe(true);
+    cleanupDocx(docxPath);
+  });
+
+  it('recognizes a REF instruction split across runs', async () => {
+    const docxPath = buildDocx(
+      '<?xml version="1.0" encoding="UTF-8"?>' +
+      `<w:document xmlns:w="${W_NS}"><w:body>` +
+      '<w:p><w:bookmarkStart w:id="0" w:name="SplitTarget"/><w:r><w:t>Target</w:t></w:r><w:bookmarkEnd w:id="0"/></w:p>' +
+      '<w:p><w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+      '<w:r><w:instrText> RE</w:instrText></w:r><w:r><w:instrText>F Split</w:instrText></w:r>' +
+      '<w:r><w:instrText>Target \\h </w:instrText></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="separate"/></w:r><w:r><w:t>Target</w:t></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="end"/></w:r></w:p>' +
+      '</w:body></w:document>',
+    );
+
+    expect(validateWordFields(docxPath)).toEqual([]);
+    cleanupDocx(docxPath);
+  });
+
+  it('reports an invalid REF field triplet', async () => {
+    const docxPath = buildDocx(
+      '<?xml version="1.0" encoding="UTF-8"?>' +
+      `<w:document xmlns:w="${W_NS}"><w:body><w:p>` +
+      '<w:bookmarkStart w:id="0" w:name="PresentTarget"/><w:bookmarkEnd w:id="0"/>' +
+      '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+      '<w:r><w:instrText> REF PresentTarget </w:instrText></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="end"/></w:r>' +
+      '</w:p></w:body></w:document>',
+    );
+
+    const diagnostics = validateWordFields(docxPath);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toContain('PresentTarget');
+    expect(diagnostics[0]).toContain('missing separate marker');
+    cleanupDocx(docxPath);
+  });
+
+  it('validates atomic fldSimple REF fields', async () => {
+    const validPath = buildDocx(
+      '<?xml version="1.0" encoding="UTF-8"?>' +
+      `<w:document xmlns:w="${W_NS}"><w:body><w:p>` +
+      '<w:bookmarkStart w:id="0" w:name="AtomicTarget"/><w:bookmarkEnd w:id="0"/>' +
+      '<w:fldSimple w:instr=" REF AtomicTarget \\h "><w:r><w:t>cached</w:t></w:r></w:fldSimple>' +
+      '</w:p></w:body></w:document>',
+    );
+    expect(validateWordFields(validPath)).toEqual([]);
+    cleanupDocx(validPath);
+  });
+
   it('skips empty string values', async () => {
     const xml =
       '<?xml version="1.0" encoding="UTF-8"?>' +

--- a/src/core/field-selector/verifier.ts
+++ b/src/core/field-selector/verifier.ts
@@ -1,6 +1,6 @@
 import AdmZip from 'adm-zip';
 import { DOMParser } from '@xmldom/xmldom';
-import type { Element } from '@xmldom/xmldom';
+import type { Document as XmlDocument, Element } from '@xmldom/xmldom';
 import { getParagraphText } from '@usejunior/docx-core';
 import type { VerifyResult, VerifyCheck } from './types.js';
 import { cleanConfigRemovesBodyContent, type CleanConfig } from '../metadata.js';
@@ -59,6 +59,20 @@ export async function verifyOutput(
   const sigilText = footnoteText ? `${rawFullText}\n${footnoteText}` : rawFullText;
   const normalizedFullText = normalizeText(rawFullText);
   const xml = extractDocumentXml(outputPath);
+
+  // Check 0: Word cross-reference fields are structurally complete and point
+  // at bookmarks that actually exist. Cached field-result text can make a
+  // broken REF look correct until Word or LibreOffice refreshes fields, at
+  // which point it becomes "Error: Reference source not found." Validate the
+  // underlying OOXML instead of relying on renderer logs or cached display
+  // text. This check is fatal because the artifact is not safe to deliver.
+  const refDiagnostics = validateWordFields(outputPath);
+  checks.push({
+    name: 'Word REF fields resolve',
+    passed: refDiagnostics.length === 0,
+    details: refDiagnostics.length > 0 ? refDiagnostics.join('; ') : undefined,
+    fatal: true,
+  });
 
   // Check 1: All context values present (with normalization)
   const missingValues: string[] = [];
@@ -212,6 +226,113 @@ export async function verifyOutput(
     passed: checks.every((c) => c.passed),
     checks,
   };
+}
+
+interface ComplexFieldFrame {
+  instruction: string[];
+  hasSeparate: boolean;
+  partName: string;
+}
+
+function fieldInstruction(el: Element): string {
+  return el.getAttributeNS(W_NS, 'instr') || el.getAttribute('w:instr') || el.getAttribute('instr') || '';
+}
+
+function refTarget(instruction: string): string | undefined {
+  const match = instruction.match(/^\s*REF\s+(?:"([^"]+)"|([^\s\\]+))/i);
+  return match?.[1] ?? match?.[2];
+}
+
+function describeInstruction(instruction: string): string {
+  const compact = instruction.replace(/\s+/g, ' ').trim();
+  return compact || '(empty instruction)';
+}
+
+/**
+ * Return actionable diagnostics for malformed complex Word fields and REF
+ * instructions whose bookmark target is absent. Both atomic `w:fldSimple`
+ * fields and complex begin/instrText/separate/end fields are supported; field
+ * instructions may be split across any number of runs.
+ */
+export function validateWordFields(docxPath: string): string[] {
+  const zip = new AdmZip(docxPath);
+  const parser = new DOMParser();
+  const partNames = getGeneralTextPartNames(enumerateTextParts(zip));
+  const bookmarks = new Set<string>();
+  const docs: Array<{ partName: string; root: XmlDocument }> = [];
+
+  for (const partName of partNames) {
+    const entry = zip.getEntry(partName);
+    if (!entry) continue;
+    const root = parser.parseFromString(entry.getData().toString('utf-8'), 'text/xml');
+    docs.push({ partName, root });
+    const starts = root.getElementsByTagNameNS(W_NS, 'bookmarkStart');
+    for (let i = 0; i < starts.length; i++) {
+      const name = starts[i].getAttributeNS(W_NS, 'name') || starts[i].getAttribute('w:name');
+      if (name) bookmarks.add(name);
+    }
+  }
+
+  const diagnostics: string[] = [];
+  const inspectRef = (partName: string, instruction: string, malformed?: string): void => {
+    const target = refTarget(instruction);
+    if (!target) return;
+    const suffix = malformed ? `; invalid field triplet: ${malformed}` : '';
+    if (malformed || !bookmarks.has(target)) {
+      diagnostics.push(
+        `${partName}: REF target "${target}" ${malformed ? 'has an invalid field structure' : 'has no matching bookmark'} ` +
+        `(instruction: "${describeInstruction(instruction)}"${suffix})`,
+      );
+    }
+  };
+
+  for (const { partName, root } of docs) {
+    const simpleFields = root.getElementsByTagNameNS(W_NS, 'fldSimple');
+    for (let i = 0; i < simpleFields.length; i++) {
+      inspectRef(partName, fieldInstruction(simpleFields[i] as unknown as Element));
+    }
+
+    const stack: ComplexFieldFrame[] = [];
+    const visit = (node: Node): void => {
+      if (node.nodeType === 1) {
+        const el = node as unknown as Element;
+        if (el.namespaceURI === W_NS && el.localName === 'fldChar') {
+          const type = el.getAttributeNS(W_NS, 'fldCharType') || el.getAttribute('w:fldCharType');
+          if (type === 'begin') {
+            stack.push({ instruction: [], hasSeparate: false, partName });
+          } else if (type === 'separate') {
+            const frame = stack[stack.length - 1];
+            if (!frame) diagnostics.push(`${partName}: invalid field triplet: orphan separate marker`);
+            else if (frame.hasSeparate) diagnostics.push(`${partName}: invalid field triplet: duplicate separate marker`);
+            else frame.hasSeparate = true;
+          } else if (type === 'end') {
+            const frame = stack.pop();
+            if (!frame) {
+              diagnostics.push(`${partName}: invalid field triplet: orphan end marker`);
+            } else {
+              inspectRef(partName, frame.instruction.join(''), frame.hasSeparate ? undefined : 'missing separate marker');
+            }
+          }
+          return;
+        }
+        if (el.namespaceURI === W_NS && el.localName === 'instrText' && stack.length > 0) {
+          const frame = stack[stack.length - 1];
+          if (!frame.hasSeparate) frame.instruction.push(el.textContent ?? '');
+          return;
+        }
+      }
+      for (let child = node.firstChild; child; child = child.nextSibling) visit(child);
+    };
+    visit(root as unknown as Node);
+    for (const frame of stack) {
+      const instruction = frame.instruction.join('');
+      const target = refTarget(instruction);
+      if (target) inspectRef(partName, instruction, 'missing end marker');
+      else diagnostics.push(`${partName}: invalid field triplet: missing end marker (instruction: "${describeInstruction(instruction)}")`);
+    }
+  }
+
+  return [...new Set(diagnostics)];
 }
 
 /**

--- a/src/core/unified-pipeline.test.ts
+++ b/src/core/unified-pipeline.test.ts
@@ -1,10 +1,10 @@
 import AdmZip from 'adm-zip';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect } from 'vitest';
 import { itAllure } from '../../integration-tests/helpers/allure-test.js';
-import { normalizeEmptyFillWhitespaceInDocx } from './unified-pipeline.js';
+import { normalizeEmptyFillWhitespaceInDocx, runFillPipeline } from './unified-pipeline.js';
 
 const it = itAllure.epic('Filling & Rendering');
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
@@ -34,6 +34,55 @@ describe('empty-fill whitespace normalization', () => {
     expect(xml).toContain('Directors</w:t>');
     expect(xml).toContain('REF _Ref1');
     expect(xml).toContain('xml:space="preserve"> , next');
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe('fatal delivery verification', () => {
+  it('does not overwrite the requested output when a fatal check fails', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'oa-fatal-delivery-'));
+    const inputPath = join(dir, 'input.docx');
+    const outputPath = join(dir, 'output.docx');
+    const sentinel = Buffer.from('pre-existing output');
+    const zip = new AdmZip();
+    zip.addFile('[Content_Types].xml', Buffer.from(
+      '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">' +
+      '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+      '<Default Extension="xml" ContentType="application/xml"/>' +
+      '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+      '</Types>',
+    ));
+    zip.addFile('_rels/.rels', Buffer.from(
+      '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+      '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>' +
+      '</Relationships>',
+    ));
+    zip.addFile('word/_rels/document.xml.rels', Buffer.from(
+      '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"/>',
+    ));
+    zip.addFile('word/document.xml', Buffer.from(
+      `<w:document xmlns:w="${W}"><w:body><w:p><w:r><w:t>Ordinary text</w:t></w:r></w:p></w:body></w:document>`,
+    ));
+    zip.writeZip(inputPath);
+    writeFileSync(outputPath, sentinel);
+
+    await expect(runFillPipeline({
+      inputPath,
+      outputPath,
+      values: {},
+      fields: [],
+      verify: () => ({
+        passed: false,
+        checks: [{
+          name: 'Word REF fields resolve',
+          passed: false,
+          fatal: true,
+          details: 'word/document.xml: REF target "Missing" has no matching bookmark',
+        }],
+      }),
+    })).rejects.toThrow(/Delivery blocked.*Missing/);
+
+    expect(readFileSync(outputPath)).toEqual(sentinel);
     rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/src/core/unified-pipeline.ts
+++ b/src/core/unified-pipeline.ts
@@ -421,20 +421,23 @@ export async function runFillPipeline(options: PipelineOptions): Promise<Pipelin
     // Collapse double spaces left by empty field substitutions (e.g. {initial_word_lower} → "")
     await normalizeEmptyFillWhitespaceInDocx(filledPath);
 
-    // Step 7: Copy to output
-    copyFileSync(filledPath, outputPath);
+    // Step 7: Stage a delivery candidate. Fatal structural verification runs
+    // against this temporary file before the caller's output path is touched.
+    const deliveryCandidatePath = join(tempDir, 'delivery-candidate.docx');
+    copyFileSync(filledPath, deliveryCandidatePath);
 
     // Optional post-processing for field-selector-specific normalization.
     if (postProcess) {
-      await postProcess(outputPath);
+      await postProcess(deliveryCandidatePath);
       // Declarative post-processing can itself remove an optional carrier and
       // expose the same empty-value whitespace seam, so normalize once more on
       // the final artifact.
-      await normalizeEmptyFillWhitespaceInDocx(outputPath);
+      await normalizeEmptyFillWhitespaceInDocx(deliveryCandidatePath);
     }
 
-    // Step 8: Verify — failures surface to callers via warnings (soft; no throw)
-    const verifyResult = await verify(outputPath, cleanedSourcePath, referencedIdentifiers);
+    // Step 8: Verify. Fatal structural failures refuse delivery; established
+    // advisory checks continue to surface as warnings for compatibility.
+    const verifyResult = await verify(deliveryCandidatePath, cleanedSourcePath, referencedIdentifiers);
     if (!verifyResult.passed) {
       const failedChecks = verifyResult.checks.filter((c) => !c.passed);
       const failures = failedChecks
@@ -444,7 +447,17 @@ export async function runFillPipeline(options: PipelineOptions): Promise<Pipelin
       for (const check of failedChecks) {
         warnings.push(`verify: ${check.name}: ${check.details ?? 'failed'}`);
       }
+      const fatalChecks = failedChecks.filter((check) => check.fatal);
+      if (fatalChecks.length > 0) {
+        throw new Error(
+          `Delivery blocked by fatal verification: ${fatalChecks
+            .map((check) => `${check.name}: ${check.details ?? 'failed'}`)
+            .join('; ')}`,
+        );
+      }
     }
+
+    copyFileSync(deliveryCandidatePath, outputPath);
 
     if (keepIntermediate) {
       console.log(`Intermediate files preserved at: ${tempDir}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,6 +86,7 @@ export { validateTemplate, type TemplateValidationResult } from './core/validati
 export { validateLicense, type LicenseValidationResult } from './core/validation/license.js';
 export { validateOutput, type OutputValidationResult } from './core/validation/output.js';
 export { validateFieldSelector, type FieldSelectorValidationResult } from './core/validation/field-selector.js';
+export { validateWordFields } from './core/field-selector/verifier.js';
 export { validateExternal, type ExternalValidationResult } from './core/validation/external.js';
 export {
   assessScanMetadataCoverage,

--- a/templates/nvca-free-non-redistributable/nvca-certificate-of-incorporation/reference-fields.json
+++ b/templates/nvca-free-non-redistributable/nvca-certificate-of-incorporation/reference-fields.json
@@ -1,0 +1,71 @@
+{
+  "version": 1,
+  "actions": [
+    {
+      "target": "_Ref264021278",
+      "strategy": "literalize",
+      "literal": "5A.1",
+      "expected_cached_result": "5A.1",
+      "expected_matches": 4,
+      "expected_target_count": 1
+    },
+    {
+      "target": "_DV_M274",
+      "strategy": "literalize",
+      "literal": "6.1",
+      "expected_cached_result": "6.1",
+      "expected_matches": 3,
+      "expected_target_count": 1
+    },
+    {
+      "target": "_DV_M84",
+      "strategy": "literalize",
+      "literal": "2.1",
+      "expected_cached_result": "2.1",
+      "expected_matches": 7,
+      "expected_target_count": 1
+    },
+    {
+      "target": "_Ref264019869",
+      "strategy": "literalize",
+      "literal": "2.1",
+      "expected_cached_result": "2.1",
+      "expected_matches": 5,
+      "expected_target_count": 1
+    },
+    {
+      "target": "_DV_M92",
+      "strategy": "literalize",
+      "literal": "2.2",
+      "expected_cached_result": "2.2",
+      "expected_matches": 4,
+      "expected_target_count": 1
+    },
+    {
+      "target": "_Ref45879228",
+      "strategy": "literalize",
+      "literal": "4.4.4",
+      "expected_cached_result": "4.4.4",
+      "expected_matches": 4,
+      "expected_target_count": 1
+    },
+    {
+      "target": "_Ref137784392",
+      "strategy": "literalize",
+      "expected_matches": 3,
+      "expected_target_count": 1,
+      "groups": [
+        {
+          "expected_cached_result": "2.3.2(b)",
+          "literal": "2.3.2(b)",
+          "expected_matches": 1
+        },
+        {
+          "expected_cached_result": "(b)",
+          "literal": "(b)",
+          "expected_matches": 2
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- validate complex and atomic Word REF fields against bookmark targets across document parts
- fail before overwriting the requested output when REF structure or targets are invalid
- report the package part, instruction, and missing target without relying on renderer logs
- project the canonical COI reference-field contract from UseJunior/legal-explainer#2471
- keep synthetic partial-source date fixtures isolated from full-source structural contracts

## Tests
- `npm run test:run` — 122 files passed, 4 skipped; 1,430 tests passed, 7 skipped
- regression coverage for missing targets, valid cached results, split instruction runs, atomic fields, malformed triplets, actionable diagnostics, and no-overwrite delivery behavior

Closes #758
Canonical recipe fix: UseJunior/legal-explainer#2468