### PR TITLE
fix(cleaner): remove declared header/footer paragraphs

### DIFF
--- a/integration-tests/nvca-indemn-mrl-production.test.ts
+++ b/integration-tests/nvca-indemn-mrl-production.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect } from 'vitest';
-import { extractAllText, runFieldSelector } from '../src/core/field-selector/index.js';
+import { cleanDocument, extractAllText, runFieldSelector } from '../src/core/field-selector/index.js';
 import { itAllure } from './helpers/allure-test.js';
 
 const it = itAllure.epic('NVCA Forms').withLabels({ feature: 'Ancillary Agreements' });
@@ -13,11 +13,13 @@ const CASES = {
     id: 'nvca-indemnification-agreement',
     sha256: 'f9b61b4d99e245573de41d9469925b4332f871ec0e6ac6593055cdfe17825300',
     fixture: 'indemnification-agreement-production-full.json',
+    disclaimerPart: 'header3.xml',
   },
   managementRights: {
     id: 'nvca-management-rights-letter',
     sha256: '9661d2a68ca20ee77cf553f1ec5804f08147e7e4c35f5a03938e76a778083e8b',
     fixture: 'management-rights-letter-production-full.json',
+    disclaimerPart: 'header1.xml',
   },
 } as const;
 
@@ -46,6 +48,33 @@ describeWithSources('NVCA Indemnification Agreement and Management Rights Letter
     for (const { id, sha256 } of Object.values(CASES)) {
       const actual = createHash('sha256').update(readFileSync(sourcePath(id))).digest('hex');
       expect(actual).toBe(sha256);
+    }
+  });
+
+  it('removes the source disclaimer from the exact declared header stories', async () => {
+    const disclaimer = 'This sample document is the work product of a national coalition of attorneys';
+    for (const { id, disclaimerPart } of Object.values(CASES)) {
+      const dir = mkdtempSync(join(tmpdir(), 'nvca-story-cleanup-'));
+      try {
+        const source = sourcePath(id);
+        const outputPath = join(dir, `${id}.docx`);
+        expect(extractAllText(source)).toContain(disclaimer);
+        await cleanDocument(source, outputPath, {
+          removeFootnotes: false,
+          removeParagraphPatterns: [],
+          removeRanges: [],
+          clearParts: [],
+          removeStoryParagraphs: [{
+            id: 'remove-source-disclaimer',
+            part: disclaimerPart,
+            pattern: `^${disclaimer}`,
+            expected_matches: 1,
+          }],
+        });
+        expect(extractAllText(outputPath)).not.toContain(disclaimer);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
     }
   });
 

--- a/src/core/field-selector/cleaner.test.ts
+++ b/src/core/field-selector/cleaner.test.ts
@@ -79,6 +79,26 @@ function addNotesPart(docxPath: string, kind: 'footnote' | 'endnote', ids: numbe
   zip.writeZip(docxPath);
 }
 
+function addStoryPart(docxPath: string, partName: string, paragraphs: string[]): void {
+  const zip = new AdmZip(docxPath);
+  const root = partName.includes('header') ? 'hdr' : 'ftr';
+  const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:${root} xmlns:w="${W_NS}">${paragraphs.map((text, index) =>
+    `<w:p><w:pPr><w:pStyle w:val="Story${index}"/></w:pPr><w:r><w:rPr><w:b/></w:rPr><w:t>${text}</w:t></w:r></w:p>`,
+  ).join('')}</w:${root}>`;
+  zip.addFile(`word/${partName}`, Buffer.from(xml, 'utf-8'));
+  zip.writeZip(docxPath);
+}
+
+function extractPartParaTexts(docxPath: string, partName: string): string[] {
+  const zip = new AdmZip(docxPath);
+  const entry = zip.getEntry(`word/${partName}`);
+  if (!entry) return [];
+  const doc = new DOMParser().parseFromString(entry.getData().toString('utf-8'), 'text/xml');
+  const paragraphs = doc.getElementsByTagNameNS(W_NS, 'p');
+  return Array.from({ length: paragraphs.length }, (_, index) => paragraphs[index].textContent ?? '');
+}
+
 describe('cleanDocument removeFootnotes inline references', () => {
   it('removes footnote and endnote reference-only runs and leaves scan/render views consistent', async () => {
     const inputPath = buildTestDocxRaw([
@@ -355,6 +375,60 @@ describe('cleanDocument removeBeforePattern', () => {
     ]);
 
     rmSync(outputDir, { recursive: true, force: true });
+  });
+});
+
+describe('cleanDocument removeStoryParagraphs', () => {
+  it('requires an explicit story rule before removing a matching header/footer paragraph', async () => {
+    const inputPath = buildTestDocx(['Body execution text']);
+    addStoryPart(inputPath, 'header1.xml', ['Source guidance', 'Active letterhead']);
+    addStoryPart(inputPath, 'header2.xml', ['Source guidance', 'Second-section heading']);
+    addStoryPart(inputPath, 'footer1.xml', ['Source guidance', 'Page footer']);
+    const unchangedPath = inputPath.replace('input.docx', 'unchanged.docx');
+    const cleanedPath = inputPath.replace('input.docx', 'cleaned.docx');
+
+    await cleanDocument(inputPath, unchangedPath, makeConfig());
+    expect(extractPartParaTexts(unchangedPath, 'header1.xml')).toContain('Source guidance');
+    expect(extractPartParaTexts(unchangedPath, 'footer1.xml')).toContain('Source guidance');
+
+    await cleanDocument(inputPath, cleanedPath, makeConfig({
+      removeStoryParagraphs: [
+        { id: 'header-guidance', part: 'header1.xml', pattern: '^Source guidance$', expected_matches: 1 },
+        { id: 'footer-guidance', part: 'word/footer1.xml', pattern: '^Source guidance$', expected_matches: 1 },
+      ],
+    }));
+
+    expect(extractPartParaTexts(cleanedPath, 'header1.xml')).toEqual(['Active letterhead']);
+    expect(partXml(cleanedPath, 'word/header1.xml')).toContain('<w:b/>');
+    expect(extractPartParaTexts(cleanedPath, 'footer1.xml')).toEqual(['Page footer']);
+    expect(extractPartParaTexts(cleanedPath, 'header2.xml')).toEqual([
+      'Source guidance',
+      'Second-section heading',
+    ]);
+    expect(extractParaTexts(cleanedPath)).toEqual(['Body execution text']);
+
+    rmSync(inputPath.replace('/input.docx', ''), { recursive: true, force: true });
+  });
+
+  it.each([
+    ['missing part', 'header9.xml', '^Source guidance$', 1, /found 0 \(part missing\)/],
+    ['missing paragraph', 'header1.xml', '^Absent$', 1, /found 0$/],
+    ['ambiguous paragraph', 'header1.xml', '^Source guidance$', 1, /found 2$/],
+  ])('fails closed for a %s', async (_case, part, pattern, expectedMatches, error) => {
+    const inputPath = buildTestDocx(['Body execution text']);
+    addStoryPart(inputPath, 'header1.xml', ['Source guidance', 'Source guidance']);
+    const outputPath = inputPath.replace('input.docx', 'output.docx');
+
+    await expect(cleanDocument(inputPath, outputPath, makeConfig({
+      removeStoryParagraphs: [{
+        id: 'declared-cleanup',
+        part,
+        pattern,
+        expected_matches: expectedMatches,
+      }],
+    }))).rejects.toThrow(error);
+
+    rmSync(inputPath.replace('/input.docx', ''), { recursive: true, force: true });
   });
 });
 

--- a/src/core/field-selector/cleaner.ts
+++ b/src/core/field-selector/cleaner.ts
@@ -79,6 +79,39 @@ export async function cleanDocument(
   // Media part names dereferenced by removed drawings (orphan candidates)
   const orphanMediaCandidates = new Set<string>();
 
+  // Header/footer stories can carry source-only guidance independently from
+  // the body. Remove only recipe-declared paragraphs and require an exact
+  // match count so an upstream source change cannot silently delete operative
+  // letterhead (or leave a disclaimer in the execution copy).
+  for (const rule of config.removeStoryParagraphs ?? []) {
+    const partName = rule.part.startsWith('word/') ? rule.part : `word/${rule.part}`;
+    const entry = zip.getEntry(partName);
+    if (!entry) {
+      throw new Error(
+        `removeStoryParagraphs "${rule.id}" expected ${rule.expected_matches} match(es) in ${partName}, found 0 (part missing)`,
+      );
+    }
+    const doc = parser.parseFromString(entry.getData().toString('utf-8'), 'text/xml');
+    const matches = matchingParagraphs(doc, rule.pattern);
+    if (matches.length !== rule.expected_matches) {
+      throw new Error(
+        `removeStoryParagraphs "${rule.id}" expected ${rule.expected_matches} match(es) in ${partName}, found ${matches.length}`,
+      );
+    }
+    for (const paragraph of matches) {
+      if (extract) {
+        entries.push({
+          source: 'pattern',
+          part: partName,
+          index: indexCounter++,
+          text: extractParagraphText(paragraph),
+        });
+      }
+      paragraph.parentNode?.removeChild(paragraph);
+    }
+    modifiedParts.set(partName, Buffer.from(serializer.serializeToString(doc), 'utf-8'));
+  }
+
   // Clear specified parts (replace content with minimal valid XML)
   if (config.clearParts && config.clearParts.length > 0) {
     for (const entry of zip.getEntries()) {
@@ -449,6 +482,18 @@ function removeParagraphsByPattern(doc: Document, patterns: string[]): void {
   for (const para of toRemove) {
     para.parentNode?.removeChild(para);
   }
+}
+
+function matchingParagraphs(doc: Document, pattern: string): Element[] {
+  const regex = new RegExp(pattern, 'i');
+  const paragraphs = doc.getElementsByTagNameNS(W_NS, 'p');
+  const matches: Element[] = [];
+  for (let i = 0; i < paragraphs.length; i++) {
+    const paragraph = paragraphs[i];
+    const text = extractParagraphText(paragraph);
+    if (text && regex.test(text)) matches.push(paragraph);
+  }
+  return matches;
 }
 
 /** Extract text from pattern-matched paragraphs, then remove them. */

--- a/src/core/metadata.test.ts
+++ b/src/core/metadata.test.ts
@@ -1014,9 +1014,39 @@ describe('CleanConfigSchema', () => {
     await allureStep('Assert clean config defaults', () => {
       expect(parsed.removeFootnotes).toBe(false);
       expect(parsed.removeParagraphPatterns).toEqual([]);
+      expect(parsed.removeStoryParagraphs).toBeUndefined();
       expect(parsed.removeHeaderFooterDrawings).toBeUndefined();
       expect(parsed.removeEmptyLeadingParagraphs).toBeUndefined();
     });
+  });
+
+  it('accepts fail-closed header/footer paragraph rules and rejects body parts', async () => {
+    await expectSafeParseOutcome(
+      'CleanConfigSchema',
+      CleanConfigSchema,
+      {
+        removeStoryParagraphs: [{
+          id: 'source-guidance',
+          part: 'word/header3.xml',
+          pattern: '^Source guidance$',
+          expected_matches: 1,
+        }],
+      },
+      true,
+    );
+    await expectSafeParseOutcome(
+      'CleanConfigSchema',
+      CleanConfigSchema,
+      {
+        removeStoryParagraphs: [{
+          id: 'unsafe-body-cleanup',
+          part: 'word/document.xml',
+          pattern: '.*',
+          expected_matches: 1,
+        }],
+      },
+      false,
+    );
   });
 
   it('accepts the issue-605 hardening fields', async () => {

--- a/src/core/metadata.ts
+++ b/src/core/metadata.ts
@@ -473,6 +473,21 @@ export const CleanConfigSchema = z.object({
   })).default([]),
   clearParts: z.array(z.string()).default([]),
   /**
+   * Remove narrowly identified paragraphs from a header/footer story.
+   *
+   * Story cleanup is opt-in because headers and footers may contain operative
+   * letterhead, dates, or signature-facing text. Each rule names one OOXML
+   * story part, supplies a paragraph regex, and declares the exact number of
+   * expected matches. Source drift therefore fails closed instead of clearing
+   * an entire story part or silently leaving source guidance behind.
+   */
+  removeStoryParagraphs: z.array(z.object({
+    id: z.string().min(1),
+    part: z.string().regex(/^(?:word\/)?(?:header|footer)\d+\.xml$/),
+    pattern: z.string().min(1),
+    expected_matches: z.number().int().positive(),
+  })).optional(),
+  /**
    * Strip <w:drawing>/<w:pict> runs from header/footer parts whose referenced
    * media exceeds the size threshold, plus the orphaned relationships and media
    * parts. Targets image-only content (e.g. a full-page "how to use this


### PR DESCRIPTION
Closes #776.

## What changed
- add opt-in `removeStoryParagraphs` rules scoped to a single header/footer OOXML part
- require exact match counts and fail closed on missing parts, missing matches, or ambiguity
- preserve all unrelated story formatting and body content
- cover unchanged-before/cleaned-after behavior across multiple header/footer stories
- exercise exact hash-pinned NVCA Indemnification and Management Rights source documents

The runtime contains no NVCA-specific text. Canonical recipe declarations are tracked upstream in UseJunior/legal-explainer#2482; this PR intentionally does not retain downstream-only recipe declarations.

## Verification
- `npm run build`
- `npm run lint`
- `npm run test:run` (122 files passed, 4 skipped; 1,436 tests passed, 7 skipped)
