### PR TITLE
Reject impossible ISO dates before document output

### DIFF
--- a/integration-tests/fill-pipeline.test.ts
+++ b/integration-tests/fill-pipeline.test.ts
@@ -710,28 +710,27 @@ describe('formatDocumentDate', () => {
     expect(formatDocumentDate(BLANK_PLACEHOLDER)).toBe(BLANK_PLACEHOLDER);
   });
 
-  it('passes through out-of-range or malformed ISO-shaped input unchanged', () => {
-    expect(formatDocumentDate('2026-13-01')).toBe('2026-13-01');
-    expect(formatDocumentDate('2026-00-10')).toBe('2026-00-10');
-    expect(formatDocumentDate('2026-07-00')).toBe('2026-07-00');
-    expect(formatDocumentDate('2026-07-32')).toBe('2026-07-32');
+  it('rejects out-of-range strict ISO-shaped input', () => {
+    for (const value of ['2026-13-01', '2026-00-10', '2026-07-00', '2026-07-32']) {
+      expect(() => formatDocumentDate(value)).toThrow(`Invalid ISO date "${value}"`);
+    }
+  });
+
+  it('passes through non-ISO input unchanged', () => {
     expect(formatDocumentDate('2026-7-5')).toBe('2026-7-5');
     expect(formatDocumentDate('07/15/2026')).toBe('07/15/2026');
   });
 
-  it('passes through impossible calendar dates unchanged (per-month day limits)', () => {
-    expect(formatDocumentDate('2026-02-31')).toBe('2026-02-31');
-    expect(formatDocumentDate('2026-02-30')).toBe('2026-02-30');
-    expect(formatDocumentDate('2026-04-31')).toBe('2026-04-31');
-    expect(formatDocumentDate('2026-06-31')).toBe('2026-06-31');
-    expect(formatDocumentDate('2026-09-31')).toBe('2026-09-31');
-    expect(formatDocumentDate('2026-11-31')).toBe('2026-11-31');
+  it('rejects impossible calendar dates (per-month day limits)', () => {
+    for (const value of ['2026-02-31', '2026-02-30', '2026-04-31', '2026-06-31', '2026-09-31', '2026-11-31']) {
+      expect(() => formatDocumentDate(value)).toThrow(`Invalid ISO date "${value}"`);
+    }
   });
 
   it('enforces leap-year rules for February 29 (deterministic, no Date)', () => {
-    // Non-leap years → Feb 29 is invalid, passed through.
-    expect(formatDocumentDate('2025-02-29')).toBe('2025-02-29');
-    expect(formatDocumentDate('2100-02-29')).toBe('2100-02-29'); // century, not /400
+    // Non-leap years → Feb 29 is invalid.
+    expect(() => formatDocumentDate('2025-02-29')).toThrow('Invalid ISO date "2025-02-29"');
+    expect(() => formatDocumentDate('2100-02-29')).toThrow('Invalid ISO date "2100-02-29"'); // century, not /400
     // Leap years → Feb 29 is valid, formatted.
     expect(formatDocumentDate('2024-02-29')).toBe('February 29, 2024');
     expect(formatDocumentDate('2000-02-29')).toBe('February 29, 2000'); // /400 leap
@@ -797,6 +796,32 @@ describe('prepareFillData date-typed field formatting', () => {
     });
     expect(result.effective_date).toBe(BLANK_PLACEHOLDER);
     expect(result.original_incorporation_date).toBe(BLANK_PLACEHOLDER);
+  });
+
+  it('rejects an impossible direct value and metadata default with the field name', () => {
+    expect(() => prepareFillData({
+      values: { effective_date: '2029-02-29' },
+      fields: dateFields,
+    })).toThrow('Invalid ISO date for field "effective_date": "2029-02-29"');
+
+    expect(() => prepareFillData({
+      values: {},
+      fields: [{ ...dateFields[0], default: '2026-04-31' }],
+    })).toThrow('Invalid ISO date for field "effective_date": "2026-04-31"');
+  });
+
+  it('formats and validates date fields nested in array rows', () => {
+    const fields = [{
+      name: 'signers', type: 'array' as const, description: 'Signers',
+      items: [{ name: 'signed_on', type: 'date' as const, description: 'Signature date' }],
+    }];
+    expect(prepareFillData({
+      values: { signers: [{ signed_on: '2024-02-29' }, { signed_on: 'March 1, 2024' }] },
+      fields,
+    }).signers).toEqual([{ signed_on: 'February 29, 2024' }, { signed_on: 'March 1, 2024' }]);
+    expect(() => prepareFillData({
+      values: { signers: [{ signed_on: '2029-02-29' }] }, fields,
+    })).toThrow('Invalid ISO date for field "signers[0].signed_on": "2029-02-29"');
   });
 });
 

--- a/src/core/field-selector/index.test.ts
+++ b/src/core/field-selector/index.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, vi } from 'vitest';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
@@ -346,6 +346,41 @@ describe('runFieldSelector', () => {
       reference_code: '2025-05-21',
     });
     expect(calls[1].values).toEqual({ company_name: 'Acme', reference_code: '2025-05-21' });
+  });
+
+  itFilling('rejects an impossible computed date before writing any artifact or document', async () => {
+    const fieldSelectorDir = createFieldSelectorFixture({
+      fields: [
+        '  - name: company_name',
+        '    type: string',
+        '    description: Company name',
+        '  - name: sunset_date',
+        '    type: date',
+        '    description: Sunset date',
+      ],
+      replacements: { '[Company Name]': '{company_name}', '[Sunset Date]': '{sunset_date}' },
+      computedProfile: {
+        rules: [{ id: 'derive-sunset', set_fill: { sunset_date: '2029-02-29' } }],
+      },
+    });
+    const outputPath = join(fieldSelectorDir, 'output.docx');
+    const computedOutPath = join(fieldSelectorDir, 'computed-output.json');
+    const runFillPipelineMock = vi.fn();
+    vi.doMock('../../utils/paths.js', () => ({ resolveFieldSelectorDir: () => fieldSelectorDir }));
+    vi.doMock('../unified-pipeline.js', () => ({ runFillPipeline: runFillPipelineMock }));
+    const { runFieldSelector } = await import('./index.js');
+
+    await expect(runFieldSelector({
+      fieldSelectorId: 'fixture-fieldSelector',
+      inputPath: '/tmp/input.docx',
+      outputPath,
+      computedOutPath,
+      values: { company_name: 'Acme Corp' },
+    })).rejects.toThrow('Invalid ISO date for field "sunset_date": "2029-02-29"');
+
+    expect(runFillPipelineMock).not.toHaveBeenCalled();
+    expect(existsSync(outputPath)).toBe(false);
+    expect(existsSync(computedOutPath)).toBe(false);
   });
 
   itFilling('uses downloader path when inputPath is omitted', async () => {

--- a/src/core/field-selector/index.ts
+++ b/src/core/field-selector/index.ts
@@ -112,9 +112,13 @@ export async function runFieldSelector(options: FieldSelectorRunOptions): Promis
   const computedEvaluation = computedProfile
     ? evaluateComputedProfile(computedProfile, computedInputValues)
     : null;
-  const effectiveValues = computedEvaluation
+  const mergedValues = computedEvaluation
     ? { ...inputValues, ...computedEvaluation.fillValues }
     : inputValues;
+  // Computed rules may populate a date-typed field. Apply the same strict
+  // formatting/validation boundary to derived values as direct inputs before
+  // writing either the computed trace or the document output.
+  const effectiveValues = formatDocumentDateFields(mergedValues, metadata.fields);
   const verificationValues: Record<string, string> = {};
   for (const field of metadata.fields) {
     if (!replacementFieldNames.has(field.name)) {

--- a/src/core/fill-pipeline.ts
+++ b/src/core/fill-pipeline.ts
@@ -127,14 +127,10 @@ const MONTH_NAMES = [
  * and `toLocaleDateString` can render the previous calendar day in
  * negative-offset timezones — and never calls any locale/`Intl` API.
  *
- * Any value that is not a strict `YYYY-MM-DD` string denoting a REAL calendar
- * date is returned UNCHANGED. Beyond the coarse month (01–12) / day (01–31)
- * range, per-month day limits and leap years are enforced, so impossible dates
- * ("2026-02-31", "2025-02-29") are never dressed up as an authoritative document
- * date — they fall through exactly like a non-ISO string. This preserves
- * backward compatibility for callers/fixtures that already supply a display-ready
- * date string (e.g. "March 20, 2026") and passes through empty-but-non-null
- * placeholders (`''`, the blank placeholder) untouched.
+ * Non-ISO values are returned unchanged so callers may continue supplying a
+ * display-ready date string (e.g. "March 20, 2026"). A strict ISO-shaped value
+ * is a machine-readable assertion, however, so an impossible calendar date is
+ * rejected rather than copied into a legal document unchanged.
  */
 export function formatDocumentDate(value: string): string {
   const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
@@ -142,13 +138,17 @@ export function formatDocumentDate(value: string): string {
   const yearStr = match[1];
   const month = Number(match[2]);
   const day = Number(match[3]);
-  if (month < 1 || month > 12 || day < 1) return value;
+  if (month < 1 || month > 12 || day < 1) {
+    throw new Error(`Invalid ISO date "${value}": expected a real calendar date in YYYY-MM-DD format`);
+  }
   // Reject impossible calendar dates (Feb 30/31, Apr 31, Feb 29 in a non-leap
   // year, …). Deterministic arithmetic only — no Date/locale.
   const year = Number(yearStr);
   const isLeapYear = (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
   const daysInMonth = [31, isLeapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
-  if (day > daysInMonth[month - 1]) return value;
+  if (day > daysInMonth[month - 1]) {
+    throw new Error(`Invalid ISO date "${value}": expected a real calendar date in YYYY-MM-DD format`);
+  }
   // Number(match[3]) drops the leading zero: "05" → 5. yearStr keeps any leading
   // zeros the (unrealistic) 4-digit year might carry.
   return `${MONTH_NAMES[month - 1]} ${day}, ${yearStr}`;
@@ -162,14 +162,32 @@ export function formatDocumentDate(value: string): string {
  */
 export function formatDocumentDateFields(
   values: Record<string, unknown>,
-  fields: FieldDefinition[]
+  fields: FieldDefinition[],
+  pathPrefix = ''
 ): Record<string, unknown> {
   const formatted = { ...values };
   for (const field of fields) {
-    if (field.type !== 'date') continue;
+    const fieldPath = pathPrefix ? `${pathPrefix}.${field.name}` : field.name;
     const value = formatted[field.name];
-    if (typeof value === 'string') {
-      formatted[field.name] = formatDocumentDate(value);
+    if (field.type === 'date' && typeof value === 'string') {
+      try {
+        formatted[field.name] = formatDocumentDate(value);
+      } catch {
+        throw new Error(
+          `Invalid ISO date for field "${fieldPath}": "${value}"; expected a real calendar date in YYYY-MM-DD format`
+        );
+      }
+      continue;
+    }
+    if (field.type === 'array' && field.items && Array.isArray(value)) {
+      formatted[field.name] = value.map((entry, index) => {
+        if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) return entry;
+        return formatDocumentDateFields(
+          entry as Record<string, unknown>,
+          field.items!,
+          `${fieldPath}[${index}]`
+        );
+      });
     }
   }
   return formatted;


### PR DESCRIPTION
Closes #778.

## What changed

- reject impossible strict ISO-shaped calendar dates with a field-aware error before document output
- preserve display-ready non-ISO date strings
- apply the same validation to direct values, metadata defaults, computed date outputs, and date fields nested in array rows
- keep failure atomic: neither the DOCX nor computed trace is written

## Verification

- `npm run lint`
- `npm run test:run` — 122 files passed, 4 skipped; 1,440 tests passed, 7 skipped
- focused date/field-selector run — 124 tests passed
