### PR TITLE
fix(runtime): validate staged source drift rules

### DIFF
--- a/integration-tests/source-drift-canary.test.ts
+++ b/integration-tests/source-drift-canary.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import AdmZip from 'adm-zip';
 import { afterEach, describe, expect } from 'vitest';
 import type { NormalizeConfig, FieldSelectorMetadata } from '../src/core/metadata.js';
+import { NormalizeConfigSchema } from '../src/core/metadata.js';
 import { checkFieldSelectorSourceDrift, checkSelectorDrift, computeSourceStructureSignature } from '../src/core/field-selector/source-drift.js';
 import type { FieldSelectorManifest } from '../src/core/selectors/index.js';
 import { itAllure } from './helpers/allure-test.js';
@@ -102,6 +103,43 @@ const NORMALIZE_CONFIG: NormalizeConfig = {
 };
 
 describe('source drift canary', () => {
+  it.each([
+    ['IRA selected paragraph', 'obligations to indemnify its officers and directors', 'selection'],
+    ['ROFR optional-block seam', 'Sanctioned Party. .', 'clean'],
+    ['Voting filled company consent', 'Comstock Fuels Corporation stockholder consent', 'fill'],
+    ['Voting filled company voting', 'Comstock Fuels Corporation voting agreement', 'fill'],
+  ])('checks raw rules against raw source but defers %s anchors to their declared stage', (_label, postAnchor, prerequisite) => {
+    const dir = mkdtempSync(join(tmpdir(), 'oa-source-drift-stage-'));
+    tempDirs.push(dir);
+    const sourcePath = join(dir, 'source.docx');
+    writeFileSync(sourcePath, buildDocx(['Raw Source Heading', 'Raw source anchor.']));
+
+    const normalizeConfig = NormalizeConfigSchema.parse({ paragraph_rules: [
+      {
+        id: 'raw-rule', section_heading: 'Raw Source Heading', paragraph_contains: 'Raw source anchor.',
+      },
+      {
+        id: 'post-rule', section_heading: '', ignore_heading: true, paragraph_contains: postAnchor,
+        expected_min_matches: 1, expected_max_matches: 1,
+        source_drift: { stage: 'post_transform', prerequisites: [prerequisite] },
+      },
+    ] });
+    const passing = checkFieldSelectorSourceDrift({
+      fieldSelectorId: 'synthetic', sourcePath, metadata: makeMetadata(sha256Hex(sourcePath)),
+      replacements: {}, normalizeConfig,
+    });
+    expect(passing.diff.missing_normalize_paragraph_anchors).toEqual([]);
+    expect(passing.ok).toBe(true);
+
+    normalizeConfig.paragraph_rules[0].paragraph_contains = 'Actually drifted raw anchor';
+    const drifted = checkFieldSelectorSourceDrift({
+      fieldSelectorId: 'synthetic', sourcePath, metadata: makeMetadata(sha256Hex(sourcePath)),
+      replacements: {}, normalizeConfig,
+    });
+    expect(drifted.diff.missing_normalize_paragraph_anchors).toEqual(['Actually drifted raw anchor']);
+    expect(drifted.ok).toBe(false);
+  });
+
   it('passes when hash and structural anchors match fieldSelector configuration', () => {
     const dir = mkdtempSync(join(tmpdir(), 'oa-source-drift-pass-'));
     tempDirs.push(dir);

--- a/src/core/field-selector/bracket-normalizer.test.ts
+++ b/src/core/field-selector/bracket-normalizer.test.ts
@@ -280,6 +280,27 @@ describe('normalizeBracketArtifacts', () => {
     );
   });
 
+  it('tracks expectation failures when a rule exceeds its maximum match bound', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'oa-bracket-normalizer-max-expectations-'));
+    tempDirs.push(dir);
+    const input = join(dir, 'input.docx');
+    const output = join(dir, 'output.docx');
+    writeFileSync(input, buildDocx(['Target seam.', 'Target seam.']));
+
+    const stats = await normalizeBracketArtifacts(input, output, {
+      rules: [{
+        id: 'duplicate-target', section_heading: '', ignore_heading: true,
+        paragraph_contains: 'Target seam.', replacements: { 'seam.': 'seam!' },
+        expected_min_matches: 1, expected_max_matches: 1,
+      }],
+    });
+
+    expect(stats.declarativeRuleMatchCounts['duplicate-target']).toBe(2);
+    expect(stats.declarativeRuleExpectationFailures).toContain(
+      'duplicate-target: expected at most 1 match(es), found 2'
+    );
+  });
+
   it('declarative rule preserves bold formatting on adjacent runs', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'oa-bracket-normalizer-bold-'));
     tempDirs.push(dir);

--- a/src/core/field-selector/bracket-normalizer.ts
+++ b/src/core/field-selector/bracket-normalizer.ts
@@ -36,6 +36,7 @@ export interface DeclarativeParagraphNormalizeRule {
   replacements?: Record<string, string>;
   trim_unmatched_trailing_bracket?: boolean;
   expected_min_matches?: number;
+  expected_max_matches?: number;
 }
 
 export interface DeclarativeNormalizeConfig {
@@ -186,11 +187,15 @@ export async function normalizeBracketArtifacts(
   }
 
   for (const rule of rules) {
-    if (rule.expected_min_matches === undefined) continue;
     const actualMatches = stats.declarativeRuleMatchCounts[rule.id] ?? 0;
-    if (actualMatches < rule.expected_min_matches) {
+    if (rule.expected_min_matches !== undefined && actualMatches < rule.expected_min_matches) {
       stats.declarativeRuleExpectationFailures.push(
         `${rule.id}: expected at least ${rule.expected_min_matches} match(es), found ${actualMatches}`
+      );
+    }
+    if (rule.expected_max_matches !== undefined && actualMatches > rule.expected_max_matches) {
+      stats.declarativeRuleExpectationFailures.push(
+        `${rule.id}: expected at most ${rule.expected_max_matches} match(es), found ${actualMatches}`
       );
     }
   }

--- a/src/core/field-selector/source-drift.ts
+++ b/src/core/field-selector/source-drift.ts
@@ -175,6 +175,7 @@ export function checkFieldSelectorSourceDrift(input: {
 
   const missingNormalizeHeadingAnchors = uniqueSorted(
     (normalizeConfig?.paragraph_rules ?? [])
+      .filter((rule) => rule.source_drift?.stage !== 'post_transform')
       .filter((rule) => !rule.ignore_heading)
       .filter((rule) => {
         const headingAnchors = [rule.section_heading, ...(rule.section_heading_any ?? [])];
@@ -185,12 +186,14 @@ export function checkFieldSelectorSourceDrift(input: {
 
   const missingNormalizeParagraphAnchors = uniqueSorted(
     (normalizeConfig?.paragraph_rules ?? [])
+      .filter((rule) => rule.source_drift?.stage !== 'post_transform')
       .map((rule) => rule.paragraph_contains)
       .filter((anchor) => !documentText.includes(anchor))
   );
 
   const missingNormalizeParagraphEndAnchors = uniqueSorted(
     (normalizeConfig?.paragraph_rules ?? [])
+      .filter((rule) => rule.source_drift?.stage !== 'post_transform')
       .map((rule) => rule.paragraph_end_contains)
       .filter((anchor): anchor is string => typeof anchor === 'string' && anchor.length > 0)
       .filter((anchor) => !documentText.includes(anchor))

--- a/src/core/metadata.ts
+++ b/src/core/metadata.ts
@@ -536,6 +536,14 @@ export function cleanConfigRemovesBodyContent(config: CleanConfig): boolean {
   );
 }
 
+const NormalizeSourceDriftSchema = z.discriminatedUnion('stage', [
+  z.object({ stage: z.literal('raw_source') }).strict(),
+  z.object({
+    stage: z.literal('post_transform'),
+    prerequisites: z.array(z.string().min(1)).min(1),
+  }).strict(),
+]);
+
 export const DeclarativeParagraphNormalizeRuleSchema = z.object({
   id: z.string(),
   section_heading: z.string(),
@@ -546,11 +554,79 @@ export const DeclarativeParagraphNormalizeRuleSchema = z.object({
   replacements: z.record(z.string(), z.string()).optional(),
   trim_unmatched_trailing_bracket: z.boolean().optional(),
   expected_min_matches: z.number().int().nonnegative().optional(),
-});
+  expected_max_matches: z.number().int().nonnegative().optional(),
+  source_drift: NormalizeSourceDriftSchema.optional(),
+}).strict();
 export type DeclarativeParagraphNormalizeRule = z.infer<typeof DeclarativeParagraphNormalizeRuleSchema>;
+
+const BUILTIN_NORMALIZE_PREREQUISITES = new Set(['clean', 'selection', 'fill']);
 
 export const NormalizeConfigSchema = z.object({
   paragraph_rules: z.array(DeclarativeParagraphNormalizeRuleSchema).default([]),
+}).strict().superRefine((config, ctx) => {
+  const idIndexes = new Map<string, number[]>();
+  config.paragraph_rules.forEach((rule, index) => {
+    const indexes = idIndexes.get(rule.id) ?? [];
+    indexes.push(index);
+    idIndexes.set(rule.id, indexes);
+  });
+
+  for (const [id, indexes] of idIndexes) {
+    if (indexes.length > 1) {
+      for (const index of indexes) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['paragraph_rules', index, 'id'], message: `duplicate normalize rule id creates ambiguous prerequisite: ${id}` });
+      }
+    }
+  }
+
+  const dependencies = new Map<string, string[]>();
+  config.paragraph_rules.forEach((rule, index) => {
+    const declaration = rule.source_drift;
+    if (declaration?.stage !== 'post_transform') return;
+    if (rule.expected_min_matches === undefined || rule.expected_max_matches === undefined) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['paragraph_rules', index, 'source_drift'], message: 'post_transform rules require expected_min_matches and expected_max_matches' });
+    } else if (rule.expected_max_matches < rule.expected_min_matches) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['paragraph_rules', index, 'expected_max_matches'], message: 'expected_max_matches must be greater than or equal to expected_min_matches' });
+    }
+
+    const ruleDependencies: string[] = [];
+    for (const prerequisite of declaration.prerequisites) {
+      if (BUILTIN_NORMALIZE_PREREQUISITES.has(prerequisite)) continue;
+      if (!prerequisite.startsWith('rule:')) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['paragraph_rules', index, 'source_drift', 'prerequisites'], message: `unknown post-transform prerequisite: ${prerequisite}` });
+        continue;
+      }
+      const prerequisiteId = prerequisite.slice('rule:'.length);
+      const prerequisiteIndexes = idIndexes.get(prerequisiteId);
+      if (!prerequisiteIndexes || prerequisiteIndexes.length !== 1) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['paragraph_rules', index, 'source_drift', 'prerequisites'], message: `unknown or ambiguous normalize rule prerequisite: ${prerequisite}` });
+        continue;
+      }
+      ruleDependencies.push(prerequisiteId);
+      if (prerequisiteIndexes[0] >= index) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['paragraph_rules', index, 'source_drift', 'prerequisites'], message: `normalize rule prerequisite must precede dependent rule: ${prerequisite}` });
+      }
+    }
+    dependencies.set(rule.id, ruleDependencies);
+  });
+
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+  const visit = (id: string): boolean => {
+    if (visiting.has(id)) return true;
+    if (visited.has(id)) return false;
+    visiting.add(id);
+    for (const dependency of dependencies.get(id) ?? []) if (visit(dependency)) return true;
+    visiting.delete(id);
+    visited.add(id);
+    return false;
+  };
+  for (const [id, indexes] of idIndexes) {
+    if (indexes.length === 1 && visit(id)) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['paragraph_rules', indexes[0], 'source_drift', 'prerequisites'], message: `normalize rule prerequisite cycle includes: ${id}` });
+      break;
+    }
+  }
 });
 export type NormalizeConfig = z.infer<typeof NormalizeConfigSchema>;
 

--- a/src/core/normalize-config-schema.test.ts
+++ b/src/core/normalize-config-schema.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { NormalizeConfigSchema } from './metadata.js';
+
+const rule = (id: string, overrides: Record<string, unknown> = {}) => ({
+  id,
+  section_heading: '',
+  ignore_heading: true,
+  paragraph_contains: id,
+  ...overrides,
+});
+
+describe('NormalizeConfigSchema staged source-drift declarations', () => {
+  it('accepts an ordered post-transform dependency graph with fail-closed bounds', () => {
+    expect(() => NormalizeConfigSchema.parse({ paragraph_rules: [
+      rule('first', { expected_min_matches: 1, expected_max_matches: 1, source_drift: { stage: 'post_transform', prerequisites: ['clean'] } }),
+      rule('second', { expected_min_matches: 1, expected_max_matches: 2, source_drift: { stage: 'post_transform', prerequisites: ['rule:first'] } }),
+    ] })).not.toThrow();
+  });
+
+  it.each([
+    ['missing prerequisite', { stage: 'post_transform', prerequisites: [] }],
+    ['unknown stage', { stage: 'after_magic', prerequisites: ['clean'] }],
+    ['unknown prerequisite', { stage: 'post_transform', prerequisites: ['magic'] }],
+  ])('rejects %s', (_label, source_drift) => {
+    expect(() => NormalizeConfigSchema.parse({ paragraph_rules: [
+      rule('post', { expected_min_matches: 1, expected_max_matches: 1, source_drift }),
+    ] })).toThrow();
+  });
+
+  it('rejects missing runtime bounds and inverted bounds', () => {
+    expect(() => NormalizeConfigSchema.parse({ paragraph_rules: [
+      rule('unbounded', { source_drift: { stage: 'post_transform', prerequisites: ['fill'] } }),
+    ] })).toThrow(/expected_min_matches and expected_max_matches/);
+    expect(() => NormalizeConfigSchema.parse({ paragraph_rules: [
+      rule('inverted', { expected_min_matches: 2, expected_max_matches: 1, source_drift: { stage: 'post_transform', prerequisites: ['fill'] } }),
+    ] })).toThrow(/greater than or equal/);
+  });
+
+  it('rejects duplicate ids as ambiguous', () => {
+    expect(() => NormalizeConfigSchema.parse({ paragraph_rules: [rule('same'), rule('same')] })).toThrow(/duplicate normalize rule id/);
+  });
+
+  it('rejects forward dependencies and cycles', () => {
+    expect(() => NormalizeConfigSchema.parse({ paragraph_rules: [
+      rule('first', { expected_min_matches: 1, expected_max_matches: 1, source_drift: { stage: 'post_transform', prerequisites: ['rule:second'] } }),
+      rule('second', { expected_min_matches: 1, expected_max_matches: 1, source_drift: { stage: 'post_transform', prerequisites: ['rule:first'] } }),
+    ] })).toThrow(/must precede|cycle/);
+  });
+});

--- a/src/core/normalize-config-schema.test.ts
+++ b/src/core/normalize-config-schema.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect } from 'vitest';
+import { itAllure } from '../../integration-tests/helpers/allure-test.js';
 import { NormalizeConfigSchema } from './metadata.js';
+
+const it = itAllure.epic('Verification & Drift');
 
 const rule = (id: string, overrides: Record<string, unknown> = {}) => ({
   id,


### PR DESCRIPTION
Closes #780.\n\n## Summary\n- add an explicit raw-source/post-transform source-drift declaration with prerequisite graph validation\n- keep raw rules strict while deferring only declared post-transform anchors\n- require fail-closed min/max runtime match bounds for deferred rules\n- reject unknown prerequisites/stages, duplicate ids, forward dependencies, cycles, and inverted bounds\n\n## Verification\n- focused staged canary/schema/runtime tests: 34 passed\n- full suite: 123 files passed, 4 skipped; 1,452 tests passed, 7 skipped\n- TypeScript build passed