### PR TITLE
feat(runtime): export canonical field-selector JSON Schemas

### DIFF
--- a/data/templates-snapshot.json
+++ b/data/templates-snapshot.json
@@ -12423,15 +12423,6 @@
           "default_value_rationale": null
         },
         {
-          "name": "registration_effectiveness_days",
-          "type": "string",
-          "required": false,
-          "section": null,
-          "description": "Base number of days a registration statement must remain effective",
-          "default": null,
-          "default_value_rationale": null
-        },
-        {
           "name": "information_right_holder_class",
           "type": "enum",
           "required": false,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -199,7 +199,7 @@ export function createProgram(): Command {
     .command('schema [field-selector-id]')
     .description('Export the canonical caller-input JSON Schema for one or all field-selectors')
     .option('-o, --output <path>', 'Write one schema to a file instead of stdout')
-    .option('--all', 'Export every field-selector schema plus a signed-by-hash manifest')
+    .option('--all', 'Export every field-selector schema plus a hash-pinned manifest')
     .option('--output-dir <path>', 'Directory for --all schema bundle')
     .option('--runtime-revision <sha>', 'Exact lowercase 40-character Git revision for --all provenance')
     .action((fieldSelectorId: string | undefined, opts: { output?: string; all?: boolean; outputDir?: string; runtimeRevision?: string }) => {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -7,6 +7,7 @@ import { runValidate } from '../commands/validate.js';
 import { runList } from '../commands/list.js';
 import { runTemplateShow } from '../commands/template.js';
 import { runFieldSelectorCommand, runFieldSelectorClean, runFieldSelectorPatch } from '../commands/field-selector.js';
+import { runFieldSelectorSchema } from '../commands/field-selector-schema.js';
 import { runScan } from '../commands/scan.js';
 import {
   runChecklistCreate,
@@ -193,6 +194,17 @@ export function createProgram(): Command {
 
   const fieldSelectorCmd = new Command('field-selector');
   fieldSelectorCmd.description('Work with field-selector-based document pipelines');
+
+  fieldSelectorCmd
+    .command('schema [field-selector-id]')
+    .description('Export the canonical caller-input JSON Schema for one or all field-selectors')
+    .option('-o, --output <path>', 'Write one schema to a file instead of stdout')
+    .option('--all', 'Export every field-selector schema plus a signed-by-hash manifest')
+    .option('--output-dir <path>', 'Directory for --all schema bundle')
+    .option('--runtime-revision <sha>', 'Exact lowercase 40-character Git revision for --all provenance')
+    .action((fieldSelectorId: string | undefined, opts: { output?: string; all?: boolean; outputDir?: string; runtimeRevision?: string }) => {
+      runFieldSelectorSchema({ fieldSelectorId, ...opts });
+    });
 
   fieldSelectorCmd
     .command('run <field-selector-id>')

--- a/src/commands/field-selector-schema.test.ts
+++ b/src/commands/field-selector-schema.test.ts
@@ -1,0 +1,39 @@
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { describe, expect, it, vi } from 'vitest';
+import { canonicalSha256, type FieldSelectorSchemaManifest } from '../core/field-selector/input-schema.js';
+import { runFieldSelectorSchema } from './field-selector-schema.js';
+
+describe('field-selector schema command', () => {
+  it('writes a complete deterministic bundle and reports its canonical hash', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'oa-schema-bundle-'));
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    runFieldSelectorSchema({
+      all: true,
+      outputDir: dir,
+      runtimeRevision: '0'.repeat(40),
+    });
+    const manifest = JSON.parse(readFileSync(join(dir, 'schema-manifest.json'), 'utf8')) as FieldSelectorSchemaManifest;
+    expect(manifest.runtime_revision).toBe('0'.repeat(40));
+    expect(manifest.schemas).toHaveLength(7);
+    expect(manifest.schemas.map((item) => item.field_selector_id)).toEqual(
+      [...manifest.schemas.map((item) => item.field_selector_id)].sort(),
+    );
+    for (const item of manifest.schemas) {
+      const schema = JSON.parse(readFileSync(join(dir, item.path), 'utf8')) as unknown;
+      expect(canonicalSha256(schema)).toBe(item.sha256);
+    }
+    expect(JSON.parse(String(log.mock.calls[0][0]))).toEqual({
+      manifest_path: 'schema-manifest.json',
+      manifest_sha256: canonicalSha256(manifest),
+    });
+    log.mockRestore();
+  });
+
+  it('rejects incomplete or ambiguous all-mode provenance', () => {
+    expect(() => runFieldSelectorSchema({ all: true })).toThrow(/output-dir/);
+    expect(() => runFieldSelectorSchema({ all: true, outputDir: '/tmp/x' })).toThrow(/runtime-revision/);
+    expect(() => runFieldSelectorSchema({ all: true, fieldSelectorId: 'x', outputDir: '/tmp/x', runtimeRevision: '0'.repeat(40) })).toThrow(/together/);
+  });
+});

--- a/src/commands/field-selector-schema.test.ts
+++ b/src/commands/field-selector-schema.test.ts
@@ -1,9 +1,12 @@
 import { mkdtempSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, vi } from 'vitest';
+import { itAllure } from '../../integration-tests/helpers/allure-test.js';
 import { canonicalSha256, type FieldSelectorSchemaManifest } from '../core/field-selector/input-schema.js';
 import { runFieldSelectorSchema } from './field-selector-schema.js';
+
+const it = itAllure.epic('Discovery & Metadata');
 
 describe('field-selector schema command', () => {
   it('writes a complete deterministic bundle and reports its canonical hash', () => {

--- a/src/commands/field-selector-schema.ts
+++ b/src/commands/field-selector-schema.ts
@@ -1,0 +1,64 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { basename, join, resolve } from 'node:path';
+import { readFileSync } from 'node:fs';
+import {
+  canonicalSha256,
+  getFieldSelectorInputSchema,
+  type FieldSelectorSchemaManifest,
+} from '../core/field-selector/input-schema.js';
+import { listFieldSelectorIds, resolveFieldSelectorDir } from '../utils/paths.js';
+
+export interface FieldSelectorSchemaArgs {
+  fieldSelectorId?: string;
+  output?: string;
+  all?: boolean;
+  outputDir?: string;
+  runtimeRevision?: string;
+}
+
+function packageVersion(): string {
+  return JSON.parse(readFileSync(new URL('../../package.json', import.meta.url), 'utf8')).version as string;
+}
+
+export function runFieldSelectorSchema(args: FieldSelectorSchemaArgs): void {
+  if (args.all) {
+    if (args.fieldSelectorId) throw new Error('Do not provide an id together with --all');
+    if (!args.outputDir) throw new Error('--all requires --output-dir');
+    if (!args.runtimeRevision || !/^[0-9a-f]{40}$/.test(args.runtimeRevision)) {
+      throw new Error('--all requires --runtime-revision with a lowercase 40-character Git SHA');
+    }
+    const outputDir = resolve(args.outputDir);
+    mkdirSync(outputDir, { recursive: true });
+    const schemas = listFieldSelectorIds().sort().map((fieldSelectorId) => {
+      const schema = getFieldSelectorInputSchema(fieldSelectorId, resolveFieldSelectorDir(fieldSelectorId));
+      const path = `${fieldSelectorId}.schema.json`;
+      writeFileSync(join(outputDir, path), `${JSON.stringify(schema, null, 2)}\n`);
+      return { field_selector_id: fieldSelectorId, path, sha256: canonicalSha256(schema) };
+    });
+    const manifest: FieldSelectorSchemaManifest = {
+      schema_version: 1,
+      generator: 'open-agreements field-selector schema --all',
+      package_version: packageVersion(),
+      runtime_revision: args.runtimeRevision,
+      canonicalization: 'RFC8785',
+      schemas,
+    };
+    const manifestPath = join(outputDir, 'schema-manifest.json');
+    writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+    console.log(JSON.stringify({
+      manifest_path: basename(manifestPath),
+      manifest_sha256: canonicalSha256(manifest),
+    }));
+    return;
+  }
+
+  if (!args.fieldSelectorId) throw new Error('Provide a field-selector id or --all');
+  const schema = getFieldSelectorInputSchema(
+    args.fieldSelectorId,
+    resolveFieldSelectorDir(args.fieldSelectorId),
+  );
+  const json = `${JSON.stringify(schema, null, 2)}\n`;
+  if (args.output) writeFileSync(resolve(args.output), json);
+  else process.stdout.write(json);
+}
+

--- a/src/core/field-selector/input-schema.test.ts
+++ b/src/core/field-selector/input-schema.test.ts
@@ -1,0 +1,116 @@
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+import { describe, expect, it } from 'vitest';
+import {
+  buildFieldSelectorInputSchema,
+  canonicalSha256,
+  computedFieldNames,
+  getFieldSelectorInputSchema,
+  type JsonSchema,
+} from './input-schema.js';
+import { loadComputedProfile } from './computed.js';
+import { loadFieldSelectorMetadata } from '../metadata.js';
+import { listFieldSelectorIds, resolveFieldSelectorDir } from '../../utils/paths.js';
+
+const NVCA_GOLDEN_HASHES: Record<string, string> = {
+  'nvca-certificate-of-incorporation': '532a0ce6922a8baa2097881f68ac139e68e91c331c44a375f5b415dfd53b4f3e',
+  'nvca-indemnification-agreement': '378070ff3d36bffc460b6b7d95a29f1c950c88f724fe90484260108900ac0b9b',
+  'nvca-investors-rights-agreement': '1d44d11fa4a0dc4513bf957b24a7b733c103670af2aa10d4f8375f5b5d016323',
+  'nvca-management-rights-letter': 'b0b62fcf846b49166a6c7045b6134cc4ca24dda6b07f459145b12324597cedf1',
+  'nvca-rofr-co-sale-agreement': 'a202c5bd4d08abafd5f67854e0a0ded2c0254d9a20c272022c50c6dc70f8c3b9',
+  'nvca-stock-purchase-agreement': '1fd6470a5f1b2280633f804de230ee6ecb6e936aa4e9dec25674fa0f7d97efe9',
+  'nvca-voting-agreement': '6959d714c6c0a444d8ea80e3558af516fa9bcf3ffdf95caccfa650ab9204fa63',
+};
+
+function validator(schema: JsonSchema) {
+  const ajv = new Ajv2020({ allErrors: true, strict: true });
+  addFormats(ajv);
+  ajv.addKeyword('x-openagreements');
+  return ajv.compile(schema);
+}
+
+describe('field-selector caller-input JSON Schema', () => {
+  it('has an intentional golden for every published NVCA field-selector', () => {
+    expect(listFieldSelectorIds().sort()).toEqual(Object.keys(NVCA_GOLDEN_HASHES).sort());
+    for (const [id, expected] of Object.entries(NVCA_GOLDEN_HASHES)) {
+      const schema = getFieldSelectorInputSchema(id, resolveFieldSelectorDir(id));
+      expect(canonicalSha256(schema), id).toBe(expected);
+      expect(() => validator(schema)).not.toThrow();
+    }
+  });
+
+  it('is generated from the exact validated metadata fields and excludes computed outputs', () => {
+    for (const id of listFieldSelectorIds()) {
+      const dir = resolveFieldSelectorDir(id);
+      const metadata = loadFieldSelectorMetadata(dir);
+      const computed = computedFieldNames(loadComputedProfile(dir));
+      const schema = buildFieldSelectorInputSchema(id, metadata, loadComputedProfile(dir));
+      const properties = schema.properties as Record<string, unknown>;
+      expect(Object.keys(properties)).toEqual(
+        metadata.fields.filter((field) => !computed.has(field.name)).map((field) => field.name),
+      );
+      expect(schema.required).toEqual(
+        metadata.priority_fields.filter((name) => !computed.has(name)),
+      );
+      expect(schema.additionalProperties).toBe(false);
+      for (const name of computed) expect(properties).not.toHaveProperty(name);
+    }
+  });
+
+  it('closes and strongly types representative repeatable-array row objects', () => {
+    const schema = getFieldSelectorInputSchema(
+      'nvca-stock-purchase-agreement',
+      resolveFieldSelectorDir('nvca-stock-purchase-agreement'),
+    );
+    const purchaser = ((schema.properties as Record<string, JsonSchema>).purchasers.items as JsonSchema);
+    expect(purchaser.additionalProperties).toBe(false);
+    expect(purchaser.required).toEqual([
+      'name_and_address', 'convertible_investment', 'convertible_shares',
+      'cash_purchase_price', 'cash_purchase_economics', 'cash_shares', 'total_shares',
+    ]);
+    const fields = purchaser.properties as Record<string, JsonSchema>;
+    expect(fields.convertible_investment.type).toBe('number');
+    expect(fields.name_and_address.type).toBe('string');
+  });
+
+  it('rejects unknown properties, missing priority fields, and malformed scalar/nested values', () => {
+    const schema: JsonSchema = buildFieldSelectorInputSchema('fixture', {
+      name: 'Fixture', source_url: 'https://example.com/source.docx', source_version: '1',
+      license_note: 'fixture', optional: false, fields: [
+        { name: 'name', type: 'string', description: 'Name' },
+        { name: 'closing_date', type: 'date', description: 'Date' },
+        { name: 'enabled', type: 'boolean', description: 'Enabled', default: 'false' },
+        { name: 'amount', type: 'number', description: 'Amount' },
+        { name: 'mode', type: 'enum', description: 'Mode', options: ['a', 'b'] },
+        { name: 'rows', type: 'array', description: 'Rows', items: [
+          { name: 'label', type: 'string', description: 'Label' },
+          { name: 'shares', type: 'number', description: 'Shares' },
+        ] },
+      ], priority_fields: ['name', 'rows'], market_data_citations: [],
+    }, null);
+    const validate = validator(schema);
+    const valid = { name: 'Acme', closing_date: '2026-09-05', enabled: true, amount: 1.5, mode: 'a', rows: [{ label: 'A', shares: 10 }] };
+    expect(validate(valid)).toBe(true);
+    for (const invalid of [
+      { ...valid, extra: true },
+      { ...valid, name: undefined },
+      { ...valid, closing_date: 'September 5, 2026' },
+      { ...valid, enabled: 'true' },
+      { ...valid, amount: '1.5' },
+      { ...valid, mode: 'c' },
+      { ...valid, rows: [{ label: 'A' }] },
+      { ...valid, rows: [{ label: 'A', shares: 10, extra: true }] },
+    ]) expect(validate(invalid), JSON.stringify(invalid)).toBe(false);
+  });
+
+  it('fails closed for unknown directories and invalid metadata', () => {
+    expect(() => getFieldSelectorInputSchema('missing', '/definitely/missing')).toThrow(/Unknown field-selector/);
+    const dir = mkdtempSync(join(tmpdir(), 'oa-invalid-schema-'));
+    writeFileSync(join(dir, 'metadata.yaml'), 'name: Broken\nfields: []\n');
+    expect(() => getFieldSelectorInputSchema('broken', dir)).toThrow();
+    expect(readFileSync(join(dir, 'metadata.yaml'), 'utf8')).toContain('Broken');
+  });
+});

--- a/src/core/field-selector/input-schema.test.ts
+++ b/src/core/field-selector/input-schema.test.ts
@@ -3,7 +3,8 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import Ajv2020 from 'ajv/dist/2020.js';
 import addFormats from 'ajv-formats';
-import { describe, expect, it } from 'vitest';
+import { describe, expect } from 'vitest';
+import { itAllure } from '../../../integration-tests/helpers/allure-test.js';
 import {
   buildFieldSelectorInputSchema,
   canonicalSha256,
@@ -24,6 +25,7 @@ const NVCA_GOLDEN_HASHES: Record<string, string> = {
   'nvca-stock-purchase-agreement': '1fd6470a5f1b2280633f804de230ee6ecb6e936aa4e9dec25674fa0f7d97efe9',
   'nvca-voting-agreement': '6959d714c6c0a444d8ea80e3558af516fa9bcf3ffdf95caccfa650ab9204fa63',
 };
+const it = itAllure.epic('Discovery & Metadata');
 
 function validator(schema: JsonSchema) {
   const ajv = new Ajv2020({ allErrors: true, strict: true });

--- a/src/core/field-selector/input-schema.test.ts
+++ b/src/core/field-selector/input-schema.test.ts
@@ -18,7 +18,7 @@ import { listFieldSelectorIds, resolveFieldSelectorDir } from '../../utils/paths
 const NVCA_GOLDEN_HASHES: Record<string, string> = {
   'nvca-certificate-of-incorporation': '532a0ce6922a8baa2097881f68ac139e68e91c331c44a375f5b415dfd53b4f3e',
   'nvca-indemnification-agreement': '378070ff3d36bffc460b6b7d95a29f1c950c88f724fe90484260108900ac0b9b',
-  'nvca-investors-rights-agreement': '1d44d11fa4a0dc4513bf957b24a7b733c103670af2aa10d4f8375f5b5d016323',
+  'nvca-investors-rights-agreement': '054fa5f41f4355c65a1054ffb9aa11dadbe1497fbd19ddd2b6e3c09c3003525b',
   'nvca-management-rights-letter': 'b0b62fcf846b49166a6c7045b6134cc4ca24dda6b07f459145b12324597cedf1',
   'nvca-rofr-co-sale-agreement': 'a202c5bd4d08abafd5f67854e0a0ded2c0254d9a20c272022c50c6dc70f8c3b9',
   'nvca-stock-purchase-agreement': '1fd6470a5f1b2280633f804de230ee6ecb6e936aa4e9dec25674fa0f7d97efe9',
@@ -39,6 +39,9 @@ describe('field-selector caller-input JSON Schema', () => {
       const schema = getFieldSelectorInputSchema(id, resolveFieldSelectorDir(id));
       expect(canonicalSha256(schema), id).toBe(expected);
       expect(() => validator(schema)).not.toThrow();
+      const validate = validator(schema);
+      expect(validate({}), `${id} must enforce priority fields`).toBe(false);
+      expect(validate({ unexpected_field: true }), `${id} must be closed`).toBe(false);
     }
   });
 

--- a/src/core/field-selector/input-schema.ts
+++ b/src/core/field-selector/input-schema.ts
@@ -1,0 +1,139 @@
+import { createHash } from 'node:crypto';
+import { existsSync } from 'node:fs';
+import canonicalizeModule from 'canonicalize/lib/canonicalize.js';
+import {
+  loadFieldSelectorMetadata,
+  type FieldDefinition,
+  type FieldSelectorMetadata,
+} from '../metadata.js';
+import { loadComputedProfile, type ComputedProfile } from './computed.js';
+
+export const FIELD_SELECTOR_INPUT_SCHEMA_VERSION = 1 as const;
+export const FIELD_SELECTOR_SCHEMA_GENERATOR = 'open-agreements field-selector schema' as const;
+
+export interface JsonSchema {
+  [key: string]: unknown;
+}
+
+export interface FieldSelectorSchemaProvenance {
+  field_selector_id: string;
+  source_version: string;
+  generator: typeof FIELD_SELECTOR_SCHEMA_GENERATOR;
+  schema_version: typeof FIELD_SELECTOR_INPUT_SCHEMA_VERSION;
+}
+
+export interface FieldSelectorSchemaManifest {
+  schema_version: 1;
+  generator: 'open-agreements field-selector schema --all';
+  package_version: string;
+  runtime_revision: string;
+  canonicalization: 'RFC8785';
+  schemas: Array<{ field_selector_id: string; path: string; sha256: string }>;
+}
+
+/** Return every metadata field owned by computed.json rather than the caller. */
+export function computedFieldNames(profile: ComputedProfile | null): Set<string> {
+  const names = new Set<string>();
+  if (!profile) return names;
+  for (const name of Object.keys(profile.defaults)) names.add(name);
+  for (const rule of profile.rules) {
+    for (const name of Object.keys(rule.set_fill)) names.add(name);
+    for (const name of Object.keys(rule.set_audit)) names.add(name);
+  }
+  return names;
+}
+
+function typedDefault(field: FieldDefinition): unknown {
+  if (field.default === undefined || field.default === '') return undefined;
+  if (field.type === 'boolean') return field.default === 'true';
+  if (field.type === 'number') {
+    const value = Number(field.default);
+    return Number.isFinite(value) ? value : field.default;
+  }
+  if (field.type === 'multiselect') {
+    try { return JSON.parse(field.default); } catch { return field.default; }
+  }
+  return field.default;
+}
+
+function fieldSchema(field: FieldDefinition): JsonSchema {
+  const common: JsonSchema = {
+    title: field.display_label ?? field.name,
+    description: field.description,
+  };
+  const defaultValue = typedDefault(field);
+  if (defaultValue !== undefined) common.default = defaultValue;
+
+  switch (field.type) {
+    case 'boolean': return { ...common, type: 'boolean' };
+    case 'number': return { ...common, type: 'number' };
+    case 'date': return { ...common, type: 'string', format: 'date' };
+    case 'enum': return { ...common, type: 'string', enum: [...(field.options ?? [])] };
+    case 'multiselect':
+      return {
+        ...common,
+        type: 'array',
+        uniqueItems: true,
+        items: { type: 'string', enum: [...(field.options ?? [])] },
+      };
+    case 'array': {
+      const items = field.items ?? [];
+      return {
+        ...common,
+        type: 'array',
+        items: {
+          type: 'object',
+          additionalProperties: false,
+          properties: Object.fromEntries(items.map((item) => [item.name, fieldSchema(item)])),
+          required: items.map((item) => item.name),
+        },
+      };
+    }
+    default: return { ...common, type: 'string' };
+  }
+}
+
+export function buildFieldSelectorInputSchema(
+  fieldSelectorId: string,
+  metadata: FieldSelectorMetadata,
+  computedProfile: ComputedProfile | null,
+): JsonSchema {
+  const computed = computedFieldNames(computedProfile);
+  const fields = metadata.fields.filter((field) => !computed.has(field.name));
+  const inputNames = new Set(fields.map((field) => field.name));
+  const required = metadata.priority_fields.filter((name) => inputNames.has(name));
+  return {
+    $schema: 'https://json-schema.org/draft/2020-12/schema',
+    $id: `https://openagreements.org/schemas/field-selector/${fieldSelectorId}.schema.json`,
+    title: `${metadata.name} input`,
+    description: metadata.description ?? `Canonical caller-supplied fields for ${metadata.name}.`,
+    type: 'object',
+    additionalProperties: false,
+    properties: Object.fromEntries(fields.map((field) => [field.name, fieldSchema(field)])),
+    required,
+    'x-openagreements': {
+      field_selector_id: fieldSelectorId,
+      source_version: metadata.source_version,
+      generator: FIELD_SELECTOR_SCHEMA_GENERATOR,
+      schema_version: FIELD_SELECTOR_INPUT_SCHEMA_VERSION,
+    } satisfies FieldSelectorSchemaProvenance,
+  };
+}
+
+export function getFieldSelectorInputSchema(fieldSelectorId: string, fieldSelectorDir: string): JsonSchema {
+  if (!existsSync(fieldSelectorDir)) throw new Error(`Unknown field-selector "${fieldSelectorId}"`);
+  const metadata = loadFieldSelectorMetadata(fieldSelectorDir);
+  return buildFieldSelectorInputSchema(fieldSelectorId, metadata, loadComputedProfile(fieldSelectorDir));
+}
+
+export function canonicalJson(value: unknown): string {
+  // canonicalize is CommonJS at runtime despite shipping an ESM-shaped .d.ts.
+  const serialize = canonicalizeModule as unknown as (input: unknown) => string | undefined;
+  const result = serialize(value);
+  if (result === undefined) throw new Error('Value cannot be represented as canonical JSON');
+  return result;
+}
+
+export function canonicalSha256(value: unknown): string {
+  return createHash('sha256').update(canonicalJson(value)).digest('hex');
+}

--- a/src/core/field-selector/input-schema.ts
+++ b/src/core/field-selector/input-schema.ts
@@ -7,6 +7,7 @@ import {
   type FieldSelectorMetadata,
 } from '../metadata.js';
 import { loadComputedProfile, type ComputedProfile } from './computed.js';
+import { resolveFieldSelectorDir } from '../../utils/paths.js';
 
 export const FIELD_SELECTOR_INPUT_SCHEMA_VERSION = 1 as const;
 export const FIELD_SELECTOR_SCHEMA_GENERATOR = 'open-agreements field-selector schema' as const;
@@ -120,7 +121,10 @@ export function buildFieldSelectorInputSchema(
   };
 }
 
-export function getFieldSelectorInputSchema(fieldSelectorId: string, fieldSelectorDir: string): JsonSchema {
+export function getFieldSelectorInputSchema(
+  fieldSelectorId: string,
+  fieldSelectorDir = resolveFieldSelectorDir(fieldSelectorId),
+): JsonSchema {
   if (!existsSync(fieldSelectorDir)) throw new Error(`Unknown field-selector "${fieldSelectorId}"`);
   const metadata = loadFieldSelectorMetadata(fieldSelectorDir);
   return buildFieldSelectorInputSchema(fieldSelectorId, metadata, loadComputedProfile(fieldSelectorDir));

--- a/src/core/metadata.test.ts
+++ b/src/core/metadata.test.ts
@@ -558,6 +558,28 @@ describe('FieldDefinitionSchema', () => {
   });
 });
 
+describe('metadata field-name uniqueness', () => {
+  const field = (name: string) => ({ name, type: 'string' as const, description: name });
+  const base = {
+    name: 'Fixture',
+    source_url: 'https://example.com/source.docx',
+    source_version: '1',
+    license_note: 'fixture',
+    fields: [field('duplicate'), field('duplicate')],
+  };
+
+  it('rejects duplicate top-level field names', () => {
+    expect(() => FieldSelectorMetadataSchema.parse(base)).toThrow(/Duplicate field name/);
+  });
+
+  it('rejects duplicate nested array item names', () => {
+    expect(() => FieldSelectorMetadataSchema.parse({
+      ...base,
+      fields: [{ name: 'rows', type: 'array', description: 'Rows', items: [field('duplicate'), field('duplicate')] }],
+    })).toThrow(/Duplicate field name/);
+  });
+});
+
 const BASE_CAPABILITY_MANIFEST = {
   artifact_kind: 'agreement' as const,
   capabilities: ['create', 'review', 'render'] as const,

--- a/src/core/metadata.ts
+++ b/src/core/metadata.ts
@@ -364,6 +364,28 @@ function validatePriorityFields(
   });
 }
 
+/** Object-shaped fill data cannot represent duplicate property names. */
+function validateUniqueFieldNames(
+  fields: FieldDefinition[],
+  ctx: z.RefinementCtx,
+  path: Array<string | number> = ['fields'],
+): void {
+  const seen = new Map<string, number>();
+  fields.forEach((field, index) => {
+    const previous = seen.get(field.name);
+    if (previous !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: [...path, index, 'name'],
+        message: `Duplicate field name "${field.name}" (first declared at index ${previous})`,
+      });
+    } else {
+      seen.set(field.name, index);
+    }
+    if (field.items) validateUniqueFieldNames(field.items, ctx, [...path, index, 'items']);
+  });
+}
+
 function validateDerivedBooleanCollisions(fields: FieldDefinition[], ctx: z.RefinementCtx): void {
   const topLevelFieldNames = new Set(fields.map((field) => field.name));
   const derivedKeyOwners = new Map<string, string>();
@@ -438,6 +460,7 @@ const TemplateMetadataBaseSchema = z.object({
 });
 
 export const TemplateMetadataSchema = TemplateMetadataBaseSchema.superRefine((meta, ctx) => {
+  validateUniqueFieldNames(meta.fields, ctx);
   validatePriorityFields(meta.fields, meta.priority_fields, ctx);
   validateDerivedBooleanCollisions(meta.fields, ctx);
 });
@@ -455,6 +478,7 @@ export type TemplateMetadata = z.infer<typeof TemplateMetadataSchema>;
 export const ExternalMetadataSchema = TemplateMetadataBaseSchema.extend({
   source_sha256: z.string(),
 }).superRefine((meta, ctx) => {
+  validateUniqueFieldNames(meta.fields, ctx);
   validatePriorityFields(meta.fields, meta.priority_fields, ctx);
   validateDerivedBooleanCollisions(meta.fields, ctx);
 });
@@ -682,6 +706,7 @@ export const FieldSelectorMetadataSchema = z.object({
   market_data_citations: z.array(MarketDataCitationSchema).optional(),
   ...TemplateCapabilityManifestSchema.shape,
 }).superRefine((meta, ctx) => {
+  validateUniqueFieldNames(meta.fields, ctx);
   validatePriorityFields(meta.fields, meta.priority_fields, ctx);
   validateDerivedBooleanCollisions(meta.fields, ctx);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,6 +113,19 @@ export {
   type ReferenceFieldsConfig,
 } from './core/field-selector/index.js';
 
+export {
+  buildFieldSelectorInputSchema,
+  getFieldSelectorInputSchema,
+  canonicalJson,
+  canonicalSha256,
+  computedFieldNames,
+  FIELD_SELECTOR_INPUT_SCHEMA_VERSION,
+  FIELD_SELECTOR_SCHEMA_GENERATOR,
+  type JsonSchema,
+  type FieldSelectorSchemaManifest,
+  type FieldSelectorSchemaProvenance,
+} from './core/field-selector/input-schema.js';
+
 // Closing checklist
 export {
   buildChecklistTemplateContext,

--- a/templates/nvca-free-non-redistributable/nvca-investors-rights-agreement/metadata.yaml
+++ b/templates/nvca-free-non-redistributable/nvca-investors-rights-agreement/metadata.yaml
@@ -332,9 +332,6 @@ fields:
   - name: form_s3_blackout_after_days
     type: string
     description: Days after a Company-initiated registration during which Form S-3 demands are unavailable
-  - name: registration_effectiveness_days
-    type: string
-    description: Base number of days a registration statement must remain effective
   - name: information_right_holder_class
     type: enum
     description: Modifier inserted before the source text "Investor" for the selected information-right holder class; omit for all Investors


### PR DESCRIPTION
Closes #784.

## What changed

- adds `open-agreements field-selector schema <id>` and `getFieldSelectorInputSchema(id)`
- adds deterministic seven-form bundle export via `--all --output-dir ... --runtime-revision <sha>`
- writes RFC 8785 / SHA-256 `schema-manifest.json` provenance
- emits closed Draft 2020-12 objects with required/default/type/enum/date/nested-array semantics
- excludes computed fill/audit outputs from caller inputs
- rejects duplicate field names recursively instead of silently collapsing them
- syncs the canonical IRA duplicate-field correction from Legal Explainer merge `01a698b9a19271f37ceba6a37323bbbfaa51e759`

## Verification

- `npm run validate` — PASS (105 templates, 4 external templates, 7 field-selectors)
- `npm run build` — PASS
- `npm run lint -- --quiet` — PASS
- focused schema/manifest/negative/duplicate tests — 9 PASS
- full suite — 125 files passed, 4 skipped; 1,456 tests passed, 7 skipped
- canonical IRA metadata is byte-identical to the upstream merged recipe

No licensed source documents are added.