### PR TITLE
fix(runtime): validate source-owned value shapes

### DIFF
--- a/integration-tests/nvca-investor-governance-production.test.ts
+++ b/integration-tests/nvca-investor-governance-production.test.ts
@@ -112,6 +112,8 @@ describeWithSources('NVCA investor and governance production fills', () => {
       expect(text).toContain('KEY HOLDERS: Maya Imani');
       expect(text).toContain('holders of at least 60%');
       expect(text).toContain('Series A Preferred Stock');
+      expect(text).not.toContain('Series Series A Preferred Stock Preferred Stock');
+      expect(text).not.toContain('60%%');
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/src/core/field-selector/index.test.ts
+++ b/src/core/field-selector/index.test.ts
@@ -73,6 +73,36 @@ function createFieldSelectorFixture(options?: {
 }
 
 describe('runFieldSelector', () => {
+  itFilling('rejects malformed source-owned values before document work', async () => {
+    const fieldSelectorDir = createFieldSelectorFixture({
+      fields: [
+        '  - name: company_name',
+        '    type: string',
+        '    description: Company name',
+        '  - name: series_designation',
+        '    type: string',
+        '    description: Series token',
+        '  - name: approval_percentage',
+        '    type: string',
+        '    description: Bare percentage',
+      ],
+    });
+    const ensureSourceDocxMock = vi.fn(async () => '/tmp/downloaded-source.docx');
+    vi.doMock('../../utils/paths.js', () => ({ resolveFieldSelectorDir: () => fieldSelectorDir }));
+    vi.doMock('./downloader.js', () => ({ ensureSourceDocx: ensureSourceDocxMock }));
+    const { runFieldSelector } = await import('./index.js');
+
+    await expect(runFieldSelector({
+      fieldSelectorId: 'fixture-fieldSelector', outputPath: '/tmp/output.docx',
+      values: { company_name: 'Acme', series_designation: 'Series A Preferred Stock', approval_percentage: '60' },
+    })).rejects.toThrow(/series_designation/);
+    await expect(runFieldSelector({
+      fieldSelectorId: 'fixture-fieldSelector', outputPath: '/tmp/output.docx',
+      values: { company_name: 'Acme', series_designation: 'A', approval_percentage: '60%' },
+    })).rejects.toThrow(/approval_percentage/);
+    expect(ensureSourceDocxMock).not.toHaveBeenCalled();
+  });
+
   itFilling('forwards priorityFieldNames when inputPath is supplied', async () => {
     const fieldSelectorDir = createFieldSelectorFixture();
 

--- a/src/core/field-selector/index.ts
+++ b/src/core/field-selector/index.ts
@@ -24,6 +24,7 @@ import { applyRepeatableTables, loadRepeatableTablesConfig, validateRepeatableTa
 import { bindAnchoredParagraphFields, loadAnchoredParagraphBindingsConfig } from './anchored-paragraph-bindings.js';
 import { normalizeNumberedHeadingSections } from './numbering-normalizer.js';
 import { loadReferenceFieldsConfig } from './reference-fields.js';
+import { assertFieldSelectorInputValueShapes } from './input-schema.js';
 
 function toComputedValueMap(values: Record<string, unknown>): ComputedValueMap {
   const computedValues: ComputedValueMap = {};
@@ -48,6 +49,9 @@ export async function runFieldSelector(options: FieldSelectorRunOptions): Promis
   const fieldSelectorDir = resolveFieldSelectorDir(fieldSelectorId);
 
   const metadata = loadFieldSelectorMetadata(fieldSelectorDir);
+  // Validate source-owned token/sigil shapes before downloading, cleaning, or
+  // writing a document. The exported caller schema uses the same constraints.
+  assertFieldSelectorInputValueShapes(values, metadata.fields);
   const cleanConfig = loadCleanConfig(fieldSelectorDir);
   const normalizeConfig = loadNormalizeConfig(fieldSelectorDir);
   const repeatableTablesConfig = loadRepeatableTablesConfig(fieldSelectorDir);

--- a/src/core/field-selector/input-schema.test.ts
+++ b/src/core/field-selector/input-schema.test.ts
@@ -9,7 +9,9 @@ import {
   buildFieldSelectorInputSchema,
   canonicalSha256,
   computedFieldNames,
+  fieldValuePattern,
   getFieldSelectorInputSchema,
+  assertFieldSelectorInputValueShapes,
   type JsonSchema,
 } from './input-schema.js';
 import { loadComputedProfile } from './computed.js';
@@ -17,13 +19,13 @@ import { loadFieldSelectorMetadata } from '../metadata.js';
 import { listFieldSelectorIds, resolveFieldSelectorDir } from '../../utils/paths.js';
 
 const NVCA_GOLDEN_HASHES: Record<string, string> = {
-  'nvca-certificate-of-incorporation': '532a0ce6922a8baa2097881f68ac139e68e91c331c44a375f5b415dfd53b4f3e',
+  'nvca-certificate-of-incorporation': '1c532b9cb4caa0f43e0707a106495ce7b28d4734b5033775804878b619907bea',
   'nvca-indemnification-agreement': '378070ff3d36bffc460b6b7d95a29f1c950c88f724fe90484260108900ac0b9b',
-  'nvca-investors-rights-agreement': '054fa5f41f4355c65a1054ffb9aa11dadbe1497fbd19ddd2b6e3c09c3003525b',
-  'nvca-management-rights-letter': 'b0b62fcf846b49166a6c7045b6134cc4ca24dda6b07f459145b12324597cedf1',
-  'nvca-rofr-co-sale-agreement': 'a202c5bd4d08abafd5f67854e0a0ded2c0254d9a20c272022c50c6dc70f8c3b9',
-  'nvca-stock-purchase-agreement': '1fd6470a5f1b2280633f804de230ee6ecb6e936aa4e9dec25674fa0f7d97efe9',
-  'nvca-voting-agreement': '6959d714c6c0a444d8ea80e3558af516fa9bcf3ffdf95caccfa650ab9204fa63',
+  'nvca-investors-rights-agreement': '496076ea3931ff2e7d7d26d5d721b77c014e205207c798efe56e55ec41f75fb3',
+  'nvca-management-rights-letter': '5e27820907e815dbb139ff81943b6a9ee68cb06994a1b732de1f60aefd410ba9',
+  'nvca-rofr-co-sale-agreement': '70b3f7017a95c812926bca57a56beb189980500b73e09ee7fad9b09e2a8c6d56',
+  'nvca-stock-purchase-agreement': 'c4c8835b56aa13071a6c89f430929ca484b376f219d930161da0fe44e92d1d99',
+  'nvca-voting-agreement': 'b8d0a54005f0dd8131655f4f8c6f589615a4341f01b70507e409799041b45962',
 };
 const it = itAllure.epic('Discovery & Metadata');
 
@@ -109,6 +111,56 @@ describe('field-selector caller-input JSON Schema', () => {
       { ...valid, rows: [{ label: 'A' }] },
       { ...valid, rows: [{ label: 'A', shares: 10, extra: true }] },
     ]) expect(validate(invalid), JSON.stringify(invalid)).toBe(false);
+  });
+
+  it('rejects rendered series names and percent signs while accepting canonical bare values', () => {
+    const schema = getFieldSelectorInputSchema(
+      'nvca-voting-agreement',
+      resolveFieldSelectorDir('nvca-voting-agreement'),
+    );
+    const properties = schema.properties as Record<string, JsonSchema>;
+    expect(properties.series_designation.pattern).toBe(fieldValuePattern({
+      name: 'series_designation', type: 'string', description: 'Series token',
+    }));
+    expect(properties.requisite_holders_percentage.pattern).toBe(fieldValuePattern({
+      name: 'requisite_holders_percentage', type: 'string', description: 'Bare percent',
+    }));
+
+    const coiSchema = getFieldSelectorInputSchema(
+      'nvca-certificate-of-incorporation',
+      resolveFieldSelectorDir('nvca-certificate-of-incorporation'),
+    );
+    const coiProperties = coiSchema.properties as Record<string, JsonSchema>;
+    expect(coiProperties.redemption_interest_rate.pattern).toBeDefined();
+    expect(new RegExp(coiProperties.redemption_interest_rate.pattern as string).test('12%')).toBe(false);
+
+    const seriesPattern = new RegExp(properties.series_designation.pattern as string);
+    const percentagePattern = new RegExp(properties.requisite_holders_percentage.pattern as string);
+    expect(seriesPattern.test('A')).toBe(true);
+    expect(seriesPattern.test('B')).toBe(true);
+    expect(seriesPattern.test('C')).toBe(true);
+    expect(seriesPattern.test('Series A Preferred Stock')).toBe(false);
+    expect(percentagePattern.test('60')).toBe(true);
+    expect(percentagePattern.test('60.5')).toBe(true);
+    expect(percentagePattern.test('60%')).toBe(false);
+  });
+
+  it('applies value-shape checks recursively before fill', () => {
+    const fields = [{
+      name: 'rows', type: 'array' as const, description: 'Rows', items: [
+        { name: 'series_designation', type: 'string' as const, description: 'Series token' },
+        { name: 'approval_percentage', type: 'string' as const, description: 'Bare percent' },
+      ],
+    }];
+    expect(() => assertFieldSelectorInputValueShapes({
+      rows: [{ series_designation: 'A', approval_percentage: '60' }],
+    }, fields)).not.toThrow();
+    expect(() => assertFieldSelectorInputValueShapes({
+      rows: [{ series_designation: 'Series A Preferred Stock', approval_percentage: '60' }],
+    }, fields)).toThrow(/rows\[0\]\.series_designation/);
+    expect(() => assertFieldSelectorInputValueShapes({
+      rows: [{ series_designation: 'A', approval_percentage: '60%' }],
+    }, fields)).toThrow(/rows\[0\]\.approval_percentage/);
   });
 
   it('fails closed for unknown directories and invalid metadata', () => {

--- a/src/core/field-selector/input-schema.ts
+++ b/src/core/field-selector/input-schema.ts
@@ -32,6 +32,68 @@ export interface FieldSelectorSchemaManifest {
   schemas: Array<{ field_selector_id: string; path: string; sha256: string }>;
 }
 
+const SERIES_DESIGNATION_FIELD = /(?:^|_)series_designation$/;
+const PERCENTAGE_FIELD = /(?:^|_)(?:percent|percentage)$/;
+const PERCENTAGE_DESCRIPTION = /\bpercentage\b/i;
+
+/**
+ * Legal value shapes whose surrounding prose is owned by the source form.
+ *
+ * Series tokens use a stable field-name contract. Percentage inputs use either
+ * that name contract or an explicit percentage declaration in canonical field
+ * metadata (for example `redemption_interest_rate`). The same helper drives
+ * both the published JSON Schema and the pre-fill runtime check, so callers
+ * cannot pass a rendered phrase or punctuation that the form adds again.
+ */
+export function fieldValuePattern(field: FieldDefinition): string | undefined {
+  if (field.type !== 'string') return undefined;
+  if (SERIES_DESIGNATION_FIELD.test(field.name)) {
+    // A designation is one token (A, B, C, Seed, A-1), never "Series A
+    // Preferred Stock". Empty remains valid for conditional/optional fields.
+    return '^(?:|[A-Za-z0-9]+(?:[.-][A-Za-z0-9]+)*)$';
+  }
+  if (PERCENTAGE_FIELD.test(field.name) || PERCENTAGE_DESCRIPTION.test(field.description)) {
+    // The source owns the percent sign. Accept a bare decimal from 0 through
+    // 100, or empty for a conditional/optional field.
+    return '^(?:|100(?:\\.0+)?|(?:\\d|[1-9]\\d)(?:\\.\\d+)?)$';
+  }
+  return undefined;
+}
+
+function assertValueShapes(
+  values: Record<string, unknown>,
+  fields: FieldDefinition[],
+  path = '',
+): void {
+  for (const field of fields) {
+    const value = values[field.name];
+    if (value === undefined) continue;
+    const fieldPath = path ? `${path}.${field.name}` : field.name;
+    const pattern = fieldValuePattern(field);
+    if (pattern && (typeof value !== 'string' || !new RegExp(pattern).test(value))) {
+      const expectation = SERIES_DESIGNATION_FIELD.test(field.name)
+        ? 'a designation token such as A, B, or C (not a rendered stock name)'
+        : 'a number-only percentage from 0 through 100 without a percent sign';
+      throw new Error(`Invalid field-selector input at "${fieldPath}": expected ${expectation}`);
+    }
+    if (field.type === 'array' && Array.isArray(value)) {
+      value.forEach((row, index) => {
+        if (row && typeof row === 'object' && !Array.isArray(row)) {
+          assertValueShapes(row as Record<string, unknown>, field.items ?? [], `${fieldPath}[${index}]`);
+        }
+      });
+    }
+  }
+}
+
+/** Fail malformed source-owned token/sigil values before any document work. */
+export function assertFieldSelectorInputValueShapes(
+  values: Record<string, unknown>,
+  fields: FieldDefinition[],
+): void {
+  assertValueShapes(values, fields);
+}
+
 /** Return every metadata field owned by computed.json rather than the caller. */
 export function computedFieldNames(profile: ComputedProfile | null): Set<string> {
   const names = new Set<string>();
@@ -64,6 +126,8 @@ function fieldSchema(field: FieldDefinition): JsonSchema {
   };
   const defaultValue = typedDefault(field);
   if (defaultValue !== undefined) common.default = defaultValue;
+  const pattern = fieldValuePattern(field);
+  if (pattern) common.pattern = pattern;
 
   switch (field.type) {
     case 'boolean': return { ...common, type: 'boolean' };


### PR DESCRIPTION
Closes #786.

## What changed
- derive one recursive value-shape contract for exported JSON Schemas and runtime preflight
- require series-designation tokens instead of rendered stock names
- require bare 0–100 decimal strings for caller-owned percentage fields, including percentage fields identified by canonical metadata
- reject malformed values before source download or document mutation
- add exact bad/good regressions and a hash-pinned real Voting Agreement fill assertion

## Verification
- `npm run lint`
- `npm run validate`
- `npm run test:run` — 1,459 passed, 7 skipped
- focused schema/runtime/real-fill tests — 23 passed

No licensed or generated DOCX is committed.