### PR TITLE
test: require quality-card allowlist coverage

### DIFF
--- a/scripts/sync_claude_marketplace_plugin.test.mjs
+++ b/scripts/sync_claude_marketplace_plugin.test.mjs
@@ -32,8 +32,12 @@ describe("Claude marketplace plugin allowlist", () => {
     // The allowlist is opt-in, so an artifact added to a skill source is
     // published to npm (via the broad `skills/` entry) while silently missing
     // from the plugin until someone lists it here.
-    for (const spec of skillSpecs) {
-      if (!existsSync(join(spec.source, "quality-card.json"))) continue;
+    const specsWithQualityCards = skillSpecs.filter((spec) =>
+      existsSync(join(spec.source, "quality-card.json")),
+    );
+
+    expect(specsWithQualityCards.length).toBeGreaterThan(0);
+    for (const spec of specsWithQualityCards) {
       expect(spec.files).toContain("quality-card.json");
     }
   });


### PR DESCRIPTION
Closes the post-merge advisory from #697 by making the plugin allowlist test fail if it discovers zero quality-card-bearing skills. This prevents the conditional loop from passing without assertions.\n\nVerified:\n- focused Vitest: 2 passed\n- ESLint\n- check:claude-plugin\n- git diff --check