### PR TITLE
Fix stranded punctuation spaces after inline option deletion

### DIFF
--- a/src/core/selector.test.ts
+++ b/src/core/selector.test.ts
@@ -880,6 +880,44 @@ describe('bounded markerless removals', () => {
 // ---------------------------------------------------------------------------
 
 describe('inline selections', () => {
+  it('removes only spaces stranded before punctuation by an omitted cross-run option', async () => {
+    const marker = '[optional condition]';
+    const config: SelectionsConfig = { groups: [{
+      id: 'optional', type: 'checkbox', standalone: true, markerless: true, inline: true,
+      options: [{ marker, trigger: { field: 'keep', equals: true } }],
+    }] };
+    const body = `<w:p>
+      <w:r><w:rPr><w:b/></w:rPr><w:t xml:space="preserve">Effective on closing </w:t></w:r>
+      <w:r><w:t>[optional </w:t></w:r><w:r><w:t>condition]</w:t></w:r>
+      <w:r><w:t xml:space="preserve"> .  Next sentence.</w:t></w:r></w:p>
+      ${para('Ordinary  spacing . stays unchanged.')}
+      ${para('Between [optional condition] words.')}
+      ${para('Nonbreaking\u00a0[optional condition].')}
+      ${para('Before [optional condition], after.')}
+      <w:p><w:r><w:fldChar w:fldCharType="begin"/></w:r>
+      <w:r><w:instrText xml:space="preserve"> REF preserved </w:instrText></w:r>
+      <w:r><w:fldChar w:fldCharType="separate"/></w:r><w:r><w:t>7</w:t></w:r>
+      <w:r><w:fldChar w:fldCharType="end"/></w:r>
+      <w:r><w:t xml:space="preserve"> [optional condition].</w:t></w:r></w:p>`;
+    const input = buildTestDocx(body);
+    const output = join(makeTempDir(), 'out.docx');
+    await applySelections(input, output, config, {});
+    const text = extractText(output);
+    expect(text).toContain('Effective on closing.  Next sentence.');
+    expect(text).toContain('Ordinary  spacing . stays unchanged.');
+    expect(text).toContain('Between  words.');
+    expect(text).toContain('Nonbreaking\u00a0.');
+    expect(text).toContain('Before, after.');
+    // The protected REF boundary is left intact when docx-core declines it.
+    expect(text).toContain('7 .');
+    const xml = new AdmZip(output).readAsText('word/document.xml');
+    expect(xml).toContain('<w:b/>');
+    expect(xml).toContain(' REF preserved ');
+    expect(xml.match(/<w:fldChar /g)).toHaveLength(3);
+    await applySelections(input, output, config, { keep: true });
+    expect(extractText(output)).toContain('Effective on closing [optional condition] .  Next sentence.');
+  });
+
   it('deletes inline marker text when trigger does not fire', async () => {
     const body = `
       ${para('Purchase at the Closing). , [Each Purchaser shall buy Tranche Shares.] The Company agrees.')}

--- a/src/core/selector.ts
+++ b/src/core/selector.ts
@@ -1202,6 +1202,27 @@ function processMarkerlessGroup(
           if (idx === -1) break;
           try {
             replaceParagraphTextRange(globalPara, idx, idx + normalizedMarker.length, replacement);
+            // An omitted inline option can strand its separator before the
+            // sentence's punctuation. Repair only this deletion boundary, not
+            // unrelated punctuation/spacing elsewhere in the document.
+            if (replacement === '') {
+              const remaining = getParagraphText(globalPara);
+              const left = remaining.slice(0, idx).match(/ +$/);
+              const right = remaining.slice(idx).match(/^ *(?=[.,;:!?])/);
+              if (right && (left || right[0])) {
+                const start = idx - (left?.[0].length ?? 0);
+                const end = idx + right[0].length;
+                if (start > 0) {
+                  try {
+                    replaceParagraphTextRange(globalPara, start, end, '');
+                  } catch (error) {
+                    // Do not flatten a field result or other protected Word
+                    // structure merely to improve whitespace.
+                    if (!(error instanceof SafeDocxError)) throw error;
+                  }
+                }
+              }
+            }
             madeChanges = true;
             paraEdited = true;
           } catch (e) {


### PR DESCRIPTION
Fixes #791.

Omitting an inline clause could leave its separator before sentence punctuation, such as `as of the Closing .`. The selector now removes ordinary spaces only at a successful empty-replacement boundary followed by punctuation. Unrelated spacing, nonbreaking spaces, selected clauses, run formatting, and protected Word fields remain intact; cleanup never uses the formatting-destructive fallback.

Validation: build, lint, catalog validation, and full suite (1,460 passed; 7 skipped). Real SHA-pinned NVCA SPA and IRA fills reproduce the defect before the fix and produce attached punctuation afterward. Regression coverage includes split runs, preserved sentence spacing, a retained option, and a REF field. Local LibreOffice render evidence is retained privately; no licensed source or generated document is committed or uploaded.

The IRA fill reports an existing inert FCPA selection warning; it has no value-verification warnings. This is an upstream runtime-only change; no legal text or legal-explainer files changed, so the requested Fable review of legal-explainer changes does not apply to this PR.
