### PR TITLE
fix(runtime): expose unmatched replacement warnings to callers

### DIFF
--- a/integration-tests/fill-command.inprocess.test.ts
+++ b/integration-tests/fill-command.inprocess.test.ts
@@ -23,6 +23,7 @@ interface FillHarnessOptions {
   fillError?: Error;
   externalError?: Error;
   fieldSelectorError?: Error;
+  warnings?: string[];
   isEmploymentTemplateId?: (templateId: string) => boolean;
   memo?: Record<string, unknown>;
   memoMarkdown?: string;
@@ -86,7 +87,7 @@ async function loadFillHarness(opts: FillHarnessOptions = {}): Promise<FillHarne
       fieldsUsed: ['company_name'],
       providedFieldsUsed: ['company_name'],
       fillCommandCount: 1,
-      warnings: [],
+      warnings: opts.warnings ?? [],
       verify: { passed: true, checks: [] },
     };
   });
@@ -99,7 +100,7 @@ async function loadFillHarness(opts: FillHarnessOptions = {}): Promise<FillHarne
       fieldsUsed: ['company_name'],
       providedFieldsUsed: ['company_name'],
       fillCommandCount: 1,
-      warnings: [],
+      warnings: opts.warnings ?? [],
       stages: {},
     };
   });
@@ -112,7 +113,7 @@ async function loadFillHarness(opts: FillHarnessOptions = {}): Promise<FillHarne
       fieldsUsed: ['company_name'],
       providedFieldsUsed: ['company_name'],
       fillCommandCount: 1,
-      warnings: [],
+      warnings: opts.warnings ?? [],
       stages: {},
     };
   });
@@ -199,6 +200,20 @@ afterEach(() => {
 });
 
 describe('runFill in-process coverage', () => {
+  itFilling('prints structured patch warnings from each fill route', async () => {
+    const warning = 'patch: 1 replacement key(s) had zero matches: [Unseen Carrier]';
+    for (const route of ['templateDir', 'externalDir', 'fieldSelectorDir'] as const) {
+      const harness = await loadFillHarness({ [route]: '/templates/example', warnings: [warning] });
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      await harness.runFill({ template: 'example', values: { company_name: 'Acme Corp' } });
+
+      expect(warnSpy).toHaveBeenCalledExactlyOnceWith(`Warning: ${warning}`);
+      vi.restoreAllMocks();
+    }
+  });
+
   itFilling('fills a template path and defaults output filename', async () => {
     const harness = await loadFillHarness({
       templateDir: '/templates/common-paper-mutual-nda',

--- a/integration-tests/fill-pipeline.test.ts
+++ b/integration-tests/fill-pipeline.test.ts
@@ -1252,6 +1252,48 @@ describe('runFillPipeline', () => {
     }
   });
 
+  it('reports novel unmatched replacements while suppressing intentionally cleaned carriers', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'fill-pipeline-patch-warning-'));
+    const inputPath = join(tempDir, 'source.docx');
+    const outputPath = join(tempDir, 'output.docx');
+    writeFileSync(inputPath, buildDocxBuffer(docXml([
+      'Remove this drafting note [Note Value]',
+      'Company: [Company Name]',
+      'Start optional range Range Value',
+      'Optional range content',
+      'End optional range',
+    ])));
+
+    try {
+      const result = await runFillPipeline({
+        inputPath,
+        outputPath,
+        values: { company_name: 'Acme Corp' },
+        fields: [{ name: 'company_name', type: 'string', description: 'Company' }],
+        cleanPatch: {
+          cleanConfig: {
+            removeParagraphPatterns: ['Remove this drafting note [Note Value]'],
+            removeRanges: [{ start: 'Start optional range Range Value', end: 'End optional range' }],
+          } as never,
+          replacements: {
+            '[Company Name]': '{company_name}',
+            '[Previously Unseen Missing Carrier]': '{company_name}',
+            'Remove this drafting note > [Note Value]': '{company_name}',
+            'Range Value': '{company_name}',
+          },
+        },
+        verify: async () => ({ passed: true, checks: [] }),
+      });
+
+      expect(result.warnings).toEqual([
+        'patch: 1 replacement key(s) had zero matches: [Previously Unseen Missing Carrier]',
+      ]);
+      expect(docxBodyText(readFileSync(outputPath))).toBe('Company: Acme Corp');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it('failed verify checks surface in result.warnings (soft, no throw)', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'fill-pipeline-verify-warn-'));
     const inputPath = join(tempDir, 'source.docx');

--- a/packages/contract-templates-mcp/src/core/tools.ts
+++ b/packages/contract-templates-mcp/src/core/tools.ts
@@ -264,7 +264,7 @@ interface RepoModules {
   listTemplateItems: () => TemplateRecord[];
   findTemplateDir: (id: string) => string | undefined;
   loadMetadata: (dir: string) => Record<string, unknown>;
-  fillTemplate: (opts: { templateDir: string; values: Record<string, unknown>; outputPath: string }) => Promise<unknown>;
+  fillTemplate: (opts: { templateDir: string; values: Record<string, unknown>; outputPath: string }) => Promise<{ warnings?: string[] }>;
   categoryFromId: (id: string) => string;
   sourceName: (url: string) => string | null;
   mapFields: (fields: Record<string, unknown>[], required: string[]) => TemplateField[];
@@ -693,18 +693,23 @@ const tools: ToolDefinition[] = [
       try {
         const mod = await importRepoModules();
 
+        let warnings: string[];
         if (mod) {
           // In-process fill via findTemplateDir + fillTemplate
           const dir = mod.findTemplateDir(input.template);
           if (!dir) {
             return toolError('fill_template', 'TEMPLATE_NOT_FOUND', `Unknown template: "${input.template}"`);
           }
-          await mod.fillTemplate({ templateDir: dir, values: input.values, outputPath });
+          const result = await mod.fillTemplate({ templateDir: dir, values: input.values, outputPath });
+          warnings = result.warnings ?? [];
         } else {
           // Child process fallback
           const dataPath = join(workingDir, 'values.json');
           writeFileSync(dataPath, `${JSON.stringify(input.values, null, 2)}\n`, 'utf8');
-          await runOpenAgreements(['fill', input.template, '--data', dataPath, '--output', outputPath]);
+          const result = await runOpenAgreements(['fill', input.template, '--data', dataPath, '--output', outputPath]);
+          warnings = result.stderr.split(/\r?\n/)
+            .filter((line) => line.startsWith('Warning: '))
+            .map((line) => line.slice('Warning: '.length));
         }
 
         const basePayload = {
@@ -712,6 +717,7 @@ const tools: ToolDefinition[] = [
           output_path: outputPath,
           content_type: DOCX_MIME,
           return_mode: input.return_mode,
+          warnings,
         };
 
         if (input.return_mode === 'inline_base64') {

--- a/packages/contract-templates-mcp/tests/tools.test.ts
+++ b/packages/contract-templates-mcp/tests/tools.test.ts
@@ -1,5 +1,7 @@
 import AdmZip from 'adm-zip';
-import { existsSync } from 'node:fs';
+import { cpSync, existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { afterEach, describe, expect } from 'vitest';
 import { itAllure } from '../../../integration-tests/helpers/allure-test.js';
 import { callTool, listToolDescriptors, _resetModuleCache, _setModuleOverride } from '../src/core/tools.js';
@@ -720,6 +722,51 @@ describe('contract-templates-mcp tools', () => {
       // priority_field_count derived from required fields
       expect(templates[0].priority_field_count).toBe(0);
       expect(templates[1].priority_field_count).toBe(1);
+    });
+
+    it('fill_template exposes structured engine warnings to MCP callers', async () => {
+      const warning = 'patch: 1 replacement key(s) had zero matches: [Unseen Carrier]';
+      _setModuleOverride(mockModules({
+        fillTemplate: async () => ({ warnings: [warning] }),
+      }));
+
+      const result = await callTool('fill_template', {
+        template: 'test-template',
+        return_mode: 'local_path',
+      });
+
+      expect(result.isError).toBeUndefined();
+      expect((getPayload(result).data as Record<string, unknown>).warnings).toEqual([warning]);
+      expect(JSON.parse(result.content[0].text).data.warnings).toEqual([warning]);
+    });
+
+    it('fill_template retains warnings from the real CLI fallback', async () => {
+      const root = mkdtempSync(join(tmpdir(), 'oa-mcp-patch-warning-'));
+      const previousRoots = process.env.OPEN_AGREEMENTS_CONTENT_ROOTS;
+      const id = 'common-paper-mutual-nda';
+      const templateDir = join(root, 'templates/common-paper-cc-by-4.0', id);
+      const key = '[Unseen MCP Legacy Carrier]';
+      try {
+        cpSync(findTemplateDir(id)!, templateDir, { recursive: true });
+        writeFileSync(join(templateDir, 'replacements.json'), JSON.stringify({ [key]: '{purpose}' }));
+        process.env.OPEN_AGREEMENTS_CONTENT_ROOTS = root;
+        _setModuleOverride(null);
+
+        const result = await callTool('fill_template', {
+          template: id,
+          values: { purpose: 'Evaluating a potential partnership' },
+          return_mode: 'inline_base64',
+        });
+
+        expect(result.isError).toBeUndefined();
+        const data = getPayload(result).data as Record<string, unknown>;
+        expect(data.warnings).toContain(`patch: 1 replacement key(s) had zero matches: ${key}`);
+        expect(readDocxText(data.inline_base64 as string)).toContain('Evaluating a potential partnership');
+      } finally {
+        if (previousRoots === undefined) delete process.env.OPEN_AGREEMENTS_CONTENT_ROOTS;
+        else process.env.OPEN_AGREEMENTS_CONTENT_ROOTS = previousRoots;
+        rmSync(root, { recursive: true, force: true });
+      }
     });
 
     it('fill_template returns FILL_FAILED on engine error', async () => {

--- a/src/core/unified-pipeline.ts
+++ b/src/core/unified-pipeline.ts
@@ -116,8 +116,8 @@ export interface PipelineResult {
   fillCommandCount: number;
   /**
    * Structured guardrail warnings for callers (CLI/API/MCP): zero-fill-command
-   * documents, failed verification checks. Other advisory console output
-   * (priority fields, selector warnings, zero-match patch keys) intentionally
+   * documents, unexpected zero-match patch keys, failed verification checks.
+   * Other advisory console output (priority fields, selector warnings) intentionally
    * stays console-only for now.
    */
   warnings: string[];
@@ -202,6 +202,7 @@ export async function runFillPipeline(options: PipelineOptions): Promise<Pipelin
     syntheticFieldKeys.add('any_confirmation_pending');
   }
   let stages: PipelineResult['stages'] | undefined;
+  const warnings: string[] = [];
 
   try {
     // Step 2: Copy source to temp dir
@@ -266,8 +267,8 @@ export async function runFillPipeline(options: PipelineOptions): Promise<Pipelin
       });
 
       if (unexpectedZeroMatch.length > 0) {
-        console.warn(
-          `Note: ${unexpectedZeroMatch.length} replacement key(s) had zero matches: ${unexpectedZeroMatch.join(', ')}`
+        warnings.push(
+          `patch: ${unexpectedZeroMatch.length} replacement key(s) had zero matches: ${unexpectedZeroMatch.join(', ')}`
         );
       }
 
@@ -310,8 +311,6 @@ export async function runFillPipeline(options: PipelineOptions): Promise<Pipelin
       computeDisplayFields: instrumentedCompute,
       confirmClauses: options.confirmClauses,
     });
-
-    const warnings: string[] = [];
 
     // Step 5: Read current buffer; apply selections if configured
     let templateBuf: Buffer = readFileSync(currentPath);


### PR DESCRIPTION
## Problem and change

Unexpected legacy replacement zero-matches were printed to the console but omitted from fill results, so API consumers could receive an empty warning list despite source drift. The shared pipeline now returns these diagnostics in `warnings`; the CLI displays them and MCP `fill_template` carries them through both its in-process and CLI fallback paths. Existing intentional-cleaning and migrated-key filtering remains intact. The policy stays advisory.

Closes #790.

## Validation

- Behavioral regressions cover an unseen unmatched key, intentionally cleaned carriers, all three CLI fill routes, MCP structured/text output, and a real CLI fallback fill.
- Build, lint, template validation, and full test suite passed; final counts are recorded in the smoke follow-up.
- Real pinned NVCA COI smoke: baseline has no patch warnings; injected unseen key produces exactly one warning; a reintroduced migrated key remains filtered; visible document text is unchanged; library, CLI, and MCP fallback all expose the warning. Synthetic identities only; no source or generated documents committed.

Visual evidence is unnecessary because this change affects diagnostic delivery, not document presentation.
