### PR TITLE
fix(runtime): publish verified recipe capability contract

### DIFF
--- a/.github/workflows/publish-gh-runtime.yml
+++ b/.github/workflows/publish-gh-runtime.yml
@@ -42,6 +42,7 @@ jobs:
           rm -rf runtime-pkg
           mkdir -p runtime-pkg
           cp -r dist runtime-pkg/dist
+          cp runtime-capabilities.json runtime-pkg/runtime-capabilities.json
           # All content is unified under templates/<source>-<rights>/<slug>/ (#1249).
           cp -r templates runtime-pkg/templates
           # bundleDependencies requires the dep to be declared in `dependencies`
@@ -63,7 +64,7 @@ jobs:
                 "./dist/*": "./dist/*",
                 "./templates/*": "./templates/*"
               },
-              files: ["dist/", "templates/"],
+              files: ["dist/", "templates/", "runtime-capabilities.json"],
               dependencies: {
                 "@usejunior/docx-core": process.env.DOCX_CORE_VERSION,
                 "@xmldom/xmldom": "^0.9.9",

--- a/docs/runtime-compatibility.md
+++ b/docs/runtime-compatibility.md
@@ -1,0 +1,30 @@
+# Runtime compatibility for recipe distribution
+
+`runtime-capabilities.json` is a versioned distribution contract. The public
+`RUNTIME_CAPABILITIES` export describes the same capabilities in the built
+runtime. Build checks require exact parity; packages must carry both.
+
+A forward sync must infer requirements from the actual recipe files and
+operations, then check the destination contract **before replacing or deleting
+any destination content**. Missing, unknown-version, or insufficient contracts
+must fail. Do not infer support from a package version alone, and do not rely on
+an unknown requirement key that an old parser can silently strip.
+
+The v1 capability names cover the current legacy replacements, cleaner,
+selector manifests, selections, computed rules, normalization, repeatable tables,
+anchored paragraph bindings and reference-field actions. Story paragraph removal,
+bounded selection removal, and grouped reference literalization have additional
+explicit capabilities because older runtimes lacked those operations. These names
+describe supported operation contracts, not a minimum npm release inferred from
+its version number. New incompatible operations require a new capability.
+
+Selections parsing is strict at the config, group, option and trigger levels.
+Unknown keys fail instead of being discarded. Existing option `label` values
+remain accepted. A schema-versioned distribution contract and a strict loader
+serve different purposes: the former stops an incompatible sync; the latter
+prevents future malformed operations from silently becoming no-ops.
+
+This cannot retroactively protect callers who manually copy new recipes into an
+old npm installation while bypassing the guarded distribution path. Historical
+OA 0.7.6 accepted removal-bearing selections while stripping the removal objects;
+the contract therefore must be checked by the distributing process.

--- a/docs/runtime-compatibility.md
+++ b/docs/runtime-compatibility.md
@@ -18,6 +18,11 @@ explicit capabilities because older runtimes lacked those operations. These name
 describe supported operation contracts, not a minimum npm release inferred from
 its version number. New incompatible operations require a new capability.
 
+`conditional-input-requirements.v1` identifies the `required_when` field contract:
+missing selected inputs are refused and exported input schemas express the same
+condition. Distributors must detect these declarations in metadata; an older
+runtime may otherwise strip them while accepting the rest of the field.
+
 Selections parsing is strict at the config, group, option and trigger levels.
 Unknown keys fail instead of being discarded. Existing option `label` values
 remain accepted. A schema-versioned distribution contract and a strict loader

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "LICENSE",
     "SECURITY.md",
     "server.json",
+    "runtime-capabilities.json",
     "gemini-extension.json",
     "AGENTS.md",
     "llms.txt",
@@ -56,7 +57,8 @@
     "@usejunior/docx-core"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && node scripts/check_runtime_capabilities.mjs",
+    "prepack": "node scripts/check_runtime_capabilities.mjs",
     "build:workspace": "tsc -p packages/contracts-workspace/tsconfig.json",
     "build:workspace-mcp": "tsc -p packages/contracts-workspace-mcp/tsconfig.json",
     "build:contract-templates-mcp": "tsc -p packages/contract-templates-mcp/tsconfig.json",

--- a/runtime-capabilities.json
+++ b/runtime-capabilities.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "capabilities": [
+    "legacy-replacements.v1",
+    "clean.v1",
+    "clean.story-paragraphs.v1",
+    "selectors.v1",
+    "selections.v1",
+    "selections.bounded-removal.v1",
+    "computed.v1",
+    "normalize.v1",
+    "repeatable-tables.v1",
+    "anchored-paragraph-bindings.v1",
+    "reference-fields.v1",
+    "reference-fields.grouped.v1"
+  ]
+}

--- a/runtime-capabilities.json
+++ b/runtime-capabilities.json
@@ -12,6 +12,7 @@
     "repeatable-tables.v1",
     "anchored-paragraph-bindings.v1",
     "reference-fields.v1",
-    "reference-fields.grouped.v1"
+    "reference-fields.grouped.v1",
+    "conditional-input-requirements.v1"
   ]
 }

--- a/scripts/check_isolated_package_runtime.mjs
+++ b/scripts/check_isolated_package_runtime.mjs
@@ -186,6 +186,14 @@ function main() {
       throw new Error('open-agreements list --json did not return expected payload in isolated runtime');
     }
 
+    run('node', ['--input-type=module', '--eval', `
+      import assert from 'node:assert/strict';
+      import { readFileSync } from 'node:fs';
+      import { RUNTIME_CAPABILITIES } from 'open-agreements';
+      assert.deepEqual(JSON.parse(readFileSync('node_modules/open-agreements/runtime-capabilities.json', 'utf8')), RUNTIME_CAPABILITIES);
+      assert.ok(RUNTIME_CAPABILITIES.capabilities.includes('selections.bounded-removal.v1'));
+    `], { cwd: sandbox, timeout: 30000 });
+
     assertMcpStartup('open-agreements-workspace-mcp', sandbox);
     assertMcpStartup('open-agreements-contract-templates-mcp', sandbox);
     assertMcpStartup('open-agreements-checklist-mcp', sandbox);

--- a/scripts/check_runtime_capabilities.mjs
+++ b/scripts/check_runtime_capabilities.mjs
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+// Run after compilation and before staging/publishing. A copied declaration
+// must not claim capabilities absent from the actual built runtime.
+const root = resolve(process.argv[2] ?? '.');
+const declared = JSON.parse(readFileSync(resolve(root, 'runtime-capabilities.json'), 'utf8'));
+const { RUNTIME_CAPABILITIES } = await import(pathToFileURL(resolve(root, 'dist/core/runtime-capabilities.js')));
+assert.deepEqual(declared, RUNTIME_CAPABILITIES, 'runtime-capabilities.json does not match the built runtime');
+console.log('Runtime capability declaration matches built runtime.');

--- a/scripts/check_runtime_capabilities.mjs
+++ b/scripts/check_runtime_capabilities.mjs
@@ -9,4 +9,5 @@ const root = resolve(process.argv[2] ?? '.');
 const declared = JSON.parse(readFileSync(resolve(root, 'runtime-capabilities.json'), 'utf8'));
 const { RUNTIME_CAPABILITIES } = await import(pathToFileURL(resolve(root, 'dist/core/runtime-capabilities.js')));
 assert.deepEqual(declared, RUNTIME_CAPABILITIES, 'runtime-capabilities.json does not match the built runtime');
-console.log('Runtime capability declaration matches built runtime.');
+// Stay silent on success: npm versions that forward lifecycle stdout into
+// `pack --json` otherwise corrupt the machine-readable package inventory.

--- a/scripts/prepare_scoped_open_agreements_package.mjs
+++ b/scripts/prepare_scoped_open_agreements_package.mjs
@@ -67,6 +67,7 @@ function getRootPackMetadata() {
 }
 
 const outDir = parseOutDir(process.argv.slice(2));
+execFileSync(process.execPath, ['scripts/check_runtime_capabilities.mjs'], { stdio: 'inherit' });
 const packageJsonRaw = fs.readFileSync(ROOT_PACKAGE_PATH, "utf8");
 const rootPackageJson = JSON.parse(packageJsonRaw);
 
@@ -85,6 +86,9 @@ const scopedPackageJson = {
 
 if (scopedPackageJson.scripts && typeof scopedPackageJson.scripts === "object") {
   delete scopedPackageJson.scripts.prepare;
+  // This staging entry point already verifies parity before copying. The
+  // development-only checker script is not part of the staged package.
+  delete scopedPackageJson.scripts.prepack;
 }
 
 fs.mkdirSync(outDir, { recursive: true });

--- a/scripts/prepare_scoped_open_agreements_package.test.mjs
+++ b/scripts/prepare_scoped_open_agreements_package.test.mjs
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 
@@ -43,6 +43,22 @@ function bundledPackages(packageDir) {
 }
 
 describe('prepare_scoped_open_agreements_package', () => {
+  it('refuses a capability declaration that exceeds the built runtime before copying', () => {
+    const fixture = tempDir('oa-incompatible-package-');
+    mkdirSync(join(fixture, 'scripts'));
+    mkdirSync(join(fixture, 'dist/core'), { recursive: true });
+    cpSync(join(REPO_ROOT, 'scripts/check_runtime_capabilities.mjs'), join(fixture, 'scripts/check_runtime_capabilities.mjs'));
+    writeFileSync(join(fixture, 'package.json'), JSON.stringify({ type: 'module', files: ['dist/'] }));
+    writeFileSync(join(fixture, 'dist/core/runtime-capabilities.js'), 'export const RUNTIME_CAPABILITIES = {schema_version:1,capabilities:[]};');
+    writeFileSync(join(fixture, 'runtime-capabilities.json'), JSON.stringify({ schema_version: 1, capabilities: ['selections.bounded-removal.v1'] }));
+    const outDir = tempDir('oa-incompatible-destination-');
+    writeFileSync(join(outDir, 'sentinel'), 'unchanged');
+
+    expect(() => execFileSync(process.execPath, [PREPARE_SCRIPT, '--out-dir', outDir], { cwd: fixture, stdio: 'pipe' })).toThrow();
+    expect(readFileSync(join(outDir, 'sentinel'), 'utf8')).toBe('unchanged');
+    expect(existsSync(join(outDir, 'dist'))).toBe(false);
+  });
+
   it(
     'stages the same bundled dependency tree as the root package',
     () => {
@@ -55,6 +71,9 @@ describe('prepare_scoped_open_agreements_package', () => {
       });
 
       const actual = bundledPackages(outDir);
+      expect(JSON.parse(readFileSync(join(outDir, 'runtime-capabilities.json'), 'utf8'))).toEqual(
+        JSON.parse(readFileSync(join(REPO_ROOT, 'runtime-capabilities.json'), 'utf8')),
+      );
       expect(actual).toContain('@usejunior/docx-core');
       expect([...actual].sort()).toEqual([...expected].sort());
       expect(

--- a/scripts/prepare_scoped_open_agreements_package.test.mjs
+++ b/scripts/prepare_scoped_open_agreements_package.test.mjs
@@ -43,6 +43,12 @@ function bundledPackages(packageDir) {
 }
 
 describe('prepare_scoped_open_agreements_package', () => {
+  it('keeps successful capability checks silent for npm pack JSON consumers', () => {
+    expect(execFileSync(process.execPath, ['scripts/check_runtime_capabilities.mjs'], {
+      cwd: REPO_ROOT, encoding: 'utf8',
+    })).toBe('');
+  });
+
   it('refuses a capability declaration that exceeds the built runtime before copying', () => {
     const fixture = tempDir('oa-incompatible-package-');
     mkdirSync(join(fixture, 'scripts'));

--- a/src/core/runtime-capabilities.test.ts
+++ b/src/core/runtime-capabilities.test.ts
@@ -1,0 +1,59 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { describe, expect } from 'vitest';
+import { z } from 'zod';
+import { itAllure } from '../../integration-tests/helpers/allure-test.js';
+import { RUNTIME_CAPABILITIES } from './runtime-capabilities.js';
+import { SelectionsConfigSchema } from './selector.js';
+
+const it = itAllure.epic('Platform & Distribution');
+const option = {
+  marker: 'Optional paragraph', trigger: { field: 'include_optional' },
+  removal: { kind: 'paragraph', anchor: 'Optional paragraph', match: 'exact', expectedMatches: 1 },
+};
+const config = { groups: [{ id: 'optional', type: 'checkbox', markerless: true, options: [option] }] };
+
+describe('runtime capability contract', () => {
+  it('matches the shipped declaration to the runtime export', () => {
+    expect(JSON.parse(readFileSync(resolve('runtime-capabilities.json'), 'utf8'))).toEqual(RUNTIME_CAPABILITIES);
+  });
+
+  it('pins the old 0.7.6 stripping behavior and preserves removal in the supported schema', () => {
+    // Frozen verbatim OptionSchema / TriggerSchema shape from published
+    // open-agreements@0.7.6 dist/core/selector.js; intentionally NOT strict.
+    const OldTriggerSchema = z.union([
+      z.literal('default'),
+      z.object({ field: z.string(), equals: z.union([z.string(), z.boolean()]) }),
+      z.object({ field: z.string() }),
+    ]);
+    const OldOptionSchema = z.object({
+      marker: z.string(), trigger: OldTriggerSchema, replaceWith: z.string().optional(),
+    });
+    expect(OldOptionSchema.parse(option)).not.toHaveProperty('removal');
+    expect(SelectionsConfigSchema.parse(config).groups[0].options[0].removal).toEqual(option.removal);
+  });
+
+  it('rejects unknown operations at every formerly stripping selections boundary', () => {
+    expect(() => SelectionsConfigSchema.parse({ ...config, futureOperation: true })).toThrow();
+    expect(() => SelectionsConfigSchema.parse({ groups: [{ ...config.groups[0], futureOperation: true }] })).toThrow();
+    expect(() => SelectionsConfigSchema.parse({ groups: [{ ...config.groups[0], options: [{ ...option, futureOperation: true }] }] })).toThrow();
+    expect(() => SelectionsConfigSchema.parse({ groups: [{ ...config.groups[0], options: [{ ...option, trigger: { field: 'include_optional', futureOperation: true } }] }] })).toThrow();
+  });
+
+  it('accepts every shipped selections file including legitimate option labels', () => {
+    let checked = 0;
+    const visit = (dir: string): void => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const path = join(dir, entry.name);
+        if (entry.isDirectory()) visit(path);
+        else if (entry.name === 'selections.json') {
+          const raw = JSON.parse(readFileSync(path, 'utf8'));
+          expect(SelectionsConfigSchema.parse(raw).groups).toMatchObject(raw.groups);
+          checked++;
+        }
+      }
+    };
+    visit(resolve('templates'));
+    expect(checked).toBeGreaterThan(7);
+  });
+});

--- a/src/core/runtime-capabilities.ts
+++ b/src/core/runtime-capabilities.ts
@@ -1,0 +1,22 @@
+/**
+ * Distribution contract for recipe operations supported by this runtime.
+ * Consumers must inspect actual operations as well as explicit requirements.
+ * A manifest cannot retrofit protection into an old loader that ignores it.
+ */
+export const RUNTIME_CAPABILITIES = Object.freeze({
+  schema_version: 1,
+  capabilities: Object.freeze([
+    'legacy-replacements.v1',
+    'clean.v1',
+    'clean.story-paragraphs.v1',
+    'selectors.v1',
+    'selections.v1',
+    'selections.bounded-removal.v1',
+    'computed.v1',
+    'normalize.v1',
+    'repeatable-tables.v1',
+    'anchored-paragraph-bindings.v1',
+    'reference-fields.v1',
+    'reference-fields.grouped.v1',
+  ]),
+});

--- a/src/core/runtime-capabilities.ts
+++ b/src/core/runtime-capabilities.ts
@@ -18,5 +18,6 @@ export const RUNTIME_CAPABILITIES = Object.freeze({
     'anchored-paragraph-bindings.v1',
     'reference-fields.v1',
     'reference-fields.grouped.v1',
+    'conditional-input-requirements.v1',
   ]),
 });

--- a/src/core/selector.ts
+++ b/src/core/selector.ts
@@ -30,12 +30,13 @@ function normalizeQuotes(text: string): string {
 
 const TriggerSchema = z.union([
   z.literal('default'),
-  z.object({ field: z.string(), equals: z.union([z.string(), z.boolean()]) }),
-  z.object({ field: z.string() }),
+  z.object({ field: z.string(), equals: z.union([z.string(), z.boolean()]) }).strict(),
+  z.object({ field: z.string() }).strict(),
 ]);
 type Trigger = z.infer<typeof TriggerSchema>;
 
 const OptionSchema = z.object({
+  label: z.string().optional(),
   marker: z.string(),
   trigger: TriggerSchema,
   replaceWith: z.string().optional(),
@@ -65,7 +66,7 @@ const OptionSchema = z.object({
       removeAdjacentBlankParagraphs: z.boolean().optional(),
     }).strict(),
   ]).optional(),
-});
+}).strict();
 
 const GroupSchema = z
   .object({
@@ -77,7 +78,7 @@ const GroupSchema = z
     cellContext: z.string().optional(),
     subClauseStopPatterns: z.array(z.string()).optional(),
     options: z.array(OptionSchema).min(1),
-  })
+  }).strict()
   .refine(
     (g) => g.standalone === true || g.markerless === true || g.options.length >= 2,
     { message: 'Non-standalone/non-markerless groups require at least 2 options' },
@@ -103,7 +104,7 @@ const GroupSchema = z
 
 export const SelectionsConfigSchema = z.object({
   groups: z.array(GroupSchema).min(1),
-});
+}).strict();
 export type SelectionsConfig = z.infer<typeof SelectionsConfigSchema>;
 
 // ---------------------------------------------------------------------------

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 // Public API exports
+export { RUNTIME_CAPABILITIES } from './core/runtime-capabilities.js';
 
 // Template engine
 export { fillTemplate, type FillOptions, type FillResult } from './core/engine.js';


### PR DESCRIPTION
## Problem and change

Older selectors parsers accepted a new recipe while silently discarding its bounded-removal operations. This adds a versioned runtime capability declaration and matching public export for distributors to check before copying content. Build, normal packaging, and scoped-package staging require declaration/runtime parity; the installed-package smoke verifies both ship together. Selections config, group, option and trigger schemas now reject unknown keys, while accepting every legitimate field in the current corpus, including option labels.

First part of #793. The following canonical-source sync change will infer requirements from real operations and reject an incompatible target before replacing or deleting any destination content. This PR alone does not protect callers manually copying recipes into an old npm runtime.

## Validation

- Frozen 0.7.6 schema regression demonstrates removal stripping; current schema preserves removal and rejects unknown keys at each formerly stripping boundary.
- All shipped selections validate, and existing bounded-removal tests execute both retained/deleted branches and drift failures.
- Mismatched package declaration is refused before any destination copy; installed packed CLI/MCP verifies capability export/declaration parity.
- Build, lint, template validation, and real pinned NVCA COI library/CLI/MCP smoke passed. Full-suite results recorded after CI/post-merge verification.

No template wording, licensed source documents, or generated outputs are committed. Diagnostic/schema behavior does not change page presentation.
