### PR TITLE
Enforce conditional required inputs consistently in fill and schema

### DIFF
--- a/docs/conditional-required-inputs.md
+++ b/docs/conditional-required-inputs.md
@@ -1,0 +1,42 @@
+# Conditional required inputs
+
+A scalar metadata field can require an explicit caller value only when a
+top-level controller has a particular value:
+
+```yaml
+- name: include_optional_regime
+  type: boolean
+  description: Enable the optional regime
+  default: false
+- name: selected_rate
+  type: string
+  description: Selected percentage, without a percent sign
+  required_when:
+    field: include_optional_regime
+    equals: true
+```
+
+The shared fill preparation and field-selector API reject an active requirement
+whose input is absent, null, empty, or only whitespace. A numeric zero, the string
+`"0"`, and boolean false are present values. Ordinary field type and enum checks
+still apply. Field-selector rejection happens before source download or document
+mutation, with error code `INCOMPLETE_CONDITIONAL_INPUT` and a `fields` array.
+The CLI exits unsuccessfully and names the missing fields.
+
+The controller must be another declared top-level scalar field. Its `equals`
+value must have the controller's type and, for an enum, be one of its options.
+Nested conditions, array controllers/targets, computed controllers/targets, and
+defaults on conditionally required inputs are rejected. This contract requires
+an explicit choice; it never supplies missing economics.
+
+An omitted controller uses its metadata default to decide whether the requirement
+applies. An explicitly supplied controller takes precedence and must have the
+declared scalar type. An absent controller with no matching default does not
+activate the requirement. Exported field-selector JSON Schema uses the same
+default-aware `if`/`then` conditions, including `required` on the controller when
+omission must not activate it. Active string inputs also require a non-whitespace
+character. Unconditional `priority_fields` remain unconditional.
+
+Recipe owners add these declarations to their canonical metadata; consumers
+must not invent a legal requirement in a downstream mirror. Runtime support
+alone does not activate a requirement on existing recipes.

--- a/integration-tests/conditional-inputs.test.ts
+++ b/integration-tests/conditional-inputs.test.ts
@@ -1,0 +1,58 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, describe, expect, vi } from 'vitest';
+import { itAllure } from './helpers/allure-test.js';
+import { runFieldSelector } from '../src/core/field-selector/index.js';
+
+const it = itAllure.epic('Filling & Rendering');
+const dirs: string[] = [];
+afterEach(() => { vi.unstubAllEnvs(); for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true }); });
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), 'oa-conditional-api-')); dirs.push(root);
+  const dir = join(root, 'templates', 'synthetic', 'conditional-input-fixture'); mkdirSync(dir, { recursive: true });
+  const fields = [
+    { name: 'enabled', type: 'boolean', description: 'Enable optional regime', default: 'false' },
+    ...['start_date', 'interest_rate', 'frequency'].map(name => ({ name, type: 'string', description: name,
+      required_when: { field: 'enabled', equals: true } })),
+  ];
+  writeFileSync(join(dir, 'metadata.yaml'), JSON.stringify({ name: 'Synthetic conditional fixture', artifact_type: 'field-selector',
+    source_url: 'https://example.com/never-downloaded.docx', source_version: '1', license_note: 'Synthetic fixture', fields }));
+  writeFileSync(join(dir, 'replacements.json'), '{}');
+  return root;
+}
+
+describe('conditional input public entry points', () => {
+  it('API rejects every missing economic before touching input or output documents', async () => {
+    const root = fixture(); vi.stubEnv('OPEN_AGREEMENTS_CONTENT_ROOTS', root);
+    const complete = { enabled: true, start_date: '2030-01-01', interest_rate: '0', frequency: 'annual' };
+    for (const name of ['start_date', 'interest_rate', 'frequency']) {
+      const values: Record<string, unknown> = { ...complete }; delete values[name];
+      const outputPath = join(root, `${name}.docx`);
+      await expect(runFieldSelector({ fieldSelectorId: 'conditional-input-fixture', values,
+        inputPath: join(root, 'does-not-exist.docx'), outputPath })).rejects.toMatchObject({
+        code: 'INCOMPLETE_CONDITIONAL_INPUT', fields: [name],
+      });
+      expect(existsSync(outputPath)).toBe(false);
+    }
+  });
+
+  it('CLI exits unsuccessfully with named missing fields and writes no output', () => {
+    const root = fixture();
+    const data = join(root, 'values.json'); const output = join(root, 'out.docx');
+    writeFileSync(data, JSON.stringify({ enabled: true, interest_rate: '0' }));
+    let error: unknown;
+    try {
+      execFileSync(process.execPath, [join(new URL('..', import.meta.url).pathname, 'bin/open-agreements.js'),
+        'field-selector', 'run', 'conditional-input-fixture', '--data', data, '--output', output,
+        '--input', join(root, 'does-not-exist.docx')], {
+        env: { ...process.env, OPEN_AGREEMENTS_CONTENT_ROOTS: root }, encoding: 'utf8', stdio: 'pipe',
+      });
+    } catch (caught) { error = caught; }
+    expect(error).toMatchObject({ status: 1 });
+    expect(String((error as { stderr: string }).stderr)).toContain('Incomplete conditional input: start_date, frequency');
+    expect(existsSync(output)).toBe(false);
+  });
+});

--- a/src/core/conditional-inputs.test.ts
+++ b/src/core/conditional-inputs.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect } from 'vitest';
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+import { itAllure } from '../../integration-tests/helpers/allure-test.js';
+import { FieldSelectorMetadataSchema } from './metadata.js';
+import { assertConditionalRequiredInputs, IncompleteConditionalInputError } from './conditional-inputs.js';
+import { buildFieldSelectorInputSchema } from './field-selector/input-schema.js';
+import { prepareFillData } from './fill-pipeline.js';
+
+const it = itAllure.epic('Filling & Rendering');
+const fixture = {
+  name: 'Conditional inputs', source_url: 'https://example.com/form.docx', source_version: '1', license_note: 'Synthetic',
+  fields: [
+    { name: 'enabled', type: 'boolean', description: 'Enable optional regime', default: 'false' },
+    { name: 'start_date', type: 'date', description: 'Start', required_when: { field: 'enabled', equals: true } },
+    { name: 'interest_rate', type: 'string', description: 'Percentage', required_when: { field: 'enabled', equals: true } },
+    { name: 'frequency', type: 'enum', description: 'Frequency', options: ['annual', 'quarterly'], required_when: { field: 'enabled', equals: true } },
+  ],
+};
+
+describe('conditional required inputs', () => {
+  it('keeps runtime and exported schema aligned for omitted, blank, disabled and complete inputs', () => {
+    const metadata = FieldSelectorMetadataSchema.parse(fixture);
+    const ajv = new Ajv2020({ strict: true });
+    addFormats(ajv); ajv.addKeyword('x-openagreements');
+    const validate = ajv.compile(buildFieldSelectorInputSchema('fixture', metadata, null));
+    const valid = { enabled: true, start_date: '2030-01-01', interest_rate: '0', frequency: 'annual' };
+    for (const field of ['start_date', 'interest_rate', 'frequency']) {
+      for (const omitted of [undefined, '', ' \t\n']) {
+        const invalid = { ...valid, [field]: omitted };
+        expect(validate(invalid)).toBe(false);
+        expect(() => assertConditionalRequiredInputs(invalid, metadata.fields)).toThrow(IncompleteConditionalInputError);
+        try { assertConditionalRequiredInputs(invalid, metadata.fields); } catch (error) {
+          expect(error).toMatchObject({ code: 'INCOMPLETE_CONDITIONAL_INPUT', fields: [field] });
+        }
+      }
+    }
+    for (const input of [{}, { enabled: false }, valid]) {
+      expect(validate(input)).toBe(true);
+      expect(() => prepareFillData({ values: input, fields: metadata.fields })).not.toThrow();
+    }
+    expect(validate({ ...valid, frequency: 'daily' })).toBe(false);
+    expect(() => prepareFillData({ values: { ...valid, frequency: 'daily' }, fields: metadata.fields })).toThrow(/unknown option/);
+    expect(validate({ enabled: 'true' })).toBe(false);
+    expect(() => assertConditionalRequiredInputs({ enabled: 'true' }, metadata.fields)).toThrow(/controller/);
+  });
+
+  it('uses matching controller defaults consistently without treating an absent controller as true otherwise', () => {
+    for (const defaultValue of [undefined, 'false', 'true']) {
+      const raw = structuredClone(fixture);
+      if (defaultValue === undefined) delete (raw.fields[0] as { default?: string }).default;
+      else raw.fields[0].default = defaultValue;
+      const metadata = FieldSelectorMetadataSchema.parse(raw);
+      const ajv = new Ajv2020({ strict: false }); addFormats(ajv);
+      const validate = ajv.compile(buildFieldSelectorInputSchema('fixture', metadata, null));
+      expect(validate({})).toBe(defaultValue !== 'true');
+      expect(validate({ enabled: false })).toBe(true);
+      if (defaultValue === 'true') expect(() => assertConditionalRequiredInputs({}, metadata.fields)).toThrow(/start_date/);
+      else expect(() => assertConditionalRequiredInputs({}, metadata.fields)).not.toThrow();
+      expect(() => assertConditionalRequiredInputs({ enabled: false }, metadata.fields)).not.toThrow();
+    }
+  });
+
+  it('rejects unknown, self, incompatible or nested controllers and silent economic defaults', () => {
+    for (const condition of [{ field: 'missing', equals: true }, { field: 'start_date', equals: true }, { field: 'enabled', equals: 'true' }]) {
+      const raw = structuredClone(fixture); raw.fields[1].required_when = condition as typeof raw.fields[1]['required_when'];
+      expect(FieldSelectorMetadataSchema.safeParse(raw).success).toBe(false);
+    }
+    const raw = structuredClone(fixture); raw.fields[1].default = '2030-01-01';
+    expect(FieldSelectorMetadataSchema.safeParse(raw).success).toBe(false);
+    expect(FieldSelectorMetadataSchema.safeParse({ ...fixture, fields: [...fixture.fields, {
+      name: 'rows', type: 'array', description: 'Rows', items: [{ ...fixture.fields[1] }],
+    }] }).success).toBe(false);
+  });
+});

--- a/src/core/conditional-inputs.ts
+++ b/src/core/conditional-inputs.ts
@@ -1,0 +1,46 @@
+import type { FieldDefinition } from './metadata.js';
+
+/** Defaults activate a regime only when the caller omitted its controller. */
+export function conditionalControllerDefault(field: FieldDefinition): unknown {
+  if (field.default === undefined) return undefined;
+  if (field.type === 'boolean') return field.default === 'true';
+  if (field.type === 'number') return Number(field.default);
+  return field.default;
+}
+
+export class IncompleteConditionalInputError extends Error {
+  readonly code = 'INCOMPLETE_CONDITIONAL_INPUT';
+  constructor(readonly fields: string[]) {
+    super(`Incomplete conditional input: ${fields.join(', ')} must be supplied with nonblank values for the enabled selection`);
+    this.name = 'IncompleteConditionalInputError';
+  }
+}
+
+export function assertConditionalInputOwnership(fields: FieldDefinition[], computed: Set<string>): void {
+  for (const field of fields) {
+    if (field.required_when && (computed.has(field.name) || computed.has(field.required_when.field))) {
+      throw new Error(`required_when for "${field.name}" must use caller inputs, not computed fields`);
+    }
+  }
+}
+
+/** Check raw caller inputs before defaults, downloads, or document mutation. */
+export function assertConditionalRequiredInputs(values: Record<string, unknown>, fields: FieldDefinition[]): void {
+  const byName = new Map(fields.map((field) => [field.name, field]));
+  const missing: string[] = [];
+  for (const field of fields) {
+    const condition = field.required_when;
+    if (!condition) continue;
+    const controller = byName.get(condition.field);
+    if (!controller) throw new Error(`Unknown required_when controller: ${condition.field}`);
+    const supplied = Object.prototype.hasOwnProperty.call(values, condition.field);
+    const actual = supplied ? values[condition.field] : conditionalControllerDefault(controller);
+    if (supplied && typeof actual !== typeof condition.equals) {
+      throw new Error(`Conditional controller "${condition.field}" must be a ${typeof condition.equals}`);
+    }
+    if (actual !== condition.equals) continue;
+    const value = values[field.name];
+    if (value == null || (typeof value === 'string' && value.trim() === '')) missing.push(field.name);
+  }
+  if (missing.length) throw new IncompleteConditionalInputError(missing);
+}

--- a/src/core/field-selector/index.ts
+++ b/src/core/field-selector/index.ts
@@ -24,7 +24,8 @@ import { applyRepeatableTables, loadRepeatableTablesConfig, validateRepeatableTa
 import { bindAnchoredParagraphFields, loadAnchoredParagraphBindingsConfig } from './anchored-paragraph-bindings.js';
 import { normalizeNumberedHeadingSections } from './numbering-normalizer.js';
 import { loadReferenceFieldsConfig } from './reference-fields.js';
-import { assertFieldSelectorInputValueShapes } from './input-schema.js';
+import { assertFieldSelectorInputValueShapes, computedFieldNames } from './input-schema.js';
+import { assertConditionalInputOwnership, assertConditionalRequiredInputs } from '../conditional-inputs.js';
 
 function toComputedValueMap(values: Record<string, unknown>): ComputedValueMap {
   const computedValues: ComputedValueMap = {};
@@ -49,6 +50,9 @@ export async function runFieldSelector(options: FieldSelectorRunOptions): Promis
   const fieldSelectorDir = resolveFieldSelectorDir(fieldSelectorId);
 
   const metadata = loadFieldSelectorMetadata(fieldSelectorDir);
+  const computedProfile = loadComputedProfile(fieldSelectorDir);
+  assertConditionalInputOwnership(metadata.fields, computedFieldNames(computedProfile));
+  assertConditionalRequiredInputs(values, metadata.fields);
   // Validate source-owned token/sigil shapes before downloading, cleaning, or
   // writing a document. The exported caller schema uses the same constraints.
   assertFieldSelectorInputValueShapes(values, metadata.fields);
@@ -112,7 +116,6 @@ export async function runFieldSelector(options: FieldSelectorRunOptions): Promis
   // the same display-ready value (and chained computed fields inherit it).
   const inputValues = formatDocumentDateFields(values, metadata.fields);
   const computedInputValues = toComputedValueMap(inputValues);
-  const computedProfile = loadComputedProfile(fieldSelectorDir);
   const computedEvaluation = computedProfile
     ? evaluateComputedProfile(computedProfile, computedInputValues)
     : null;

--- a/src/core/field-selector/input-schema.ts
+++ b/src/core/field-selector/input-schema.ts
@@ -8,6 +8,7 @@ import {
 } from '../metadata.js';
 import { loadComputedProfile, type ComputedProfile } from './computed.js';
 import { resolveFieldSelectorDir } from '../../utils/paths.js';
+import { assertConditionalInputOwnership, conditionalControllerDefault } from '../conditional-inputs.js';
 
 export const FIELD_SELECTOR_INPUT_SCHEMA_VERSION = 1 as const;
 export const FIELD_SELECTOR_SCHEMA_GENERATOR = 'open-agreements field-selector schema' as const;
@@ -164,9 +165,31 @@ export function buildFieldSelectorInputSchema(
   computedProfile: ComputedProfile | null,
 ): JsonSchema {
   const computed = computedFieldNames(computedProfile);
+  assertConditionalInputOwnership(metadata.fields, computed);
   const fields = metadata.fields.filter((field) => !computed.has(field.name));
   const inputNames = new Set(fields.map((field) => field.name));
   const required = metadata.priority_fields.filter((name) => inputNames.has(name));
+  const conditions = fields.filter((field) => field.required_when).map((field) => {
+    const condition = field.required_when!;
+    const controller = fields.find((candidate) => candidate.name === condition.field);
+    if (!controller) throw new Error(`required_when controller "${condition.field}" must be a caller input`);
+    const usesDefault = conditionalControllerDefault(controller) === condition.equals;
+    return {
+      if: {
+        properties: { [condition.field]: { const: condition.equals } },
+        // Without a matching controller default, omission must not vacuously
+        // activate the condition. JSON Schema does not apply defaults itself.
+        ...(!usesDefault ? { required: [condition.field] } : {}),
+      },
+      then: {
+        required: [field.name],
+        properties: {
+          [field.name]: ['string', 'enum', 'date'].includes(field.type)
+            ? { type: 'string', pattern: '\\S' } : { type: field.type },
+        },
+      },
+    };
+  });
   return {
     $schema: 'https://json-schema.org/draft/2020-12/schema',
     $id: `https://openagreements.org/schemas/field-selector/${fieldSelectorId}.schema.json`,
@@ -176,6 +199,7 @@ export function buildFieldSelectorInputSchema(
     additionalProperties: false,
     properties: Object.fromEntries(fields.map((field) => [field.name, fieldSchema(field)])),
     required,
+    ...(conditions.length ? { allOf: conditions } : {}),
     'x-openagreements': {
       field_selector_id: fieldSelectorId,
       source_version: metadata.source_version,

--- a/src/core/fill-pipeline.ts
+++ b/src/core/fill-pipeline.ts
@@ -20,6 +20,7 @@ import {
   rezipWithoutDirEntries,
 } from './field-selector/ooxml-parts.js';
 import type { FieldDefinition } from './metadata.js';
+import { assertConditionalRequiredInputs } from './conditional-inputs.js';
 
 const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 
@@ -211,6 +212,8 @@ export function prepareFillData(options: PrepareFillDataOptions): Record<string,
     computeDisplayFields,
     confirmClauses,
   } = options;
+
+  assertConditionalRequiredInputs(values, fields);
 
   // Apply defaults for fields not provided
   const defaultValue = useBlankPlaceholder ? BLANK_PLACEHOLDER : '';

--- a/src/core/metadata.ts
+++ b/src/core/metadata.ts
@@ -66,6 +66,8 @@ export interface FieldDefinition {
   derive_booleans?: boolean;
   section?: string;
   items?: FieldDefinition[];
+  /** Require an explicit, nonblank input when a top-level scalar field matches. */
+  required_when?: { field: string; equals: string | number | boolean };
   /**
    * Marks this boolean field as a *statutory compliance representation*: its
    * `true` value asserts a past real-world fact that is a statutory precondition
@@ -122,6 +124,10 @@ export const FieldDefinitionSchema: z.ZodType<FieldDefinition> = z.lazy(() =>
     derive_booleans: z.boolean().optional(),
     section: z.string().optional(),
     items: z.array(FieldDefinitionSchema).nonempty().optional(),
+    required_when: z.object({
+      field: z.string().min(1),
+      equals: z.union([z.string(), z.number().finite(), z.boolean()]),
+    }).strict().optional(),
     statutory_compliance_representation: z.boolean().optional(),
     authority_url: z.string().optional(),
     confirm_note: z.string().optional(),
@@ -341,6 +347,7 @@ function validatePriorityFields(
   priorityFields: string[],
   ctx: z.RefinementCtx
 ): void {
+  validateConditionalRequirements(fields, ctx);
   const fieldNames = new Set(fields.map((field) => field.name));
   const seen = new Set<string>();
 
@@ -362,6 +369,33 @@ function validatePriorityFields(
       });
     }
   });
+}
+
+function validateConditionalRequirements(fields: FieldDefinition[], ctx: z.RefinementCtx): void {
+  const byName = new Map(fields.map((field) => [field.name, field]));
+  const visit = (items: FieldDefinition[], path: (string | number)[], nested: boolean) => {
+    items.forEach((field, index) => {
+      const at = [...path, index];
+      if (field.required_when) {
+        const controller = byName.get(field.required_when.field);
+        const expectedType = controller?.type === 'boolean' ? 'boolean'
+          : controller?.type === 'number' ? 'number' : 'string';
+        if (nested || !controller || controller.name === field.name ||
+            ['array', 'multiselect'].includes(controller.type) ||
+            typeof field.required_when.equals !== expectedType ||
+            (controller.type === 'enum' && !controller.options?.includes(String(field.required_when.equals)))) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, path: [...at, 'required_when'],
+            message: 'required_when must reference another top-level scalar field with a compatible equals value; nested requirements are unsupported' });
+        }
+        if (field.default !== undefined || ['array', 'multiselect'].includes(field.type)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, path: [...at, 'required_when'],
+            message: 'Conditionally required fields must be scalar inputs without defaults' });
+        }
+      }
+      if (field.items) visit(field.items, [...at, 'items'], true);
+    });
+  };
+  visit(fields, ['fields'], false);
 }
 
 /** Object-shaped fill data cannot represent duplicate property names. */


### PR DESCRIPTION
Supports #794 with generic runtime/schema enforcement. Canonical recipe declarations follow separately from their owning repository.

An enabled optional regime can currently fill with missing economics. Metadata now supports `required_when: { field, equals }` on scalar inputs. The field-selector API rejects active missing/blank values before source download or document mutation, reporting `INCOMPLETE_CONDITIONAL_INPUT` and the missing field names; the CLI exits unsuccessfully. Shared fill preparation enforces the same contract, and exported JSON Schema uses matching default-aware `if`/`then` conditions.

Controller references and scalar types are validated. Nested/computed conditions and defaults on required targets are rejected. Disabled regimes permit omission, and a zero rate remains valid. No legal defaults or recipe requirements are invented by this runtime change.

Validation: build, lint, catalog validation, and all 1,469 tests passed (7 skipped). Behavioral API/CLI tests confirm rejection before output. A real SHA-pinned COI smoke, using declarations staged in canonical LE metadata, rejected each individually missing/blank economic and invalid rate/enum types; complete inputs rendered the chosen date, 0% rate, and quarterly compounding, while the disabled regime allowed omission. Source documents and generated output remain local and are not committed or uploaded.
