### PR TITLE
Share typed default parsing across schemas and conditional inputs

### DIFF
--- a/src/core/conditional-inputs.test.ts
+++ b/src/core/conditional-inputs.test.ts
@@ -61,6 +61,40 @@ describe('conditional required inputs', () => {
     }
   });
 
+  it('preserves empty controller semantics separately from schema default annotations', () => {
+    const metadata = FieldSelectorMetadataSchema.parse({ ...fixture, fields: [
+      { name: 'enabled', type: 'string', description: 'Controller', default: '' },
+      ...fixture.fields.slice(1).map(field => ({ ...field, required_when: { field: 'enabled', equals: '' } })),
+    ] });
+    const ajv = new Ajv2020({ strict: false }); addFormats(ajv);
+    const schema = buildFieldSelectorInputSchema('fixture', metadata, null);
+    const validate = ajv.compile(schema);
+    expect((schema.properties as Record<string, object>).enabled).not.toHaveProperty('default');
+    expect(validate({})).toBe(false);
+    expect(() => assertConditionalRequiredInputs({}, metadata.fields)).toThrow(/start_date/);
+    expect(validate({ enabled: '' })).toBe(false);
+    expect(() => assertConditionalRequiredInputs({ enabled: '' }, metadata.fields)).toThrow(/start_date/);
+  });
+
+  it('preserves numeric zero and enum defaults in both condition evaluation and schema annotations', () => {
+    for (const controller of [
+      { name: 'enabled', type: 'number', description: 'Controller', default: '0' },
+      { name: 'enabled', type: 'enum', description: 'Controller', default: 'yes', options: ['yes', 'no'] },
+    ]) {
+      const equals = controller.type === 'number' ? 0 : 'yes';
+      const metadata = FieldSelectorMetadataSchema.parse({ ...fixture, fields: [controller, {
+        name: 'chosen', type: 'string', description: 'Choice', required_when: { field: 'enabled', equals },
+      }] });
+      const schema = buildFieldSelectorInputSchema('fixture', metadata, null);
+      const ajv = new Ajv2020({ strict: false }); const validate = ajv.compile(schema);
+      expect((schema.properties as Record<string, object>).enabled).toHaveProperty('default', equals);
+      expect(validate({})).toBe(false);
+      expect(() => assertConditionalRequiredInputs({}, metadata.fields)).toThrow(/chosen/);
+      expect(validate({ chosen: '0' })).toBe(true);
+      expect(() => assertConditionalRequiredInputs({ chosen: '0' }, metadata.fields)).not.toThrow();
+    }
+  });
+
   it('rejects unknown, self, incompatible or nested controllers and silent economic defaults', () => {
     for (const condition of [{ field: 'missing', equals: true }, { field: 'start_date', equals: true }, { field: 'enabled', equals: 'true' }]) {
       const raw = structuredClone(fixture); raw.fields[1].required_when = condition as typeof raw.fields[1]['required_when'];

--- a/src/core/conditional-inputs.ts
+++ b/src/core/conditional-inputs.ts
@@ -1,12 +1,5 @@
 import type { FieldDefinition } from './metadata.js';
-
-/** Defaults activate a regime only when the caller omitted its controller. */
-export function conditionalControllerDefault(field: FieldDefinition): unknown {
-  if (field.default === undefined) return undefined;
-  if (field.type === 'boolean') return field.default === 'true';
-  if (field.type === 'number') return Number(field.default);
-  return field.default;
-}
+import { typedFieldDefault } from './field-defaults.js';
 
 export class IncompleteConditionalInputError extends Error {
   readonly code = 'INCOMPLETE_CONDITIONAL_INPUT';
@@ -34,7 +27,7 @@ export function assertConditionalRequiredInputs(values: Record<string, unknown>,
     const controller = byName.get(condition.field);
     if (!controller) throw new Error(`Unknown required_when controller: ${condition.field}`);
     const supplied = Object.prototype.hasOwnProperty.call(values, condition.field);
-    const actual = supplied ? values[condition.field] : conditionalControllerDefault(controller);
+    const actual = supplied ? values[condition.field] : typedFieldDefault(controller);
     if (supplied && typeof actual !== typeof condition.equals) {
       throw new Error(`Conditional controller "${condition.field}" must be a ${typeof condition.equals}`);
     }

--- a/src/core/field-defaults.test.ts
+++ b/src/core/field-defaults.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect } from 'vitest';
+import { itAllure } from '../../integration-tests/helpers/allure-test.js';
+import { typedFieldDefault } from './field-defaults.js';
+import type { FieldDefinition } from './metadata.js';
+
+const it = itAllure.epic('Filling & Rendering');
+
+describe('typed field defaults', () => {
+  it('preserves scalar and multiselect parsing, including fallback values', () => {
+    const cases: [FieldDefinition['type'], string | undefined, unknown][] = [
+      ['string', undefined, undefined], ['string', '', ''], ['string', 'value', 'value'],
+      ['boolean', 'true', true], ['boolean', 'false', false],
+      ['number', '0', 0], ['number', '1.5', 1.5], ['number', 'not-a-number', 'not-a-number'],
+      ['multiselect', '["one","two"]', ['one', 'two']], ['multiselect', 'invalid-json', 'invalid-json'],
+    ];
+    for (const [type, defaultValue, expected] of cases) {
+      expect(typedFieldDefault({ name: 'choice', description: 'Choice', type, default: defaultValue })).toEqual(expected);
+    }
+  });
+});

--- a/src/core/field-defaults.ts
+++ b/src/core/field-defaults.ts
@@ -1,0 +1,15 @@
+import type { FieldDefinition } from './metadata.js';
+
+/** Parse a declared metadata default; callers decide whether to expose empties. */
+export function typedFieldDefault(field: FieldDefinition): unknown {
+  if (field.default === undefined) return undefined;
+  if (field.type === 'boolean') return field.default === 'true';
+  if (field.type === 'number') {
+    const value = Number(field.default);
+    return Number.isFinite(value) ? value : field.default;
+  }
+  if (field.type === 'multiselect') {
+    try { return JSON.parse(field.default); } catch { return field.default; }
+  }
+  return field.default;
+}

--- a/src/core/field-selector/input-schema.ts
+++ b/src/core/field-selector/input-schema.ts
@@ -8,7 +8,8 @@ import {
 } from '../metadata.js';
 import { loadComputedProfile, type ComputedProfile } from './computed.js';
 import { resolveFieldSelectorDir } from '../../utils/paths.js';
-import { assertConditionalInputOwnership, conditionalControllerDefault } from '../conditional-inputs.js';
+import { assertConditionalInputOwnership } from '../conditional-inputs.js';
+import { typedFieldDefault } from '../field-defaults.js';
 
 export const FIELD_SELECTOR_INPUT_SCHEMA_VERSION = 1 as const;
 export const FIELD_SELECTOR_SCHEMA_GENERATOR = 'open-agreements field-selector schema' as const;
@@ -107,25 +108,14 @@ export function computedFieldNames(profile: ComputedProfile | null): Set<string>
   return names;
 }
 
-function typedDefault(field: FieldDefinition): unknown {
-  if (field.default === undefined || field.default === '') return undefined;
-  if (field.type === 'boolean') return field.default === 'true';
-  if (field.type === 'number') {
-    const value = Number(field.default);
-    return Number.isFinite(value) ? value : field.default;
-  }
-  if (field.type === 'multiselect') {
-    try { return JSON.parse(field.default); } catch { return field.default; }
-  }
-  return field.default;
-}
-
 function fieldSchema(field: FieldDefinition): JsonSchema {
   const common: JsonSchema = {
     title: field.display_label ?? field.name,
     description: field.description,
   };
-  const defaultValue = typedDefault(field);
+  // Empty defaults are omitted from the schema annotation, even when the
+  // declared scalar default has meaning to a conditional controller.
+  const defaultValue = field.default === '' ? undefined : typedFieldDefault(field);
   if (defaultValue !== undefined) common.default = defaultValue;
   const pattern = fieldValuePattern(field);
   if (pattern) common.pattern = pattern;
@@ -173,7 +163,7 @@ export function buildFieldSelectorInputSchema(
     const condition = field.required_when!;
     const controller = fields.find((candidate) => candidate.name === condition.field);
     if (!controller) throw new Error(`required_when controller "${condition.field}" must be a caller input`);
-    const usesDefault = conditionalControllerDefault(controller) === condition.equals;
+    const usesDefault = typedFieldDefault(controller) === condition.equals;
     return {
       if: {
         properties: { [condition.field]: { const: condition.equals } },


### PR DESCRIPTION
Resolves the code-reuse advisory on #797 by extracting one typed metadata-default parser for both schema defaults and conditional-input evaluation.

The schema still omits empty default annotations, while conditional controllers retain the existing explicit empty-string behavior. Tests cover that distinction alongside boolean defaults, numeric zero, and enum defaults. Published schema hashes remain unchanged.

Validation: build, lint, catalog validation, and full suite (1,471 passed; 7 skipped). The conditional-input behavior was also exercised with the real pinned COI smoke. No recipe or legal text changes are included.
