### PR TITLE
feat(selector): gate applicable groups and unwrap selected brackets

### DIFF
--- a/runtime-capabilities.json
+++ b/runtime-capabilities.json
@@ -7,6 +7,8 @@
     "selectors.v1",
     "selections.v1",
     "selections.bounded-removal.v1",
+    "selections.applies-when.v1",
+    "selections.unwrap-brackets.v1",
     "computed.v1",
     "normalize.v1",
     "repeatable-tables.v1",

--- a/src/core/runtime-capabilities.ts
+++ b/src/core/runtime-capabilities.ts
@@ -12,6 +12,8 @@ export const RUNTIME_CAPABILITIES = Object.freeze({
     'selectors.v1',
     'selections.v1',
     'selections.bounded-removal.v1',
+    'selections.applies-when.v1',
+    'selections.unwrap-brackets.v1',
     'computed.v1',
     'normalize.v1',
     'repeatable-tables.v1',

--- a/src/core/selector.test.ts
+++ b/src/core/selector.test.ts
@@ -193,6 +193,101 @@ describe('SelectionsConfigSchema', () => {
     });
     expect(result.success).toBe(true);
   });
+
+  it('strictly scopes selected bracket unwrap to markerless inline bracketed options', () => {
+    const valid = SelectionsConfigSchema.safeParse({ groups: [{
+      id: 'opt_out', type: 'checkbox', markerless: true, inline: true,
+      applies_when: { field: 'include_regime', equals: true },
+      options: [{ marker: '[Optional text]', trigger: { field: 'include_opt_out', equals: true }, selectedAction: 'unwrap_brackets' }],
+    }] });
+    expect(valid.success).toBe(true);
+    expect(SelectionsConfigSchema.safeParse({ groups: [{
+      id: 'bad', type: 'checkbox', markerless: true,
+      options: [{ marker: '[Optional text]', trigger: { field: 'flag' }, selectedAction: 'unwrap_brackets' }],
+    }] }).success).toBe(false);
+    expect(SelectionsConfigSchema.safeParse({ groups: [{
+      id: 'bad', type: 'checkbox', markerless: true, inline: true,
+      options: [{ marker: 'Optional text', trigger: { field: 'flag' }, selectedAction: 'unwrap_brackets' }],
+    }] }).success).toBe(false);
+  });
+});
+
+describe('applicable markerless selected actions', () => {
+  const marker = '[Holder may opt out under Section 6.]';
+  const config: SelectionsConfig = {
+    groups: [{
+      id: 'holder_opt_out',
+      type: 'checkbox',
+      markerless: true,
+      inline: true,
+      applies_when: { field: 'include_redemption', equals: true },
+      options: [{
+        marker,
+        trigger: { field: 'include_holder_opt_out', equals: true },
+        selectedAction: 'unwrap_brackets',
+      }],
+    }],
+  };
+  const body = `<w:p xmlns:w="${W_NS}">`
+    + '<w:r><w:t>[Holder may opt out under Section </w:t></w:r>'
+    + '<w:r><w:rPr><w:b/></w:rPr><w:fldChar w:fldCharType="begin"/></w:r>'
+    + '<w:r><w:instrText xml:space="preserve"> REF _RefOptOut \\h </w:instrText></w:r>'
+    + '<w:r><w:fldChar w:fldCharType="separate"/></w:r>'
+    + '<w:r><w:rPr><w:b/></w:rPr><w:t>6</w:t></w:r>'
+    + '<w:r><w:fldChar w:fldCharType="end"/></w:r>'
+    + '<w:r><w:t>.]</w:t></w:r></w:p>';
+
+  it('skips an explicitly inapplicable group without match reports or warnings', async () => {
+    const input = buildTestDocx(body);
+    const output = join(makeTempDir(), 'out.docx');
+    const result = await applySelections(input, output, config, {
+      include_redemption: false,
+      include_holder_opt_out: true,
+    });
+    expect(result.options).toEqual([]);
+    expect(extractText(output)).toContain(marker);
+  });
+
+  it('fails closed for missing or wrongly typed applicability input', async () => {
+    const input = buildTestDocx(body);
+    await expect(applySelections(input, join(makeTempDir(), 'missing.docx'), config, {}))
+      .rejects.toThrow(/applicability field "include_redemption" is missing/);
+    await expect(applySelections(input, join(makeTempDir(), 'wrong.docx'), config, { include_redemption: 'true' }))
+      .rejects.toThrow(/must be boolean, received string/);
+  });
+
+  it('unwraps only selected outer brackets while preserving REF runs and styles', async () => {
+    const input = buildTestDocx(body);
+    const output = join(makeTempDir(), 'selected.docx');
+    const result = await applySelections(input, output, config, {
+      include_redemption: true,
+      include_holder_opt_out: true,
+    });
+    expect(extractText(output)).toBe('Holder may opt out under Section 6.');
+    expect(result.options[0]).toMatchObject({ selected: true, matchCount: 1, appliedCount: 1 });
+    const xml = readDocumentXml(output);
+    expect(xml).toContain(' REF _RefOptOut \\h ');
+    expect(xml).toContain('w:fldCharType="begin"');
+    expect(xml).toContain('<w:b/>');
+  });
+
+  it('retains existing unselected deletion and fails selected source drift', async () => {
+    const input = buildTestDocx(body);
+    const output = join(makeTempDir(), 'unselected.docx');
+    await applySelections(input, output, config, {
+      include_redemption: true,
+      include_holder_opt_out: false,
+    });
+    expect(extractText(output)).toBe('');
+
+    const drifted: SelectionsConfig = {
+      groups: [{ ...config.groups[0], options: [{ ...config.groups[0].options[0], marker: '[Drifted marker]' }] }],
+    };
+    await expect(applySelections(input, join(makeTempDir(), 'drift.docx'), drifted, {
+      include_redemption: true,
+      include_holder_opt_out: true,
+    })).rejects.toThrow(/matched 0 paragraphs \(expected 1\)/);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/core/selector.ts
+++ b/src/core/selector.ts
@@ -34,12 +34,17 @@ const TriggerSchema = z.union([
   z.object({ field: z.string() }).strict(),
 ]);
 type Trigger = z.infer<typeof TriggerSchema>;
+const ApplicabilitySchema = z.object({
+  field: z.string().min(1),
+  equals: z.union([z.string(), z.boolean()]),
+}).strict();
 
 const OptionSchema = z.object({
   label: z.string().optional(),
   marker: z.string(),
   trigger: TriggerSchema,
   replaceWith: z.string().optional(),
+  selectedAction: z.literal('unwrap_brackets').optional(),
   removal: z.discriminatedUnion('kind', [
     z.object({
       kind: z.literal('table'),
@@ -77,6 +82,7 @@ const GroupSchema = z
     inline: z.boolean().optional(),
     cellContext: z.string().optional(),
     subClauseStopPatterns: z.array(z.string()).optional(),
+    applies_when: ApplicabilitySchema.optional(),
     options: z.array(OptionSchema).min(1),
   }).strict()
   .refine(
@@ -100,6 +106,12 @@ const GroupSchema = z
   .refine(
     (g) => g.options.every((o) => !o.removal || (g.markerless === true && !g.inline && o.replaceWith === undefined)),
     { message: 'bounded removal requires markerless:true, inline:false, and no replaceWith' },
+  )
+  .refine(
+    (g) => g.options.every((o) => !o.selectedAction || (
+      g.markerless === true && g.inline === true && o.marker.startsWith('[') && o.marker.endsWith(']')
+    )),
+    { message: 'selectedAction:unwrap_brackets requires markerless:true, inline:true, and a square-bracket-delimited marker' },
   );
 
 export const SelectionsConfigSchema = z.object({
@@ -518,6 +530,21 @@ function triggerFires(trigger: Trigger, data: Record<string, unknown>): boolean 
   return val !== undefined && val !== '' && val !== false && val !== 'false';
 }
 
+function groupApplies(group: z.infer<typeof GroupSchema>, data: Record<string, unknown>): boolean {
+  const predicate = group.applies_when;
+  if (!predicate) return true;
+  const value = data[predicate.field];
+  if (value === undefined || value === '') {
+    throw new Error(`[selector] Group "${group.id}" applicability field "${predicate.field}" is missing`);
+  }
+  if (typeof value !== typeof predicate.equals) {
+    throw new Error(
+      `[selector] Group "${group.id}" applicability field "${predicate.field}" must be ${typeof predicate.equals}, received ${typeof value}`,
+    );
+  }
+  return value === predicate.equals;
+}
+
 // ---------------------------------------------------------------------------
 // Match reporting (#720)
 // ---------------------------------------------------------------------------
@@ -727,6 +754,7 @@ export async function applySelections(
 
     let partModified = false;
     for (const group of config.groups) {
+      if (!groupApplies(group, data)) continue;
       const result = processGroup(doc, group, data, stats, partName === 'word/document.xml', resolveNumbering);
       if (result) partModified = true;
     }
@@ -1146,6 +1174,10 @@ function processMarkerlessGroup(
   for (let oi = 0; oi < group.options.length; oi++) {
     const option = group.options[oi];
 
+    // Selected bracket actions are body-only, like bounded removals. This
+    // gives their exact-one assertion a single deterministic OOXML part.
+    if (option.selectedAction && !isMainDocument) continue;
+
     if (option.removal) {
       // Whole tables and sections are body-block concepts. Ignoring headers and
       // footers also makes the exact-one assertion global for the only part in
@@ -1175,6 +1207,12 @@ function processMarkerlessGroup(
 
     matchCounts[oi] += matchedParas.length;
 
+    if (option.selectedAction && matchedParas.length !== 1) {
+      throw new Error(
+        `[selector] Group "${group.id}" selected action for marker "${option.marker}" matched ${matchedParas.length} paragraphs (expected 1)`,
+      );
+    }
+
     // #720: a zero-match UNSELECTED option is not a benign no-op — the
     // alternative it was meant to delete survives into the filled document.
     // The count recorded above is what lets the caller reject that outcome
@@ -1182,7 +1220,21 @@ function processMarkerlessGroup(
     if (matchedParas.length === 0) continue;
 
     if (selectedIndices.has(oi)) {
-      // Selected — keep paragraphs as-is, no changes needed
+      if (option.selectedAction === 'unwrap_brackets') {
+        const markerPara = matchedParas[0] as unknown as globalThis.Element;
+        const paragraphText = normalizeQuotes(getParagraphText(markerPara));
+        const markerText = normalizeQuotes(option.marker);
+        const start = paragraphText.indexOf(markerText);
+        if (start < 0) {
+          throw new Error(`[selector] Group "${group.id}" could not locate selected bracket marker`);
+        }
+        // Delete only the two delimiter characters. Closing-first keeps the
+        // opening index stable and preserves every interior run and REF field.
+        replaceParagraphTextRange(markerPara, start + markerText.length - 1, start + markerText.length, '');
+        replaceParagraphTextRange(markerPara, start, start + 1, '');
+        appliedCounts[oi]++;
+        madeChanges = true;
+      }
       continue;
     }
 


### PR DESCRIPTION
Closes #798.

Adds strict `applies_when` predicates for selection groups and selected-only `unwrap_brackets` actions for markerless inline options. Missing or wrongly typed applicability values fail closed; explicitly inapplicable groups produce no match reports; applicable groups retain exact match enforcement. Bracket unwrapping deletes only the two delimiter characters and preserves interior styled runs and REF fields.

Publishes `selections.applies-when.v1` and `selections.unwrap-brackets.v1` in both runtime capability surfaces.

Verification: build/capability parity, lint, focused selector tests (55), and full suite (1,480 passed, 7 skipped). No licensed source or generated document committed.
