### PR TITLE
fix(numbering): support explicit source-pinned heading continuations

### DIFF
--- a/docs/numbering-continuations.md
+++ b/docs/numbering-continuations.md
@@ -16,6 +16,7 @@ independent lists merely because they share an abstract numbering definition.
       {
         "anchor": "Continued heading",
         "num_id": "2",
+        "expected_abstract_num_id": "0",
         "ilvl": 1,
         "expected_starts": { "0": 2, "1": 3, "2": 1 }
       }
@@ -38,11 +39,19 @@ upstream, not in the generic runtime.
 - Anchors compare concatenated Word text after whitespace normalization, removal
   of square brackets, and removal of one terminal period. This permits ordinary
   optional-heading cleanup without substring matching or regex guesses.
-- A declared instance must reference the same original abstract definition as
-  `source_num_id`. Its only children may be that abstract link and `lvlOverride`
+- A declared instance must reference `expected_abstract_num_id`. Its only children
+  may be that abstract link and `lvlOverride`
   elements containing only `startOverride`. `expected_starts` must specify the
-  exact override set, including the heading level and all its parents. Additional
+  exact concrete override set; `{}` means no overrides (starts come from the
+  pinned abstract). Additional
   or changed overrides, replacement levels, and numbering-style links fail closed.
+- A different abstract is accepted only when levels 0 through `ilvl` have matching
+  counter semantics and formatting. Starts and paragraph-style associations are
+  excluded from that comparison. The only font exception is an otherwise empty
+  `rFonts` with `hint="default"`, equivalent to no explicit hint. Font names,
+  themes, indents, glyphs, restart rules, and suffixes must match. Unused levels
+  may differ because a declared instance has exactly one paragraph at its declared
+  level; they are never rebound as a family. Source-instance overrides are unsupported.
 - After selection, a declaration can be absent only when both its anchor and its
   concrete instance are gone. A remaining mismatched or duplicated anchor or
   instance fails before normalized output is written.
@@ -53,6 +62,9 @@ upstream, not in the generic runtime.
 - The normalizer accepts only an in-process plan produced by original-source
   validation. A caller cannot bypass the original hash check by passing plain JSON
   directly to its post-selection entry point.
+- The opaque plan fingerprints the original source and target instances and
+  entire abstract definitions. Any post-validation change, even to an unused
+  level or default start, fails closed before output normalization.
 
 Capability: `normalize.numbering-continuations.v1`. Consumers must inspect this
 operation when checking runtime compatibility. Old strict normalize loaders
@@ -64,6 +76,13 @@ The historical defect normalized only the dominant concrete instance. Source
 override headings stayed on the old abstract definition while children moved to
 section-specific definitions. A heading numbered 2.12 could therefore acquire
 children whose full numbering context still resolved to 2.11.
+
+Correction (2026-09-08): the initial implementation required the same abstract ID. A complete source
+inventory showed a compatible heading on a separate abstract, preceding another
+manual heading. Omitting that first heading left the shared parent stream one
+step behind. The corrected contract therefore supports individually declared,
+compatible different-abstract headings, with complete source fingerprints and
+used-level formatting checks; it never infers continuation from similarity.
 
 Tests use synthetic DOCX fixtures to verify pinned-source validation, drift
 rejection, declaration-only rebinding, selection removal, and preservation of an

--- a/docs/numbering-continuations.md
+++ b/docs/numbering-continuations.md
@@ -1,0 +1,73 @@
+# Explicit numbering continuations
+
+Some source-authored outline headings use a concrete numbering override while
+their children use the main outline instance. Section normalization must not
+silently separate those headings from their children. It also must not merge
+independent lists merely because they share an abstract numbering definition.
+
+`normalize.json` can explicitly declare approved continuations:
+
+```json
+{
+  "numbering_continuations": {
+    "source_sha256": "<64-character lowercase SHA-256 of the original DOCX>",
+    "source_num_id": "1",
+    "headings": [
+      {
+        "anchor": "Continued heading",
+        "num_id": "2",
+        "ilvl": 1,
+        "expected_starts": { "0": 2, "1": 3, "2": 1 }
+      }
+    ]
+  }
+}
+```
+
+The example is illustrative; replace the hash and every source-specific value
+with independently inspected source facts. Canonical recipe declarations belong
+upstream, not in the generic runtime.
+
+## Contract
+
+- The original input bytes must match `source_sha256` before the fill pipeline
+  starts. Source validation is mandatory even when an explicit input path is used.
+- Every declaration must identify exactly one original paragraph and exactly one
+  use of its concrete numbering instance. The paragraph's numbering and outline
+  levels must match `ilvl` (1 through 8).
+- Anchors compare concatenated Word text after whitespace normalization, removal
+  of square brackets, and removal of one terminal period. This permits ordinary
+  optional-heading cleanup without substring matching or regex guesses.
+- A declared instance must reference the same original abstract definition as
+  `source_num_id`. Its only children may be that abstract link and `lvlOverride`
+  elements containing only `startOverride`. `expected_starts` must specify the
+  exact override set, including the heading level and all its parents. Additional
+  or changed overrides, replacement levels, and numbering-style links fail closed.
+- After selection, a declaration can be absent only when both its anchor and its
+  concrete instance are gone. A remaining mismatched or duplicated anchor or
+  instance fails before normalized output is written.
+- Only explicitly declared headings join the existing active section stream.
+  Their children already using that stream then inherit the correct parent and
+  ordinary restart semantics. Undeclared instances remain unchanged, including
+  independent lists and intentional restarts sharing the same abstract definition.
+- The normalizer accepts only an in-process plan produced by original-source
+  validation. A caller cannot bypass the original hash check by passing plain JSON
+  directly to its post-selection entry point.
+
+Capability: `normalize.numbering-continuations.v1`. Consumers must inspect this
+operation when checking runtime compatibility. Old strict normalize loaders
+reject the unknown key rather than silently ignoring it.
+
+## Regression and scope
+
+The historical defect normalized only the dominant concrete instance. Source
+override headings stayed on the old abstract definition while children moved to
+section-specific definitions. A heading numbered 2.12 could therefore acquire
+children whose full numbering context still resolved to 2.11.
+
+Tests use synthetic DOCX fixtures to verify pinned-source validation, drift
+rejection, declaration-only rebinding, selection removal, and preservation of an
+undeclared restart. Real-source smoke documents and references stay local-only.
+This feature does not modify legal wording, add style-separator carriers, freeze
+editable numbering, or evaluate REF fields. Renderer-only REF handling is a
+separate concern.

--- a/docs/numbering-continuations.md
+++ b/docs/numbering-continuations.md
@@ -71,3 +71,10 @@ undeclared restart. Real-source smoke documents and references stay local-only.
 This feature does not modify legal wording, add style-separator carriers, freeze
 editable numbering, or evaluate REF fields. Renderer-only REF handling is a
 separate concern.
+
+Known existing resolver limitation: an outline-only paragraph style with no
+numbering instance in its inheritance chain can lose its outline value when
+the paragraph supplies numbering directly. Such a continuation is safely
+rejected by the level/outline guard, not silently rebound. Supporting that style
+shape requires a separate paragraph-numbering inheritance fix; this change does
+not claim it is supported.

--- a/runtime-capabilities.json
+++ b/runtime-capabilities.json
@@ -11,6 +11,7 @@
     "selections.unwrap-brackets.v1",
     "computed.v1",
     "normalize.v1",
+    "normalize.numbering-continuations.v1",
     "repeatable-tables.v1",
     "anchored-paragraph-bindings.v1",
     "reference-fields.v1",

--- a/src/core/field-selector/index.test.ts
+++ b/src/core/field-selector/index.test.ts
@@ -73,6 +73,24 @@ function createFieldSelectorFixture(options?: {
 }
 
 describe('runFieldSelector', () => {
+  itFilling('rejects continuation source drift before invoking the fill pipeline', async () => {
+    const fieldSelectorDir = createFieldSelectorFixture({ normalizeConfig: {
+      numbering_continuations: {
+        source_sha256: '0'.repeat(64), source_num_id: '1',
+        headings: [{ anchor: 'Continued', num_id: '2', ilvl: 1, expected_starts: { 0: 2, 1: 2 } }],
+      },
+    } });
+    const inputPath = join(fieldSelectorDir, 'source.docx');
+    writeFileSync(inputPath, 'changed source bytes');
+    const runFillPipelineMock = vi.fn();
+    vi.doMock('../../utils/paths.js', () => ({ resolveFieldSelectorDir: () => fieldSelectorDir }));
+    vi.doMock('../unified-pipeline.js', () => ({ runFillPipeline: runFillPipelineMock }));
+    const { runFieldSelector } = await import('./index.js');
+    await expect(runFieldSelector({ fieldSelectorId: 'fixture', inputPath, outputPath: join(fieldSelectorDir, 'output.docx'), values: { company_name: 'Acme' } })).rejects.toThrow(/source SHA-256 mismatch/);
+    expect(runFillPipelineMock).not.toHaveBeenCalled();
+    expect(existsSync(join(fieldSelectorDir, 'output.docx'))).toBe(false);
+  });
+
   itFilling('rejects malformed source-owned values before document work', async () => {
     const fieldSelectorDir = createFieldSelectorFixture({
       fields: [
@@ -101,6 +119,28 @@ describe('runFieldSelector', () => {
       values: { company_name: 'Acme', series_designation: 'A', approval_percentage: '60%' },
     })).rejects.toThrow(/approval_percentage/);
     expect(ensureSourceDocxMock).not.toHaveBeenCalled();
+  });
+
+  itFilling('runs declared continuations even when bracket normalization is disabled', async () => {
+    const config = { source_sha256: '0'.repeat(64), source_num_id: '1', headings: [{ anchor: 'Continued', num_id: '2', ilvl: 1, expected_starts: { 0: 2, 1: 2 } }] };
+    const fieldSelectorDir = createFieldSelectorFixture({ normalizeConfig: { numbering_continuations: config } });
+    const plan = { sourceNumId: '1', sourceSha256: config.source_sha256 };
+    const validateSource = vi.fn(() => plan), normalizeNumbering = vi.fn(), normalizeBrackets = vi.fn();
+    vi.doMock('../../utils/paths.js', () => ({ resolveFieldSelectorDir: () => fieldSelectorDir }));
+    vi.doMock('./numbering-continuations.js', () => ({ validateNumberingContinuationSource: validateSource }));
+    vi.doMock('./numbering-normalizer.js', () => ({ normalizeNumberedHeadingSections: normalizeNumbering }));
+    vi.doMock('./bracket-normalizer.js', () => ({ normalizeBracketArtifacts: normalizeBrackets }));
+    vi.doMock('./heading-punctuation-normalizer.js', () => ({ normalizeDetachedHeadingPunctuation: vi.fn() }));
+    vi.doMock('../unified-pipeline.js', () => ({ runFillPipeline: vi.fn(async ({ outputPath, postProcess }: { outputPath: string; postProcess: (path: string) => Promise<void> }) => {
+      expect(validateSource).toHaveBeenCalledWith('/tmp/source.docx', config);
+      await postProcess(outputPath);
+      return { outputPath, fieldsUsed: [], providedFieldsUsed: [], fillCommandCount: 1, warnings: [], stages: {} };
+    }) }));
+    const { runFieldSelector } = await import('./index.js');
+    await runFieldSelector({ fieldSelectorId: 'fixture', inputPath: '/tmp/source.docx', outputPath: '/tmp/output.docx', values: { company_name: 'Acme' }, normalizeBracketArtifacts: false });
+    expect(normalizeNumbering).toHaveBeenCalledWith('/tmp/output.docx', '/tmp/output.docx', plan);
+    expect(normalizeBrackets).not.toHaveBeenCalled();
+    vi.doUnmock('./numbering-continuations.js');
   });
 
   itFilling('forwards priorityFieldNames when inputPath is supplied', async () => {

--- a/src/core/field-selector/index.test.ts
+++ b/src/core/field-selector/index.test.ts
@@ -77,7 +77,7 @@ describe('runFieldSelector', () => {
     const fieldSelectorDir = createFieldSelectorFixture({ normalizeConfig: {
       numbering_continuations: {
         source_sha256: '0'.repeat(64), source_num_id: '1',
-        headings: [{ anchor: 'Continued', num_id: '2', ilvl: 1, expected_starts: { 0: 2, 1: 2 } }],
+        headings: [{ anchor: 'Continued', num_id: '2', expected_abstract_num_id: '0', ilvl: 1, expected_starts: { 0: 2, 1: 2 } }],
       },
     } });
     const inputPath = join(fieldSelectorDir, 'source.docx');
@@ -122,7 +122,7 @@ describe('runFieldSelector', () => {
   });
 
   itFilling('runs declared continuations even when bracket normalization is disabled', async () => {
-    const config = { source_sha256: '0'.repeat(64), source_num_id: '1', headings: [{ anchor: 'Continued', num_id: '2', ilvl: 1, expected_starts: { 0: 2, 1: 2 } }] };
+    const config = { source_sha256: '0'.repeat(64), source_num_id: '1', headings: [{ anchor: 'Continued', num_id: '2', expected_abstract_num_id: '0', ilvl: 1, expected_starts: { 0: 2, 1: 2 } }] };
     const fieldSelectorDir = createFieldSelectorFixture({ normalizeConfig: { numbering_continuations: config } });
     const plan = { sourceNumId: '1', sourceSha256: config.source_sha256 };
     const validateSource = vi.fn(() => plan), normalizeNumbering = vi.fn(), normalizeBrackets = vi.fn();

--- a/src/core/field-selector/index.ts
+++ b/src/core/field-selector/index.ts
@@ -23,6 +23,7 @@ import type { ComputedValueMap } from './computed.js';
 import { applyRepeatableTables, loadRepeatableTablesConfig, validateRepeatableTableFields } from './repeatable-tables.js';
 import { bindAnchoredParagraphFields, loadAnchoredParagraphBindingsConfig } from './anchored-paragraph-bindings.js';
 import { normalizeNumberedHeadingSections } from './numbering-normalizer.js';
+import { validateNumberingContinuationSource } from './numbering-continuations.js';
 import { loadReferenceFieldsConfig } from './reference-fields.js';
 import { assertFieldSelectorInputValueShapes, computedFieldNames } from './input-schema.js';
 import { assertConditionalInputOwnership, assertConditionalRequiredInputs } from '../conditional-inputs.js';
@@ -74,6 +75,9 @@ export async function runFieldSelector(options: FieldSelectorRunOptions): Promis
 
   // Resolve input: explicit path or auto-download
   const inputPath = options.inputPath ?? await ensureSourceDocx(fieldSelectorId, metadata);
+  const numberingContinuationPlan = normalizeConfig.numbering_continuations
+    ? validateNumberingContinuationSource(inputPath, normalizeConfig.numbering_continuations)
+    : undefined;
 
   // Load replacements.json
   const replacementsPath = join(fieldSelectorDir, 'replacements.json');
@@ -180,9 +184,10 @@ export async function runFieldSelector(options: FieldSelectorRunOptions): Promis
       }
       : undefined,
     referenceFieldsConfig,
-    postProcess: shouldNormalizeBracketArtifacts
+    postProcess: shouldNormalizeBracketArtifacts || numberingContinuationPlan
       ? async (outputDocPath: string) => {
-        normalizeNumberedHeadingSections(outputDocPath, outputDocPath);
+        if (numberingContinuationPlan) normalizeNumberedHeadingSections(outputDocPath, outputDocPath, numberingContinuationPlan);
+        else normalizeNumberedHeadingSections(outputDocPath, outputDocPath);
         if (shouldNormalizeBracketArtifacts) {
           await normalizeBracketArtifacts(outputDocPath, outputDocPath, {
             rules: normalizeConfig.paragraph_rules,

--- a/src/core/field-selector/numbering-continuations.test.ts
+++ b/src/core/field-selector/numbering-continuations.test.ts
@@ -1,0 +1,96 @@
+import AdmZip from 'adm-zip';
+import { createHash } from 'node:crypto';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { DOMParser } from '@xmldom/xmldom';
+import { afterEach, describe, expect } from 'vitest';
+import { itAllure } from '../../../integration-tests/helpers/allure-test.js';
+import { NumberingContinuationsSchema, NormalizeConfigSchema } from '../metadata.js';
+import type { NumberingContinuations } from '../metadata.js';
+import { validateNumberingContinuationSource } from './numbering-continuations.js';
+import { normalizeNumberedHeadingSections } from './numbering-normalizer.js';
+
+const it = itAllure.epic('Filling & Rendering');
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const directories: string[] = [];
+afterEach(() => { for (const dir of directories.splice(0)) rmSync(dir, { recursive: true, force: true }); });
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), 'numbering-continuations-')); directories.push(root);
+  const source = join(root, 'source.docx'), output = join(root, 'output.docx');
+  const p = (name: string, level: number, id = '1') => `<w:p><w:pPr><w:pStyle w:val="L${level}"/><w:numPr><w:ilvl w:val="${level}"/><w:numId w:val="${id}"/></w:numPr></w:pPr><w:r><w:t>${name}</w:t></w:r></w:p>`;
+  const zip = new AdmZip();
+  zip.addFile('word/document.xml', Buffer.from(`<w:document xmlns:w="${W}"><w:body>${p('First', 0)}${p('First child', 1)}${p('Second', 0)}${p('Before', 1)}${p('Continued', 1, '2')}${p('Child A', 2)}${p('Child B', 2)}${p('Independent restart', 1, '3')}${p('Independent child', 2, '3')}</w:body></w:document>`));
+  zip.addFile('word/styles.xml', Buffer.from(`<w:styles xmlns:w="${W}">${[0, 1, 2].map(i => `<w:style w:type="paragraph" w:styleId="L${i}"><w:pPr><w:numPr><w:numId w:val="1"/><w:ilvl w:val="${i}"/></w:numPr><w:outlineLvl w:val="${i}"/></w:pPr></w:style>`).join('')}</w:styles>`));
+  const num = (id: string, starts: number[]) => `<w:num w:numId="${id}"><w:abstractNumId w:val="0"/>${starts.map((start, i) => `<w:lvlOverride w:ilvl="${i}"><w:startOverride w:val="${start}"/></w:lvlOverride>`).join('')}</w:num>`;
+  zip.addFile('word/numbering.xml', Buffer.from(`<w:numbering xmlns:w="${W}"><w:abstractNum w:abstractNumId="0">${[0, 1, 2].map(i => `<w:lvl w:ilvl="${i}"><w:start w:val="1"/><w:numFmt w:val="decimal"/><w:lvlText w:val="%1.%2"/></w:lvl>`).join('')}</w:abstractNum>${num('1', [])}${num('2', [2, 2, 1])}${num('3', [9, 7, 1])}</w:numbering>`));
+  zip.writeZip(source);
+  const config: NumberingContinuations = { source_sha256: createHash('sha256').update(readFileSync(source)).digest('hex'), source_num_id: '1', headings: [{ anchor: 'Continued', num_id: '2', ilvl: 1, expected_starts: { 0: 2, 1: 2, 2: 1 } }] };
+  return { root, source, output, config };
+}
+function edit(path: string, part: string, mutate: (xml: string) => string) {
+  const zip = new AdmZip(path); zip.updateFile(part, Buffer.from(mutate(zip.readAsText(part)))); zip.writeZip(path);
+}
+function repin(f: ReturnType<typeof fixture>) { f.config.source_sha256 = createHash('sha256').update(readFileSync(f.source)).digest('hex'); }
+
+describe('explicit source-pinned numbering continuations', () => {
+  it('rebases only a declared heading into its child stream, retaining unrelated same-abstract restarts', () => {
+    const f = fixture(), before = readFileSync(f.source);
+    const plan = validateNumberingContinuationSource(f.source, f.config);
+    expect(normalizeNumberedHeadingSections(f.source, f.output, plan)).toEqual({ sections: 2, paragraphs: 7 });
+    const doc = new DOMParser().parseFromString(new AdmZip(f.output).readAsText('word/document.xml'), 'text/xml');
+    const ids = Array.from(doc.getElementsByTagNameNS(W, 'numId')).map(n => n.getAttributeNS(W, 'val'));
+    expect(ids).toEqual(['4', '4', '5', '5', '5', '5', '5', '3', '3']);
+    expect(readFileSync(f.source)).toEqual(before);
+    expect(new AdmZip(f.output).readAsText('word/numbering.xml')).toContain('<w:startOverride w:val="7"/>');
+  });
+
+  it('leaves legacy behavior unchanged without declarations', () => {
+    const f = fixture(); normalizeNumberedHeadingSections(f.source, f.output);
+    expect(new AdmZip(f.output).readAsText('word/document.xml')).toContain('<w:numId w:val="2"/>');
+  });
+
+  it('allows a selection to remove the validated heading and accepts bracket/period cleanup', () => {
+    const f = fixture(), plan = validateNumberingContinuationSource(f.source, f.config);
+    edit(f.source, 'word/document.xml', xml => xml.replace('Continued', '[Continued].'));
+    expect(() => normalizeNumberedHeadingSections(f.source, f.output, plan)).not.toThrow();
+    edit(f.source, 'word/document.xml', xml => xml.replace(/<w:p><w:pPr><w:pStyle w:val="L1"\/><w:numPr><w:ilvl w:val="1"\/><w:numId w:val="2"\/><\/w:numPr><\/w:pPr><w:r><w:t>\[Continued\]\.<\/w:t><\/w:r><\/w:p>/, ''));
+    expect(normalizeNumberedHeadingSections(f.source, f.output, plan).paragraphs).toBe(6);
+  });
+
+  it('rejects changed source bytes even if the declaration itself still matches', () => {
+    const f = fixture(); edit(f.source, 'word/document.xml', xml => xml.replace('First child', 'Different'));
+    expect(() => validateNumberingContinuationSource(f.source, f.config)).toThrow(/SHA-256/);
+  });
+
+  it('does not let caller mutation or a fabricated plan bypass source validation', () => {
+    const f = fixture(), plan = validateNumberingContinuationSource(f.source, f.config);
+    f.config.headings[0].anchor = 'Wrong';
+    expect(() => normalizeNumberedHeadingSections(f.source, f.output, plan)).not.toThrow();
+    expect(() => normalizeNumberedHeadingSections(f.source, f.output, { sourceNumId: '1', sourceSha256: f.config.source_sha256 })).toThrow(/unvalidated/);
+  });
+
+  for (const [name, part, mutate] of [
+    ['anchor drift', 'word/document.xml', (s: string) => s.replace('Continued', 'Different')],
+    ['level drift', 'word/document.xml', (s: string) => s.replace('<w:ilvl w:val="1"/><w:numId w:val="2"/>', '<w:ilvl w:val="2"/><w:numId w:val="2"/>')],
+    ['override drift', 'word/numbering.xml', (s: string) => s.replace('<w:startOverride w:val="2"/>', '<w:startOverride w:val="3"/>')],
+    ['replacement level', 'word/numbering.xml', (s: string) => s.replace('<w:startOverride w:val="2"/>', '<w:startOverride w:val="2"/><w:lvl w:ilvl="0"/>')],
+    ['unknown instance property', 'word/numbering.xml', (s: string) => s.replace('<w:num w:numId="2">', '<w:num w:numId="2"><w:unexpected/>')],
+    ['different abstract', 'word/numbering.xml', (s: string) => s.replace('<w:num w:numId="2"><w:abstractNumId w:val="0"/>', '<w:num w:numId="2"><w:abstractNumId w:val="9"/>')],
+  ] as const) {
+    it(`rejects ${name} in the source and after transformation`, () => {
+      const f = fixture(), plan = validateNumberingContinuationSource(f.source, f.config);
+      edit(f.source, part, mutate); repin(f);
+      expect(() => validateNumberingContinuationSource(f.source, f.config)).toThrow(/numbering continuations:/);
+      expect(() => normalizeNumberedHeadingSections(f.source, f.output, plan)).toThrow(/numbering continuations:/);
+    });
+  }
+
+  it('rejects duplicate anchors and instances, missing parent starts and unknown keys at load time', () => {
+    const f = fixture();
+    expect(() => NumberingContinuationsSchema.parse({ ...f.config, headings: [...f.config.headings, f.config.headings[0]] })).toThrow();
+    expect(() => NumberingContinuationsSchema.parse({ ...f.config, headings: [{ ...f.config.headings[0], expected_starts: { 1: 2 } }] })).toThrow();
+    expect(() => NumberingContinuationsSchema.parse({ ...f.config, guess_same_abstract: true })).toThrow();
+    expect(NormalizeConfigSchema.parse({ numbering_continuations: f.config }).numbering_continuations).toEqual(f.config);
+  });
+});

--- a/src/core/field-selector/numbering-continuations.test.ts
+++ b/src/core/field-selector/numbering-continuations.test.ts
@@ -25,7 +25,7 @@ function fixture() {
   const num = (id: string, starts: number[]) => `<w:num w:numId="${id}"><w:abstractNumId w:val="0"/>${starts.map((start, i) => `<w:lvlOverride w:ilvl="${i}"><w:startOverride w:val="${start}"/></w:lvlOverride>`).join('')}</w:num>`;
   zip.addFile('word/numbering.xml', Buffer.from(`<w:numbering xmlns:w="${W}"><w:abstractNum w:abstractNumId="0">${[0, 1, 2].map(i => `<w:lvl w:ilvl="${i}"><w:start w:val="1"/><w:numFmt w:val="decimal"/><w:lvlText w:val="%1.%2"/></w:lvl>`).join('')}</w:abstractNum>${num('1', [])}${num('2', [2, 2, 1])}${num('3', [9, 7, 1])}</w:numbering>`));
   zip.writeZip(source);
-  const config: NumberingContinuations = { source_sha256: createHash('sha256').update(readFileSync(source)).digest('hex'), source_num_id: '1', headings: [{ anchor: 'Continued', num_id: '2', ilvl: 1, expected_starts: { 0: 2, 1: 2, 2: 1 } }] };
+  const config: NumberingContinuations = { source_sha256: createHash('sha256').update(readFileSync(source)).digest('hex'), source_num_id: '1', headings: [{ anchor: 'Continued', num_id: '2', expected_abstract_num_id: '0', ilvl: 1, expected_starts: { 0: 2, 1: 2, 2: 1 } }] };
   return { root, source, output, config };
 }
 function edit(path: string, part: string, mutate: (xml: string) => string) {
@@ -86,11 +86,60 @@ describe('explicit source-pinned numbering continuations', () => {
     });
   }
 
-  it('rejects duplicate anchors and instances, missing parent starts and unknown keys at load time', () => {
+  it('rejects duplicate anchors and instances, missing abstract ID and unknown keys at load time', () => {
     const f = fixture();
     expect(() => NumberingContinuationsSchema.parse({ ...f.config, headings: [...f.config.headings, f.config.headings[0]] })).toThrow();
-    expect(() => NumberingContinuationsSchema.parse({ ...f.config, headings: [{ ...f.config.headings[0], expected_starts: { 1: 2 } }] })).toThrow();
+    expect(() => NumberingContinuationsSchema.parse({ ...f.config, headings: [{ ...f.config.headings[0], expected_abstract_num_id: undefined }] })).toThrow();
     expect(() => NumberingContinuationsSchema.parse({ ...f.config, guess_same_abstract: true })).toThrow();
     expect(NormalizeConfigSchema.parse({ numbering_continuations: f.config }).numbering_continuations).toEqual(f.config);
+  });
+
+  function distinctAbstract(mutate: (xml: string) => string = x => x) {
+    const f = fixture();
+    edit(f.source, 'word/numbering.xml', xml => {
+      const source = xml.match(/<w:abstractNum w:abstractNumId="0">[\s\S]*?<\/w:abstractNum>/)![0];
+      const target = mutate(source.replace('abstractNumId="0"', 'abstractNumId="9"').replace('<w:start w:val="1"/>', '<w:start w:val="2"/>'));
+      return xml.replace('</w:abstractNum>', `</w:abstractNum>${target}`).replace(/<w:num w:numId="2">[\s\S]*?<\/w:num>/, '<w:num w:numId="2"><w:abstractNumId w:val="9"/></w:num>');
+    });
+    f.config.headings[0].expected_abstract_num_id = '9';
+    f.config.headings[0].expected_starts = {};
+    repin(f);
+    return f;
+  }
+
+  it('accepts explicit compatible different abstracts with no overrides and ignores unused-level differences', () => {
+    const f = distinctAbstract(xml => xml.replace('<w:lvl w:ilvl="2">', '<w:lvl w:ilvl="2"><w:pPr><w:ind w:left="999"/></w:pPr>').replace('<w:lvl w:ilvl="1">', '<w:lvl w:ilvl="1"><w:pStyle w:val="L1"/>'));
+    const plan = validateNumberingContinuationSource(f.source, f.config);
+    expect(normalizeNumberedHeadingSections(f.source, f.output, plan)).toEqual({ sections: 2, paragraphs: 7 });
+  });
+
+  it('accepts only an otherwise empty explicit default font hint as an equivalent font declaration', () => {
+    const f = distinctAbstract();
+    edit(f.source, 'word/numbering.xml', xml => xml.replaceAll('<w:numFmt', '<w:rPr><w:rFonts w:hint="default"/></w:rPr><w:numFmt').replace('<w:abstractNum w:abstractNumId="9">', '<w:abstractNum w:abstractNumId="9">'));
+    // Remove the hint only in the target; both sides retain equivalent rPr.
+    edit(f.source, 'word/numbering.xml', xml => xml.replace(/(<w:abstractNum w:abstractNumId="9">)([\s\S]*?)(<\/w:abstractNum>)/, (_, a, b: string, c) => a + b.replaceAll('<w:rFonts w:hint="default"/>', '') + c));
+    repin(f);
+    expect(() => validateNumberingContinuationSource(f.source, f.config)).not.toThrow();
+  });
+
+  for (const [name, insertion] of [
+    ['indent', '<w:pPr><w:ind w:left="99"/></w:pPr>'],
+    ['font', '<w:rPr><w:rFonts w:ascii="Different"/></w:rPr>'],
+    ['restart', '<w:lvlRestart w:val="0"/>'],
+    ['suffix', '<w:suff w:val="space"/>'],
+  ]) it(`rejects a different-abstract ${name} mismatch`, () => {
+    const f = distinctAbstract(xml => xml.replace('<w:lvl w:ilvl="1">', `<w:lvl w:ilvl="1">${insertion}`));
+    expect(() => validateNumberingContinuationSource(f.source, f.config)).toThrow(/incompatible/);
+  });
+
+  it('rejects different-abstract label formats even with matching anchors and starts', () => {
+    const f = distinctAbstract(xml => xml.replace('w:val="decimal"', 'w:val="upperRoman"'));
+    expect(() => validateNumberingContinuationSource(f.source, f.config)).toThrow(/incompatible/);
+  });
+
+  it('fingerprints unused levels and source defaults against post-validation drift', () => {
+    const f = distinctAbstract(), plan = validateNumberingContinuationSource(f.source, f.config);
+    edit(f.source, 'word/numbering.xml', xml => xml.replace('<w:start w:val="2"/>', '<w:start w:val="3"/>'));
+    expect(() => normalizeNumberedHeadingSections(f.source, f.output, plan)).toThrow(/fingerprint drifted/);
   });
 });

--- a/src/core/field-selector/numbering-continuations.ts
+++ b/src/core/field-selector/numbering-continuations.ts
@@ -1,0 +1,123 @@
+import AdmZip from 'adm-zip';
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { DOMParser } from '@xmldom/xmldom';
+import type { Document, Element } from '@xmldom/xmldom';
+import type { NumberingContinuations } from '../metadata.js';
+import { NumberingContinuationsSchema } from '../metadata.js';
+import { createParagraphNumberingResolver } from './paragraph-numbering.js';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+/** Only plans returned by validateNumberingContinuationSource are accepted. */
+export interface ValidatedNumberingContinuations { readonly sourceNumId: string; readonly sourceSha256: string }
+const plans = new WeakMap<ValidatedNumberingContinuations, NumberingContinuations>();
+const anchorKey = (text: string) => text.replaceAll('[', '').replaceAll(']', '').replace(/\s+/g, ' ').trim().replace(/\.$/, '');
+const text = (paragraph: Element) => Array.from(paragraph.getElementsByTagNameNS(W, 't')).map(node => node.textContent).join('');
+function elements(parent: Element, local: string): Element[] {
+  return Array.from(parent.childNodes).filter((node): node is Element => node.nodeType === 1
+    && (node as Element).namespaceURI === W && (node as Element).localName === local);
+}
+function one(parent: Element, local: string): Element {
+  const found = elements(parent, local);
+  if (found.length !== 1) throw new Error(`numbering continuations: expected exactly one ${local}`);
+  return found[0];
+}
+function numbers(numbering: Document): Map<string, Element> {
+  if (!numbering.documentElement) throw new Error('numbering continuations: missing numbering root');
+  const result = new Map<string, Element>();
+  for (const num of elements(numbering.documentElement, 'num')) {
+    const id = num.getAttributeNS(W, 'numId') ?? '';
+    if (result.has(id)) throw new Error('numbering continuations: duplicate numbering instance');
+    result.set(id, num);
+  }
+  return result;
+}
+function checkShape(numbering: Document, config: NumberingContinuations): void {
+  const nums = numbers(numbering);
+  const source = nums.get(config.source_num_id);
+  if (!source) throw new Error('numbering continuations: missing source instance');
+  const abstractId = one(source, 'abstractNumId').getAttributeNS(W, 'val');
+  const abstracts = Array.from(numbering.getElementsByTagNameNS(W, 'abstractNum')).filter(node => node.getAttributeNS(W, 'abstractNumId') === abstractId);
+  if (abstracts.length !== 1 || elements(abstracts[0], 'numStyleLink').length || elements(abstracts[0], 'styleLink').length) {
+    throw new Error('numbering continuations: missing, ambiguous or style-linked source abstract');
+  }
+  for (const heading of config.headings) {
+    const num = nums.get(heading.num_id);
+    if (!num || one(num, 'abstractNumId').getAttributeNS(W, 'val') !== abstractId) {
+      throw new Error(`numbering continuations: ${heading.num_id} does not share the declared source abstract`);
+    }
+    const starts: Record<string, number> = {};
+    for (const child of Array.from(num.childNodes).filter((node): node is Element => node.nodeType === 1)) {
+      if (child.namespaceURI !== W || !['abstractNumId', 'lvlOverride'].includes(child.localName ?? '')) {
+        throw new Error('numbering continuations: unsupported instance properties');
+      }
+      if (child.localName !== 'lvlOverride') continue;
+      const index = child.getAttributeNS(W, 'ilvl') ?? '';
+      const start = one(child, 'startOverride');
+      const elementChildren = Array.from(child.childNodes).filter(node => node.nodeType === 1);
+      const raw = start.getAttributeNS(W, 'val') ?? '';
+      if (elementChildren.length !== 1 || !/^[0-8]$/.test(index) || !/^\d+$/.test(raw) || starts[index] !== undefined) {
+        throw new Error('numbering continuations: expected startOverride-only shape');
+      }
+      starts[index] = Number(raw);
+    }
+    const keys = Object.keys(starts).sort();
+    if (keys.join(',') !== Object.keys(heading.expected_starts).sort().join(',')
+      || keys.some(key => starts[key] !== heading.expected_starts[key])) {
+      throw new Error(`numbering continuations: start overrides drifted for ${heading.num_id}`);
+    }
+  }
+}
+
+function declaredParagraphs(document: Document, styles: Document, config: NumberingContinuations, source: boolean): Set<Element> {
+  const resolve = createParagraphNumberingResolver(styles);
+  const paragraphs = Array.from(document.getElementsByTagNameNS(W, 'p'));
+  const result = new Set<Element>();
+  for (const heading of config.headings) {
+    const anchored = paragraphs.filter(paragraph => anchorKey(text(paragraph)) === anchorKey(heading.anchor));
+    const owned = paragraphs.filter(paragraph => resolve(paragraph)?.numId === heading.num_id);
+    // Selection may remove a validated source heading. It may not leave a
+    // mismatched or multiply-used declared numbering instance behind.
+    if (!source && anchored.length === 0 && owned.length === 0) continue;
+    if (anchored.length !== 1 || owned.length !== 1 || anchored[0] !== owned[0]) {
+      throw new Error(`numbering continuations: missing or ambiguous anchor/instance for ${heading.num_id}`);
+    }
+    const resolved = resolve(anchored[0]);
+    if (resolved?.ilvl !== heading.ilvl || resolved.outlineLvl !== heading.ilvl) {
+      throw new Error(`numbering continuations: heading level/outline drifted for ${heading.num_id}`);
+    }
+    result.add(anchored[0]);
+  }
+  return result;
+}
+
+/** Validate the original source, before selections/fill mutate its bytes. */
+export function validateNumberingContinuationSource(sourcePath: string, input: NumberingContinuations): ValidatedNumberingContinuations {
+  const config = NumberingContinuationsSchema.parse(input);
+  const bytes = readFileSync(sourcePath);
+  if (createHash('sha256').update(bytes).digest('hex') !== config.source_sha256) {
+    throw new Error('numbering continuations: source SHA-256 mismatch');
+  }
+  const zip = new AdmZip(bytes);
+  const parser = new DOMParser({ onError: (level, message) => { if (level !== 'warning') throw new Error(message); } });
+  const part = (name: string) => {
+    const entry = zip.getEntry(`word/${name}.xml`);
+    if (!entry) throw new Error(`numbering continuations: missing ${name} part`);
+    return parser.parseFromString(entry.getData().toString('utf8'), 'text/xml');
+  };
+  const numbering = part('numbering');
+  checkShape(numbering, config);
+  declaredParagraphs(part('document'), part('styles'), config, true);
+  const plan = Object.freeze({ sourceNumId: config.source_num_id, sourceSha256: config.source_sha256 });
+  plans.set(plan, config);
+  return plan;
+}
+
+export function resolveNumberingContinuationParagraphs(
+  document: Document, styles: Document, numbering: Document, plan: ValidatedNumberingContinuations,
+): Set<Element> {
+  const config = plans.get(plan);
+  if (!config) throw new Error('numbering continuations: unvalidated source plan');
+  checkShape(numbering, config);
+  return declaredParagraphs(document, styles, config, false);
+}

--- a/src/core/field-selector/numbering-continuations.ts
+++ b/src/core/field-selector/numbering-continuations.ts
@@ -10,7 +10,7 @@ import { createParagraphNumberingResolver } from './paragraph-numbering.js';
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 /** Only plans returned by validateNumberingContinuationSource are accepted. */
 export interface ValidatedNumberingContinuations { readonly sourceNumId: string; readonly sourceSha256: string }
-const plans = new WeakMap<ValidatedNumberingContinuations, NumberingContinuations>();
+const plans = new WeakMap<ValidatedNumberingContinuations, { config: NumberingContinuations; fingerprint: string }>();
 const anchorKey = (text: string) => text.replaceAll('[', '').replaceAll(']', '').replace(/\s+/g, ' ').trim().replace(/\.$/, '');
 const text = (paragraph: Element) => Array.from(paragraph.getElementsByTagNameNS(W, 't')).map(node => node.textContent).join('');
 function elements(parent: Element, local: string): Element[] {
@@ -32,7 +32,28 @@ function numbers(numbering: Document): Map<string, Element> {
   }
   return result;
 }
-function checkShape(numbering: Document, config: NumberingContinuations): void {
+// Namespace-aware structural comparison ignores XML serialization details, not
+// numbering or formatting properties. These fingerprints never leave the plan.
+function structure(element: Element): unknown {
+  return [element.namespaceURI, element.localName,
+    Array.from(element.attributes).filter(a => a.namespaceURI !== 'http://www.w3.org/2000/xmlns/')
+      .map(a => [a.namespaceURI, a.localName, a.value]).sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b))),
+    Array.from(element.childNodes).filter((n): n is Element => n.nodeType === 1).map(structure)];
+}
+function compatibleLevel(level: Element): string {
+  const clone = level.cloneNode(true) as Element;
+  for (const child of [...elements(clone, 'start'), ...elements(clone, 'pStyle')]) clone.removeChild(child);
+  // Missing font hint and an otherwise empty explicit default hint both select
+  // the default script classification. Never discard font names/theme choices.
+  for (const props of elements(clone, 'rPr')) {
+    for (const fonts of elements(props, 'rFonts')) {
+      const attrs = Array.from(fonts.attributes).filter(a => a.namespaceURI !== 'http://www.w3.org/2000/xmlns/');
+      if (attrs.length === 1 && attrs[0].namespaceURI === W && attrs[0].localName === 'hint' && attrs[0].value === 'default') props.removeChild(fonts);
+    }
+  }
+  return JSON.stringify(structure(clone));
+}
+function checkShape(numbering: Document, config: NumberingContinuations): string {
   const nums = numbers(numbering);
   const source = nums.get(config.source_num_id);
   if (!source) throw new Error('numbering continuations: missing source instance');
@@ -41,11 +62,25 @@ function checkShape(numbering: Document, config: NumberingContinuations): void {
   if (abstracts.length !== 1 || elements(abstracts[0], 'numStyleLink').length || elements(abstracts[0], 'styleLink').length) {
     throw new Error('numbering continuations: missing, ambiguous or style-linked source abstract');
   }
+  if (elements(source, 'lvlOverride').length) throw new Error('numbering continuations: source overrides are unsupported');
+  const pinned: unknown[] = [structure(source), structure(abstracts[0])];
   for (const heading of config.headings) {
     const num = nums.get(heading.num_id);
-    if (!num || one(num, 'abstractNumId').getAttributeNS(W, 'val') !== abstractId) {
-      throw new Error(`numbering continuations: ${heading.num_id} does not share the declared source abstract`);
+    if (!num || one(num, 'abstractNumId').getAttributeNS(W, 'val') !== heading.expected_abstract_num_id) {
+      throw new Error(`numbering continuations: abstract ID drifted for ${heading.num_id}`);
     }
+    const targets = Array.from(numbering.getElementsByTagNameNS(W, 'abstractNum')).filter(node => node.getAttributeNS(W, 'abstractNumId') === heading.expected_abstract_num_id);
+    if (targets.length !== 1 || elements(targets[0], 'numStyleLink').length || elements(targets[0], 'styleLink').length) throw new Error('numbering continuations: missing, ambiguous or style-linked target abstract');
+    if (heading.expected_abstract_num_id !== abstractId) {
+      for (let index = 0; index <= heading.ilvl; index += 1) {
+        const level = (abstract: Element) => elements(abstract, 'lvl').filter(l => l.getAttributeNS(W, 'ilvl') === String(index));
+        const from = level(targets[0]), to = level(abstracts[0]);
+        if (from.length !== 1 || to.length !== 1 || compatibleLevel(from[0]) !== compatibleLevel(to[0])) {
+          throw new Error(`numbering continuations: incompatible formatting or counter semantics at level ${index}`);
+        }
+      }
+    }
+    pinned.push(structure(num), structure(targets[0]));
     const starts: Record<string, number> = {};
     for (const child of Array.from(num.childNodes).filter((node): node is Element => node.nodeType === 1)) {
       if (child.namespaceURI !== W || !['abstractNumId', 'lvlOverride'].includes(child.localName ?? '')) {
@@ -67,6 +102,7 @@ function checkShape(numbering: Document, config: NumberingContinuations): void {
       throw new Error(`numbering continuations: start overrides drifted for ${heading.num_id}`);
     }
   }
+  return createHash('sha256').update(JSON.stringify(pinned)).digest('hex');
 }
 
 function declaredParagraphs(document: Document, styles: Document, config: NumberingContinuations, source: boolean): Set<Element> {
@@ -106,18 +142,19 @@ export function validateNumberingContinuationSource(sourcePath: string, input: N
     return parser.parseFromString(entry.getData().toString('utf8'), 'text/xml');
   };
   const numbering = part('numbering');
-  checkShape(numbering, config);
+  const fingerprint = checkShape(numbering, config);
   declaredParagraphs(part('document'), part('styles'), config, true);
   const plan = Object.freeze({ sourceNumId: config.source_num_id, sourceSha256: config.source_sha256 });
-  plans.set(plan, config);
+  plans.set(plan, { config, fingerprint });
   return plan;
 }
 
 export function resolveNumberingContinuationParagraphs(
   document: Document, styles: Document, numbering: Document, plan: ValidatedNumberingContinuations,
 ): Set<Element> {
-  const config = plans.get(plan);
-  if (!config) throw new Error('numbering continuations: unvalidated source plan');
-  checkShape(numbering, config);
+  const stored = plans.get(plan);
+  if (!stored) throw new Error('numbering continuations: unvalidated source plan');
+  const { config, fingerprint } = stored;
+  if (checkShape(numbering, config) !== fingerprint) throw new Error('numbering continuations: pinned instance/abstract fingerprint drifted');
   return declaredParagraphs(document, styles, config, false);
 }

--- a/src/core/field-selector/numbering-normalizer.ts
+++ b/src/core/field-selector/numbering-normalizer.ts
@@ -3,6 +3,8 @@ import { writeFileSync } from 'node:fs';
 import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
 import type { Element as XmlElement } from '@xmldom/xmldom';
 import { createParagraphNumberingResolver } from './paragraph-numbering.js';
+import { resolveNumberingContinuationParagraphs } from './numbering-continuations.js';
+import type { ValidatedNumberingContinuations } from './numbering-continuations.js';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 
@@ -19,17 +21,23 @@ function direct(parent: XmlElement, local: string): XmlElement | null {
   return null;
 }
 
-export function normalizeNumberedHeadingSections(inputPath: string, outputPath: string): NumberingNormalizationStats {
+export function normalizeNumberedHeadingSections(inputPath: string, outputPath: string, continuationPlan?: ValidatedNumberingContinuations): NumberingNormalizationStats {
   const zip = new AdmZip(inputPath);
   const documentEntry = zip.getEntry('word/document.xml');
   const stylesEntry = zip.getEntry('word/styles.xml');
   const numberingEntry = zip.getEntry('word/numbering.xml');
-  if (!documentEntry || !stylesEntry || !numberingEntry) return { sections: 0, paragraphs: 0 };
+  if (!documentEntry || !stylesEntry || !numberingEntry) {
+    if (continuationPlan) throw new Error('numbering continuations: missing required document parts');
+    return { sections: 0, paragraphs: 0 };
+  }
   const parser = new DOMParser();
   const serializer = new XMLSerializer();
   const document = parser.parseFromString(documentEntry.getData().toString('utf8'), 'text/xml');
   const styles = parser.parseFromString(stylesEntry.getData().toString('utf8'), 'text/xml');
   const numbering = parser.parseFromString(numberingEntry.getData().toString('utf8'), 'text/xml');
+  const continuationParagraphs = continuationPlan
+    ? resolveNumberingContinuationParagraphs(document, styles, numbering, continuationPlan)
+    : new Set<XmlElement>();
 
   const resolveNumbering = createParagraphNumberingResolver(styles);
   const numToAbstract = new Map<string, string>();
@@ -59,7 +67,10 @@ export function normalizeNumberedHeadingSections(inputPath: string, outputPath: 
       : null;
   });
   const roots = candidates.filter((item) => item?.ilvl === 0 && hierarchicalAbstracts.has(numToAbstract.get(item.numId) ?? ''));
-  if (roots.length < 2) return { sections: 0, paragraphs: 0 };
+  if (roots.length < 2) {
+    if (continuationPlan) throw new Error('numbering continuations: expected multiple source heading sections');
+    return { sections: 0, paragraphs: 0 };
+  }
   const counts = new Map<string, number>();
   for (const root of roots) counts.set(root!.numId, (counts.get(root!.numId) ?? 0) + 1);
   const ranked = [...counts.entries()].sort((a, b) => b[1] - a[1]);
@@ -67,6 +78,9 @@ export function normalizeNumberedHeadingSections(inputPath: string, outputPath: 
     throw new Error('numbering normalization: ambiguous dominant top-level numbering instance');
   }
   const sourceNumId = ranked[0][0];
+  if (continuationPlan && continuationPlan.sourceNumId !== sourceNumId) {
+    throw new Error('numbering continuations: declared source is not the normalized heading instance');
+  }
   const abstractNumId = numToAbstract.get(sourceNumId);
   if (!abstractNumId) throw new Error(`numbering normalization: missing abstract numbering for numId ${sourceNumId}`);
   const sourceAbstract = abstractElements.get(abstractNumId);
@@ -76,7 +90,7 @@ export function normalizeNumberedHeadingSections(inputPath: string, outputPath: 
   let rewritten = 0;
   let activeNumId: string | null = null;
   for (const item of candidates) {
-    if (!item || item.numId !== sourceNumId) continue;
+    if (!item || (item.numId !== sourceNumId && !continuationParagraphs.has(item.paragraph))) continue;
     if (item.ilvl === 0) {
       section += 1;
       activeNumId = String(++maxNumId);

--- a/src/core/metadata.ts
+++ b/src/core/metadata.ts
@@ -622,6 +622,7 @@ const BUILTIN_NORMALIZE_PREREQUISITES = new Set(['clean', 'selection', 'fill']);
 const NumberingContinuationHeadingSchema = z.object({
   anchor: z.string().trim().min(1),
   num_id: z.string().regex(/^[1-9]\d*$/),
+  expected_abstract_num_id: z.string().regex(/^(0|[1-9]\d*)$/),
   ilvl: z.number().int().min(1).max(8),
   expected_starts: z.record(z.string().regex(/^[0-8]$/), z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER)),
 }).strict();
@@ -637,11 +638,6 @@ export const NumberingContinuationsSchema = z.object({
     const anchor = heading.anchor.replaceAll('[', '').replaceAll(']', '').replace(/\s+/g, ' ').trim().replace(/\.$/, '');
     if (!anchor || anchors.has(anchor) || ids.has(heading.num_id) || heading.num_id === config.source_num_id) {
       ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['headings', index], message: 'continuation anchors and instances must be unique and distinct from the source instance' });
-    }
-    for (let level = 0; level <= heading.ilvl; level += 1) {
-      if (heading.expected_starts[String(level)] === undefined) {
-        ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['headings', index, 'expected_starts'], message: 'continuation requires explicit starts for its level and all parents' });
-      }
     }
     anchors.add(anchor);
     ids.add(heading.num_id);

--- a/src/core/metadata.ts
+++ b/src/core/metadata.ts
@@ -619,8 +619,39 @@ export type DeclarativeParagraphNormalizeRule = z.infer<typeof DeclarativeParagr
 
 const BUILTIN_NORMALIZE_PREREQUISITES = new Set(['clean', 'selection', 'fill']);
 
+const NumberingContinuationHeadingSchema = z.object({
+  anchor: z.string().trim().min(1),
+  num_id: z.string().regex(/^[1-9]\d*$/),
+  ilvl: z.number().int().min(1).max(8),
+  expected_starts: z.record(z.string().regex(/^[0-8]$/), z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER)),
+}).strict();
+
+export const NumberingContinuationsSchema = z.object({
+  source_sha256: z.string().regex(/^[a-f0-9]{64}$/),
+  source_num_id: z.string().regex(/^[1-9]\d*$/),
+  headings: z.array(NumberingContinuationHeadingSchema).min(1),
+}).strict().superRefine((config, ctx) => {
+  const ids = new Set<string>();
+  const anchors = new Set<string>();
+  config.headings.forEach((heading, index) => {
+    const anchor = heading.anchor.replaceAll('[', '').replaceAll(']', '').replace(/\s+/g, ' ').trim().replace(/\.$/, '');
+    if (!anchor || anchors.has(anchor) || ids.has(heading.num_id) || heading.num_id === config.source_num_id) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['headings', index], message: 'continuation anchors and instances must be unique and distinct from the source instance' });
+    }
+    for (let level = 0; level <= heading.ilvl; level += 1) {
+      if (heading.expected_starts[String(level)] === undefined) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['headings', index, 'expected_starts'], message: 'continuation requires explicit starts for its level and all parents' });
+      }
+    }
+    anchors.add(anchor);
+    ids.add(heading.num_id);
+  });
+});
+export type NumberingContinuations = z.infer<typeof NumberingContinuationsSchema>;
+
 export const NormalizeConfigSchema = z.object({
   paragraph_rules: z.array(DeclarativeParagraphNormalizeRuleSchema).default([]),
+  numbering_continuations: NumberingContinuationsSchema.optional(),
 }).strict().superRefine((config, ctx) => {
   const idIndexes = new Map<string, number[]>();
   config.paragraph_rules.forEach((rule, index) => {

--- a/src/core/runtime-capabilities.ts
+++ b/src/core/runtime-capabilities.ts
@@ -16,6 +16,7 @@ export const RUNTIME_CAPABILITIES = Object.freeze({
     'selections.unwrap-brackets.v1',
     'computed.v1',
     'normalize.v1',
+    'normalize.numbering-continuations.v1',
     'repeatable-tables.v1',
     'anchored-paragraph-bindings.v1',
     'reference-fields.v1',


### PR DESCRIPTION
## Summary

Fixes #804.

Add explicit, source-pinned numbering continuation declarations for isolated outline headings whose children use the main section stream. The runtime validates the original DOCX hash, unique paragraph anchor, concrete numbering ID, expected abstract ID, exact start-override map, and compatible used-level formatting before issuing an opaque normalization plan.

After selection, only the declared surviving headings join the dynamic section instance. Original instance/abstract fingerprints reject drift. Undeclared lists and intentional restarts remain untouched. Compatible distinct abstracts are permitted only for the uniquely declared paragraph; this is not heuristic list merging.

The change includes loader/entrypoint regressions, synthetic DOCX fixtures, documentation, and the `normalize.numbering-continuations.v1` capability. Canonical recipe declarations follow separately upstream. Editable numbering remains dynamic; this does not implement render-only snapshots or REF evaluation.

## Verification

- Build, lint, and catalog validation passed (7 field-selectors).
- Focused continuation and actual entrypoint tests passed (31 tests).
- Private pinned-source fill with all four independently audited continuation carriers passed with zero warnings.
- Independently checked all 169 main-outline counter tuples and the complete 16-heading section-five sequence.
- Three selective heading/body deletions each decremented subsequent labels dynamically without altering numbering definitions or re-normalizing the document.
- Full-suite diagnostic passed: 1,505 tests passed, 7 skipped, using one worker and an explicit 15-second test limit under independently observed unrelated system load. Standard local 5-second runs had timeout-only failures in existing fill tests; no tracked timeout was changed. Standard CI must pass before merge.
- Local render-only verification preserved all 64 numeric cross-references, with dynamic labels also verified in the deletion PDF. Existing baseline style-separator layout defects remain; this is not a claim of pristine whole-document layout or Word fidelity.

No licensed source documents, generated documents, private fixture values, or rendered artifacts are included in this PR.
