### PR TITLE
fix(render): prepare numbering-safe disposable PDF inputs

### DIFF
--- a/docs/numbering-render-copies.md
+++ b/docs/numbering-render-copies.md
@@ -1,0 +1,56 @@
+# Numbering-safe PDF rendering
+
+Keep the filled DOCX as the editable deliverable. For PDF conversion, prepare a
+separate disposable copy:
+
+```sh
+open-agreements field-selector render-copy agreement.docx -o agreement.render.docx
+soffice --headless --convert-to pdf --outdir rendered agreement.render.docx
+```
+
+The first command prints JSON with `renderOnly: true`, source/output SHA-256,
+and counts of snapshotted `paragraphs` and materialized numeric `references`.
+Retain this receipt and the actual
+converter command, exit status and output with the run evidence. Rename the PDF
+to the intended deliverable name if necessary; do not rename or deliver the
+`.render.docx` as the editable agreement.
+
+The output must be a **new** `*.render.docx`; input replacement, existing files,
+and chained render copies are rejected. The original DOCX bytes and automatic
+numbering are unchanged. The render copy freezes effective list counters into
+independent instances solely for a static PDF, preserving ordinary text,
+bookmarks, number formats and paragraph layout. Numeric references must be
+evaluated from the same final counter snapshot; their editable fields remain
+in the original, not in the disposable copy. Unsupported numbering structures
+fail closed rather than silently choosing labels. Inspect rendered references
+and all numbering levels; preparation is not a production-readiness verdict.
+
+This first version handles main-story numbering, including tables. Numbering or
+REF fields within mutually exclusive `AlternateContent` branches are rejected;
+the tool does not guess which renderer-specific branch to select. Numbered
+textboxes and numbering or REF fields in headers, footers, footnotes, endnotes,
+or comments are rejected rather than silently omitted. Prepare the **filled**
+document, after the normal recipe cleanup; unfilled source forms may still
+contain instructional footnotes that are outside this rendering scope.
+
+Numeric REF evaluation is deliberately bounded: decimal, alphabetic counters
+1–26, Roman counters 1–3999, and English ordinal words 1–20. Supported switches
+are `n`, `r`, `w`, `h`, `t`, and `MERGEFORMAT`; combined numeric switches use
+`r` before `n` before `w`. Relative references use the preceding numbered
+paragraph's concrete list context, not heading-text guesses. Composite level
+labels stay intact. The `t` switch suppresses literal label text according to
+the documented Word semantics; LibreOffice does not consistently do that
+itself. Unsupported fields, ambiguous or incomplete bookmark targets, and
+unsupported languages or formats fail closed. This is not a general Word
+field evaluator or a guarantee of identical pagination across renderers.
+
+## Why this is separate from filling
+
+In the pinned IRA source, LibreOffice imports mixed ordinary headings and Word
+style-separator headings into inconsistent counter streams. A shared explicit
+numbering ID alone does not fix its PDF output. A proposed uniform-separator
+repair corrected section numbers but regressed nested alphabetic labels; it
+was rejected after visual checks. Freezing every heading in the editable
+document would instead impair later automatic renumbering. This separate
+render-only path avoids both compromises. This is a reproduced LibreOffice
+interoperability defect, not a claim of a reproduced Word display failure.

--- a/runtime-capabilities.json
+++ b/runtime-capabilities.json
@@ -16,6 +16,7 @@
     "anchored-paragraph-bindings.v1",
     "reference-fields.v1",
     "reference-fields.grouped.v1",
-    "conditional-input-requirements.v1"
+    "conditional-input-requirements.v1",
+    "render.numbering-snapshot.v1"
   ]
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -8,6 +8,7 @@ import { runList } from '../commands/list.js';
 import { runTemplateShow } from '../commands/template.js';
 import { runFieldSelectorCommand, runFieldSelectorClean, runFieldSelectorPatch } from '../commands/field-selector.js';
 import { runFieldSelectorSchema } from '../commands/field-selector-schema.js';
+import { createNumberingRenderCopy } from '../core/field-selector/numbering-render-copy.js';
 import { runScan } from '../commands/scan.js';
 import {
   runChecklistCreate,
@@ -194,6 +195,14 @@ export function createProgram(): Command {
 
   const fieldSelectorCmd = new Command('field-selector');
   fieldSelectorCmd.description('Work with field-selector-based document pipelines');
+
+  fieldSelectorCmd
+    .command('render-copy <input>')
+    .description('Create a disposable numbering snapshot for PDF conversion; never replace the editable DOCX')
+    .requiredOption('-o, --output <path>', 'New *.render.docx path (must not exist)')
+    .action((input: string, opts: { output: string }) => {
+      console.log(JSON.stringify(createNumberingRenderCopy(input, opts.output), null, 2));
+    });
 
   fieldSelectorCmd
     .command('schema [field-selector-id]')

--- a/src/core/field-selector/numbering-counters.test.ts
+++ b/src/core/field-selector/numbering-counters.test.ts
@@ -1,0 +1,121 @@
+import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
+import { describe, expect } from 'vitest';
+import { itAllure } from '../../../integration-tests/helpers/allure-test.js';
+import { resolveNumberingSnapshots } from './numbering-counters.js';
+
+const it = itAllure.epic('Filling & Rendering');
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const parse = (xml: string) => new DOMParser().parseFromString(xml, 'text/xml');
+const level = (index: number, extra = '', start: number | null = 1) => `<w:lvl w:ilvl="${index}">${start === null ? '' : `<w:start w:val="${start}"/>`}<w:numFmt w:val="${['decimal', 'lowerLetter', 'lowerRoman'][index] ?? 'decimal'}"/>${extra}<w:lvlText w:val="${Array.from({ length: index + 1 }, (_, i) => `%${i + 1}`).join('.')}"/></w:lvl>`;
+const paragraph = (ilvl: number, numId = '1', text = '') => `<w:p><w:pPr><w:numPr><w:ilvl w:val="${ilvl}"/><w:numId w:val="${numId}"/></w:numPr></w:pPr><w:r><w:t>${text}</w:t></w:r></w:p>`;
+const document = (ps: string) => parse(`<w:document xmlns:w="${W}"><w:body>${ps}</w:body></w:document>`);
+const numbering = (levels = level(0) + level(1) + level(2), overrides = '', extra = '') => parse(`<w:numbering xmlns:w="${W}"><w:abstractNum w:abstractNumId="0">${levels}</w:abstractNum><w:num w:numId="1"><w:abstractNumId w:val="0"/>${overrides}</w:num>${extra}</w:numbering>`);
+const sequence = (indices: number[], levels?: string, overrides?: string) => resolveNumberingSnapshots(document(indices.map(i => paragraph(i)).join('')), undefined, numbering(levels, overrides));
+const tuples = (indices: number[], levels?: string, overrides?: string) => sequence(indices, levels, overrides).map(s => s.counters.slice(0, 3));
+
+describe('render-copy numbering counter resolution', () => {
+  it('resolves the complete decimal/letter/roman hierarchy and resets descendants', () => {
+    expect(tuples([0, 1, 2, 2, 1, 2, 0, 1, 2])).toEqual([
+      [1, 1, 1], [1, 1, 1], [1, 1, 1], [1, 1, 2], [1, 2, 1], [1, 2, 1], [2, 1, 1], [2, 1, 1], [2, 1, 1],
+    ]);
+    const result = sequence([0, 1, 2]);
+    expect(Array.from(result[2].effectiveAbstract.getElementsByTagNameNS(W, 'numFmt')).map(n => n.getAttributeNS(W, 'val'))).toEqual(['decimal', 'lowerLetter', 'lowerRoman']);
+    expect(result[2].counters).toHaveLength(9);
+  });
+
+  it('honors never-restart even across all higher levels', () => {
+    expect(tuples([0, 1, 2, 2, 0, 1, 2], level(0) + level(1) + level(2, '<w:lvlRestart w:val="0"/>'))).toEqual([
+      [1, 1, 1], [1, 1, 1], [1, 1, 1], [1, 1, 2], [2, 1, 2], [2, 1, 2], [2, 1, 3],
+    ]);
+  });
+
+  it('uses a custom one-based ancestor restart instead of the immediate parent', () => {
+    expect(tuples([0, 1, 2, 1, 2, 0, 2], level(0) + level(1) + level(2, '<w:lvlRestart w:val="1"/>'))).toEqual([
+      [1, 1, 1], [1, 1, 1], [1, 1, 1], [1, 2, 1], [1, 2, 2], [2, 1, 1], [2, 1, 1],
+    ]);
+  });
+
+  it('ignores a restart reference to a non-ancestor as specified by OOXML', () => {
+    expect(tuples([0, 1, 1, 0, 1], level(0) + level(1, '<w:lvlRestart w:val="9"/>'))).toEqual([
+      [1, 1, 0], [1, 1, 0], [1, 2, 0], [2, 1, 0], [2, 1, 0],
+    ]);
+  });
+
+  it('uses zero for omitted starts and does not consume unseen ancestor starts', () => {
+    expect(tuples([2, 2, 0, 1, 2], level(0, '', 5) + level(1, '', null) + level(2, '', null))).toEqual([
+      [5, 0, 0], [5, 0, 1], [5, 0, 0], [5, 0, 0], [5, 0, 0],
+    ]);
+  });
+
+  it('folds level replacements and startOverride, including every subsequent restart', () => {
+    const override = `<w:lvlOverride w:ilvl="1"><w:startOverride w:val="4"/>${level(1, '<w:lvlRestart w:val="1"/>', 8)}</w:lvlOverride>`;
+    expect(tuples([0, 1, 1, 0, 1], undefined, override)).toEqual([
+      [1, 4, 1], [1, 4, 1], [1, 5, 1], [2, 4, 1], [2, 4, 1],
+    ]);
+    const effective = sequence([1], undefined, override)[0].effectiveAbstract;
+    expect(effective.getElementsByTagNameNS(W, 'lvl')[1].getElementsByTagNameNS(W, 'start')[0].getAttributeNS(W, 'val')).toBe('4');
+  });
+
+  it('resolves start-only overrides and full overrides adding a previously undefined level', () => {
+    expect(tuples([0, 0], level(0), '<w:lvlOverride w:ilvl="0"><w:startOverride w:val="7"/></w:lvlOverride>')).toEqual([[7, 0, 0], [8, 0, 0]]);
+    expect(tuples([0, 1], level(0), `<w:lvlOverride w:ilvl="1">${level(1)}</w:lvlOverride>`)).toEqual([[1, 1, 0], [1, 1, 0]]);
+  });
+
+  it('keeps interleaved instances independent even when they share an abstract definition', () => {
+    const doc = document(paragraph(0) + paragraph(0, '2') + paragraph(0) + paragraph(0, '0') + paragraph(0, '2'));
+    const num = numbering(level(0), '', '<w:num w:numId="2"><w:abstractNumId w:val="0"/><w:lvlOverride w:ilvl="0"><w:startOverride w:val="8"/></w:lvlOverride></w:num>');
+    expect(resolveNumberingSnapshots(doc, undefined, num).map(s => [s.numId, s.counters[0]])).toEqual([['1', 1], ['2', 8], ['1', 2], ['2', 9]]);
+  });
+
+  it('merges partial numbering through basedOn, defaults and direct paragraph properties', () => {
+    const styles = parse(`<w:styles xmlns:w="${W}"><w:style w:type="paragraph" w:default="1" w:styleId="Base"><w:pPr><w:numPr><w:numId w:val="1"/></w:numPr></w:pPr></w:style><w:style w:type="paragraph" w:styleId="Child"><w:basedOn w:val="Base"/><w:pPr><w:numPr><w:ilvl w:val="1"/></w:numPr></w:pPr></w:style></w:styles>`);
+    const doc = document('<w:p/>' + '<w:p><w:pPr><w:pStyle w:val="Child"/></w:pPr></w:p>' + '<w:p><w:pPr><w:pStyle w:val="Child"/><w:numPr><w:ilvl w:val="2"/></w:numPr></w:pPr></w:p>' + '<w:p><w:pPr><w:pStyle w:val="Child"/><w:numPr><w:numId w:val="0"/></w:numPr></w:pPr></w:p>');
+    expect(resolveNumberingSnapshots(doc, styles, numbering()).map(s => s.ilvl)).toEqual([0, 1, 2]);
+  });
+
+  it('includes numbered body paragraphs and table cells, and ignores separator run formatting', () => {
+    const doc = document(paragraph(0) + paragraph(1).replace('</w:pPr>', '<w:rPr><w:vanish/><w:specVanish/></w:rPr></w:pPr>') + '<w:tbl><w:tr><w:tc>' + paragraph(2) + '</w:tc></w:tr></w:tbl>' + paragraph(1));
+    expect(resolveNumberingSnapshots(doc, undefined, numbering()).map(s => s.counters.slice(0, 3))).toEqual([[1, 1, 1], [1, 1, 1], [1, 1, 1], [1, 2, 1]]);
+  });
+
+  it('does not mutate inputs or share mutable effective definitions between snapshots', () => {
+    const doc = document(paragraph(0) + paragraph(1));
+    const num = numbering();
+    const serializer = new XMLSerializer();
+    const before = [serializer.serializeToString(doc), serializer.serializeToString(num)];
+    const result = resolveNumberingSnapshots(doc, undefined, num);
+    result[0].effectiveAbstract.setAttribute('probe', 'changed');
+    expect(result[1].effectiveAbstract.hasAttribute('probe')).toBe(false);
+    expect([serializer.serializeToString(doc), serializer.serializeToString(num)]).toEqual(before);
+    expect(result[0].paragraph).toBe(doc.getElementsByTagNameNS(W, 'p')[0]);
+  });
+
+  for (const [name, levels, override, index] of [
+    ['invalid abstract level', level(9), '', 0],
+    ['duplicate level', level(0) + level(0), '', 0],
+    ['invalid start', level(0, '', -1), '', 0],
+    ['invalid restart', level(0) + level(1, '<w:lvlRestart w:val="-1"/>'), '', 0],
+    ['undefined used level', level(0), '', 1],
+    ['undefined referenced ancestor', level(1), '', 1],
+    ['numbering style link', '<w:numStyleLink w:val="ListStyle"/>' + level(0), '', 0],
+    ['override level mismatch', level(0), `<w:lvlOverride w:ilvl="0">${level(1)}</w:lvlOverride>`, 0],
+    ['duplicate override', level(0), '<w:lvlOverride w:ilvl="0"/><w:lvlOverride w:ilvl="0"/>', 0],
+    ['undefined overridden level', level(0), '<w:lvlOverride w:ilvl="1"><w:startOverride w:val="2"/></w:lvlOverride>', 0],
+  ] as const) {
+    it(`fails closed for ${name}`, () => {
+      expect(() => sequence([index], levels, override)).toThrow(/numbering counters:/);
+    });
+  }
+
+  it('rejects unresolved numbering and malformed paragraph levels', () => {
+    expect(() => resolveNumberingSnapshots(document(paragraph(0, '99')), undefined, numbering())).toThrow(/unresolved numbering/);
+    expect(() => resolveNumberingSnapshots(document(paragraph(9)), undefined, numbering())).toThrow(/paragraph level/);
+  });
+
+  it('rejects used cyclic or missing paragraph styles rather than dropping numbering', () => {
+    const styles = parse(`<w:styles xmlns:w="${W}"><w:style w:type="paragraph" w:styleId="Cycle"><w:basedOn w:val="Cycle"/></w:style></w:styles>`);
+    const styled = (id: string) => document(`<w:p><w:pPr><w:pStyle w:val="${id}"/></w:pPr></w:p>`);
+    expect(() => resolveNumberingSnapshots(styled('Cycle'), styles, numbering())).toThrow(/style cycle/);
+    expect(() => resolveNumberingSnapshots(styled('Missing'), styles, numbering())).toThrow(/unresolved paragraph style/);
+  });
+});

--- a/src/core/field-selector/numbering-counters.ts
+++ b/src/core/field-selector/numbering-counters.ts
@@ -1,0 +1,196 @@
+import type { Document as XmlDocument, Element as XmlElement } from '@xmldom/xmldom';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+export interface NumberingSnapshot {
+  paragraph: XmlElement;
+  numId: string;
+  ilvl: number;
+  /** Nine scalar values; unseen levels use their effective starts, or zero if undefined. */
+  counters: number[];
+  /** Detached effective definition with instance overrides folded in. Never an input node. */
+  effectiveAbstract: XmlElement;
+}
+
+function children(parent: XmlElement, local: string): XmlElement[] {
+  return Array.from(parent.childNodes).filter((node): node is XmlElement => node.nodeType === 1
+    && (node as XmlElement).namespaceURI === W && (node as XmlElement).localName === local);
+}
+function direct(parent: XmlElement | null, local: string): XmlElement | null {
+  if (!parent) return null;
+  const found = children(parent, local);
+  if (found.length > 1) throw new Error(`numbering counters: duplicate ${local}`);
+  return found[0] ?? null;
+}
+function attr(element: XmlElement, local: string): string {
+  return element.getAttributeNS(W, local) ?? '';
+}
+function integer(raw: string, context: string, max = Number.MAX_SAFE_INTEGER): number {
+  if (!/^\d+$/.test(raw) || !Number.isSafeInteger(Number(raw)) || Number(raw) > max) {
+    throw new Error(`numbering counters: invalid ${context}: ${raw}`);
+  }
+  return Number(raw);
+}
+function id(element: XmlElement, local: string): string {
+  return String(integer(attr(element, local), local));
+}
+
+interface PartialNumbering { numId?: string; ilvl?: number }
+function fromProperties(properties: XmlElement | null): PartialNumbering {
+  const numPr = direct(properties, 'numPr');
+  if (!numPr) return {};
+  if (direct(numPr, 'numberingChange') || direct(numPr, 'ins')) {
+    throw new Error('numbering counters: tracked numbering changes are unsupported');
+  }
+  const num = direct(numPr, 'numId');
+  const level = direct(numPr, 'ilvl');
+  return {
+    ...(num ? { numId: id(num, 'val') } : {}),
+    ...(level ? { ilvl: integer(attr(level, 'val'), 'paragraph level', 8) } : {}),
+  };
+}
+
+function paragraphResolver(styles: XmlDocument | undefined): (p: XmlElement) => PartialNumbering {
+  const definitions = new Map<string, XmlElement>();
+  let defaultId: string | undefined;
+  for (const style of Array.from(styles?.getElementsByTagNameNS(W, 'style') ?? [])) {
+    if (attr(style, 'type') !== 'paragraph') continue;
+    const key = attr(style, 'styleId');
+    if (!key || definitions.has(key)) throw new Error('numbering counters: missing/duplicate paragraph style ID');
+    definitions.set(key, style);
+    if (['1', 'true', 'on'].includes(attr(style, 'default'))) {
+      if (defaultId) throw new Error('numbering counters: multiple default paragraph styles');
+      defaultId = key;
+    }
+  }
+  const defaults = fromProperties(direct(direct(direct(styles?.documentElement ?? null, 'docDefaults'), 'pPrDefault'), 'pPr'));
+  const cache = new Map<string, PartialNumbering>();
+  const visiting = new Set<string>();
+  const resolve = (key: string): PartialNumbering => {
+    if (cache.has(key)) return cache.get(key)!;
+    if (visiting.has(key)) throw new Error(`numbering counters: paragraph style cycle at ${key}`);
+    const style = definitions.get(key);
+    if (!style) throw new Error(`numbering counters: unresolved paragraph style ${key}`);
+    visiting.add(key);
+    const parent = direct(style, 'basedOn');
+    const result = { ...(parent ? resolve(attr(parent, 'val')) : defaults), ...fromProperties(direct(style, 'pPr')) };
+    visiting.delete(key);
+    cache.set(key, result);
+    return result;
+  };
+  return (paragraph) => {
+    const properties = direct(paragraph, 'pPr');
+    const style = direct(properties, 'pStyle');
+    const styleId = style ? attr(style, 'val') : defaultId;
+    return { ...(styleId ? resolve(styleId) : defaults), ...fromProperties(properties) };
+  };
+}
+
+interface Level { start: number; restart: number }
+interface Instance { abstract: XmlElement; levels: Map<number, Level>; values: Array<number | undefined> }
+
+/**
+ * Pure counter projection for a transient renderer copy, not editable-DOCX rewriting.
+ * OOXML defaults: absent start = 0; absent lvlRestart = previous level; 0 = never.
+ * https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.wordprocessing.levelrestart
+ * https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.wordprocessing.startnumberingvalue
+ * https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.wordprocessing.startoverridenumberingvalue
+ */
+export function resolveNumberingSnapshots(
+  document: XmlDocument, styles: XmlDocument | undefined, numbering: XmlDocument,
+): NumberingSnapshot[] {
+  const abstracts = new Map<string, XmlElement>();
+  const numbers = new Map<string, XmlElement>();
+  const numberingRoot = numbering.documentElement;
+  if (!numberingRoot) throw new Error('numbering counters: missing numbering document root');
+  for (const node of children(numberingRoot, 'abstractNum')) {
+    const key = id(node, 'abstractNumId');
+    if (abstracts.has(key)) throw new Error(`numbering counters: duplicate abstractNum ${key}`);
+    abstracts.set(key, node);
+  }
+  for (const node of children(numberingRoot, 'num')) {
+    const key = id(node, 'numId');
+    if (numbers.has(key)) throw new Error(`numbering counters: duplicate numId ${key}`);
+    numbers.set(key, node);
+  }
+  const instances = new Map<string, Instance>();
+  const instance = (numId: string): Instance => {
+    if (instances.has(numId)) return instances.get(numId)!;
+    const num = numbers.get(numId);
+    const abstractId = num && direct(num, 'abstractNumId');
+    const source = abstractId && abstracts.get(id(abstractId, 'val'));
+    if (!num || !source) throw new Error(`numbering counters: unresolved numbering instance ${numId}`);
+    if (direct(source, 'numStyleLink') || direct(source, 'styleLink')) {
+      throw new Error(`numbering counters: numbering style links unsupported for ${numId}`);
+    }
+    const effective = source.cloneNode(true) as XmlElement;
+    const levelNodes = new Map<number, XmlElement>();
+    for (const node of children(effective, 'lvl')) {
+      const level = integer(attr(node, 'ilvl'), 'abstract level', 8);
+      if (levelNodes.has(level)) throw new Error(`numbering counters: duplicate level ${level}`);
+      levelNodes.set(level, node);
+    }
+    const overridden = new Set<number>();
+    for (const override of children(num, 'lvlOverride')) {
+      const level = integer(attr(override, 'ilvl'), 'override level', 8);
+      if (overridden.has(level)) throw new Error(`numbering counters: duplicate override ${level}`);
+      overridden.add(level);
+      const replacement = direct(override, 'lvl');
+      let node = levelNodes.get(level);
+      if (replacement) {
+        if (integer(attr(replacement, 'ilvl'), 'override child level', 8) !== level) {
+          throw new Error('numbering counters: override level mismatch');
+        }
+        const clone = replacement.cloneNode(true) as XmlElement;
+        if (node) effective.replaceChild(clone, node); else effective.appendChild(clone);
+        node = clone;
+        levelNodes.set(level, node);
+      }
+      if (!node) throw new Error(`numbering counters: override references undefined level ${level}`);
+      const startOverride = direct(override, 'startOverride');
+      if (startOverride) {
+        const startValue = integer(attr(startOverride, 'val'), 'startOverride');
+        let start = direct(node, 'start');
+        if (!start) { start = numbering.createElementNS(W, 'w:start'); node.insertBefore(start, node.firstChild); }
+        start.setAttributeNS(W, 'w:val', String(startValue));
+      }
+    }
+    const levels = new Map<number, Level>();
+    for (const [level, node] of levelNodes) {
+      const start = direct(node, 'start');
+      const restart = direct(node, 'lvlRestart');
+      const restartValue = restart ? integer(attr(restart, 'val'), 'lvlRestart', 9) : level;
+      // A restart reference to this/lower level is ignored by OOXML, using the default.
+      levels.set(level, { start: start ? integer(attr(start, 'val'), 'start') : 0, restart: restartValue > level ? level : restartValue });
+      const text = direct(node, 'lvlText');
+      for (const match of attr(text ?? node, 'val').matchAll(/%([1-9])/g)) {
+        const referenced = Number(match[1]) - 1;
+        if (referenced <= level && !levelNodes.has(referenced)) {
+          throw new Error(`numbering counters: level ${level} references undefined ancestor ${referenced}`);
+        }
+      }
+    }
+    const result: Instance = { abstract: effective, levels, values: Array<number | undefined>(9).fill(undefined) };
+    instances.set(numId, result);
+    return result;
+  };
+  const resolveParagraph = paragraphResolver(styles);
+  const snapshots: NumberingSnapshot[] = [];
+  for (const paragraph of Array.from(document.getElementsByTagNameNS(W, 'p'))) {
+    const resolved = resolveParagraph(paragraph);
+    if (!resolved.numId || resolved.numId === '0') continue;
+    const ilvl = resolved.ilvl ?? 0;
+    const state = instance(resolved.numId);
+    const definition = state.levels.get(ilvl);
+    if (!definition) throw new Error(`numbering counters: undefined level ${ilvl} for ${resolved.numId}`);
+    const prior = state.values[ilvl];
+    state.values[ilvl] = prior === undefined ? definition.start : prior + 1;
+    if (!Number.isSafeInteger(state.values[ilvl])) throw new Error('numbering counters: counter overflow');
+    for (const [level, lower] of state.levels) {
+      if (level > ilvl && lower.restart > 0 && ilvl < lower.restart) state.values[level] = undefined;
+    }
+    const counters = Array.from({ length: 9 }, (_, level) => state.values[level] ?? state.levels.get(level)?.start ?? 0);
+    snapshots.push({ paragraph, numId: resolved.numId, ilvl, counters, effectiveAbstract: state.abstract.cloneNode(true) as XmlElement });
+  }
+  return snapshots;
+}

--- a/src/core/field-selector/numbering-render-copy.test.ts
+++ b/src/core/field-selector/numbering-render-copy.test.ts
@@ -1,0 +1,154 @@
+import AdmZip from 'adm-zip';
+import { existsSync, mkdtempSync, readFileSync, rmSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+import { DOMParser } from '@xmldom/xmldom';
+import { afterEach, describe, expect } from 'vitest';
+import { itAllure } from '../../../integration-tests/helpers/allure-test.js';
+import { createNumberingRenderCopy } from './numbering-render-copy.js';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const it = itAllure.epic('Filling & Rendering');
+const dirs: string[] = [];
+afterEach(() => { for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true }); });
+
+function fixture(numbering = true) {
+  const dir = mkdtempSync(join(tmpdir(), 'render-copy-')); dirs.push(dir);
+  const input = join(dir, 'editable.docx'); const output = join(dir, 'preview.render.docx');
+  const zip = new AdmZip();
+  const p = (level: number, text: string, hidden = false) => `<w:p><w:pPr><w:numPr><w:ilvl w:val="${level}"/><w:numId w:val="1"/></w:numPr>${hidden ? '<w:rPr><w:vanish/><w:specVanish/></w:rPr>' : ''}</w:pPr>${text === 'Child one' ? '<w:bookmarkStart w:id="1" w:name="Target"/>' : ''}<w:r><w:t>${text}</w:t></w:r>${text === 'Child one' ? '<w:bookmarkEnd w:id="1"/>' : ''}</w:p>`;
+  zip.addFile('word/document.xml', Buffer.from(`<w:document xmlns:w="${W}"><w:body>${p(0, 'Article')}${p(1, 'Alpha', true)}${p(2, 'Child one')}${p(2, 'Child two')}${p(1, 'Beta')}${p(2, 'Child three')}<w:p><w:r><w:fldChar w:fldCharType="begin"/></w:r><w:r><w:instrText> REF Target \\w </w:instrText></w:r><w:r><w:fldChar w:fldCharType="separate"/></w:r><w:r><w:t>1.1</w:t></w:r><w:r><w:fldChar w:fldCharType="end"/></w:r></w:p></w:body></w:document>`));
+  if (numbering) zip.addFile('word/numbering.xml', Buffer.from(`<w:numbering xmlns:w="${W}"><w:abstractNum w:abstractNumId="0"><w:nsid w:val="12345678"/>${[0, 1, 2].map((i) => `<w:lvl w:ilvl="${i}"><w:start w:val="1"/><w:numFmt w:val="${i === 2 ? 'lowerLetter' : 'decimal'}"/><w:pStyle w:val="Heading${i + 1}"/><w:lvlText w:val="${i === 2 ? '(%3)' : i === 1 ? '%1.%2' : '%1.'}"/></w:lvl>`).join('')}</w:abstractNum><w:num w:numId="1"><w:abstractNumId w:val="0"/></w:num></w:numbering>`));
+  zip.addFile('[Content_Types].xml', Buffer.from('<Types/>'));
+  zip.writeZip(input);
+  return { input, output, dir };
+}
+
+describe('disposable numbering render copies', () => {
+  it('preserves editable bytes, text, fields, bookmarks and hierarchy while snapshotting counters', () => {
+    const f = fixture(); const original = readFileSync(f.input);
+    const result = createNumberingRenderCopy(f.input, f.output);
+    expect(result.renderOnly).toBe(true); expect(result.paragraphs).toBe(6);
+    expect(readFileSync(f.input)).toEqual(original);
+    expect(result.inputSha256).toBe(createHash('sha256').update(original).digest('hex'));
+    expect(result.outputSha256).toBe(createHash('sha256').update(readFileSync(f.output)).digest('hex'));
+    const parser = new DOMParser(); const before = parser.parseFromString(new AdmZip(original).readAsText('word/document.xml'), 'text/xml');
+    const zip = new AdmZip(f.output); const after = parser.parseFromString(zip.readAsText('word/document.xml'), 'text/xml');
+    for (const local of ['bookmarkStart', 'bookmarkEnd', 'specVanish']) {
+      expect(Array.from(after.getElementsByTagNameNS(W, local)).map((n) => n.toString()))
+        .toEqual(Array.from(before.getElementsByTagNameNS(W, local)).map((n) => n.toString()));
+    }
+    expect(result.references).toBe(1);
+    expect(after.getElementsByTagNameNS(W, 'instrText').length).toBe(0);
+    expect(after.getElementsByTagNameNS(W, 'fldChar').length).toBe(0);
+    const beforeText = Array.from(before.getElementsByTagNameNS(W, 't')).map((n) => n.textContent);
+    const afterText = Array.from(after.getElementsByTagNameNS(W, 't')).map((n) => n.textContent);
+    expect(afterText.slice(0, -1)).toEqual(beforeText.slice(0, -1));
+    expect(afterText.at(-1)).toBe('1.1(a)');
+    const numbering = parser.parseFromString(zip.readAsText('word/numbering.xml'), 'text/xml');
+    const abstracts = Array.from(numbering.getElementsByTagNameNS(W, 'abstractNum')).slice(1);
+    expect(abstracts.map((a) => Array.from(a.getElementsByTagNameNS(W, 'start')).map((s) => Number(s.getAttributeNS(W, 'val')))))
+      .toEqual([[1, 1, 1], [1, 1, 1], [1, 1, 1], [1, 1, 2], [1, 2, 1], [1, 2, 1]]);
+    expect(abstracts.every((a) => a.getElementsByTagNameNS(W, 'pStyle').length === 0)).toBe(true);
+    expect(new Set(abstracts.map((a) => a.getElementsByTagNameNS(W, 'nsid')[0].getAttributeNS(W, 'val'))).size).toBe(6);
+    const children = Array.from(numbering.documentElement!.childNodes).filter((n) => n.nodeType === 1);
+    const names = children.map((n) => n.nodeName);
+    expect(names).toEqual([...Array(7).fill('w:abstractNum'), ...Array(7).fill('w:num')]);
+  });
+
+  it('never overwrites input, an existing copy, or a symlink alias', () => {
+    const f = fixture(); const bytes = readFileSync(f.input);
+    expect(() => createNumberingRenderCopy(f.input, f.input)).toThrow(/distinct/);
+    expect(() => createNumberingRenderCopy(f.input, join(f.dir, 'deliverable.docx'))).toThrow(/render.docx/);
+    symlinkSync(f.input, f.output);
+    expect(() => createNumberingRenderCopy(f.input, f.output)).toThrow(/EEXIST/);
+    expect(readFileSync(f.input)).toEqual(bytes);
+  });
+
+  it('adds renderer identities when absent and preserves the numbering cleanup tail order', () => {
+    const f = fixture();
+    const zip = new AdmZip(f.input);
+    zip.updateFile('word/numbering.xml', Buffer.from(zip.readAsText('word/numbering.xml')
+      .replace('<w:nsid w:val="12345678"/>', '')
+      .replace('</w:numbering>', '<w:numIdMacAtCleanup w:val="1"/></w:numbering>')));
+    zip.writeZip(f.input);
+    createNumberingRenderCopy(f.input, f.output);
+    const document = new DOMParser().parseFromString(new AdmZip(f.output).readAsText('word/numbering.xml'), 'text/xml');
+    const names = Array.from(document.documentElement!.childNodes).filter((n) => n.nodeType === 1).map((n) => n.nodeName);
+    expect(names).toEqual([...Array(7).fill('w:abstractNum'), ...Array(7).fill('w:num'), 'w:numIdMacAtCleanup']);
+    const identities = Array.from(document.getElementsByTagNameNS(W, 'nsid')).map((n) => n.getAttributeNS(W, 'val'));
+    expect(new Set(identities).size).toBe(6);
+    expect(identities.every((value) => /^[0-9A-F]{8}$/.test(value ?? ''))).toBe(true);
+  });
+
+  it('refuses to chain render-only copies into a supposed editable source', () => {
+    const f = fixture(); createNumberingRenderCopy(f.input, f.output);
+    expect(() => createNumberingRenderCopy(f.output, join(f.dir, 'second.render.docx'))).toThrow(/original DOCX/);
+  });
+
+  it('materializes a default level before an existing numId', () => {
+    const f = fixture(); const zip = new AdmZip(f.input);
+    zip.updateFile('word/document.xml', Buffer.from(zip.readAsText('word/document.xml').replace('<w:ilvl w:val="0"/>', '')));
+    zip.writeZip(f.input);
+    createNumberingRenderCopy(f.input, f.output);
+    const document = new DOMParser().parseFromString(new AdmZip(f.output).readAsText('word/document.xml'), 'text/xml');
+    const numPr = document.getElementsByTagNameNS(W, 'numPr')[0];
+    expect(Array.from(numPr.childNodes).filter((n) => n.nodeType === 1).map((n) => n.nodeName)).toEqual(['w:ilvl', 'w:numId']);
+  });
+
+  it('copies an unnumbered document without claiming rewritten paragraphs', () => {
+    const f = fixture(false);
+    const zip = new AdmZip(f.input);
+    zip.updateFile('word/document.xml', Buffer.from(`<w:document xmlns:w="${W}"><w:body><w:p><w:r><w:t>Plain unnumbered text.</w:t></w:r></w:p></w:body></w:document>`));
+    zip.writeZip(f.input);
+    expect(createNumberingRenderCopy(f.input, f.output).paragraphs).toBe(0);
+    expect(new AdmZip(f.output).readAsText('word/document.xml')).toBe(new AdmZip(f.input).readAsText('word/document.xml'));
+  });
+
+  it('rejects used numbering references when the numbering part is missing', () => {
+    const f = fixture(false);
+    expect(() => createNumberingRenderCopy(f.input, f.output)).toThrow(/unresolved numbering instance/);
+    expect(existsSync(f.output)).toBe(false);
+  });
+
+  it.each(['hdr', 'ftr', 'footnotes', 'endnotes'])('rejects numbered %s stories before writing output', (root) => {
+    const f = fixture(); const zip = new AdmZip(f.input);
+    zip.addFile('word/custom-story.xml', Buffer.from(`<w:${root} xmlns:w="${W}"><w:p><w:pPr><w:numPr><w:numId w:val="1"/></w:numPr></w:pPr><w:r><w:t>Other story</w:t></w:r></w:p></w:${root}>`));
+    zip.writeZip(f.input); const original = readFileSync(f.input);
+    expect(() => createNumberingRenderCopy(f.input, f.output)).toThrow(/stories are unsupported|custom-story.xml.*unsupported/);
+    expect(existsSync(f.output)).toBe(false);
+    expect(readFileSync(f.input)).toEqual(original);
+  });
+
+  it('rejects numbered textboxes instead of advancing main-story counters', () => {
+    const f = fixture(); const zip = new AdmZip(f.input);
+    zip.updateFile('word/document.xml', Buffer.from(zip.readAsText('word/document.xml').replace('<w:body>', '<w:body><w:txbxContent>').replace('</w:body>', '</w:txbxContent></w:body>')));
+    zip.writeZip(f.input);
+    expect(() => createNumberingRenderCopy(f.input, f.output)).toThrow(/numbered textbox/);
+    expect(existsSync(f.output)).toBe(false);
+  });
+
+  it('rejects split REF instructions in an otherwise unnumbered header', () => {
+    const f = fixture(); const zip = new AdmZip(f.input);
+    zip.addFile('word/header1.xml', Buffer.from(`<w:hdr xmlns:w="${W}"><w:p><w:r><w:instrText> R</w:instrText></w:r><w:r><w:instrText>EF Target \\w </w:instrText></w:r></w:p></w:hdr>`));
+    zip.writeZip(f.input);
+    expect(() => createNumberingRenderCopy(f.input, f.output)).toThrow(/header1.xml.*unsupported/);
+    expect(existsSync(f.output)).toBe(false);
+  });
+
+  it.each(['numbered branches', 'split REF', 'simple REF'])('rejects AlternateContent with %s before writing', kind => {
+    const f = fixture(); const zip = new AdmZip(f.input);
+    const content = kind === 'numbered branches'
+      ? '<w:p><w:pPr><w:numPr><w:numId w:val="1"/></w:numPr></w:pPr><w:r><w:t>Alternative numbered paragraph</w:t></w:r></w:p>'
+      : kind === 'split REF'
+        ? '<w:p><w:r><w:fldChar w:fldCharType="begin"/></w:r><w:r><w:instrText> R</w:instrText></w:r><w:r><w:instrText>EF Target \\w </w:instrText></w:r><w:r><w:fldChar w:fldCharType="separate"/></w:r><w:r><w:t>1</w:t></w:r><w:r><w:fldChar w:fldCharType="end"/></w:r></w:p>'
+        : '<w:p><w:fldSimple w:instr="REF Target \\w"><w:r><w:t>1</w:t></w:r></w:fldSimple></w:p>';
+    const alternate = `<mc:AlternateContent xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"><mc:Choice Requires="w14">${content}</mc:Choice><mc:Fallback>${content}</mc:Fallback></mc:AlternateContent>`;
+    zip.updateFile('word/document.xml', Buffer.from(zip.readAsText('word/document.xml').replace('<w:body>', `<w:body>${alternate}`)));
+    zip.writeZip(f.input); const original = readFileSync(f.input);
+    expect(() => createNumberingRenderCopy(f.input, f.output)).toThrow(/AlternateContent.*unsupported/);
+    expect(existsSync(f.output)).toBe(false);
+    expect(readFileSync(f.input)).toEqual(original);
+  });
+});

--- a/src/core/field-selector/numbering-render-copy.ts
+++ b/src/core/field-selector/numbering-render-copy.ts
@@ -1,0 +1,169 @@
+import AdmZip from 'adm-zip';
+import { createHash } from 'node:crypto';
+import { readFileSync, realpathSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
+import type { Element as XmlElement } from '@xmldom/xmldom';
+import { resolveNumberingSnapshots } from './numbering-counters.js';
+import { materializeNumberingReferences } from './numbering-render-references.js';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const MC = 'http://schemas.openxmlformats.org/markup-compatibility/2006';
+const hash = (bytes: Buffer) => createHash('sha256').update(bytes).digest('hex');
+
+export interface NumberingRenderCopyResult {
+  renderOnly: true;
+  inputSha256: string;
+  outputSha256: string;
+  outputPath: string;
+  paragraphs: number;
+  references: number;
+}
+
+function direct(parent: XmlElement, local: string): XmlElement | undefined {
+  return Array.from(parent.childNodes).find((node) => node.nodeType === 1
+    && (node as XmlElement).namespaceURI === W && (node as XmlElement).localName === local) as XmlElement | undefined;
+}
+
+/**
+ * Create a disposable PDF-rendering input, NEVER an editable deliverable.
+ * LibreOffice splits counters around Word style separators even with explicit
+ * shared numIds. Snapshot each effective counter tuple only in this copy; the
+ * original DOCX retains its automatic numbering and exact original bytes.
+ */
+export function createNumberingRenderCopy(inputPath: string, outputPath: string): NumberingRenderCopyResult {
+  const input = realpathSync(inputPath);
+  const output = resolve(outputPath);
+  if (input === output || !output.endsWith('.render.docx') || input.endsWith('.render.docx')) {
+    throw new Error('render-copy requires an original DOCX and a distinct, new *.render.docx output');
+  }
+  const original = readFileSync(input);
+  const inputSha256 = hash(original);
+  const zip = new AdmZip(original);
+  const documentEntry = zip.getEntry('word/document.xml');
+  if (!documentEntry) throw new Error('render-copy: missing Word document part');
+  const numberingEntry = zip.getEntry('word/numbering.xml');
+  let paragraphs = 0;
+  const parser = new DOMParser({ onError: (level, message) => {
+    if (level !== 'warning') throw new Error(`render-copy: ${message}`);
+  } });
+  const document = parser.parseFromString(documentEntry.getData().toString('utf8'), 'text/xml');
+  const numbering = parser.parseFromString(numberingEntry?.getData().toString('utf8') ?? `<w:numbering xmlns:w="${W}"/>`, 'text/xml');
+  const stylesEntry = zip.getEntry('word/styles.xml');
+  const styles = stylesEntry ? parser.parseFromString(stylesEntry.getData().toString('utf8'), 'text/xml') : undefined;
+  const snapshots = resolveNumberingSnapshots(document, styles, numbering);
+  // Choice and Fallback are mutually exclusive renderer branches. Walking both
+  // would consume phantom counters or combine incompatible field instructions.
+  // Until capability negotiation is implemented, reject affected alternatives.
+  for (const alternate of Array.from(document.getElementsByTagNameNS(MC, 'AlternateContent'))) {
+    const numbered = snapshots.some((snapshot) => {
+      for (let node = snapshot.paragraph.parentNode; node; node = node.parentNode) if (node === alternate) return true;
+      return false;
+    });
+    const instructions = Array.from(alternate.getElementsByTagNameNS(W, 'instrText')).map((node) => node.textContent ?? '').join('')
+      + '\n' + Array.from(alternate.getElementsByTagNameNS(W, 'fldSimple')).map((node) => node.getAttributeNS(W, 'instr') ?? '').join('\n');
+    if (numbered || /\bREF\s/i.test(instructions)) {
+      throw new Error('render-copy: numbering or references in AlternateContent are unsupported');
+    }
+  }
+  // Other Word stories have independent list scope. Never count a textbox
+  // inside the main story or silently leave a numbered header unprocessed.
+  for (const snapshot of snapshots) {
+    for (let ancestor = snapshot.paragraph.parentNode; ancestor; ancestor = ancestor.parentNode) {
+      if (ancestor.nodeType === 1 && (ancestor as XmlElement).namespaceURI === W
+        && (ancestor as XmlElement).localName === 'txbxContent') {
+        throw new Error('render-copy: numbered textbox stories are unsupported');
+      }
+    }
+  }
+  for (const entry of zip.getEntries()) {
+    if (!entry.entryName.startsWith('word/') || !entry.entryName.endsWith('.xml')
+      || ['word/document.xml', 'word/numbering.xml', 'word/styles.xml'].includes(entry.entryName)) continue;
+    const story = parser.parseFromString(entry.getData().toString('utf8'), 'text/xml');
+    const root = story.documentElement;
+    if (!root || root.namespaceURI !== W || !['hdr', 'ftr', 'footnotes', 'endnotes', 'comments'].includes(root.localName ?? '')) continue;
+    const instruction = Array.from(story.getElementsByTagNameNS(W, 'p')).map((paragraph) =>
+      Array.from(paragraph.getElementsByTagNameNS(W, 'instrText')).map((node) => node.textContent ?? '').join('')).join('\n')
+      + '\n' + Array.from(story.getElementsByTagNameNS(W, 'fldSimple')).map((node) => node.getAttributeNS(W, 'instr') ?? '').join('\n');
+    if (resolveNumberingSnapshots(story, styles, numbering).length > 0 || /\bREF\s/i.test(instruction)) {
+      throw new Error(`render-copy: numbering or references in ${entry.entryName} are unsupported`);
+    }
+  }
+  const references = materializeNumberingReferences(document, snapshots, styles);
+  let abstractId = Math.max(0, ...Array.from(numbering.getElementsByTagNameNS(W, 'abstractNum'))
+    .map((node) => Number(node.getAttributeNS(W, 'abstractNumId'))));
+  let numId = Math.max(0, ...Array.from(numbering.getElementsByTagNameNS(W, 'num'))
+    .map((node) => Number(node.getAttributeNS(W, 'numId'))));
+  if (!Number.isSafeInteger(abstractId) || !Number.isSafeInteger(numId)) throw new Error('render-copy: invalid numbering IDs');
+  if (abstractId > Number.MAX_SAFE_INTEGER - snapshots.length || numId > Number.MAX_SAFE_INTEGER - snapshots.length) {
+    throw new Error('render-copy: numbering ID overflow');
+  }
+  const usedNsids = new Set(Array.from(numbering.getElementsByTagNameNS(W, 'nsid'))
+    .map((node) => (node.getAttributeNS(W, 'val') ?? '').toUpperCase()));
+  const firstNumber = direct(numbering.documentElement!, 'num');
+  const numberingTail = direct(numbering.documentElement!, 'numIdMacAtCleanup');
+  for (const snapshot of snapshots) {
+    const abstract = numbering.importNode(snapshot.effectiveAbstract, true) as XmlElement;
+    const id = String(++abstractId);
+    abstract.setAttributeNS(W, 'w:abstractNumId', id);
+    let nsid = direct(abstract, 'nsid');
+    if (!nsid) { nsid = numbering.createElementNS(W, 'w:nsid'); abstract.insertBefore(nsid, abstract.firstChild); }
+    let salt = 0;
+    let identity: string;
+    do {
+      identity = createHash('sha256').update(`${inputSha256}:${id}:${salt++}`).digest('hex').slice(0, 8).toUpperCase();
+    } while (usedNsids.has(identity));
+    usedNsids.add(identity);
+    nsid.setAttributeNS(W, 'w:val', identity);
+    // Do not let renderer-global heading-style associations override the
+    // explicit per-paragraph snapshot. Fonts/indents and list glyphs remain.
+    for (const style of Array.from(abstract.getElementsByTagNameNS(W, 'pStyle'))) style.parentNode!.removeChild(style);
+    for (const level of Array.from(abstract.getElementsByTagNameNS(W, 'lvl'))) {
+      const index = Number(level.getAttributeNS(W, 'ilvl'));
+      let start = direct(level, 'start');
+      if (!start) { start = numbering.createElementNS(W, 'w:start'); level.insertBefore(start, level.firstChild); }
+      start.setAttributeNS(W, 'w:val', String(snapshot.counters[index]));
+    }
+    // CT_Numbering requires every abstractNum before any concrete num.
+    numbering.documentElement!.insertBefore(abstract, firstNumber ?? numberingTail ?? null);
+    const number = numbering.createElementNS(W, 'w:num');
+    const concreteId = String(++numId);
+    number.setAttributeNS(W, 'w:numId', concreteId);
+    const link = numbering.createElementNS(W, 'w:abstractNumId');
+    link.setAttributeNS(W, 'w:val', id);
+    number.appendChild(link);
+    numbering.documentElement!.insertBefore(number, numberingTail ?? null);
+    let properties = direct(snapshot.paragraph, 'pPr');
+    if (!properties) {
+      properties = document.createElementNS(W, 'w:pPr');
+      snapshot.paragraph.insertBefore(properties, snapshot.paragraph.firstChild);
+    }
+    let numPr = direct(properties, 'numPr');
+    if (!numPr) {
+      numPr = document.createElementNS(W, 'w:numPr');
+      const before = Array.from(properties.childNodes).find((node) => node.nodeType === 1
+        && !['pStyle', 'keepNext', 'keepLines', 'pageBreakBefore', 'framePr', 'widowControl'].includes((node as XmlElement).localName ?? ''));
+      properties.insertBefore(numPr, before ?? null);
+    }
+    for (const [local, value] of [['ilvl', String(snapshot.ilvl)], ['numId', concreteId]]) {
+      let node = direct(numPr, local);
+      if (!node) {
+        node = document.createElementNS(W, `w:${local}`);
+        if (local === 'ilvl') numPr.insertBefore(node, numPr.firstChild);
+        else numPr.appendChild(node);
+      }
+      node.setAttributeNS(W, `w:val`, value);
+    }
+    paragraphs += 1;
+  }
+  const serializer = new XMLSerializer();
+  if (numberingEntry) {
+    zip.updateFile('word/document.xml', Buffer.from(serializer.serializeToString(document)));
+    zip.updateFile('word/numbering.xml', Buffer.from(serializer.serializeToString(numbering)));
+  }
+  if (hash(readFileSync(input)) !== inputSha256) throw new Error('render-copy: input changed during preparation');
+  const bytes = zip.toBuffer();
+  // Exclusive creation also rejects symlink/hardlink aliases and stale copies.
+  writeFileSync(output, bytes, { flag: 'wx' });
+  return { renderOnly: true, inputSha256, outputSha256: hash(bytes), outputPath: output, paragraphs, references };
+}

--- a/src/core/field-selector/numbering-render-references.test.ts
+++ b/src/core/field-selector/numbering-render-references.test.ts
@@ -1,0 +1,208 @@
+import {DOMParser, XMLSerializer, type Element} from '@xmldom/xmldom';
+import {describe, expect} from 'vitest';
+import {itAllure} from '../../../integration-tests/helpers/allure-test.js';
+import type {NumberingSnapshot} from './numbering-counters.js';
+import {materializeNumberingReferences} from './numbering-render-references.js';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const it = itAllure.epic('Filling & Rendering');
+const parse = (xml: string) => new DOMParser().parseFromString(xml, 'text/xml');
+const complex = (code: string, cached = 'WRONG') => `<w:r><w:fldChar w:fldCharType="begin"/></w:r><w:r><w:instrText>${code}</w:instrText></w:r><w:r><w:fldChar w:fldCharType="separate"/></w:r><w:r><w:rPr><w:b/></w:rPr><w:t>${cached}</w:t></w:r><w:r><w:fldChar w:fldCharType="end"/></w:r>`;
+function fixture(code = ' REF Target \\w \\h \\* MERGEFORMAT ', context?: number[], patterns = ['%1.', '%2.', '%3.'], formats = ['decimal', 'decimal', 'decimal']) {
+  const document = parse(`<w:document xmlns:w="${W}"><w:body><w:p><w:bookmarkStart w:id="1" w:name="Target"/><w:r><w:t>Target heading</w:t></w:r><w:bookmarkEnd w:id="1"/></w:p><w:p>${complex(code)}</w:p></w:body></w:document>`);
+  const abstract = parse(`<w:abstractNum xmlns:w="${W}" w:abstractNumId="1">${patterns.map((pattern, index) => `<w:lvl w:ilvl="${index}"><w:numFmt w:val="${formats[index]}"/><w:lvlText w:val="${pattern}"/></w:lvl>`).join('')}</w:abstractNum>`).documentElement!;
+  const ps = Array.from(document.getElementsByTagNameNS(W, 'p'));
+  const snapshot = (paragraph: Element, counters: number[]): NumberingSnapshot => ({paragraph, numId: '1', ilvl: 2, counters: [...counters, ...Array(6).fill(1)], effectiveAbstract: abstract});
+  const snapshots = [snapshot(ps[0], [4, 5, 2]), ...(context ? [snapshot(ps[1], context)] : [])];
+  return {document, snapshots, reference: ps[1], target: ps[0], abstract};
+}
+const text = (node: Element) => Array.from(node.getElementsByTagNameNS(W, 't')).map(n => n.textContent).join('');
+const xml = (node: Parameters<XMLSerializer['serializeToString']>[0]) => new XMLSerializer().serializeToString(node);
+
+describe('render-only numeric REF materialization', () => {
+  it.each([
+    ['w', [4, 3, 1], '4.5.2'],
+    ['r', [4, 3, 1], '5.2'],
+    ['n', [4, 3, 1], '2'],
+    ['r', undefined, '2'],
+    ['r', [4, 5, 2], '2'],
+  ] as const)('Microsoft switch %s with context %j yields %s', (mode, context, expected) => {
+    const f = fixture(`REF Target \\${mode}`, context ? [...context] : undefined);
+    expect(materializeNumberingReferences(f.document, f.snapshots)).toBe(1);
+    expect(text(f.reference)).toBe(expected);
+    expect(f.document.getElementsByTagNameNS(W, 'fldChar')).toHaveLength(0);
+    expect(f.document.getElementsByTagNameNS(W, 'instrText')).toHaveLength(0);
+    expect(f.document.getElementsByTagNameNS(W, 'bookmarkStart')).toHaveLength(1);
+    expect(f.reference.getElementsByTagNameNS(W, 'b')).toHaveLength(1);
+  });
+
+  it.each([['w', undefined, '4.5(b)'], ['n', undefined, '(b)'], ['r', [4, 5, 2], '(b)'], ['r', [4, 3, 1], '4.5(b)']] as const)('preserves punctuation for %s', (mode, context, expected) => {
+    const f = fixture(`REF Target \\${mode}`, context ? [...context] : undefined, ['%1.', '%1.%2', '(%3)'], ['decimal', 'decimal', 'lowerLetter']);
+    expect(materializeNumberingReferences(f.document, f.snapshots)).toBe(1);
+    expect(text(f.reference)).toBe(expected);
+  });
+
+  it('does not strip embedded ancestors from a composite relative target label', () => {
+    const f = fixture('REF Target \\r', [4, 5, 2], ['%1.', '%1.%2', '%1.%2.%3']);
+    materializeNumberingReferences(f.document, f.snapshots);
+    expect(text(f.reference)).toBe('4.5.2');
+  });
+
+  it.each([['\\n', 'Exhibit B'], ['\\n \\t', 'B']])('preserves or suppresses literal text only for %s', (switches, expected) => {
+    const f = fixture(`REF Target ${switches}`, undefined, ['%1.', '%2.', 'Exhibit %3'], ['decimal', 'decimal', 'upperLetter']);
+    materializeNumberingReferences(f.document, f.snapshots);
+    expect(text(f.reference)).toBe(expected);
+  });
+
+  it('preserves the pinned-style fixed alphanumeric current-level prefix', () => {
+    const f = fixture('REF Target \\n', undefined, ['%1.', '%2.', '5A.%3.']);
+    materializeNumberingReferences(f.document, f.snapshots);
+    expect(text(f.reference)).toBe('5A.2');
+  });
+
+  it('keeps ancestor placeholders explicitly included in the current level for n', () => {
+    const f = fixture('REF Target \\n', undefined, ['%1.', '%1.%2', '%1.%2.%3']);
+    materializeNumberingReferences(f.document, f.snapshots);
+    expect(text(f.reference)).toBe('4.5.2');
+  });
+
+  it.each([['\\w \\n', '2'], ['\\n \\w', '2'], ['\\r \\w', '5.2'], ['\\w \\r', '5.2'], ['\\n \\r', '5.2'], ['\\r \\n', '5.2'], ['\\w \\t', '4.5.2']])('matches native LibreOffice precedence for %s', (switches, expected) => {
+    const f = fixture(`REF Target ${switches}`, [4, 6, 3]);
+    materializeNumberingReferences(f.document, f.snapshots);
+    expect(text(f.reference)).toBe(expected);
+  });
+
+  it.each([['before', '4.5.2'], ['level0', '5.2'], ['level1', '5.2'], ['other-instance', '4.5.2']])('matches native LibreOffice unnumbered context %s', (kind, expected) => {
+    const f = fixture('REF Target \\r');
+    if (kind === 'before') f.target.parentNode!.insertBefore(f.reference, f.target);
+    else {
+      const context = f.document.createElementNS(W, 'w:p');
+      f.reference.parentNode!.insertBefore(context, f.reference);
+      f.snapshots.push({...f.snapshots[0], paragraph: context, ilvl: kind === 'level0' ? 0 : 1, counters: [4, 6, 2, 1, 1, 1, 1, 1, 1], numId: kind === 'other-instance' ? '2' : '1'});
+    }
+    materializeNumberingReferences(f.document, f.snapshots);
+    expect(text(f.reference)).toBe(expected);
+  });
+
+  it('does not suppress coincidental prefixes from another numbering instance', () => {
+    const f = fixture('REF Target \\r', [4, 5, 2]); f.snapshots[1].numId = '2';
+    materializeNumberingReferences(f.document, f.snapshots);
+    expect(text(f.reference)).toBe('4.5.2');
+  });
+
+  it('handles Roman and uppercase letters, without trusting cached labels', () => {
+    const f = fixture('REF Target \\w', undefined, ['%1.', '%2.', '(%3)'], ['upperRoman', 'upperLetter', 'lowerRoman']);
+    materializeNumberingReferences(f.document, f.snapshots);
+    expect(text(f.reference)).toBe('IV.E.(ii)');
+  });
+
+  it.each(['First', 'Second', 'Third', 'Fourth', 'Fifth', 'Sixth', 'Seventh', 'Eighth', 'Ninth', 'Tenth', 'Eleventh', 'Twelfth', 'Thirteenth', 'Fourteenth', 'Fifteenth', 'Sixteenth', 'Seventeenth', 'Eighteenth', 'Nineteenth', 'Twentieth'].map((word, index) => [index + 1, word] as const))('matches native English ordinal %i', (value, expected) => {
+    const f = fixture('REF Target \\n', undefined, ['%1.', '%2.', '%3.'], ['decimal', 'decimal', 'ordinalText']);
+    f.snapshots[0].counters[2] = value;
+    const styles = parse(`<w:styles xmlns:w="${W}"><w:docDefaults><w:rPrDefault><w:rPr><w:lang w:val="en-US"/></w:rPr></w:rPrDefault></w:docDefaults></w:styles>`);
+    materializeNumberingReferences(f.document, f.snapshots, styles);
+    expect(text(f.reference)).toBe(expected);
+  });
+
+  it.each(['unknown', 'French default', 'French level', 'French inherited style', 'range'])('rejects ordinal language/range %s', kind => {
+    const f = fixture('REF Target \\n', undefined, ['%1.', '%2.', '%3.'], ['decimal', 'decimal', 'ordinalText']);
+    const styles = parse(`<w:styles xmlns:w="${W}"><w:docDefaults><w:rPrDefault><w:rPr><w:lang w:val="${kind === 'French default' ? 'fr-FR' : 'en-US'}"/></w:rPr></w:rPrDefault></w:docDefaults><w:style w:type="paragraph" w:default="1" w:styleId="Normal"><w:basedOn w:val="Base"/></w:style><w:style w:styleId="Base"><w:rPr>${kind === 'French inherited style' ? '<w:lang w:val="fr-FR"/>' : ''}</w:rPr></w:style></w:styles>`);
+    if (kind === 'French level') f.abstract.getElementsByTagNameNS(W, 'lvl')[2].appendChild(f.abstract.ownerDocument!.importNode(parse(`<w:rPr xmlns:w="${W}"><w:lang w:val="fr-FR"/></w:rPr>`).documentElement!, true));
+    if (kind === 'range') f.snapshots[0].counters[2] = 21;
+    expect(() => materializeNumberingReferences(f.document, f.snapshots, kind === 'unknown' ? undefined : styles)).toThrow(/ordinalText/);
+  });
+
+  it('handles split instruction/result runs and preserves styles and interior bookmarks', () => {
+    const f = fixture();
+    const instruction = f.reference.getElementsByTagNameNS(W, 'instrText')[0];
+    instruction.textContent = ' REF Tar';
+    const extraRun = parse(`<w:r xmlns:w="${W}"><w:instrText>get \\w\\h\\*MERGEFORMAT</w:instrText></w:r>`).documentElement!;
+    f.reference.insertBefore(f.document.importNode(extraRun, true), instruction.parentNode!.nextSibling);
+    const old = f.reference.getElementsByTagNameNS(W, 't')[0]; old.textContent = '0';
+    const second = parse(`<w:r xmlns:w="${W}"><w:rPr><w:i/></w:rPr><w:t>.0</w:t></w:r>`).documentElement!;
+    f.reference.insertBefore(f.document.importNode(second, true), old.parentNode!.nextSibling);
+    materializeNumberingReferences(f.document, f.snapshots);
+    expect(text(f.reference)).toBe('4.5.2');
+    expect(f.reference.getElementsByTagNameNS(W, 'b')).toHaveLength(1);
+    expect(f.reference.getElementsByTagNameNS(W, 'i')).toHaveLength(1);
+  });
+
+  it('unwraps a simple numeric field while leaving text REF fields intact', () => {
+    const f = fixture();
+    while (f.reference.firstChild) f.reference.removeChild(f.reference.firstChild);
+    const simple = parse(`<w:fldSimple xmlns:w="${W}" w:instr="REF Target \\w"><w:r><w:t>WRONG</w:t></w:r></w:fldSimple>`).documentElement!;
+    f.reference.appendChild(f.document.importNode(simple, true));
+    const ordinary = simple.cloneNode(true) as Element; ordinary.setAttributeNS(W, 'w:instr', 'REF Target \\h');
+    f.reference.appendChild(f.document.importNode(ordinary, true));
+    expect(materializeNumberingReferences(f.document, f.snapshots)).toBe(1);
+    expect(text(f.reference)).toBe('4.5.2WRONG');
+    expect(f.document.getElementsByTagNameNS(W, 'fldSimple')).toHaveLength(1);
+  });
+
+  for (const code of ['REF Target \\w \\p', 'REF Target \\w \\w', 'REF Missing \\w']) {
+    it(`rejects ${code} before mutation`, () => {
+      const f = fixture(code); const before = xml(f.document);
+      expect(() => materializeNumberingReferences(f.document, f.snapshots)).toThrow(/render-copy REF:/);
+      expect(xml(f.document)).toBe(before);
+    });
+  }
+
+  it('preflights every field before materializing any result', () => {
+    const f = fixture();
+    const extra = parse(`<w:p xmlns:w="${W}">${complex('REF Missing \\w')}</w:p>`).documentElement!;
+    f.reference.parentNode!.appendChild(f.document.importNode(extra, true));
+    const before = xml(f.document);
+    expect(() => materializeNumberingReferences(f.document, f.snapshots)).toThrow(/Missing/);
+    expect(xml(f.document)).toBe(before);
+  });
+
+  it.each(['1', '01'])('rejects differently named starts sharing numeric ID %s before mutation', id => {
+    const f = fixture();
+    const extra = parse(`<w:bookmarkStart xmlns:w="${W}" w:id="${id}" w:name="OtherName"/>`).documentElement!;
+    f.reference.appendChild(f.document.importNode(extra, true));
+    const before = xml(f.document);
+    expect(() => materializeNumberingReferences(f.document, f.snapshots)).toThrow(/duplicate numeric bookmark ID/);
+    expect(xml(f.document)).toBe(before);
+  });
+
+  it.each(['nested', 'unclosed', 'missing separator', 'missing bookmark end', 'duplicate bookmark end', 'reversed bookmark', 'nested target paragraph', 'textbox field', 'unnumbered target', 'unsupported format'])('rejects %s', kind => {
+    const f = fixture();
+    if (kind === 'nested') f.reference.insertBefore(f.document.importNode(parse(`<w:r xmlns:w="${W}"><w:fldChar w:fldCharType="begin"/></w:r>`).documentElement!, true), f.reference.childNodes[1]);
+    if (kind === 'unclosed') f.reference.removeChild(f.reference.lastChild!);
+    if (kind === 'missing separator') f.reference.removeChild(f.reference.childNodes[2]);
+    if (kind === 'missing bookmark end') f.target.removeChild(f.target.lastChild!);
+    if (kind === 'duplicate bookmark end') f.target.appendChild(f.target.lastChild!.cloneNode(true));
+    if (kind === 'reversed bookmark') f.target.insertBefore(f.target.lastChild!, f.target.firstChild);
+    if (kind === 'nested target paragraph') f.target.insertBefore(f.document.importNode(parse(`<w:p xmlns:w="${W}"><w:r><w:t>nested</w:t></w:r></w:p>`).documentElement!, true), f.target.lastChild);
+    if (kind === 'textbox field') { const box = f.document.createElementNS(W, 'w:txbxContent'); f.reference.parentNode!.appendChild(box); box.appendChild(f.reference); }
+    if (kind === 'unnumbered target') f.snapshots.shift();
+    if (kind === 'unsupported format') f.abstract.getElementsByTagNameNS(W, 'numFmt')[2].setAttributeNS(W, 'w:val', 'bullet');
+    const before = xml(f.document);
+    expect(() => materializeNumberingReferences(f.document, f.snapshots)).toThrow(/render-copy REF:/);
+    expect(xml(f.document)).toBe(before);
+  });
+
+  it('uses the numbered bookmark start, not later numbered paragraphs in the range', () => {
+    const f = fixture('REF Target \\w', [4, 6, 3]);
+    f.reference.appendChild(f.target.lastChild!);
+    materializeNumberingReferences(f.document, f.snapshots);
+    expect(text(f.reference)).toBe('4.5.2');
+  });
+
+  it('resolves a heading bookmark extending into unnumbered body without inventing context', () => {
+    const f = fixture('REF Target \\r');
+    f.reference.appendChild(f.target.lastChild!);
+    expect(materializeNumberingReferences(f.document, f.snapshots)).toBe(1);
+    expect(text(f.reference)).toBe('2');
+  });
+
+  it('replaces parsed xml:space without duplicate namespace attributes', () => {
+    const f = fixture();
+    const old = f.reference.getElementsByTagNameNS(W, 't')[0];
+    old.setAttributeNS('http://www.w3.org/XML/1998/namespace', 'xml:space', 'default');
+    materializeNumberingReferences(f.document, f.snapshots);
+    expect(xml(old).match(/xml:space=/g)).toHaveLength(1);
+    expect(old.getAttributeNS('http://www.w3.org/XML/1998/namespace', 'space')).toBe('preserve');
+    expect(() => parse(xml(f.document))).not.toThrow();
+  });
+});

--- a/src/core/field-selector/numbering-render-references.ts
+++ b/src/core/field-selector/numbering-render-references.ts
@@ -1,0 +1,265 @@
+import type {Document, Element, Node} from '@xmldom/xmldom';
+import type {NumberingSnapshot} from './numbering-counters.js';
+import {preserveXmlSpace} from './ooxml-parts.js';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+function fail(message: string): never { throw new Error(`render-copy REF: ${message}`); }
+const attr = (node: Element, name: string) => node.getAttributeNS(W, name) ?? '';
+const is = (node: Node, name: string): boolean => node.nodeType === 1 && (node as Element).namespaceURI === W && node.localName === name;
+function all(root: Node): Element[] {
+  const out: Element[] = [];
+  const visit = (node: Node) => { if (node.nodeType === 1) out.push(node as Element); for (const child of Array.from(node.childNodes)) visit(child); };
+  visit(root);
+  return out;
+}
+function ancestor(node: Node, name: string): Element | undefined {
+  for (let current: Node | null = node; current; current = current.parentNode) if (is(current, name)) return current as Element;
+  return undefined;
+}
+function direct(node: Element, name: string): Element | undefined {
+  const found = Array.from(node.childNodes).filter((child): child is Element => is(child, name));
+  if (found.length > 1) fail(`duplicate ${name}`);
+  return found[0];
+}
+
+function englishOrdinalLanguage(snapshot: NumberingSnapshot, level: Element, styles?: Document): void {
+  const definitions = styles ? Array.from(styles.getElementsByTagNameNS(W, 'style')) : [];
+  const runLanguage = (properties?: Element): string | undefined => {
+    const language = properties && direct(properties, 'lang');
+    return language && attr(language, 'val') || undefined;
+  };
+  const styleLanguage = (id: string, visited = new Set<string>()): string | undefined => {
+    if (visited.has(id)) fail('cyclic language style inheritance');
+    visited.add(id);
+    const matches = definitions.filter(node => attr(node, 'styleId') === id);
+    if (matches.length !== 1) fail(`missing or duplicate language style ${id}`);
+    const style = matches[0];
+    const paragraph = direct(style, 'pPr');
+    const own = runLanguage(direct(style, 'rPr')) ?? runLanguage(paragraph && direct(paragraph, 'rPr'));
+    if (own) return own;
+    const base = direct(style, 'basedOn');
+    return base ? styleLanguage(attr(base, 'val'), visited) : undefined;
+  };
+  const propertiesLanguage = (properties?: Element): string | undefined => {
+    const own = runLanguage(properties);
+    if (own) return own;
+    const characterStyle = properties && direct(properties, 'rStyle');
+    return characterStyle ? styleLanguage(attr(characterStyle, 'val')) : undefined;
+  };
+  const paragraph = direct(snapshot.paragraph, 'pPr');
+  const paragraphStyle = paragraph && direct(paragraph, 'pStyle');
+  const defaults = styles?.documentElement ? direct(styles.documentElement, 'docDefaults') : undefined;
+  const defaultRun = defaults && direct(defaults, 'rPrDefault');
+  const defaultStyles = definitions.filter(node => attr(node, 'type') === 'paragraph' && ['1', 'true', 'on'].includes(attr(node, 'default')));
+  if (defaultStyles.length > 1) fail('ambiguous default paragraph language style');
+  const styleId = paragraphStyle ? attr(paragraphStyle, 'val') : defaultStyles[0] && attr(defaultStyles[0], 'styleId');
+  const language = propertiesLanguage(direct(level, 'rPr')) ??
+    propertiesLanguage(paragraph && direct(paragraph, 'rPr')) ??
+    (styleId ? styleLanguage(styleId) : undefined) ?? runLanguage(defaultRun && direct(defaultRun, 'rPr'));
+  if (!language || !/^en(?:-[a-z0-9]+)*$/i.test(language)) fail(`ordinalText requires known English numbering language, got ${language ?? 'unknown'}`);
+}
+
+function formatted(value: number, format: string, snapshot: NumberingSnapshot, level: Element, styles?: Document): string {
+  if (!Number.isSafeInteger(value) || value < 0) return fail('invalid counter');
+  if (format === 'decimal') return String(value);
+  if (format === 'ordinalText') {
+    englishOrdinalLanguage(snapshot, level, styles);
+    const words = ['First', 'Second', 'Third', 'Fourth', 'Fifth', 'Sixth', 'Seventh', 'Eighth', 'Ninth', 'Tenth', 'Eleventh', 'Twelfth', 'Thirteenth', 'Fourteenth', 'Fifteenth', 'Sixteenth', 'Seventeenth', 'Eighteenth', 'Nineteenth', 'Twentieth'];
+    return words[value - 1] ?? fail('ordinalText counter outside supported 1..20 range');
+  }
+  // Keep the supported alphabetic range explicit rather than assuming Excel's
+  // base-26 convention for Word's extended alphabetic numbering.
+  if (format === 'lowerLetter' || format === 'upperLetter') {
+    if (value < 1 || value > 26) return fail('alphabetic counter outside supported 1..26 range');
+    return String.fromCharCode((format === 'lowerLetter' ? 96 : 64) + value);
+  }
+  if (format === 'lowerRoman' || format === 'upperRoman') {
+    if (value < 1 || value > 3999) return fail('Roman counter outside supported 1..3999 range');
+    let remaining = value; let result = '';
+    for (const [number, token] of [[1000, 'M'], [900, 'CM'], [500, 'D'], [400, 'CD'], [100, 'C'], [90, 'XC'], [50, 'L'], [40, 'XL'], [10, 'X'], [9, 'IX'], [5, 'V'], [4, 'IV'], [1, 'I']] as const) {
+      while (remaining >= number) { result += token; remaining -= number; }
+    }
+    return format === 'lowerRoman' ? result.toLowerCase() : result;
+  }
+  return fail(`unsupported number format ${format}`);
+}
+
+function label(snapshot: NumberingSnapshot, mode: 'n' | 'r' | 'w', context?: NumberingSnapshot, styles?: Document, suppressText = false): string {
+  const levels = new Map<number, Element>();
+  for (const node of Array.from(snapshot.effectiveAbstract.childNodes)) if (is(node, 'lvl')) levels.set(Number(attr(node as Element, 'ilvl')), node as Element);
+  let from = 0;
+  // Context is an explicit numbered paragraph snapshot, never a heading inferred
+  // from text or style. Different list instances never share numeric context.
+  if (mode === 'r' && context?.numId === snapshot.numId) {
+    while (from < snapshot.ilvl && from <= context.ilvl && snapshot.counters[from] === context.counters[from]) from++;
+  }
+  const targetLevel = levels.get(snapshot.ilvl) ?? fail('missing target level');
+  const legal = direct(targetLevel, 'isLgl');
+  if (legal && !['', '1', 'true', 'on', '0', 'false', 'off'].includes(attr(legal, 'val'))) fail('invalid isLgl');
+  const decimal = !!legal && !['0', 'false', 'off'].includes(attr(legal, 'val'));
+  const render = (index: number, minimum: number, ownOnly: boolean): string => {
+    const level = levels.get(index) ?? fail(`missing ancestor level ${index}`);
+    const originalTemplate = attr(direct(level, 'lvlText') ?? fail('missing lvlText'), 'val');
+    if (/[^\sA-Za-z0-9.()[\]:%-]/.test(originalTemplate)) fail(`unsupported lvlText ${originalTemplate}`);
+    // Microsoft REF t suppresses literal text, not alphabetic counter values.
+    // Work on literal template segments before expanding numeric placeholders.
+    const template = suppressText ? originalTemplate.split(/(%[1-9])/g).map(part => /^%[1-9]$/.test(part) ? part : part.replace(/[A-Za-z]+/g, '').trim()).join('') : originalTemplate;
+    const matches = Array.from(template.matchAll(/%([1-9])/g));
+    if (!matches.length || /%/.test(template.replace(/%[1-9]/g, ''))) fail(`unsupported lvlText ${template}`);
+    const refs = matches.map(match => Number(match[1]) - 1);
+    if (refs[refs.length - 1] !== index || refs.some((ref, i) => ref > index || (i > 0 && ref !== refs[i - 1] + 1))) fail(`unsupported placeholder hierarchy ${template}`);
+    // A compound level label is indivisible: native REF r retains ancestor
+    // placeholders embedded in this level's own template, just as REF n does.
+    // Relative context suppresses only separately prepended ancestor levels.
+    const retained = matches;
+    if (!retained.length) return fail('empty relative label');
+    // Preserve the current level's literal punctuation and all embedded tokens.
+    const prefix = template.slice(0, matches[0].index!);
+    const text = prefix + template.slice(retained[0].index!);
+    const rendered = text.replace(/%([1-9])/g, (_token, raw: string) => {
+      const ref = Number(raw) - 1;
+      const definition = levels.get(ref) ?? fail(`missing referenced level ${ref}`);
+      const format = decimal ? 'decimal' : attr(direct(definition, 'numFmt') ?? fail('missing numFmt'), 'val');
+      return formatted(snapshot.counters[ref], format, snapshot, definition, styles);
+    });
+    const first = Number(retained[0][1]) - 1;
+    return !ownOnly && first > minimum ? render(first - 1, minimum, false) + rendered : rendered;
+  };
+  const result = render(snapshot.ilvl, mode === 'n' ? 0 : from, mode === 'n').replace(/[.\s]+$/, '');
+  return result || fail('empty paragraph label');
+}
+
+interface Instruction {target: string; mode: 'n' | 'r' | 'w'; suppressText: boolean}
+function instruction(raw: string): Instruction | undefined {
+  const match = /^\s*REF\s+(?:"([^"]+)"|([^\s\\]+))([\s\S]*)$/i.exec(raw);
+  if (!match) { if (/^\s*REF(?:\s|$)/i.test(raw)) fail('malformed REF instruction'); return undefined; }
+  const rest = match[3];
+  if (!/\\[nrw](?=\s|\\|$)/i.test(rest)) return undefined; // Non-numeric text REF stays a field.
+  let cursor = 0; let mode: Instruction['mode'] | undefined; const seen = new Set<string>();
+  while (cursor < rest.length) {
+    const tail = rest.slice(cursor);
+    const token = /^\s*(?:\\([nrwht])|\\\*\s*(MERGEFORMAT))(?=\s|\\|$)/i.exec(tail);
+    if (!token) { if (!tail.trim()) break; return fail(`unsupported REF switches: ${rest}`); }
+    const key = (token[1] ?? '*').toLowerCase();
+    if (seen.has(key)) fail('duplicate REF switch');
+    seen.add(key);
+    // LibreOffice's DOCX importer gives r > n > w, independent of flag order.
+    // This is the PDF-renderer policy, not a claim about all Word versions.
+    if (['n', 'r', 'w'].includes(key) && (!mode || ['w', 'n', 'r'].indexOf(key) > ['w', 'n', 'r'].indexOf(mode))) mode = key as Instruction['mode'];
+    cursor += token[0].length;
+  }
+  return {target: match[1] ?? match[2], mode: mode ?? fail('missing numeric REF mode'), suppressText: seen.has('t')};
+}
+
+interface Field {code: string; paragraph: Element; texts: Element[]; controls: Element[]; simple?: Element; end?: Element}
+
+/**
+ * Materialize numeric REF results in the disposable DOM BEFORE cloning list
+ * instances. No IO; all fields/targets/labels preflight before the first edit.
+ * Microsoft switch semantics: MS-OE376 2.1.523, sections c/e/f:
+ * https://learn.microsoft.com/en-us/openspecs/office_standards/ms-oe376/20bc6d15-ba77-479f-82f4-db3cf7447334
+ * The disposable LibreOffice render policy uses the previous numbered snapshot
+ * for an unnumbered source paragraph; no preceding snapshot means empty context.
+ * Combined numeric switches use LibreOffice precedence r > n > w. The t switch
+ * follows Microsoft Word's literal-text suppression (an explicit interop fix,
+ * because native LibreOffice ignores t), with ASCII literal words supported.
+ * English ordinalText is bounded to 1..20 with verified inherited language.
+ * Historical Microsoft-authored switch documentation:
+ * https://documentation.help/MS-Office-Word-2003/worefBOOKMARK1.htm
+ */
+export function materializeNumberingReferences(document: Document, snapshots: NumberingSnapshot[], styles?: Document): number {
+  const elements = all(document);
+  const snapshotByParagraph = new Map<Element, NumberingSnapshot>();
+  for (const snapshot of snapshots) {
+    if (snapshot.paragraph.ownerDocument !== document || snapshotByParagraph.has(snapshot.paragraph)) fail('invalid or duplicate snapshot paragraph');
+    snapshotByParagraph.set(snapshot.paragraph, snapshot);
+  }
+  const fields: Field[] = [];
+  const precedingSnapshot = new Map<Element, NumberingSnapshot>();
+  let previous: NumberingSnapshot | undefined;
+  for (const node of elements) {
+    if (!is(node, 'p') || ancestor(node, 'txbxContent')) continue;
+    previous = snapshotByParagraph.get(node) ?? previous;
+    if (previous) precedingSnapshot.set(node, previous);
+  }
+  let active: Field | undefined; let separated = false;
+  const skipped = new Set<Element>();
+  for (const node of elements) {
+    if (skipped.has(node)) continue;
+    if (is(node, 'fldSimple')) {
+      if (active) fail('nested field');
+      const descendants = all(node).slice(1);
+      if (descendants.some(child => is(child, 'fldSimple') || is(child, 'fldChar') || is(child, 'instrText'))) fail('nested simple field');
+      for (const child of descendants) skipped.add(child);
+      fields.push({code: attr(node, 'instr'), paragraph: ancestor(node, 'p') ?? fail('field outside paragraph'), texts: descendants.filter(child => is(child, 't')), controls: [], simple: node});
+    } else if (is(node, 'fldChar')) {
+      const kind = attr(node, 'fldCharType');
+      if (kind === 'begin') {
+        if (active) fail('nested complex field');
+        active = {code: '', paragraph: ancestor(node, 'p') ?? fail('field outside paragraph'), texts: [], controls: [node]}; separated = false;
+      } else {
+        if (!active || ancestor(node, 'p') !== active.paragraph) fail('unpaired or cross-paragraph field');
+        active.controls.push(node);
+        if (kind === 'separate') { if (separated) fail('duplicate field separator'); separated = true; }
+        else if (kind === 'end') { if (!separated) fail('field lacks separator'); active.end = node; fields.push(active); active = undefined; }
+        else fail(`unsupported fldCharType ${kind}`);
+      }
+    } else if (is(node, 'instrText')) {
+      if (!active || separated || ancestor(node, 'p') !== active.paragraph) fail('instruction outside field code');
+      active.code += node.textContent ?? ''; active.controls.push(node);
+    } else if (active && separated && is(node, 't')) {
+      if (ancestor(node, 'p') !== active.paragraph) fail('cross-paragraph field result');
+      active.texts.push(node);
+    }
+    else if (active && separated && ['tab', 'br', 'cr', 'drawing', 'object', 'sym'].some(name => is(node, name))) fail('non-text field result');
+  }
+  if (active) fail('unclosed field');
+  const selected = fields.flatMap(field => { const parsed = instruction(field.code); return parsed ? [{field, parsed}] : []; });
+  const plans = selected.map(({field, parsed}) => {
+    if (ancestor(field.paragraph, 'txbxContent')) fail('numeric REF in textbox is unsupported');
+    if (field.simple && all(field.simple).some(node => ['tab', 'br', 'cr', 'drawing', 'object', 'sym'].some(name => is(node, name)))) fail('non-text simple field result');
+    const insertionRun = !field.simple && !field.texts.length ? ancestor(field.end!, 'r') ?? fail('field end outside run') : undefined;
+    const starts = elements.filter(node => is(node, 'bookmarkStart') && attr(node, 'name') === parsed.target);
+    if (starts.length !== 1) fail(`target ${parsed.target} has ${starts.length} bookmark starts`);
+    const start = starts[0];
+    const rawId = attr(start, 'id');
+    if (!/^\d+$/.test(rawId) || !Number.isSafeInteger(Number(rawId))) fail(`target ${parsed.target} has invalid bookmark ID`);
+    const sameId = (node: Element) => /^\d+$/.test(attr(node, 'id')) && Number(attr(node, 'id')) === Number(rawId);
+    if (elements.filter(node => is(node, 'bookmarkStart') && sameId(node)).length !== 1) fail(`target ${parsed.target} has duplicate numeric bookmark ID`);
+    const ends = elements.filter(node => is(node, 'bookmarkEnd') && sameId(node));
+    if (ends.length !== 1) fail(`target ${parsed.target} has ${ends.length} bookmark ends`);
+    const startIndex = elements.indexOf(start); const endIndex = elements.indexOf(ends[0]);
+    if (endIndex <= startIndex) fail(`target ${parsed.target} has reversed range`);
+    const paragraphs = new Set(elements.slice(startIndex, endIndex + 1).map(node => ancestor(node, 'p')).filter((p): p is Element => !!p));
+    const targetParagraph = ancestor(start, 'p') ?? fail('bookmark start outside paragraph');
+    // LibreOffice numeric REF resolves the bookmark's START paragraph, even if
+    // the range includes further numbered paragraphs. Nested stories remain
+    // unsupported; an unnumbered start is never replaced with a later heading.
+    if ([...paragraphs].some(paragraph => ancestor(paragraph.parentNode!, 'p') || ancestor(paragraph, 'txbxContent'))) fail(`target ${parsed.target} spans ambiguous paragraphs`);
+    if (ancestor(targetParagraph, 'txbxContent')) fail('numbered textbox target unsupported');
+    const snapshot = snapshotByParagraph.get(targetParagraph) ?? fail(`target ${parsed.target} is not a numbered paragraph`);
+    const value = label(snapshot, parsed.mode, precedingSnapshot.get(field.paragraph), styles, parsed.suppressText);
+    return {field, value, insertionRun};
+  });
+  for (const {field, value, insertionRun} of plans) {
+    let offset = 0;
+    if (!field.texts.length) {
+      const run = field.simple ? document.createElementNS(W, 'w:r') : insertionRun!;
+      const text = document.createElementNS(W, 'w:t'); run.appendChild(text);
+      if (field.simple) field.simple.appendChild(run);
+      field.texts.push(text);
+    }
+    field.texts.forEach((text, index) => {
+      const length = index === field.texts.length - 1 ? value.length - offset : Math.min((text.textContent ?? '').length, value.length - offset);
+      text.textContent = value.slice(offset, offset + length); offset += length;
+      preserveXmlSpace(text);
+    });
+    for (const control of field.controls) control.parentNode!.removeChild(control);
+    if (field.simple) {
+      const parent = field.simple.parentNode!;
+      while (field.simple.firstChild) parent.insertBefore(field.simple.firstChild, field.simple);
+      parent.removeChild(field.simple);
+    }
+  }
+  return plans.length;
+}

--- a/src/core/runtime-capabilities.ts
+++ b/src/core/runtime-capabilities.ts
@@ -22,5 +22,6 @@ export const RUNTIME_CAPABILITIES = Object.freeze({
     'reference-fields.v1',
     'reference-fields.grouped.v1',
     'conditional-input-requirements.v1',
+    'render.numbering-snapshot.v1',
   ]),
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 // Public API exports
 export { RUNTIME_CAPABILITIES } from './core/runtime-capabilities.js';
+export { createNumberingRenderCopy, type NumberingRenderCopyResult } from './core/field-selector/numbering-render-copy.js';
 
 // Template engine
 export { fillTemplate, type FillOptions, type FillResult } from './core/engine.js';


### PR DESCRIPTION
## Summary

Fixes #802.

Add an explicit `field-selector render-copy` command and public API for disposable PDF-conversion inputs. The filled editable DOCX remains byte-for-byte unchanged, with dynamic numbering and fields retained. A new `*.render.docx` snapshots effective counter tuples into independent numbering instances and evaluates supported numeric REF fields against that same snapshot.

This addresses a reproduced LibreOffice interaction with Word style-separator headings. It is not a claim of a reproduced Word display defect or universal Word/PDF fidelity. An earlier carrier-based implementation was rejected because it repaired main headings while corrupting nested alphabetic labels.

The output is never an editable deliverable. Exclusive creation rejects overwrites and aliases; source/output hashes and paragraph/reference counts provide a conversion receipt. Unsupported stories, numbering, fields, or bookmark targets fail closed. The implementation includes `render.numbering-snapshot.v1` and documents bounded field semantics.

## Verification

- Build and lint passed; 112 focused cases cover counters, rendering preparation, and numeric references. Full diagnostic suite: 1,595 passed / 7 skipped, with the explicit local timeout qualification below.
- Actual CLI success, rejection on overwrite, and unchanged original hash independently verified.
- Real pinned IRA verification accounts for the complete main numbering hierarchy, preserves 64 numeric references and all non-field paragraph text, and checks dynamic deletion behavior. The separate explicit continuation repair is identified as a dependency of that all-four-heading fixture; this PR does not heuristically merge independent source numbering streams.
- Native LibreOffice probes exercise numeric-switch precedence, relative context, composite labels, bookmark ranges, English ordinals, and literal prefixes. The Word-documented `t` behavior is implemented deliberately despite LibreOffice ignoring it in the probe.
- Existing style-separator layout defects remain. Inspected pages show no new clipping, but measured vertical positions differ; this is not a pristine-layout or production-readiness certification.
- Local system load caused existing five-second test timeouts. A one-worker, 15-second run is diagnostic only; no tracked test timeout is changed, and normal CI must pass before merge.
- Independent local-agent dynamic review found and drove regressions for XML ordering, unsupported stories, numeric-reference context, ambiguous bookmark IDs, and mutually exclusive alternate content. Requested Claude Fable review could not run because worktree disclosure was denied by the environment; no Fable approval is claimed.

No licensed source DOCX, generated documents, private fill values, render artifacts, or local paths are included in this PR.
