### PR TITLE
fix: preserve visible boundaries when folding heading punctuation

### DIFF
--- a/src/core/field-selector/heading-punctuation-normalizer.test.ts
+++ b/src/core/field-selector/heading-punctuation-normalizer.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect } from 'vitest';
 import { itAllure } from '../../../integration-tests/helpers/allure-test.js';
 import AdmZip from 'adm-zip';
+import { DOMParser } from '@xmldom/xmldom';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -9,7 +10,7 @@ import { normalizeDetachedHeadingPunctuation } from './heading-punctuation-norma
 const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const it = itAllure.epic('Filling & Rendering');
 
-function fixture(body: string): { dir: string; input: string; output: string } {
+function fixture(body: string, styles?: string): { dir: string; input: string; output: string } {
   const dir = mkdtempSync(join(tmpdir(), 'heading-punctuation-'));
   const input = join(dir, 'input.docx');
   const output = join(dir, 'output.docx');
@@ -18,11 +19,109 @@ function fixture(body: string): { dir: string; input: string; output: string } {
     `<?xml version="1.0"?><w:document xmlns:w="${W_NS}"><w:body>${body}</w:body></w:document>`,
   ));
   zip.addFile('[Content_Types].xml', Buffer.from('<Types/>'));
+  if (styles) zip.addFile('word/styles.xml', Buffer.from(`<w:styles xmlns:w="${W_NS}">${styles}</w:styles>`));
   zip.writeZip(input);
   return { dir, input, output };
 }
 
 describe('detached heading punctuation normalization', () => {
+  const heading = '<w:p><w:pPr><w:pStyle w:val="Heading2"/><w:rPr><w:vanish/><w:specVanish/></w:rPr></w:pPr><w:bookmarkStart w:id="42" w:name="Target"/><w:r><w:rPr><w:u w:val="single"/></w:rPr><w:t>Parent</w:t></w:r></w:p>';
+  const carrier = (properties = '') => `<w:p><w:pPr><w:pStyle w:val="HeadingPara2"/>${properties}</w:pPr><w:r><w:t>.</w:t></w:r><w:bookmarkEnd w:id="42"/><w:r><w:commentReference w:id="7"/></w:r></w:p>`;
+  const next = '<w:p><w:pPr><w:pStyle w:val="Heading3"/></w:pPr><w:r><w:t>Child</w:t></w:r></w:p>';
+
+  it('preserves the visible boundary before a numbered child and all semantic children in order', () => {
+    const f = fixture(heading + carrier() + next);
+    expect(normalizeDetachedHeadingPunctuation(f.input, f.output)).toBe(1);
+    const xml = new AdmZip(f.output).readAsText('word/document.xml');
+    const doc = new DOMParser().parseFromString(xml, 'text/xml');
+    const ps = Array.from(doc.getElementsByTagNameNS(W_NS, 'p'));
+    expect(ps).toHaveLength(2);
+    for (const name of ['vanish', 'specVanish']) expect(ps[0].getElementsByTagNameNS(W_NS, name)[0].getAttributeNS(W_NS, 'val')).toBe('0');
+    expect(xml).toContain('<w:u w:val="single"/>');
+    expect(xml).toContain('<w:t>.</w:t></w:r><w:bookmarkEnd w:id="42"/><w:r><w:commentReference w:id="7"/></w:r>');
+    expect(ps[1].getElementsByTagNameNS(W_NS, 't')[0].textContent).toBe('Child');
+    expect(ps[1].getElementsByTagNameNS(W_NS, 'rPr')).toHaveLength(0);
+    rmSync(f.dir, { recursive: true, force: true });
+  });
+
+  it('does not let an adjacent hidden heading become a continuation of the previous heading', () => {
+    const second = heading.replace('Parent', 'Second').replace('w:id="42"', 'w:id="43"');
+    const f = fixture(heading + carrier() + second + '<w:p><w:pPr><w:pStyle w:val="HeadingPara2"/></w:pPr><w:r><w:t>. Body</w:t></w:r></w:p>');
+    expect(normalizeDetachedHeadingPunctuation(f.input, f.output)).toBe(1);
+    const doc = new DOMParser().parseFromString(new AdmZip(f.output).readAsText('word/document.xml'), 'text/xml');
+    const ps = Array.from(doc.getElementsByTagNameNS(W_NS, 'p'));
+    expect(ps).toHaveLength(3);
+    expect(ps[0].getElementsByTagNameNS(W_NS, 'specVanish')[0].getAttributeNS(W_NS, 'val')).toBe('0');
+    expect(ps[1].getElementsByTagNameNS(W_NS, 'specVanish')[0].hasAttributeNS(W_NS, 'val')).toBe(false);
+    rmSync(f.dir, { recursive: true, force: true });
+  });
+
+  const style = (id: string, body: string) => `<w:style w:type="paragraph" w:styleId="${id}">${body}</w:style>`;
+  for (const [name, properties, styles, expected] of [
+    ['direct hidden carrier', '<w:rPr><w:vanish/></w:rPr>', undefined, 0],
+    ['character-style carrier mark', '<w:rPr><w:rStyle w:val="HiddenCharacter"/></w:rPr>', style('HiddenCharacter', '<w:rPr><w:vanish/></w:rPr>') + style('HeadingPara2', ''), 0],
+    ['inherited hidden carrier', '', style('HeadingPara2', '<w:basedOn w:val="Base"/>') + style('Base', '<w:rPr><w:specVanish/></w:rPr>'), 0],
+    ['style false does not cancel base hidden toggle', '', style('HeadingPara2', '<w:basedOn w:val="Base"/><w:rPr><w:vanish w:val="0"/></w:rPr>') + style('Base', '<w:rPr><w:vanish/></w:rPr>'), 0],
+    ['inherited toggles are conservatively left untouched', '', style('HeadingPara2', '<w:basedOn w:val="Base"/><w:rPr><w:vanish/></w:rPr>') + style('Base', '<w:rPr><w:vanish/></w:rPr>'), 0],
+    ['hidden document defaults', '', '<w:docDefaults><w:rPrDefault><w:rPr><w:vanish/></w:rPr></w:rPrDefault></w:docDefaults>' + style('HeadingPara2', ''), 0],
+    ['direct false overrides inherited flags', '<w:rPr><w:vanish w:val="0"/><w:specVanish w:val="false"/></w:rPr>', style('HeadingPara2', '<w:rPr><w:vanish/><w:specVanish/></w:rPr>'), 1],
+    ['cyclic style inheritance', '', style('HeadingPara2', '<w:basedOn w:val="HeadingPara2"/>'), 0],
+    ['missing style definition', '', style('Other', ''), 0],
+    ['inherited page break', '', style('HeadingPara2', '<w:pPr><w:pageBreakBefore/></w:pPr>'), 0],
+    ['inherited frame', '', style('HeadingPara2', '<w:pPr><w:framePr/></w:pPr>'), 0],
+  ] as const) it(`handles ${name} conservatively`, () => {
+    const f = fixture(heading + carrier(properties) + next, styles);
+    expect(normalizeDetachedHeadingPunctuation(f.input, f.output)).toBe(expected);
+    rmSync(f.dir, { recursive: true, force: true });
+  });
+
+  it('explicitly overrides inherited hidden heading marks without changing heading run formatting', () => {
+    const f = fixture(heading.replace('<w:rPr><w:vanish/><w:specVanish/></w:rPr>', '') + carrier() + next,
+      style('Heading2', '<w:rPr><w:vanish/><w:specVanish/></w:rPr>') + style('HeadingPara2', ''));
+    expect(normalizeDetachedHeadingPunctuation(f.input, f.output)).toBe(1);
+    const xml = new AdmZip(f.output).readAsText('word/document.xml');
+    expect(xml).toContain('<w:vanish w:val="0"/><w:specVanish w:val="0"/>');
+    expect(xml).toContain('<w:rPr><w:u w:val="single"/></w:rPr><w:t>Parent</w:t>');
+    rmSync(f.dir, { recursive: true, force: true });
+  });
+
+  for (const value of ['0', '1']) it(`preserves terminal keepNext=${value}, widowControl and mark formatting in order`, () => {
+    const configuredHeading = heading.replace('<w:rPr><w:vanish/>', '<w:keepNext w:val="1"/><w:numPr><w:numId w:val="7"/></w:numPr><w:rPr><w:lang w:val="en-US"/><w:vanish/>');
+    const f = fixture(configuredHeading + carrier(`<w:keepNext w:val="${value}"/><w:widowControl w:val="0"/><w:rPr><w:szCs w:val="22"/><w:lang w:val="fr-FR"/></w:rPr>`) + next);
+    expect(normalizeDetachedHeadingPunctuation(f.input, f.output)).toBe(1);
+    const doc = new DOMParser().parseFromString(new AdmZip(f.output).readAsText('word/document.xml'), 'text/xml');
+    const pPr = doc.getElementsByTagNameNS(W_NS, 'pPr')[0];
+    expect(Array.from(pPr.childNodes).filter(node => node.nodeType === 1).map(node => node.localName)).toEqual(['pStyle', 'keepNext', 'widowControl', 'numPr', 'rPr']);
+    expect(pPr.getElementsByTagNameNS(W_NS, 'keepNext')[0].getAttributeNS(W_NS, 'val')).toBe(value);
+    expect(pPr.getElementsByTagNameNS(W_NS, 'numId')[0].getAttributeNS(W_NS, 'val')).toBe('7');
+    const mark = pPr.getElementsByTagNameNS(W_NS, 'rPr')[0];
+    expect(mark.getElementsByTagNameNS(W_NS, 'lang')).toHaveLength(1);
+    expect(mark.getElementsByTagNameNS(W_NS, 'lang')[0].getAttributeNS(W_NS, 'val')).toBe('fr-FR');
+    expect(Array.from(mark.childNodes).filter(node => node.nodeType === 1).map(node => node.localName)).toEqual(['vanish', 'specVanish', 'szCs', 'lang']);
+    expect(mark.getElementsByTagNameNS(W_NS, 'szCs')[0].getAttributeNS(W_NS, 'val')).toBe('22');
+    rmSync(f.dir, { recursive: true, force: true });
+  });
+
+  for (const property of ['sectPr', 'framePr', 'pageBreakBefore', 'pPrChange', 'numPr', 'spacing']) {
+    it(`preserves a carrier with unsupported ${property} properties`, () => {
+      const f = fixture(heading + carrier(`<w:${property}/>`)+ next);
+      expect(normalizeDetachedHeadingPunctuation(f.input, f.output)).toBe(0);
+      expect(new AdmZip(f.output).readAsText('word/document.xml')).toContain(`<w:${property}/>`);
+      rmSync(f.dir, { recursive: true, force: true });
+    });
+  }
+
+  for (const revision of ['del', 'ins', 'moveFrom', 'moveTo']) {
+    for (const target of ['heading', 'carrier']) it(`preserves ${target} paragraph-mark ${revision} revisions`, () => {
+      const marker = `<w:${revision} w:id="99" w:author="Synthetic Reviewer"/>`;
+      const f = fixture((target === 'heading' ? heading.replace('<w:vanish/>', marker + '<w:vanish/>') : heading) +
+        carrier(target === 'carrier' ? `<w:rPr>${marker}</w:rPr>` : '') + next);
+      expect(normalizeDetachedHeadingPunctuation(f.input, f.output)).toBe(0);
+      expect(new AdmZip(f.output).readAsText('word/document.xml')).toContain(marker);
+      rmSync(f.dir, { recursive: true, force: true });
+    });
+  }
+
   it('joins an isolated punctuation continuation to its matching heading and preserves bookmarks', () => {
     const f = fixture(
       '<w:p><w:pPr><w:pStyle w:val="Heading2"/></w:pPr><w:r><w:t>Sale of the Company</w:t></w:r></w:p>' +

--- a/src/core/field-selector/heading-punctuation-normalizer.ts
+++ b/src/core/field-selector/heading-punctuation-normalizer.ts
@@ -28,17 +28,101 @@ function directElementChildren(node: Element): Element[] {
   return result;
 }
 
+function child(parent: Element | undefined, name: string): Element | undefined {
+  return parent && directElementChildren(parent).find(node => node.namespaceURI === W_NS && node.localName === name);
+}
+
+function inheritedProperty(paragraph: Element, styles: Element | undefined, name: string, mark: boolean): Element | null | undefined {
+  const properties = child(paragraph, 'pPr');
+  const own = child(mark ? child(properties, 'rPr') : properties, name);
+  if (own) return own;
+  let id = child(properties, 'pStyle')?.getAttributeNS(W_NS, 'val');
+  const seen = new Set<string>();
+  while (id && styles) {
+    if (seen.has(id)) return undefined;
+    seen.add(id);
+    const matches = directElementChildren(styles).filter(node => node.localName === 'style' && node.namespaceURI === W_NS && node.getAttributeNS(W_NS, 'styleId') === id);
+    if (matches.length !== 1) return undefined;
+    const style = matches[0], pPr = child(style, 'pPr');
+    const found = mark ? child(child(pPr, 'rPr'), name) ?? child(child(style, 'rPr'), name) : child(pPr, name);
+    // Style-level hidden formatting has toggle semantics: style false does
+    // not necessarily cancel inherited hiding. This narrow join deliberately
+    // declines inherited hidden declarations rather than implementing a full
+    // style cascade. A direct paragraph-mark false above remains absolute.
+    // https://learn.microsoft.com/en-us/office/open-xml/word/how-to-remove-hidden-text-from-a-word-processing-document
+    if (found) return mark ? undefined : found;
+    id = child(style, 'basedOn')?.getAttributeNS(W_NS, 'val');
+  }
+  const defaults = child(styles, 'docDefaults');
+  const inherited = child(child(child(defaults, mark ? 'rPrDefault' : 'pPrDefault'), mark ? 'rPr' : 'pPr'), name);
+  return inherited ? (mark ? undefined : inherited) : null;
+}
+
+function flag(property: Element | null | undefined): boolean | undefined {
+  if (property === undefined) return undefined;
+  if (property === null) return false;
+  const value = property.getAttributeNS(W_NS, 'val');
+  if (!value || ['1', 'true', 'on'].includes(value)) return true;
+  if (['0', 'false', 'off'].includes(value)) return false;
+  return undefined;
+}
+
+function safeVisibleCarrier(paragraph: Element, styles: Element | undefined): boolean {
+  const pPr = child(paragraph, 'pPr');
+  // These are the only carrier properties currently preserved by this narrow
+  // punctuation join. Do not erase structural/layout/revision properties.
+  if (pPr && directElementChildren(pPr).some(node => node.namespaceURI !== W_NS || !['pStyle', 'keepNext', 'widowControl', 'rPr'].includes(node.localName ?? ''))) return false;
+  if (['rPrChange', 'del', 'ins', 'moveFrom', 'moveTo', 'rStyle'].some(name => pPr?.getElementsByTagNameNS(W_NS, name).length)) return false;
+  if (inheritedProperty(paragraph, styles, 'framePr', false) !== null) return false;
+  if (flag(inheritedProperty(paragraph, styles, 'pageBreakBefore', false)) !== false) return false;
+  return ['vanish', 'specVanish'].every(name => flag(inheritedProperty(paragraph, styles, name, true)) === false);
+}
+
+function terminateVisibleHeading(heading: Element, continuation: Element): void {
+  const pPr = child(heading, 'pPr')!;
+  const terminal = child(continuation, 'pPr');
+  for (const name of ['keepNext', 'widowControl']) {
+    const property = child(terminal, name);
+    if (!property) continue;
+    const existing = child(pPr, name);
+    if (existing) pPr.removeChild(existing);
+    const preceding = name === 'keepNext' ? ['pStyle'] : ['pStyle', 'keepNext', 'keepLines', 'pageBreakBefore', 'framePr'];
+    const following = directElementChildren(pPr).find(node => node.namespaceURI !== W_NS || !preceding.includes(node.localName ?? ''));
+    pPr.insertBefore(property.cloneNode(true), following ?? null);
+  }
+  let mark = child(pPr, 'rPr');
+  if (!mark) { mark = heading.ownerDocument!.createElementNS(W_NS, 'w:rPr'); pPr.appendChild(mark); }
+  const terminalMark = child(terminal, 'rPr');
+  if (terminalMark) {
+    for (const property of directElementChildren(terminalMark)) {
+      if (property.namespaceURI === W_NS && ['vanish', 'specVanish'].includes(property.localName ?? '')) continue;
+      for (const previous of directElementChildren(mark).filter(node => node.namespaceURI === property.namespaceURI && node.localName === property.localName)) mark.removeChild(previous);
+      mark.appendChild(property.cloneNode(true));
+    }
+  }
+  for (const name of ['vanish', 'specVanish']) {
+    let property = child(mark, name);
+    if (!property) { property = heading.ownerDocument!.createElementNS(W_NS, `w:${name}`); mark.appendChild(property); }
+    // Explicit false also overrides a hidden mark inherited from the heading
+    // style. Removing only the direct flag would not preserve the boundary.
+    property.setAttributeNS(W_NS, 'w:val', '0');
+  }
+}
+
 /** Join an isolated punctuation continuation back to its matching split heading. */
 export function normalizeDetachedHeadingPunctuation(inputPath: string, outputPath: string): number {
   const zip = new AdmZip(inputPath);
   const entry = zip.getEntry('word/document.xml');
   if (!entry) throw new Error('heading punctuation normalizer: word/document.xml not found');
   const doc = new DOMParser().parseFromString(entry.getData().toString('utf-8'), 'text/xml');
+  const stylesEntry = zip.getEntry('word/styles.xml');
+  const styles = stylesEntry ? new DOMParser().parseFromString(stylesEntry.getData().toString('utf-8'), 'text/xml').documentElement ?? undefined : undefined;
   const paragraphs = Array.from(doc.getElementsByTagNameNS(W_NS, 'p')) as Element[];
   let normalized = 0;
 
   for (const continuation of paragraphs) {
     if (!/^[.,;:!?]\s*$/.test(getParagraphText(continuation as unknown as globalThis.Element))) continue;
+    if (!safeVisibleCarrier(continuation, styles)) continue;
     if (['fldChar', 'drawing', 'pict', 'object', 'footnoteReference', 'endnoteReference', 'br']
       .some((name) => continuation.getElementsByTagNameNS(W_NS, name).length > 0)) continue;
 
@@ -48,17 +132,16 @@ export function normalizeDetachedHeadingPunctuation(inputPath: string, outputPat
     const heading = previous as Element;
     if (heading.localName !== 'p' || heading.namespaceURI !== W_NS ||
         !matchingSplitHeadingStyles(heading, continuation)) continue;
+    if (['sectPr', 'framePr', 'pageBreakBefore', 'pPrChange', 'rPrChange', 'del', 'ins', 'moveFrom', 'moveTo', 'rStyle'].some(name => child(heading, 'pPr')?.getElementsByTagNameNS(W_NS, name).length)) continue;
 
     for (const child of directElementChildren(continuation)) {
       if (child.localName === 'pPr' && child.namespaceURI === W_NS) continue;
-      if (child.localName === 'r' && child.namespaceURI === W_NS) {
-        const text = getParagraphText(continuation as unknown as globalThis.Element);
-        const runText = Array.from(child.getElementsByTagNameNS(W_NS, 't'))
-          .map((node) => node.textContent ?? '').join('');
-        if (runText.trim().length === 0 && text.trim().length > 0) continue;
-      }
       heading.appendChild(child);
     }
+    // The punctuation carrier supplied the visible paragraph termination.
+    // Keep that termination when deleting its paragraph, rather than allowing
+    // the next numbered child (or next heading) to join this hidden separator.
+    terminateVisibleHeading(heading, continuation);
     continuation.parentNode?.removeChild(continuation);
     normalized++;
   }


### PR DESCRIPTION
## Summary

Closes #806.

Preserve the visible paragraph boundary when folding a detached heading-punctuation carrier into its heading. Previously, deleting the carrier left the preceding style-separator mark hidden, so the next numbered child could appear before its parent heading, or adjacent headings could collapse and inherit underline styling.

- Preserve semantic children in order, including bookmarks and textless reference runs.
- Preserve explicit terminal keep-next/widow-control and non-hidden paragraph-mark formatting, while making the terminal mark explicitly visible.
- Conservatively skip hidden or ambiguous inherited visibility, unsupported layout properties, character-style marks, and tracked paragraph-mark revisions. Genuine substantive inline continuations remain unchanged.
- Add 30 behavioral regressions (33 focused tests total), including inherited-toggle and revision cases identified during independent review.

## Verification

- Build, lint, catalog validation, and 33 focused tests pass; independent read-only review also passes.
- Fresh locally cached, hash-pinned IRA and SPA source documents exercised through real fill and render-copy entry points, then LibreOffice PDF export. No licensed sources or generated artifacts are committed or uploaded.
- IRA: all 166 nonblank numbered paragraph labels match in rendered order (six previous boundary failures eliminated); 169 hierarchy tuples checked, 64 numeric REF values unchanged, and three selective deletion probes preserve dynamic renumbering without modifying numbering definitions. Three existing blank numbered paragraphs are reported separately.
- SPA: all five punctuation carriers preserve visible termination; 177 surviving bookmark starts each retain exactly one end, including the affected cross-reference target. An unrelated preexisting orphan end marker remains outside this fix.
- Visually inspected six affected IRA pages and four SPA pages. IRA remains 32 pages; SPA fixture renders 34 pages. These are scoped regression fixtures with remaining unfilled options, not blank-free deliverables or a claim of pristine whole-document layout. Word rendering was not independently executed.
- Full local suite: 1,647 passed, 7 skipped (163.19 seconds). This used an explicitly disclosed diagnostic single worker and 15-second timeout under measured unrelated machine load; no tracked timeout is changed. Standard CI must pass before merge.

## Review boundaries

This is a runtime layout repair, not a legal-content change. It does not flatten inherited styles, rewrite substantive inline headings, alter editable numbering counters, or accept tracked revisions. Source-specific recipe cleanup and numbering declarations remain separate canonical changes.
