### PR TITLE
feat: support caller-only conjunctive input requirements

### DIFF
--- a/docs/adding-field-selectors.md
+++ b/docs/adding-field-selectors.md
@@ -15,6 +15,31 @@ Field-selectors enable OpenAgreements to work with non-redistributable document 
 - A publicly downloadable DOCX source document
 - Understanding of the document's placeholder conventions
 
+### Caller-only conditional requirements
+
+A scalar field may use `required_when: { field: enabled, equals: true }`.
+When a value is required only for a parent **and** child election, use the bounded
+conjunction form:
+
+```yaml
+required_when:
+  all_of:
+    - { field: include_parent, equals: true }
+    - { field: include_child, equals: true }
+```
+
+`all_of` requires at least two distinct caller-field predicates. Each controller
+must be another top-level scalar input with a type-compatible equality value;
+computed controllers/targets, nested expressions, and conditionally required
+target defaults are rejected. Missing controllers use their declared typed
+defaults; without a matching default they do not activate that predicate. Every
+predicate must match before the target becomes required. Runtime validation and
+the exported JSON Schema enforce the same conjunction and nonblank requirement.
+
+Mirrors/packages using this form must require capability
+`conditional-input-requirements.all-of.v1` in addition to the base conditional
+requirements capability. Older single-predicate consumers cannot execute it.
+
 ## Step 1: Scan the Source Document
 
 Use the `scan` command to discover all bracketed placeholders:

--- a/integration-tests/conditional-inputs.test.ts
+++ b/integration-tests/conditional-inputs.test.ts
@@ -10,13 +10,16 @@ const it = itAllure.epic('Filling & Rendering');
 const dirs: string[] = [];
 afterEach(() => { vi.unstubAllEnvs(); for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true }); });
 
-function fixture() {
+function fixture(conjunctive = false) {
   const root = mkdtempSync(join(tmpdir(), 'oa-conditional-api-')); dirs.push(root);
   const dir = join(root, 'templates', 'synthetic', 'conditional-input-fixture'); mkdirSync(dir, { recursive: true });
   const fields = [
     { name: 'enabled', type: 'boolean', description: 'Enable optional regime', default: 'false' },
+    ...(conjunctive ? [{ name: 'child', type: 'boolean', description: 'Nested election', default: 'false' }] : []),
     ...['start_date', 'interest_rate', 'frequency'].map(name => ({ name, type: 'string', description: name,
-      required_when: { field: 'enabled', equals: true } })),
+      required_when: conjunctive
+        ? { all_of: [{ field: 'enabled', equals: true }, { field: 'child', equals: true }] }
+        : { field: 'enabled', equals: true } })),
   ];
   writeFileSync(join(dir, 'metadata.yaml'), JSON.stringify({ name: 'Synthetic conditional fixture', artifact_type: 'field-selector',
     source_url: 'https://example.com/never-downloaded.docx', source_version: '1', license_note: 'Synthetic fixture', fields }));
@@ -25,6 +28,36 @@ function fixture() {
 }
 
 describe('conditional input public entry points', () => {
+  it('API and CLI reject active conjunctions before input I/O; inactive siblings do not require economics', async () => {
+    const root = fixture(true); vi.stubEnv('OPEN_AGREEMENTS_CONTENT_ROOTS', root);
+    const outputPath = join(root, 'out.docx');
+    const inputPath = join(root, 'does-not-exist.docx');
+    for (const value of [undefined, '', ' \t']) {
+      const values = { enabled: true, child: true, start_date: value, interest_rate: '0', frequency: 'annual' };
+      await expect(runFieldSelector({ fieldSelectorId: 'conditional-input-fixture', values, inputPath, outputPath }))
+        .rejects.toMatchObject({ code: 'INCOMPLETE_CONDITIONAL_INPUT', fields: ['start_date'] });
+      expect(existsSync(outputPath)).toBe(false);
+    }
+    for (const values of [{ enabled: false, child: true }, { enabled: true, child: false }, { child: true }]) {
+      // Passing the conditional gate advances to the deliberately missing source.
+      await expect(runFieldSelector({ fieldSelectorId: 'conditional-input-fixture', values, inputPath, outputPath }))
+        .rejects.toThrow(/not.exist|ENOENT|Invalid filename/i);
+      expect(existsSync(outputPath)).toBe(false);
+    }
+    const data = join(root, 'values.json');
+    writeFileSync(data, JSON.stringify({ enabled: true, child: true, interest_rate: '0', frequency: 'annual' }));
+    let error: unknown;
+    try {
+      execFileSync(process.execPath, [join(new URL('..', import.meta.url).pathname, 'bin/open-agreements.js'),
+        'field-selector', 'run', 'conditional-input-fixture', '--data', data, '--output', outputPath, '--input', inputPath], {
+        env: { ...process.env, OPEN_AGREEMENTS_CONTENT_ROOTS: root }, encoding: 'utf8', stdio: 'pipe',
+      });
+    } catch (caught) { error = caught; }
+    expect(error).toMatchObject({ status: 1 });
+    expect(String((error as { stderr: string }).stderr)).toContain('Incomplete conditional input: start_date');
+    expect(existsSync(outputPath)).toBe(false);
+  });
+
   it('API rejects every missing economic before touching input or output documents', async () => {
     const root = fixture(); vi.stubEnv('OPEN_AGREEMENTS_CONTENT_ROOTS', root);
     const complete = { enabled: true, start_date: '2030-01-01', interest_rate: '0', frequency: 'annual' };

--- a/runtime-capabilities.json
+++ b/runtime-capabilities.json
@@ -17,6 +17,7 @@
     "reference-fields.v1",
     "reference-fields.grouped.v1",
     "conditional-input-requirements.v1",
+    "conditional-input-requirements.all-of.v1",
     "render.numbering-snapshot.v1"
   ]
 }

--- a/scripts/smoke_conditional_all_of.mjs
+++ b/scripts/smoke_conditional_all_of.mjs
@@ -1,0 +1,44 @@
+/** Real-source validation smoke; outputs remain local, not finished documents. */
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { cpSync, existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import yaml from 'js-yaml';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const scratch = mkdtempSync(join(tmpdir(), 'oa-all-of-real-'));
+const id = 'nvca-investors-rights-agreement';
+const source = join(homedir(), '.open-agreements/cache', id, 'source.docx');
+const hash = path => createHash('sha256').update(readFileSync(path)).digest('hex');
+const sourceHash = hash(source);
+assert.equal(sourceHash, 'be8ad13f171a343bdb53716b1d318689ae3477cdf7f1986b2e3985e1cabbd08a');
+const recipe = join(scratch, 'templates/nvca-free-non-redistributable', id);
+cpSync(join(root, 'templates/nvca-free-non-redistributable', id), recipe, { recursive: true });
+const metadataPath = join(recipe, 'metadata.yaml');
+const metadata = yaml.load(readFileSync(metadataPath, 'utf8'));
+// Exercise the new contract on a real existing field and source; this temporary
+// overlay is validation scaffolding, not a new legal requirement in the recipe.
+metadata.fields.find(field => field.name === 'company_name').required_when = { all_of: [
+  { field: 'include_standoff_pro_rata_release', equals: true },
+  { field: 'include_standoff_discretionary_minimum_release', equals: true },
+] };
+writeFileSync(metadataPath, yaml.dump(metadata));
+process.env.OPEN_AGREEMENTS_CONTENT_ROOTS = scratch;
+const { runFieldSelector, extractAllText } = await import('../dist/core/field-selector/index.js');
+const base = JSON.parse(readFileSync(join(root, 'integration-tests/fixtures/ira-production-full.json'), 'utf8'));
+const values = { ...base, include_standoff_pro_rata_release: true, include_standoff_discretionary_minimum_release: true };
+for (const company_name of [undefined, '', ' \t']) {
+  const outputPath = join(scratch, `rejected-${String(company_name).length}.docx`);
+  await assert.rejects(runFieldSelector({ fieldSelectorId: id, inputPath: source, outputPath,
+    values: { ...values, company_name } }), error => error.code === 'INCOMPLETE_CONDITIONAL_INPUT' && error.fields.includes('company_name'));
+  assert.equal(existsSync(outputPath), false);
+}
+const outputPath = join(scratch, 'filled.docx');
+const result = await runFieldSelector({ fieldSelectorId: id, inputPath: source, outputPath, values });
+assert.ok(extractAllText(outputPath).includes(base.company_name));
+assert.equal(hash(source), sourceHash);
+console.log(JSON.stringify({ result: 'PASS', source_sha256: sourceHash, output_sha256: hash(outputPath),
+  rejected_before_output: 3, warnings: result.warnings, output_directory: scratch,
+  scope: 'Validation-only temporary metadata overlay. Existing partial regression fixture and recipe warnings are not certified as a finished document.' }));

--- a/src/core/conditional-all-of.test.ts
+++ b/src/core/conditional-all-of.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect } from 'vitest';
+import Ajv2020 from 'ajv/dist/2020.js';
+import { itAllure } from '../../integration-tests/helpers/allure-test.js';
+import { FieldSelectorMetadataSchema } from './metadata.js';
+import { assertConditionalInputOwnership, assertConditionalRequiredInputs } from './conditional-inputs.js';
+import { buildFieldSelectorInputSchema } from './field-selector/input-schema.js';
+
+const it = itAllure.epic('Filling & Rendering');
+const predicates = [{ field: 'parent', equals: true }, { field: 'child', equals: true }];
+const fixture = {
+  name: 'Conjunctive caller requirements', source_url: 'https://example.com/form.docx', source_version: '1', license_note: 'Synthetic',
+  fields: [
+    { name: 'parent', type: 'boolean', description: 'Parent election' },
+    { name: 'child', type: 'boolean', description: 'Child election' },
+    { name: 'amount', type: 'string', description: 'Explicit amount', required_when: { all_of: predicates } },
+  ],
+};
+
+describe('caller-only conjunctive requirements', () => {
+  it('requires an amount only for both true, with schema/runtime parity across omissions and blanks', () => {
+    for (const parentDefault of [undefined, 'false', 'true']) {
+      for (const childDefault of [undefined, 'false', 'true']) {
+        const raw = structuredClone(fixture);
+        Object.assign(raw.fields[0], { default: parentDefault });
+        Object.assign(raw.fields[1], { default: childDefault });
+        const metadata = FieldSelectorMetadataSchema.parse(raw);
+        const ajv = new Ajv2020({ strict: true }); ajv.addKeyword('x-openagreements');
+        const validate = ajv.compile(buildFieldSelectorInputSchema('fixture', metadata, null));
+        for (const parent of [undefined, false, true]) for (const child of [undefined, false, true]) {
+          const required = (parent ?? (parentDefault === 'true')) && (child ?? (childDefault === 'true'));
+          for (const amount of [undefined, '', ' \t', '100']) {
+            const input = { ...(parent === undefined ? {} : { parent }), ...(child === undefined ? {} : { child }), ...(amount === undefined ? {} : { amount }) };
+            const valid = !required || amount === '100';
+            expect(validate(input), JSON.stringify({ parentDefault, childDefault, input })).toBe(valid);
+            if (valid) expect(() => assertConditionalRequiredInputs(input, metadata.fields)).not.toThrow();
+            else expect(() => assertConditionalRequiredInputs(input, metadata.fields)).toThrow(/amount/);
+          }
+        }
+      }
+    }
+  });
+
+  it('rejects malformed controllers regardless of predicate order or an inactive sibling', () => {
+    for (const all_of of [predicates, [...predicates].reverse()]) {
+      const metadata = FieldSelectorMetadataSchema.parse({ ...fixture, fields: [...fixture.fields.slice(0, 2), {
+        ...fixture.fields[2], required_when: { all_of },
+      }] });
+      const ajv = new Ajv2020({ strict: false });
+      const validate = ajv.compile(buildFieldSelectorInputSchema('fixture', metadata, null));
+      for (const input of [{ parent: false, child: 'true' }, { parent: 'false', child: false }, { parent: true, child: null }]) {
+        expect(validate(input)).toBe(false);
+        expect(() => assertConditionalRequiredInputs(input, metadata.fields)).toThrow(/controller/);
+      }
+    }
+  });
+
+  it('rejects empty/singleton/duplicate/nested/unknown/self/type-incompatible predicates and expressions', () => {
+    for (const required_when of [
+      { all_of: [] }, { all_of: [predicates[0]] }, { all_of: [predicates[0], predicates[0]] },
+      { all_of: [predicates[0], { field: 'parent', equals: false }] },
+      { all_of: [predicates[0], { all_of: predicates }] },
+      { all_of: [predicates[0], { field: 'unknown', equals: true }] },
+      { all_of: [predicates[0], { field: 'amount', equals: '100' }] },
+      { all_of: [predicates[0], { field: 'child', equals: 'true' }] },
+      { all_of: predicates, expression: 'parent && child' },
+      { all_of: predicates, field: 'parent', equals: true },
+      { any_of: predicates },
+    ]) {
+      expect(FieldSelectorMetadataSchema.safeParse({ ...fixture, fields: [...fixture.fields.slice(0, 2), {
+        ...fixture.fields[2], required_when,
+      }] }).success, JSON.stringify(required_when)).toBe(false);
+    }
+    for (const target of [{ ...fixture.fields[2], default: '100' }, {
+      name: 'rows', type: 'array', description: 'Nested', items: [fixture.fields[2]],
+    }]) {
+      expect(FieldSelectorMetadataSchema.safeParse({ ...fixture, fields: [...fixture.fields.slice(0, 2), target] }).success).toBe(false);
+    }
+  });
+
+  it('rejects computed ownership for every controller and the target', () => {
+    const metadata = FieldSelectorMetadataSchema.parse(fixture);
+    for (const computed of ['parent', 'child', 'amount']) {
+      expect(() => assertConditionalInputOwnership(metadata.fields, new Set([computed]))).toThrow(/not computed fields/);
+    }
+    expect(() => assertConditionalInputOwnership(metadata.fields, new Set())).not.toThrow();
+  });
+});

--- a/src/core/conditional-all-of.test.ts
+++ b/src/core/conditional-all-of.test.ts
@@ -84,4 +84,13 @@ describe('caller-only conjunctive requirements', () => {
     }
     expect(() => assertConditionalInputOwnership(metadata.fields, new Set())).not.toThrow();
   });
+
+  it('defends runtime and schema entry points against a mutated missing controller', () => {
+    const metadata = FieldSelectorMetadataSchema.parse(fixture);
+    metadata.fields[1].name = 'renamed_after_parsing';
+    expect(() => assertConditionalRequiredInputs({ parent: false, child: true }, metadata.fields))
+      .toThrow(/Unknown required_when controller: child/);
+    expect(() => buildFieldSelectorInputSchema('fixture', metadata, null))
+      .toThrow(/required_when controller "child" must be a caller input/);
+  });
 });

--- a/src/core/conditional-inputs.ts
+++ b/src/core/conditional-inputs.ts
@@ -1,5 +1,6 @@
 import type { FieldDefinition } from './metadata.js';
 import { typedFieldDefault } from './field-defaults.js';
+import { conditionalPredicates } from './conditional-predicates.js';
 
 export class IncompleteConditionalInputError extends Error {
   readonly code = 'INCOMPLETE_CONDITIONAL_INPUT';
@@ -11,7 +12,7 @@ export class IncompleteConditionalInputError extends Error {
 
 export function assertConditionalInputOwnership(fields: FieldDefinition[], computed: Set<string>): void {
   for (const field of fields) {
-    if (field.required_when && (computed.has(field.name) || computed.has(field.required_when.field))) {
+    if (field.required_when && (computed.has(field.name) || conditionalPredicates(field.required_when).some(predicate => computed.has(predicate.field)))) {
       throw new Error(`required_when for "${field.name}" must use caller inputs, not computed fields`);
     }
   }
@@ -24,14 +25,19 @@ export function assertConditionalRequiredInputs(values: Record<string, unknown>,
   for (const field of fields) {
     const condition = field.required_when;
     if (!condition) continue;
-    const controller = byName.get(condition.field);
-    if (!controller) throw new Error(`Unknown required_when controller: ${condition.field}`);
-    const supplied = Object.prototype.hasOwnProperty.call(values, condition.field);
-    const actual = supplied ? values[condition.field] : typedFieldDefault(controller);
-    if (supplied && typeof actual !== typeof condition.equals) {
-      throw new Error(`Conditional controller "${condition.field}" must be a ${typeof condition.equals}`);
-    }
-    if (actual !== condition.equals) continue;
+    // Validate every controller even when an earlier predicate is false.
+    // A malformed later value must not pass depending on predicate order.
+    const matches = conditionalPredicates(condition).map(predicate => {
+      const controller = byName.get(predicate.field);
+      if (!controller) throw new Error(`Unknown required_when controller: ${predicate.field}`);
+      const supplied = Object.prototype.hasOwnProperty.call(values, predicate.field);
+      const actual = supplied ? values[predicate.field] : typedFieldDefault(controller);
+      if (supplied && typeof actual !== typeof predicate.equals) {
+        throw new Error(`Conditional controller "${predicate.field}" must be a ${typeof predicate.equals}`);
+      }
+      return actual === predicate.equals;
+    });
+    if (!matches.every(Boolean)) continue;
     const value = values[field.name];
     if (value == null || (typeof value === 'string' && value.trim() === '')) missing.push(field.name);
   }

--- a/src/core/conditional-predicates.ts
+++ b/src/core/conditional-predicates.ts
@@ -1,0 +1,11 @@
+/** Bounded caller-input conditions; not an expression or computed-value language. */
+export interface ConditionalPredicate {
+  field: string;
+  equals: string | number | boolean;
+}
+
+export type ConditionalRequirement = ConditionalPredicate | { all_of: ConditionalPredicate[] };
+
+export function conditionalPredicates(condition: ConditionalRequirement): ConditionalPredicate[] {
+  return 'all_of' in condition ? condition.all_of : [condition];
+}

--- a/src/core/field-selector/input-schema.ts
+++ b/src/core/field-selector/input-schema.ts
@@ -10,6 +10,7 @@ import { loadComputedProfile, type ComputedProfile } from './computed.js';
 import { resolveFieldSelectorDir } from '../../utils/paths.js';
 import { assertConditionalInputOwnership } from '../conditional-inputs.js';
 import { typedFieldDefault } from '../field-defaults.js';
+import { conditionalPredicates } from '../conditional-predicates.js';
 
 export const FIELD_SELECTOR_INPUT_SCHEMA_VERSION = 1 as const;
 export const FIELD_SELECTOR_SCHEMA_GENERATOR = 'open-agreements field-selector schema' as const;
@@ -161,16 +162,19 @@ export function buildFieldSelectorInputSchema(
   const required = metadata.priority_fields.filter((name) => inputNames.has(name));
   const conditions = fields.filter((field) => field.required_when).map((field) => {
     const condition = field.required_when!;
-    const controller = fields.find((candidate) => candidate.name === condition.field);
-    if (!controller) throw new Error(`required_when controller "${condition.field}" must be a caller input`);
-    const usesDefault = typedFieldDefault(controller) === condition.equals;
-    return {
-      if: {
-        properties: { [condition.field]: { const: condition.equals } },
+    const predicates = conditionalPredicates(condition).map(predicate => {
+      const controller = fields.find((candidate) => candidate.name === predicate.field);
+      if (!controller) throw new Error(`required_when controller "${predicate.field}" must be a caller input`);
+      const usesDefault = typedFieldDefault(controller) === predicate.equals;
+      return {
+        properties: { [predicate.field]: { const: predicate.equals } },
         // Without a matching controller default, omission must not vacuously
         // activate the condition. JSON Schema does not apply defaults itself.
-        ...(!usesDefault ? { required: [condition.field] } : {}),
-      },
+        ...(!usesDefault ? { required: [predicate.field] } : {}),
+      };
+    });
+    return {
+      if: 'all_of' in condition ? { allOf: predicates } : predicates[0],
       then: {
         required: [field.name],
         properties: {

--- a/src/core/metadata.ts
+++ b/src/core/metadata.ts
@@ -2,6 +2,12 @@ import { z } from 'zod';
 import { readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import yaml from 'js-yaml';
+import { conditionalPredicates, type ConditionalRequirement } from './conditional-predicates.js';
+
+const ConditionalPredicateSchema = z.object({
+  field: z.string().min(1),
+  equals: z.union([z.string(), z.number().finite(), z.boolean()]),
+}).strict();
 
 /**
  * License values accepted by template metadata.
@@ -67,7 +73,7 @@ export interface FieldDefinition {
   section?: string;
   items?: FieldDefinition[];
   /** Require an explicit, nonblank input when a top-level scalar field matches. */
-  required_when?: { field: string; equals: string | number | boolean };
+  required_when?: ConditionalRequirement;
   /**
    * Marks this boolean field as a *statutory compliance representation*: its
    * `true` value asserts a past real-world fact that is a statutory precondition
@@ -124,10 +130,12 @@ export const FieldDefinitionSchema: z.ZodType<FieldDefinition> = z.lazy(() =>
     derive_booleans: z.boolean().optional(),
     section: z.string().optional(),
     items: z.array(FieldDefinitionSchema).nonempty().optional(),
-    required_when: z.object({
-      field: z.string().min(1),
-      equals: z.union([z.string(), z.number().finite(), z.boolean()]),
-    }).strict().optional(),
+    required_when: z.union([
+      ConditionalPredicateSchema,
+      z.object({ all_of: z.array(ConditionalPredicateSchema).min(2) }).strict()
+        .refine(condition => new Set(condition.all_of.map(predicate => predicate.field)).size === condition.all_of.length,
+          'all_of must contain unique caller field predicates'),
+    ]).optional(),
     statutory_compliance_representation: z.boolean().optional(),
     authority_url: z.string().optional(),
     confirm_note: z.string().optional(),
@@ -377,15 +385,17 @@ function validateConditionalRequirements(fields: FieldDefinition[], ctx: z.Refin
     items.forEach((field, index) => {
       const at = [...path, index];
       if (field.required_when) {
-        const controller = byName.get(field.required_when.field);
-        const expectedType = controller?.type === 'boolean' ? 'boolean'
-          : controller?.type === 'number' ? 'number' : 'string';
-        if (nested || !controller || controller.name === field.name ||
-            ['array', 'multiselect'].includes(controller.type) ||
-            typeof field.required_when.equals !== expectedType ||
-            (controller.type === 'enum' && !controller.options?.includes(String(field.required_when.equals)))) {
-          ctx.addIssue({ code: z.ZodIssueCode.custom, path: [...at, 'required_when'],
-            message: 'required_when must reference another top-level scalar field with a compatible equals value; nested requirements are unsupported' });
+        for (const predicate of conditionalPredicates(field.required_when)) {
+          const controller = byName.get(predicate.field);
+          const expectedType = controller?.type === 'boolean' ? 'boolean'
+            : controller?.type === 'number' ? 'number' : 'string';
+          if (nested || !controller || controller.name === field.name ||
+              ['array', 'multiselect'].includes(controller.type) ||
+              typeof predicate.equals !== expectedType ||
+              (controller.type === 'enum' && !controller.options?.includes(String(predicate.equals)))) {
+            ctx.addIssue({ code: z.ZodIssueCode.custom, path: [...at, 'required_when'],
+              message: 'required_when must reference another top-level scalar field with a compatible equals value; nested requirements are unsupported' });
+          }
         }
         if (field.default !== undefined || ['array', 'multiselect'].includes(field.type)) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, path: [...at, 'required_when'],

--- a/src/core/runtime-capabilities.ts
+++ b/src/core/runtime-capabilities.ts
@@ -22,6 +22,7 @@ export const RUNTIME_CAPABILITIES = Object.freeze({
     'reference-fields.v1',
     'reference-fields.grouped.v1',
     'conditional-input-requirements.v1',
+    'conditional-input-requirements.all-of.v1',
     'render.numbering-snapshot.v1',
   ]),
 });


### PR DESCRIPTION
## Summary

Adds caller-only `required_when.all_of` conjunctions with at least two distinct scalar predicates. Strict parsing preserves the existing restrictions against computed ownership, nested expressions, self-reference, incompatible equality values, and target defaults. Runtime preflight and exported JSON Schema share the same predicate expansion and controller-default semantics.

Publishes `conditional-input-requirements.all-of.v1` through the source/built/package capability parity contract. LE mirror inference and the actual basket input are a separate sequential canonical PR; this runtime PR does not modify recipes or resolve the basket amount by default.

Closes #811. Prerequisite for UseJunior/legal-explainer#2554.

## Verification

- Build, lint, Allure label gate, catalog validation, seven-schema export, package dry-run pass. Catalog retains existing unrelated recipe warnings.
- 12 focused tests pass: strict shape/ownership rejection; runtime/AJV truth/default/omission/blank matrix; API/CLI rejection before input/output I/O.
- Real hash-pinned IRA smoke passes with a temporary metadata validation overlay: three active missing/blank values reject before output, an existing supplied company name fills successfully. Existing partial fixture and two pre-projection selection warnings are explicitly disclosed, not certified as a finished document. No licensed output committed.
- Full default-timeout suite passed: 1,652 tests, 7 skipped (168 seconds). Independent dynamic review passed, including additional mixed number/enum/default-zero controller probes. A subsequent test-only commit covers the two defensive missing-controller branches; its five focused tests pass. Default CI remains required on that head.

Initial local package dry-run hit a restricted default npm cache; rerun used a task-local cache without changing permissions. An initial schema-export attempt correctly rejected an abbreviated revision; the successful export used the exact 40-character commit.
