### PR TITLE
fix(fill): preserve declared boolean default types

### DIFF
--- a/integration-tests/fill-pipeline.test.ts
+++ b/integration-tests/fill-pipeline.test.ts
@@ -548,6 +548,46 @@ describe('prepareFillData', () => {
     expect(result.is_free).toBe(true);
   });
 
+  it.each([false, true])('materializes declared boolean defaults as booleans (%s) without caller coercion', (value) => {
+    const field = { name: 'enabled', type: 'boolean' as const, default: String(value) };
+    expect(prepareFillData({ values: {}, fields: [field], coerceBooleans: false }).enabled).toBe(value);
+    expect(prepareFillData({ values: { enabled: !value }, fields: [field], coerceBooleans: false }).enabled).toBe(!value);
+    expect(prepareFillData({ values: { enabled: 'true' }, fields: [field], coerceBooleans: false }).enabled).toBe('true');
+  });
+
+  it.each([false, true])('passes a typed default (%s) through actual pipeline selection applicability', async (value) => {
+    const inputPath = buildDocxFile(docXml(['Before {company} [Parent [child]] After']));
+    const outputPath = join(dirname(inputPath), 'filled.docx');
+    try {
+      const result = await runFillPipeline({
+        inputPath, outputPath, values: { child: true, company: 'Acme' },
+        fields: [{ name: 'enabled', type: 'boolean', default: String(value) }, { name: 'child', type: 'boolean' }, { name: 'company', type: 'string' }],
+        coerceBooleans: false,
+        selectionsZeroMatchPolicy: 'error',
+        verify: (candidate) => {
+          expect(new AdmZip(candidate).readAsText('word/document.xml')).toContain('Acme');
+          return { passed: true, checks: [] };
+        },
+        selectionsConfig: { groups: [
+          { id: 'parent', type: 'checkbox', standalone: true, markerless: true, inline: true,
+            options: [{ marker: '[Parent [child]]', selectedAction: 'unwrap_brackets', trigger: { field: 'enabled', equals: true } }] },
+          { id: 'child', type: 'checkbox', standalone: true, markerless: true, inline: true,
+            applies_when: { field: 'enabled', equals: true },
+            options: [{ marker: '[child]', selectedAction: 'unwrap_brackets', trigger: { field: 'child', equals: true } }] },
+        ] },
+      });
+      expect(result.warnings).toEqual([]);
+      const xml = new AdmZip(outputPath).readAsText('word/document.xml');
+      const text = xml.replace(/<[^>]+>/g, '');
+      expect(text.includes('Parent')).toBe(value);
+      expect(text.includes('child')).toBe(value);
+      expect(text).toContain('Before');
+      expect(text).toContain('After');
+    } finally {
+      rmSync(dirname(inputPath), { recursive: true, force: true });
+    }
+  });
+
   it('coerces "false" string to false boolean', () => {
     const result = prepareFillData({
       values: { company: 'Acme', is_free: 'false' },

--- a/src/core/fill-pipeline.ts
+++ b/src/core/fill-pipeline.ts
@@ -21,6 +21,7 @@ import {
 } from './field-selector/ooxml-parts.js';
 import type { FieldDefinition } from './metadata.js';
 import { assertConditionalRequiredInputs } from './conditional-inputs.js';
+import { typedFieldDefault } from './field-defaults.js';
 
 const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 
@@ -225,6 +226,11 @@ export function prepareFillData(options: PrepareFillDataOptions): Record<string,
         data[field.name] = [];
       } else if (field.type === 'multiselect') {
         data[field.name] = field.default ? JSON.parse(field.default) : [];
+      } else if (field.type === 'boolean' && field.default !== undefined) {
+        // Metadata defaults already have a declared type. Preserve it even
+        // when coercion of caller-supplied strings is intentionally disabled;
+        // selection applicability requires the same typed values as schemas.
+        data[field.name] = typedFieldDefault(field);
       } else {
         data[field.name] = field.default ?? defaultValue;
       }


### PR DESCRIPTION
## Summary

Fixes #810. Omitted boolean metadata defaults now retain their declared type even when coercion of caller-supplied strings is disabled. Reuses `typedFieldDefault`; explicit booleans and raw caller strings retain their existing behavior.

The real IRA nested-selection path exposed this: a declared false default reached strict `applies_when` as a string and prevented document generation. This does not relax applicability validation or change omitted fields without a declared default.

## Verification

- Four new regressions fail on baseline and pass with the fix, including actual nested-selection pipeline output.
- Independent read-only review: entire fill-pipeline integration file, 121/121 tests passed at default timeouts.
- Build, lint, Allure label gate, documentation and generated-artifact checks pass. Catalog validation passes with existing warnings.
- Six actual pinned-source IRA fills pass with the separately tracked canonical #2553 configuration: omitted/false/true parent × false/true child, strict zero-match handling, adjacent content and source hash preserved. This deliberately partial fixture retains 17 unfilled inputs; it is not a document-readiness claim.
- Full-suite check is queued behind the current coordinated validation job; automerge will wait for its result, normal CI, and advisory review.

No paid model calls, licensed source files, generated documents, or local paths are included in this PR. Claude Fable review was unavailable; no Fable approval is claimed.
