### PR TITLE
feat: add explicit nonnegative integer string input format

### DIFF
--- a/docs/adding-field-selectors.md
+++ b/docs/adding-field-selectors.md
@@ -50,8 +50,8 @@ and exported JSON Schema. Existing unformatted fields are unchanged.
 Accepted values include `"0"`, `"1"`, and `"100"`. Reject signs, leading zeros
 (`"01"`), decimals, scientific notation, commas, whitespace (including a final
 newline), non-ASCII digits, units, and non-string values such as numeric `0`.
-Empty strings remain valid for inactive/optional fields; an active
-`required_when` additionally rejects missing or blank values. Invalid declared
+The format permits empty strings; an active `required_when` additionally rejects
+missing or blank values. Generic priority-field blank handling is unchanged. Invalid declared
 defaults and incompatible field types are rejected when metadata loads.
 
 The end-of-input assertion deliberately does not use JavaScript's `$` alone,

--- a/docs/adding-field-selectors.md
+++ b/docs/adding-field-selectors.md
@@ -40,6 +40,30 @@ Mirrors/packages using this form must require capability
 `conditional-input-requirements.all-of.v1` in addition to the base conditional
 requirements capability. Older single-predicate consumers cannot execute it.
 
+### Explicit whole-number string format
+
+Use `type: string` with `value_format: nonnegative_integer` when a source-owned
+blank requires a bare nonnegative whole-number token. This opt-in declaration,
+not the field name or description, drives the same pattern in runtime preflight
+and exported JSON Schema. Existing unformatted fields are unchanged.
+
+Accepted values include `"0"`, `"1"`, and `"100"`. Reject signs, leading zeros
+(`"01"`), decimals, scientific notation, commas, whitespace (including a final
+newline), non-ASCII digits, units, and non-string values such as numeric `0`.
+Empty strings remain valid for inactive/optional fields; an active
+`required_when` additionally rejects missing or blank values. Invalid declared
+defaults and incompatible field types are rejected when metadata loads.
+
+The end-of-input assertion deliberately does not use JavaScript's `$` alone,
+which can match before a final newline. Values remain strings, so large counts
+are not rounded through floating-point conversion. This format does not infer
+a legal maximum or supply an economic default.
+
+This is a bounded format vocabulary, not arbitrary regex support. Consumers
+must advertise `input-value-format.nonnegative-integer.v1`; guarded mirrors
+must infer that requirement from the actual `value_format` declaration before
+any destination mutation. Manual copying into old consumers bypasses that guard.
+
 ## Step 1: Scan the Source Document
 
 Use the `scan` command to discover all bracketed placeholders:

--- a/integration-tests/conditional-inputs.test.ts
+++ b/integration-tests/conditional-inputs.test.ts
@@ -10,13 +10,14 @@ const it = itAllure.epic('Filling & Rendering');
 const dirs: string[] = [];
 afterEach(() => { vi.unstubAllEnvs(); for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true }); });
 
-function fixture(conjunctive = false) {
+function fixture(conjunctive = false, integerFormat = false) {
   const root = mkdtempSync(join(tmpdir(), 'oa-conditional-api-')); dirs.push(root);
   const dir = join(root, 'templates', 'synthetic', 'conditional-input-fixture'); mkdirSync(dir, { recursive: true });
   const fields = [
     { name: 'enabled', type: 'boolean', description: 'Enable optional regime', default: 'false' },
     ...(conjunctive ? [{ name: 'child', type: 'boolean', description: 'Nested election', default: 'false' }] : []),
-    ...['start_date', 'interest_rate', 'frequency'].map(name => ({ name, type: 'string', description: name,
+    ...(integerFormat ? ['amount'] : ['start_date', 'interest_rate', 'frequency']).map(name => ({ name, type: 'string', description: name,
+      ...(integerFormat ? {value_format: 'nonnegative_integer'} : {}),
       required_when: conjunctive
         ? { all_of: [{ field: 'enabled', equals: true }, { field: 'child', equals: true }] }
         : { field: 'enabled', equals: true } })),
@@ -28,6 +29,31 @@ function fixture(conjunctive = false) {
 }
 
 describe('conditional input public entry points', () => {
+  it('rejects invalid explicit integer formats through API and CLI before source/output I/O', async () => {
+    const root = fixture(false, true); vi.stubEnv('OPEN_AGREEMENTS_CONTENT_ROOTS', root);
+    const outputPath = join(root, 'out.docx'); const inputPath = join(root, 'missing.docx');
+    for (const amount of ['-1', '+1', '1.5', '1e3', '1,000', '1\n', '100 shares', 0]) {
+      await expect(runFieldSelector({fieldSelectorId: 'conditional-input-fixture', inputPath, outputPath,
+        values: {enabled: true, amount}})).rejects.toThrow(/nonnegative integer string/);
+      expect(existsSync(outputPath)).toBe(false);
+    }
+    for (const amount of ['0', '100']) {
+      await expect(runFieldSelector({fieldSelectorId: 'conditional-input-fixture', inputPath, outputPath,
+        values: {enabled: true, amount}})).rejects.toThrow(/not.exist|ENOENT|Invalid filename/i);
+    }
+    const data = join(root, 'values.json'); writeFileSync(data, JSON.stringify({enabled: true, amount: '1\n'}));
+    let error: unknown;
+    try {
+      execFileSync(process.execPath, [join(new URL('..', import.meta.url).pathname, 'bin/open-agreements.js'),
+        'field-selector', 'run', 'conditional-input-fixture', '--data', data, '--output', outputPath, '--input', inputPath], {
+        env: {...process.env, OPEN_AGREEMENTS_CONTENT_ROOTS: root}, encoding: 'utf8', stdio: 'pipe',
+      });
+    } catch (caught) { error = caught; }
+    expect(error).toMatchObject({status: 1});
+    expect(String((error as {stderr: string}).stderr)).toContain('nonnegative integer string');
+    expect(existsSync(outputPath)).toBe(false);
+  });
+
   it('API and CLI reject active conjunctions before input I/O; inactive siblings do not require economics', async () => {
     const root = fixture(true); vi.stubEnv('OPEN_AGREEMENTS_CONTENT_ROOTS', root);
     const outputPath = join(root, 'out.docx');

--- a/runtime-capabilities.json
+++ b/runtime-capabilities.json
@@ -18,6 +18,7 @@
     "reference-fields.grouped.v1",
     "conditional-input-requirements.v1",
     "conditional-input-requirements.all-of.v1",
+    "input-value-format.nonnegative-integer.v1",
     "render.numbering-snapshot.v1"
   ]
 }

--- a/src/core/field-selector/input-schema.ts
+++ b/src/core/field-selector/input-schema.ts
@@ -11,6 +11,7 @@ import { resolveFieldSelectorDir } from '../../utils/paths.js';
 import { assertConditionalInputOwnership } from '../conditional-inputs.js';
 import { typedFieldDefault } from '../field-defaults.js';
 import { conditionalPredicates } from '../conditional-predicates.js';
+import { INPUT_VALUE_FORMATS } from '../input-value-formats.js';
 
 export const FIELD_SELECTOR_INPUT_SCHEMA_VERSION = 1 as const;
 export const FIELD_SELECTOR_SCHEMA_GENERATOR = 'open-agreements field-selector schema' as const;
@@ -50,6 +51,7 @@ const PERCENTAGE_DESCRIPTION = /\bpercentage\b/i;
  */
 export function fieldValuePattern(field: FieldDefinition): string | undefined {
   if (field.type !== 'string') return undefined;
+  if (field.value_format) return INPUT_VALUE_FORMATS[field.value_format].pattern;
   if (SERIES_DESIGNATION_FIELD.test(field.name)) {
     // A designation is one token (A, B, C, Seed, A-1), never "Series A
     // Preferred Stock". Empty remains valid for conditional/optional fields.
@@ -74,7 +76,7 @@ function assertValueShapes(
     const fieldPath = path ? `${path}.${field.name}` : field.name;
     const pattern = fieldValuePattern(field);
     if (pattern && (typeof value !== 'string' || !new RegExp(pattern).test(value))) {
-      const expectation = SERIES_DESIGNATION_FIELD.test(field.name)
+      const expectation = field.value_format ? INPUT_VALUE_FORMATS[field.value_format].expectation : SERIES_DESIGNATION_FIELD.test(field.name)
         ? 'a designation token such as A, B, or C (not a rendered stock name)'
         : 'a number-only percentage from 0 through 100 without a percent sign';
       throw new Error(`Invalid field-selector input at "${fieldPath}": expected ${expectation}`);

--- a/src/core/input-value-formats.test.ts
+++ b/src/core/input-value-formats.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect } from 'vitest';
+import Ajv2020 from 'ajv/dist/2020.js';
+import { itAllure } from '../../integration-tests/helpers/allure-test.js';
+import { FieldSelectorMetadataSchema } from './metadata.js';
+import { assertConditionalRequiredInputs } from './conditional-inputs.js';
+import { assertFieldSelectorInputValueShapes, buildFieldSelectorInputSchema } from './field-selector/input-schema.js';
+
+const it = itAllure.epic('Filling & Rendering');
+const fixture = {
+  name: 'Explicit integer format', source_url: 'https://example.com/form.docx', source_version: '1', license_note: 'Synthetic',
+  fields: [
+    {name: 'enabled', type: 'boolean', description: 'Enable'},
+    {name: 'arbitrary_name', type: 'string', description: 'Explicit format independent of its name', value_format: 'nonnegative_integer',
+      required_when: {field: 'enabled', equals: true}},
+  ],
+};
+
+describe('explicit nonnegative integer string format', () => {
+  it('shares a full-string ASCII grammar between runtime and schema, including newline edges', () => {
+    const metadata = FieldSelectorMetadataSchema.parse(fixture);
+    const ajv = new Ajv2020({strict: true}); ajv.addKeyword('x-openagreements');
+    const validate = ajv.compile(buildFieldSelectorInputSchema('fixture', metadata, null));
+    const cases: Array<[unknown, boolean]> = [
+      ['0', true], ['1', true], ['100', true], ['999999999999999999999999999999999999', true],
+      ['00', false], ['01', false], ['-1', false], ['+1', false], ['1.0', false], ['1e3', false],
+      ['1,000', false], [' 1', false], ['1 ', false], ['1\n', false], ['1\r\n', false], ['\n1', false],
+      ['1\u2028', false], ['1\u2029', false], ['1\u0000', false], ['١', false], ['１', false],
+      ['100 shares', false], [0, false], [1, false], [false, false], [null, false], [{}, false], [[], false],
+    ];
+    for (const [amount, valid] of cases) {
+      const values = {enabled: true, arbitrary_name: amount};
+      expect(validate(values), JSON.stringify(amount)).toBe(valid);
+      if (valid) expect(() => assertFieldSelectorInputValueShapes(values, metadata.fields)).not.toThrow();
+      else expect(() => assertFieldSelectorInputValueShapes(values, metadata.fields)).toThrow(/nonnegative integer string/);
+    }
+  });
+
+  it('allows absent/empty inactive values but requires explicit nonblank active values', () => {
+    const metadata = FieldSelectorMetadataSchema.parse(fixture);
+    const ajv = new Ajv2020({strict: false});
+    const validate = ajv.compile(buildFieldSelectorInputSchema('fixture', metadata, null));
+    for (const enabled of [false, true]) for (const amount of [undefined, '']) {
+      const values = {enabled, ...(amount === undefined ? {} : {arbitrary_name: amount})};
+      expect(validate(values)).toBe(!enabled);
+      expect(() => assertFieldSelectorInputValueShapes(values, metadata.fields)).not.toThrow();
+      if (enabled) expect(() => assertConditionalRequiredInputs(values, metadata.fields)).toThrow(/arbitrary_name/);
+      else expect(() => assertConditionalRequiredInputs(values, metadata.fields)).not.toThrow();
+    }
+    expect(() => assertConditionalRequiredInputs({enabled: true, arbitrary_name: ' \t\n'}, metadata.fields)).toThrow(/arbitrary_name/);
+  });
+
+  it('rejects unsupported formats/types/defaults without changing unformatted fields', () => {
+    for (const field of [
+      {name: 'x', type: 'string', description: 'X', value_format: 'arbitrary_regex'},
+      {name: 'x', type: 'number', description: 'X', value_format: 'nonnegative_integer'},
+      {name: 'x', type: 'string', description: 'X', value_format: 'nonnegative_integer', default: '-1'},
+      {name: 'x', type: 'string', description: 'X', value_format: 'nonnegative_integer', default: '1\n'},
+    ]) expect(FieldSelectorMetadataSchema.safeParse({...fixture, fields: [field]}).success).toBe(false);
+    for (const defaultValue of ['', '0', '123']) {
+      expect(FieldSelectorMetadataSchema.safeParse({...fixture, fields: [{
+        name: 'x', type: 'string', description: 'X', value_format: 'nonnegative_integer', default: defaultValue,
+      }]}).success).toBe(true);
+    }
+    const metadata = FieldSelectorMetadataSchema.parse({...fixture, fields: [{name: 'x', type: 'string', description: 'X'}]});
+    expect(() => assertFieldSelectorInputValueShapes({x: '-1 units'}, metadata.fields)).not.toThrow();
+  });
+});

--- a/src/core/input-value-formats.test.ts
+++ b/src/core/input-value-formats.test.ts
@@ -64,4 +64,20 @@ describe('explicit nonnegative integer string format', () => {
     const metadata = FieldSelectorMetadataSchema.parse({...fixture, fields: [{name: 'x', type: 'string', description: 'X'}]});
     expect(() => assertFieldSelectorInputValueShapes({x: '-1 units'}, metadata.fields)).not.toThrow();
   });
+
+  it('preserves runtime/schema parity for explicit formats in existing array item fields', () => {
+    const metadata = FieldSelectorMetadataSchema.parse({...fixture, fields: [{
+      name: 'rows', type: 'array', description: 'Rows', items: [{
+        name: 'count', type: 'string', description: 'Count', value_format: 'nonnegative_integer',
+      }],
+    }]});
+    const ajv = new Ajv2020({strict: false});
+    const validate = ajv.compile(buildFieldSelectorInputSchema('fixture', metadata, null));
+    const valid = {rows: [{count: '0'}, {count: '123'}]};
+    expect(validate(valid)).toBe(true);
+    expect(() => assertFieldSelectorInputValueShapes(valid, metadata.fields)).not.toThrow();
+    const invalid = {rows: [{count: '0'}, {count: '1\n'}]};
+    expect(validate(invalid)).toBe(false);
+    expect(() => assertFieldSelectorInputValueShapes(invalid, metadata.fields)).toThrow(/rows\[1\]\.count/);
+  });
 });

--- a/src/core/input-value-formats.ts
+++ b/src/core/input-value-formats.ts
@@ -1,0 +1,13 @@
+/** Explicit opt-in formats; do not infer these from legal field names. */
+export const INPUT_VALUE_FORMAT_IDS = ['nonnegative_integer'] as const;
+export type InputValueFormat = typeof INPUT_VALUE_FORMAT_IDS[number];
+
+export const INPUT_VALUE_FORMATS: Record<InputValueFormat, { pattern: string; expectation: string }> = {
+  nonnegative_integer: {
+    // Unlike `$`, the final negative lookahead cannot match before a trailing
+    // newline. Empty is allowed only for optional/inactive fields; required_when
+    // independently rejects missing or blank values for active conditions.
+    pattern: '^(?:|0|[1-9][0-9]*)(?![\\s\\S])',
+    expectation: 'a bare nonnegative integer string without signs, separators, whitespace, or units',
+  },
+};

--- a/src/core/input-value-formats.ts
+++ b/src/core/input-value-formats.ts
@@ -5,8 +5,9 @@ export type InputValueFormat = typeof INPUT_VALUE_FORMAT_IDS[number];
 export const INPUT_VALUE_FORMATS: Record<InputValueFormat, { pattern: string; expectation: string }> = {
   nonnegative_integer: {
     // Unlike `$`, the final negative lookahead cannot match before a trailing
-    // newline. Empty is allowed only for optional/inactive fields; required_when
-    // independently rejects missing or blank values for active conditions.
+    // newline. The format permits empty; required_when independently rejects
+    // missing or blank values for active conditions. Generic presence rules
+    // (including priority-field blank handling) are not changed here.
     pattern: '^(?:|0|[1-9][0-9]*)(?![\\s\\S])',
     expectation: 'a bare nonnegative integer string without signs, separators, whitespace, or units',
   },

--- a/src/core/metadata.ts
+++ b/src/core/metadata.ts
@@ -3,6 +3,7 @@ import { readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import yaml from 'js-yaml';
 import { conditionalPredicates, type ConditionalRequirement } from './conditional-predicates.js';
+import { INPUT_VALUE_FORMAT_IDS, INPUT_VALUE_FORMATS, type InputValueFormat } from './input-value-formats.js';
 
 const ConditionalPredicateSchema = z.object({
   field: z.string().min(1),
@@ -74,6 +75,8 @@ export interface FieldDefinition {
   items?: FieldDefinition[];
   /** Require an explicit, nonblank input when a top-level scalar field matches. */
   required_when?: ConditionalRequirement;
+  /** Explicit caller value shape; does not depend on field names or prose. */
+  value_format?: InputValueFormat;
   /**
    * Marks this boolean field as a *statutory compliance representation*: its
    * `true` value asserts a past real-world fact that is a statutory precondition
@@ -136,10 +139,19 @@ export const FieldDefinitionSchema: z.ZodType<FieldDefinition> = z.lazy(() =>
         .refine(condition => new Set(condition.all_of.map(predicate => predicate.field)).size === condition.all_of.length,
           'all_of must contain unique caller field predicates'),
     ]).optional(),
+    value_format: z.enum(INPUT_VALUE_FORMAT_IDS).optional(),
     statutory_compliance_representation: z.boolean().optional(),
     authority_url: z.string().optional(),
     confirm_note: z.string().optional(),
   }).superRefine((field, ctx) => {
+    if (field.value_format) {
+      if (field.type !== 'string') {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['value_format'], message: 'value_format requires a string field' });
+      }
+      if (field.default !== undefined && !new RegExp(INPUT_VALUE_FORMATS[field.value_format].pattern).test(field.default)) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['default'], message: 'Default does not match value_format' });
+      }
+    }
     if (
       (field.type === 'enum' || field.type === 'multiselect') &&
       (field.options === undefined || field.options.length === 0)

--- a/src/core/runtime-capabilities.ts
+++ b/src/core/runtime-capabilities.ts
@@ -23,6 +23,7 @@ export const RUNTIME_CAPABILITIES = Object.freeze({
     'reference-fields.grouped.v1',
     'conditional-input-requirements.v1',
     'conditional-input-requirements.all-of.v1',
+    'input-value-format.nonnegative-integer.v1',
     'render.numbering-snapshot.v1',
   ]),
 });


### PR DESCRIPTION
## Summary

Adds explicit string metadata `value_format: nonnegative_integer`, backed by one shared runtime/schema pattern and distribution capability. No field-name heuristic, arbitrary regex language, legal maximum, or economic default. Generic numeric-field validation remains separate (#813).

The full-string ASCII grammar accepts string `0` and bare positive integer strings without floating-point conversion. It rejects signs, leading zeros, decimals, scientific notation, commas, whitespace/final newlines, non-ASCII digits, units, and non-string values. The base format permits empty; active conditional requirements separately enforce nonblank values. Invalid metadata types/defaults reject at load time. Existing unformatted fields are unchanged.

Closes #815. Prerequisite for UseJunior/legal-explainer#2554; conjunction support already merged in #812. Canonical basket bindings and guarded-mirror inference remain in the separate LE repair.

## Verification

- Build/lint and eight focused runtime/schema/API/CLI tests pass, including final-newline, large-string-count, array-item path, invalid-default, and no-output-on-error cases.
- Independent dynamic root review passed; requested recursive-array regression and precise empty-value documentation are included.
- Actual hash-pinned IRA pipeline with the separately prepared canonical binding passed all six parent/child cases, eleven missing/invalid-count rejections before output, and explicit string-zero rendering. Source SHA256 `be8ad13f171a343bdb53716b1d318689ae3477cdf7f1986b2e3985e1cabbd08a` unchanged; warnings empty. Counts `100` and `0` are explicitly synthetic regression values, not transaction instructions. The existing fixture still lacks seventeen unrelated priority inputs and is not certified as a finished agreement. No licensed outputs committed.
- Full default-timeout suite queued for the coordinated CPU window; default CI required before merge.
