### PR TITLE
fix: add opt-in nonbreaking hyphen render font

### DIFF
--- a/docs/render-glyph-fallback.md
+++ b/docs/render-glyph-fallback.md
@@ -1,0 +1,57 @@
+# Optional nonbreaking-hyphen font in render copies
+
+Some LibreOffice/font combinations render U+2011 as a missing-glyph square.
+Changing `w:noBreakHyphen` to equivalent Unicode text alone does not reliably
+enable fallback. An optional, explicit font override isolates only that glyph
+in the disposable render copy:
+
+```sh
+open-agreements field-selector render-copy editable.docx -o preview.render.docx \
+  --nonbreaking-hyphen-font "Host Verified Font Family"
+```
+
+The API accepts a third options argument:
+`createNumberingRenderCopy(input, output, { nonbreakingHyphenFont: family })`.
+Capability: `render.nonbreaking-hyphen-font.v1`.
+
+Default behavior is unchanged. The original editable DOCX remains byte-identical.
+Only main-document `w:noBreakHyphen` tokens and U+2011 characters in text runs are
+isolated into glyph runs with the requested font. Other text and its font,
+formatting, bookmarks and field events are preserved. The hyphen remains U+2011,
+not an ordinary breakable ASCII hyphen. Glyphs in other stories, AlternateContent,
+textboxes, ruby or tracked-revision contexts are rejected before output creation.
+This is not a general font substitution or style-flattening facility.
+
+The returned JSON includes an optional receipt:
+
+```json
+{
+  "glyphFallback": {
+    "fontFamily": "Host Verified Font Family",
+    "codePoint": "U+2011",
+    "replacements": 2,
+    "parts": ["word/document.xml"]
+  }
+}
+```
+
+**The render host/controller must verify font availability and U+2011 coverage.**
+The core library deliberately does not discover, install, or select fonts, and
+the receipt is not an availability certificate. A sealed rendering workflow
+should record the resolved family, font file hash, renderer identity and coverage
+check, then bind those facts to the requested family and output receipt. Do not
+let a builder silently choose a substitute family. No machine-specific font
+belongs in canonical template metadata.
+
+Different glyph metrics can cause line/page reflow. Validate the actual PDF and
+nonbreaking behavior on the actual rendering host; do not claim pixel identity.
+No change to editable legal text or whole-document font family is implied.
+
+## Reproduction history
+
+On 2026-09-08, an unchanged pinned source and a synthetic Times New Roman control
+both displayed squares for the OOXML token and literal U+2011. The installed
+font lacked that code point. A host-verified supporting font on only the glyph
+fixed the visual output; a narrow-line test kept the compound word together
+while the ASCII-hyphen control broke. This corrected the initial hypothesis that
+token-to-Unicode materialization alone would resolve fallback.

--- a/integration-tests/render-glyph-font.test.ts
+++ b/integration-tests/render-glyph-font.test.ts
@@ -45,9 +45,9 @@ describe('render-copy glyph fallback API and CLI', () => {
     expect(() => createNumberingRenderCopy(f.input, f.output, { nonbreakingHyphenFont: 'Verified Serif' })).toThrow(/EEXIST/);
   });
 
-  it.each(['header1.xml', 'footer1.xml', 'footnotes.xml', 'endnotes.xml', 'comments.xml', 'custom-story.xml'])('rejects unsupported glyph story %s before output', name => {
+  it.each(['header1.xml', 'footer1.xml', 'footnotes.xml', 'endnotes.xml', 'comments.xml', 'custom-story.xml', 'glossary/document.xml'])('rejects unsupported glyph story %s before output', name => {
     const f = fixture();
-    const root = name.startsWith('header') || name === 'custom-story.xml' ? 'hdr' : name.startsWith('footer') ? 'ftr' : name.replace('.xml', '');
+    const root = name.startsWith('glossary') ? 'glossaryDocument' : name.startsWith('header') || name === 'custom-story.xml' ? 'hdr' : name.startsWith('footer') ? 'ftr' : name.replace('.xml', '');
     f.zip.addFile(`word/${name}`, Buffer.from(`<w:${root} xmlns:w="${W}"><w:p><w:r><w:t>Other‑story</w:t></w:r></w:p></w:${root}>`));
     f.zip.writeZip(f.input);
     expect(() => createNumberingRenderCopy(f.input, f.output, { nonbreakingHyphenFont: 'Verified Serif' })).toThrow(/nonbreaking hyphens.*unsupported/);
@@ -58,5 +58,15 @@ describe('render-copy glyph fallback API and CLI', () => {
     const f = fixture();
     expect(() => createNumberingRenderCopy(f.input, f.output, { nonbreakingHyphenFont: 'Bad\nFont' })).toThrow(/font must/);
     expect(existsSync(f.output)).toBe(false);
+  });
+
+  it('rejects deleted-text glyphs without accepting revisions or writing output', () => {
+    const f = fixture();
+    f.zip.updateFile('word/document.xml', Buffer.from(`<w:document xmlns:w="${W}"><w:body><w:p><w:del w:id="1"><w:r><w:delText>A‑B</w:delText></w:r></w:del></w:p></w:body></w:document>`));
+    f.zip.writeZip(f.input);
+    const before = readFileSync(f.input);
+    expect(() => createNumberingRenderCopy(f.input, f.output, { nonbreakingHyphenFont: 'Verified Serif' })).toThrow(/deleted text.*unsupported/);
+    expect(existsSync(f.output)).toBe(false);
+    expect(readFileSync(f.input)).toEqual(before);
   });
 });

--- a/integration-tests/render-glyph-font.test.ts
+++ b/integration-tests/render-glyph-font.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect } from 'vitest';
+import { itAllure } from './helpers/allure-test.js';
+import { mkdtempSync, readFileSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import AdmZip from 'adm-zip';
+import { DOMParser } from '@xmldom/xmldom';
+import { createNumberingRenderCopy } from '../src/core/field-selector/numbering-render-copy.js';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const it = itAllure.epic('Filling & Rendering');
+const dirs: string[] = [];
+afterEach(() => { for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true }); });
+function fixture() {
+  const dir = mkdtempSync(join(tmpdir(), 'glyph-font-')); dirs.push(dir);
+  const input = join(dir, 'original.docx'), output = join(dir, 'preview.render.docx');
+  const zip = new AdmZip();
+  zip.addFile('word/document.xml', Buffer.from(`<w:document xmlns:w="${W}"><w:body><w:p><w:bookmarkStart w:id="1" w:name="anchor"/><w:r><w:t>Alpha</w:t><w:noBreakHyphen/><w:t>Beta‑Gamma</w:t></w:r><w:bookmarkEnd w:id="1"/></w:p></w:body></w:document>`));
+  zip.addFile('word/styles.xml', Buffer.from(`<w:styles xmlns:w="${W}"/>`));
+  zip.writeZip(input);
+  return { dir, input, output, zip };
+}
+
+describe('render-copy glyph fallback API and CLI', () => {
+  it('leaves default behavior and original bytes unchanged without numbering', () => {
+    const f = fixture(), original = readFileSync(f.input);
+    const result = createNumberingRenderCopy(f.input, f.output);
+    expect(result).not.toHaveProperty('glyphFallback');
+    expect(new AdmZip(f.output).readAsText('word/document.xml')).toBe(f.zip.readAsText('word/document.xml'));
+    expect(readFileSync(f.input)).toEqual(original);
+  });
+
+  it('uses the public CLI option and emits a bound receipt without requiring a numbering part', () => {
+    const f = fixture(), original = readFileSync(f.input);
+    const receipt = JSON.parse(execFileSync(process.execPath, ['bin/open-agreements.js', 'field-selector', 'render-copy', f.input,
+      '-o', f.output, '--nonbreaking-hyphen-font', 'Verified Serif'], { encoding: 'utf8' }));
+    expect(receipt.glyphFallback).toEqual({ fontFamily: 'Verified Serif', codePoint: 'U+2011', replacements: 2, parts: ['word/document.xml'] });
+    const out = new AdmZip(f.output);
+    expect(out.readAsText('word/styles.xml')).toBe(f.zip.readAsText('word/styles.xml'));
+    const doc = new DOMParser().parseFromString(out.readAsText('word/document.xml'), 'text/xml');
+    expect(doc.getElementsByTagNameNS(W, 'noBreakHyphen')).toHaveLength(0);
+    expect(Array.from(doc.getElementsByTagNameNS(W, 't')).map(t => t.textContent).join('')).toBe('Alpha‑Beta‑Gamma');
+    expect(readFileSync(f.input)).toEqual(original);
+    expect(() => createNumberingRenderCopy(f.input, f.output, { nonbreakingHyphenFont: 'Verified Serif' })).toThrow(/EEXIST/);
+  });
+
+  it.each(['header1.xml', 'footer1.xml', 'footnotes.xml', 'endnotes.xml', 'comments.xml', 'custom-story.xml'])('rejects unsupported glyph story %s before output', name => {
+    const f = fixture();
+    const root = name.startsWith('header') || name === 'custom-story.xml' ? 'hdr' : name.startsWith('footer') ? 'ftr' : name.replace('.xml', '');
+    f.zip.addFile(`word/${name}`, Buffer.from(`<w:${root} xmlns:w="${W}"><w:p><w:r><w:t>Other‑story</w:t></w:r></w:p></w:${root}>`));
+    f.zip.writeZip(f.input);
+    expect(() => createNumberingRenderCopy(f.input, f.output, { nonbreakingHyphenFont: 'Verified Serif' })).toThrow(/nonbreaking hyphens.*unsupported/);
+    expect(existsSync(f.output)).toBe(false);
+  });
+
+  it('rejects bad font input before creating output', () => {
+    const f = fixture();
+    expect(() => createNumberingRenderCopy(f.input, f.output, { nonbreakingHyphenFont: 'Bad\nFont' })).toThrow(/font must/);
+    expect(existsSync(f.output)).toBe(false);
+  });
+});

--- a/runtime-capabilities.json
+++ b/runtime-capabilities.json
@@ -19,6 +19,7 @@
     "conditional-input-requirements.v1",
     "conditional-input-requirements.all-of.v1",
     "input-value-format.nonnegative-integer.v1",
-    "render.numbering-snapshot.v1"
+    "render.numbering-snapshot.v1",
+    "render.nonbreaking-hyphen-font.v1"
   ]
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -200,8 +200,9 @@ export function createProgram(): Command {
     .command('render-copy <input>')
     .description('Create a disposable numbering snapshot for PDF conversion; never replace the editable DOCX')
     .requiredOption('-o, --output <path>', 'New *.render.docx path (must not exist)')
-    .action((input: string, opts: { output: string }) => {
-      console.log(JSON.stringify(createNumberingRenderCopy(input, opts.output), null, 2));
+    .option('--nonbreaking-hyphen-font <family>', 'Host-verified font for U+2011 glyphs in the temporary main-story render copy')
+    .action((input: string, opts: { output: string; nonbreakingHyphenFont?: string }) => {
+      console.log(JSON.stringify(createNumberingRenderCopy(input, opts.output, { nonbreakingHyphenFont: opts.nonbreakingHyphenFont }), null, 2));
     });
 
   fieldSelectorCmd

--- a/src/core/field-selector/nonbreaking-hyphen-font.test.ts
+++ b/src/core/field-selector/nonbreaking-hyphen-font.test.ts
@@ -43,6 +43,7 @@ describe('opt-in nonbreaking-hyphen font isolation', () => {
     '<mc:AlternateContent><mc:Choice><w:p><w:r><w:noBreakHyphen/></w:r></w:p></mc:Choice></mc:AlternateContent>',
     '<w:txbxContent><w:p><w:r><w:t>A‑B</w:t></w:r></w:p></w:txbxContent>',
     '<w:p><w:ins><w:r><w:noBreakHyphen/></w:r></w:ins></w:p>',
+    '<w:p><w:del><w:r><w:delText>A‑B</w:delText></w:r></w:del></w:p>',
     '<w:p><w:r><w:rPr><w:rPrChange/></w:rPr><w:noBreakHyphen/></w:r></w:p>',
     '<w:p><w:noBreakHyphen/></w:p>',
   ])('fails unsupported glyph contexts atomically', content => {

--- a/src/core/field-selector/nonbreaking-hyphen-font.test.ts
+++ b/src/core/field-selector/nonbreaking-hyphen-font.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect } from 'vitest';
+import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
+import { itAllure } from '../../../integration-tests/helpers/allure-test.js';
+import { applyNonbreakingHyphenFont } from './nonbreaking-hyphen-font.js';
+
+const it = itAllure.epic('Filling & Rendering');
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const parse = (body: string) => new DOMParser().parseFromString(`<w:document xmlns:w="${W}" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"><w:body>${body}</w:body></w:document>`, 'text/xml');
+const xml = (node: Parameters<XMLSerializer['serializeToString']>[0]) => new XMLSerializer().serializeToString(node);
+
+describe('opt-in nonbreaking-hyphen font isolation', () => {
+  it('isolates token and literal glyphs while preserving text, run properties and semantic events', () => {
+    const doc = parse('<w:p><w:bookmarkStart w:id="9" w:name="Target"/><w:r w:rsidR="1234"><w:rPr><w:rStyle w:val="Emphasis"/><w:rFonts w:ascii="Original" w:asciiTheme="majorHAnsi"/><w:b/><w:lang w:val="en-US"/></w:rPr><w:t xml:space="preserve"> A </w:t><w:noBreakHyphen/><w:t> B‑ C‑D </w:t><w:commentReference w:id="4"/></w:r><w:bookmarkEnd w:id="9"/><w:r><w:fldChar w:fldCharType="begin"/><w:instrText> REF Target </w:instrText><w:fldChar w:fldCharType="end"/></w:r><w:r><w:t>Unrelated ASCII-hyphen</w:t></w:r></w:p>');
+    const before = Array.from(doc.getElementsByTagNameNS(W, 'r')).slice(1).map(xml);
+    expect(applyNonbreakingHyphenFont(doc, 'Example & "Serif"')).toEqual({ fontFamily: 'Example & "Serif"', codePoint: 'U+2011', replacements: 3, parts: ['word/document.xml'] });
+    const runs = Array.from(doc.getElementsByTagNameNS(W, 'r'));
+    expect(runs.slice(-2).map(xml)).toEqual(before);
+    expect(Array.from(doc.getElementsByTagNameNS(W, 't')).map(n => n.textContent).join('')).toBe(' A ‑ B‑ C‑D Unrelated ASCII-hyphen');
+    const glyphs = runs.filter(run => run.getElementsByTagNameNS(W, 't')[0]?.textContent === '‑');
+    expect(glyphs).toHaveLength(3);
+    for (const run of glyphs) {
+      expect(run.getAttributeNS(W, 'rsidR')).toBe('1234');
+      expect(run.getElementsByTagNameNS(W, 'b')).toHaveLength(1);
+      expect(run.getElementsByTagNameNS(W, 'lang')[0].getAttributeNS(W, 'val')).toBe('en-US');
+      const fonts = run.getElementsByTagNameNS(W, 'rFonts')[0];
+      expect(fonts.getAttributeNS(W, 'ascii')).toBe('Example & "Serif"');
+      expect(fonts.hasAttributeNS(W, 'asciiTheme')).toBe(false);
+    }
+    expect(doc.getElementsByTagNameNS(W, 'bookmarkStart')[0].getAttributeNS(W, 'id')).toBe('9');
+    expect(doc.getElementsByTagNameNS(W, 'bookmarkEnd')[0].getAttributeNS(W, 'id')).toBe('9');
+    expect(doc.getElementsByTagNameNS(W, 'commentReference')).toHaveLength(1);
+    expect(xml(doc)).toContain('&amp;');
+    expect(xml(doc)).toContain('&quot;');
+  });
+
+  it.each(['', ' ', ' Leading', 'Trailing ', 'Bad\nFont', 'Bad\u0000Font', 'Bad\u0085Font'])('rejects invalid font %j before mutation', font => {
+    const doc = parse('<w:p><w:r><w:noBreakHyphen/></w:r></w:p>'), before = xml(doc);
+    expect(() => applyNonbreakingHyphenFont(doc, font)).toThrow(/font must/);
+    expect(xml(doc)).toBe(before);
+  });
+
+  it.each([
+    '<mc:AlternateContent><mc:Choice><w:p><w:r><w:noBreakHyphen/></w:r></w:p></mc:Choice></mc:AlternateContent>',
+    '<w:txbxContent><w:p><w:r><w:t>A‑B</w:t></w:r></w:p></w:txbxContent>',
+    '<w:p><w:ins><w:r><w:noBreakHyphen/></w:r></w:ins></w:p>',
+    '<w:p><w:r><w:rPr><w:rPrChange/></w:rPr><w:noBreakHyphen/></w:r></w:p>',
+    '<w:p><w:noBreakHyphen/></w:p>',
+  ])('fails unsupported glyph contexts atomically', content => {
+    const doc = parse(`<w:p><w:r><w:noBreakHyphen/></w:r></w:p>${content}`), before = xml(doc);
+    expect(() => applyNonbreakingHyphenFont(doc, 'Verified Serif')).toThrow(/unsupported/);
+    expect(xml(doc)).toBe(before);
+  });
+});

--- a/src/core/field-selector/nonbreaking-hyphen-font.ts
+++ b/src/core/field-selector/nonbreaking-hyphen-font.ts
@@ -21,12 +21,15 @@ export function validateNonbreakingHyphenFont(family: string): void {
 
 export function hasNonbreakingHyphen(document: Document | Element): boolean {
   return document.getElementsByTagNameNS(W, 'noBreakHyphen').length > 0
-    || Array.from(document.getElementsByTagNameNS(W, 't')).some(text => text.textContent?.includes('\u2011'));
+    || ['t', 'delText'].some(name => Array.from(document.getElementsByTagNameNS(W, name)).some(text => text.textContent?.includes('\u2011')));
 }
 
 /** Only split affected main-story runs; never discover or substitute host fonts. */
 export function applyNonbreakingHyphenFont(document: Document, fontFamily: string): GlyphFallbackReceipt {
   validateNonbreakingHyphenFont(fontFamily);
+  if (Array.from(document.getElementsByTagNameNS(W, 'delText')).some(text => text.textContent?.includes('\u2011'))) {
+    throw new Error('render-copy: nonbreaking hyphens in deleted text are unsupported');
+  }
   const tokens = [
     ...Array.from(document.getElementsByTagNameNS(W, 'noBreakHyphen')),
     ...Array.from(document.getElementsByTagNameNS(W, 't')).filter(text => text.textContent?.includes('\u2011')),

--- a/src/core/field-selector/nonbreaking-hyphen-font.ts
+++ b/src/core/field-selector/nonbreaking-hyphen-font.ts
@@ -1,0 +1,95 @@
+import type { Document, Element, Node } from '@xmldom/xmldom';
+import { preserveXmlSpace } from './ooxml-parts.js';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const MC = 'http://schemas.openxmlformats.org/markup-compatibility/2006';
+const is = (node: Node, name: string): node is Element => node.nodeType === 1 && node.namespaceURI === W && node.localName === name;
+
+export interface GlyphFallbackReceipt {
+  fontFamily: string;
+  codePoint: 'U+2011';
+  replacements: number;
+  parts: string[];
+}
+
+export function validateNonbreakingHyphenFont(family: string): void {
+  if (typeof family !== 'string' || !family.trim() || family !== family.trim()
+    || Array.from(family).some(character => { const code = character.codePointAt(0)!; return code < 32 || (code >= 127 && code <= 159); })) {
+    throw new Error('render-copy: nonbreaking-hyphen font must be a nonblank family without surrounding whitespace or controls');
+  }
+}
+
+export function hasNonbreakingHyphen(document: Document | Element): boolean {
+  return document.getElementsByTagNameNS(W, 'noBreakHyphen').length > 0
+    || Array.from(document.getElementsByTagNameNS(W, 't')).some(text => text.textContent?.includes('\u2011'));
+}
+
+/** Only split affected main-story runs; never discover or substitute host fonts. */
+export function applyNonbreakingHyphenFont(document: Document, fontFamily: string): GlyphFallbackReceipt {
+  validateNonbreakingHyphenFont(fontFamily);
+  const tokens = [
+    ...Array.from(document.getElementsByTagNameNS(W, 'noBreakHyphen')),
+    ...Array.from(document.getElementsByTagNameNS(W, 't')).filter(text => text.textContent?.includes('\u2011')),
+  ];
+  const runs = new Set<Element>();
+  // Preflight the entire affected set before changing any nodes.
+  for (const token of tokens) {
+    const run = token.parentNode;
+    if (!run || !is(run, 'r')) throw new Error('render-copy: unsupported nonbreaking-hyphen run');
+    for (let ancestor: Node | null = run; ancestor; ancestor = ancestor.parentNode) {
+      if ((ancestor.namespaceURI === MC && ancestor.localName === 'AlternateContent')
+        || (ancestor.namespaceURI === W && ['txbxContent', 'del', 'ins', 'moveFrom', 'moveTo', 'ruby'].includes(ancestor.localName ?? ''))) {
+        throw new Error('render-copy: nonbreaking hyphens in alternate, revision, ruby or textbox stories are unsupported');
+      }
+    }
+    if (run.getElementsByTagNameNS(W, 'rPrChange').length) throw new Error('render-copy: revised glyph run properties are unsupported');
+    if (Array.from(run.childNodes).filter(node => is(node, 'rPr')).length > 1) throw new Error('render-copy: duplicate glyph run properties');
+    runs.add(run);
+  }
+  let replacements = 0;
+  for (const run of runs) {
+    const properties = Array.from(run.childNodes).find(node => is(node, 'rPr')) as Element | undefined;
+    const fresh = (): Element => {
+      const result = run.cloneNode(false) as Element;
+      if (properties) result.appendChild(properties.cloneNode(true));
+      return result;
+    };
+    const segments: Element[] = [];
+    let ordinary = fresh();
+    const flush = (): void => {
+      if (Array.from(ordinary.childNodes).some(node => !is(node, 'rPr'))) segments.push(ordinary);
+      ordinary = fresh();
+    };
+    const glyph = (): void => {
+      flush();
+      const result = fresh();
+      let rPr = Array.from(result.childNodes).find(node => is(node, 'rPr')) as Element | undefined;
+      if (!rPr) { rPr = document.createElementNS(W, 'w:rPr'); result.insertBefore(rPr, result.firstChild); }
+      for (const fonts of Array.from(rPr.childNodes).filter(node => is(node, 'rFonts'))) rPr.removeChild(fonts);
+      const fonts = document.createElementNS(W, 'w:rFonts');
+      for (const script of ['ascii', 'hAnsi', 'eastAsia', 'cs']) fonts.setAttributeNS(W, `w:${script}`, fontFamily);
+      const afterStyle = Array.from(rPr.childNodes).find(node => !is(node, 'rStyle'));
+      rPr.insertBefore(fonts, afterStyle ?? null);
+      const text = document.createElementNS(W, 'w:t'); text.appendChild(document.createTextNode('\u2011'));
+      result.appendChild(text); segments.push(result); replacements++;
+    };
+    for (const item of Array.from(run.childNodes)) {
+      if (is(item, 'rPr')) continue;
+      if (is(item, 'noBreakHyphen')) { glyph(); continue; }
+      if (is(item, 't') && item.textContent?.includes('\u2011')) {
+        const pieces = item.textContent.split('\u2011');
+        pieces.forEach((piece, index) => {
+          if (index) glyph();
+          if (piece) {
+            const text = item.cloneNode(false) as Element;
+            preserveXmlSpace(text); text.appendChild(document.createTextNode(piece)); ordinary.appendChild(text);
+          }
+        });
+      } else ordinary.appendChild(item.cloneNode(true));
+    }
+    flush();
+    for (const segment of segments) run.parentNode!.insertBefore(segment, run);
+    run.parentNode!.removeChild(run);
+  }
+  return { fontFamily, codePoint: 'U+2011', replacements, parts: replacements ? ['word/document.xml'] : [] };
+}

--- a/src/core/field-selector/numbering-render-copy.ts
+++ b/src/core/field-selector/numbering-render-copy.ts
@@ -6,6 +6,8 @@ import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
 import type { Element as XmlElement } from '@xmldom/xmldom';
 import { resolveNumberingSnapshots } from './numbering-counters.js';
 import { materializeNumberingReferences } from './numbering-render-references.js';
+import { applyNonbreakingHyphenFont, hasNonbreakingHyphen, validateNonbreakingHyphenFont, type GlyphFallbackReceipt } from './nonbreaking-hyphen-font.js';
+import { enumerateTextParts, getAllTextPartNames } from './ooxml-parts.js';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const MC = 'http://schemas.openxmlformats.org/markup-compatibility/2006';
@@ -18,7 +20,10 @@ export interface NumberingRenderCopyResult {
   outputPath: string;
   paragraphs: number;
   references: number;
+  glyphFallback?: GlyphFallbackReceipt;
 }
+
+export interface NumberingRenderCopyOptions { nonbreakingHyphenFont?: string }
 
 function direct(parent: XmlElement, local: string): XmlElement | undefined {
   return Array.from(parent.childNodes).find((node) => node.nodeType === 1
@@ -31,7 +36,8 @@ function direct(parent: XmlElement, local: string): XmlElement | undefined {
  * shared numIds. Snapshot each effective counter tuple only in this copy; the
  * original DOCX retains its automatic numbering and exact original bytes.
  */
-export function createNumberingRenderCopy(inputPath: string, outputPath: string): NumberingRenderCopyResult {
+export function createNumberingRenderCopy(inputPath: string, outputPath: string, options: NumberingRenderCopyOptions = {}): NumberingRenderCopyResult {
+  if (options.nonbreakingHyphenFont !== undefined) validateNonbreakingHyphenFont(options.nonbreakingHyphenFont);
   const input = realpathSync(inputPath);
   const output = resolve(outputPath);
   if (input === output || !output.endsWith('.render.docx') || input.endsWith('.render.docx')) {
@@ -48,6 +54,13 @@ export function createNumberingRenderCopy(inputPath: string, outputPath: string)
     if (level !== 'warning') throw new Error(`render-copy: ${message}`);
   } });
   const document = parser.parseFromString(documentEntry.getData().toString('utf8'), 'text/xml');
+  if (options.nonbreakingHyphenFont !== undefined) {
+    for (const name of getAllTextPartNames(enumerateTextParts(zip)).filter(name => name !== 'word/document.xml')) {
+      if (hasNonbreakingHyphen(parser.parseFromString(zip.readAsText(name), 'text/xml'))) {
+        throw new Error(`render-copy: nonbreaking hyphens in ${name} are unsupported`);
+      }
+    }
+  }
   const numbering = parser.parseFromString(numberingEntry?.getData().toString('utf8') ?? `<w:numbering xmlns:w="${W}"/>`, 'text/xml');
   const stylesEntry = zip.getEntry('word/styles.xml');
   const styles = stylesEntry ? parser.parseFromString(stylesEntry.getData().toString('utf8'), 'text/xml') : undefined;
@@ -82,6 +95,9 @@ export function createNumberingRenderCopy(inputPath: string, outputPath: string)
     const story = parser.parseFromString(entry.getData().toString('utf8'), 'text/xml');
     const root = story.documentElement;
     if (!root || root.namespaceURI !== W || !['hdr', 'ftr', 'footnotes', 'endnotes', 'comments'].includes(root.localName ?? '')) continue;
+    if (options.nonbreakingHyphenFont !== undefined && hasNonbreakingHyphen(story)) {
+      throw new Error(`render-copy: nonbreaking hyphens in ${entry.entryName} are unsupported`);
+    }
     const instruction = Array.from(story.getElementsByTagNameNS(W, 'p')).map((paragraph) =>
       Array.from(paragraph.getElementsByTagNameNS(W, 'instrText')).map((node) => node.textContent ?? '').join('')).join('\n')
       + '\n' + Array.from(story.getElementsByTagNameNS(W, 'fldSimple')).map((node) => node.getAttributeNS(W, 'instr') ?? '').join('\n');
@@ -90,6 +106,8 @@ export function createNumberingRenderCopy(inputPath: string, outputPath: string)
     }
   }
   const references = materializeNumberingReferences(document, snapshots, styles);
+  const glyphFallback = options.nonbreakingHyphenFont === undefined ? undefined
+    : applyNonbreakingHyphenFont(document, options.nonbreakingHyphenFont);
   let abstractId = Math.max(0, ...Array.from(numbering.getElementsByTagNameNS(W, 'abstractNum'))
     .map((node) => Number(node.getAttributeNS(W, 'abstractNumId'))));
   let numId = Math.max(0, ...Array.from(numbering.getElementsByTagNameNS(W, 'num'))
@@ -157,13 +175,16 @@ export function createNumberingRenderCopy(inputPath: string, outputPath: string)
     paragraphs += 1;
   }
   const serializer = new XMLSerializer();
-  if (numberingEntry) {
+  if (numberingEntry || glyphFallback?.replacements) {
     zip.updateFile('word/document.xml', Buffer.from(serializer.serializeToString(document)));
+  }
+  if (numberingEntry) {
     zip.updateFile('word/numbering.xml', Buffer.from(serializer.serializeToString(numbering)));
   }
   if (hash(readFileSync(input)) !== inputSha256) throw new Error('render-copy: input changed during preparation');
   const bytes = zip.toBuffer();
   // Exclusive creation also rejects symlink/hardlink aliases and stale copies.
   writeFileSync(output, bytes, { flag: 'wx' });
-  return { renderOnly: true, inputSha256, outputSha256: hash(bytes), outputPath: output, paragraphs, references };
+  return { renderOnly: true, inputSha256, outputSha256: hash(bytes), outputPath: output, paragraphs, references,
+    ...(glyphFallback ? { glyphFallback } : {}) };
 }

--- a/src/core/field-selector/numbering-render-copy.ts
+++ b/src/core/field-selector/numbering-render-copy.ts
@@ -94,10 +94,10 @@ export function createNumberingRenderCopy(inputPath: string, outputPath: string,
       || ['word/document.xml', 'word/numbering.xml', 'word/styles.xml'].includes(entry.entryName)) continue;
     const story = parser.parseFromString(entry.getData().toString('utf8'), 'text/xml');
     const root = story.documentElement;
-    if (!root || root.namespaceURI !== W || !['hdr', 'ftr', 'footnotes', 'endnotes', 'comments'].includes(root.localName ?? '')) continue;
     if (options.nonbreakingHyphenFont !== undefined && hasNonbreakingHyphen(story)) {
       throw new Error(`render-copy: nonbreaking hyphens in ${entry.entryName} are unsupported`);
     }
+    if (!root || root.namespaceURI !== W || !['hdr', 'ftr', 'footnotes', 'endnotes', 'comments'].includes(root.localName ?? '')) continue;
     const instruction = Array.from(story.getElementsByTagNameNS(W, 'p')).map((paragraph) =>
       Array.from(paragraph.getElementsByTagNameNS(W, 'instrText')).map((node) => node.textContent ?? '').join('')).join('\n')
       + '\n' + Array.from(story.getElementsByTagNameNS(W, 'fldSimple')).map((node) => node.getAttributeNS(W, 'instr') ?? '').join('\n');

--- a/src/core/runtime-capabilities.ts
+++ b/src/core/runtime-capabilities.ts
@@ -25,5 +25,6 @@ export const RUNTIME_CAPABILITIES = Object.freeze({
     'conditional-input-requirements.all-of.v1',
     'input-value-format.nonnegative-integer.v1',
     'render.numbering-snapshot.v1',
+    'render.nonbreaking-hyphen-font.v1',
   ]),
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 // Public API exports
 export { RUNTIME_CAPABILITIES } from './core/runtime-capabilities.js';
-export { createNumberingRenderCopy, type NumberingRenderCopyResult } from './core/field-selector/numbering-render-copy.js';
+export { createNumberingRenderCopy, type NumberingRenderCopyResult, type NumberingRenderCopyOptions } from './core/field-selector/numbering-render-copy.js';
 
 // Template engine
 export { fillTemplate, type FillOptions, type FillResult } from './core/engine.js';


### PR DESCRIPTION
## Summary

Closes #817.

Add an explicit, opt-in `--nonbreaking-hyphen-font` option to `field-selector render-copy` and the matching API option. The default remains unchanged. Only U+2011 glyphs in affected main-story runs receive the requested font in the temporary copy; editable input bytes remain unchanged.

- Preserve other run properties, surrounding text, bookmark/field events and unrelated package parts.
- Reject affected unsupported stories, alternate branches, textboxes and revision contexts before creating output.
- Emit the selected family, U+2011 code point, count and affected parts in an optional `glyphFallback` receipt.
- Advertise `render.nonbreaking-hyphen-font.v1`; document controller-owned font availability/coverage validation and possible metric reflow. No automatic font discovery, installation, hardcoded family or whole-document substitution.

## Evidence

An unchanged pinned source and synthetic Times New Roman control both reproduced missing-glyph squares. Replacing only OOXML tokens with literal U+2011 did not fix them. Isolating only those glyphs with a verified available font did fix the real output; a narrow-line control proved the nonbreaking compound stayed together while ASCII hyphen permitted a break.

- Build, lint, catalog, documentation and Allure-label checks pass.
- 41 focused unit/API/CLI/render-copy tests pass. Independent review also passes, including its deleted-text fail-closed probe and actual visual evidence.
- Actual CLI run on a fresh local pinned-source SPA fill: 188 numbered paragraphs, 46 references, seven glyph replacements. Its output bytes exactly match the scratch copy already rendered and visually inspected; original editable hash remains unchanged.
- Normalized text and bookmark/field event sequence are preserved; 30 unrelated package parts remain byte-identical in the isolated glyph probe.
- No licensed source documents, filled outputs, images or private values are committed or uploaded. Real fixture remains partial; this is not a finished-document or pixel-identical-layout claim.

Full local suite: **1,687 passed / 7 skipped**, 197.24 seconds, one worker with normal test timeouts. Standard CI and advisory verdict audit remain merge gates.
