### PR TITLE
Preserve boundary formatting in atomic field replacement

### DIFF
--- a/src/core/field-selector/patcher.test.ts
+++ b/src/core/field-selector/patcher.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect } from 'vitest';
 import { itAllure } from '../../../integration-tests/helpers/allure-test.js';
 import { join } from 'node:path';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import AdmZip from 'adm-zip';
 import { DOMParser } from '@xmldom/xmldom';
@@ -638,6 +638,33 @@ describe('patchDocument — formatting preservation (docx-core)', () => {
 });
 
 describe('patchDocument — atomic complex-field range deletion', () => {
+  it('preserves boundary formatting and semantic events around atomic replacement', async () => {
+    const xml = `<w:document xmlns:w="${W_NS}"><w:body><w:p>` +
+      '<w:r w:rsidR="00112233"><w:rPr><w:b/><w:u w:val="single"/></w:rPr><w:t>Before [Section </w:t></w:r>' +
+      '<w:bookmarkStart w:id="9" w:name="target"/>' +
+      field('target', '3') +
+      '<w:r><w:commentReference w:id="4"/></w:r>' +
+      '<w:bookmarkEnd w:id="9"/>' +
+      '<w:r w:rsidR="00445566"><w:rPr><w:i/><w:u w:val="none"/></w:rPr><w:t>] After</w:t><w:br/></w:r>' +
+      '</w:p></w:body></w:document>';
+    const input = buildMinimalDocx(xml), output = input.replace('test.docx', 'output.docx');
+    const sourceBytes = readFileSync(input);
+    await patchDocument(input, output, {'[Section 3]': 'Replacement'}, {replacementColor: 'FF0000'});
+    expect(readFileSync(input)).toEqual(sourceBytes);
+    const doc = new DOMParser().parseFromString(outputXml(output), 'text/xml');
+    const runs = Array.from(doc.getElementsByTagNameNS(W_NS, 'r'));
+    const textRun = (text: string) => runs.find(r => Array.from(r.getElementsByTagNameNS(W_NS, 't')).map(t => t.textContent).join('') === text)!;
+    expect(extractText(output)).toBe('Before Replacement After');
+    expect(textRun('Before ').getElementsByTagNameNS(W_NS, 'b').length).toBe(1);
+    expect(textRun('Before ').getElementsByTagNameNS(W_NS, 'color').length).toBe(0);
+    expect(textRun(' After').getElementsByTagNameNS(W_NS, 'i').length).toBe(1);
+    expect(textRun(' After').getElementsByTagNameNS(W_NS, 'u')[0].getAttribute('w:val')).toBe('none');
+    expect(textRun(' After').getAttribute('w:rsidR')).toBe('00445566');
+    expect(textRun('Replacement').getElementsByTagNameNS(W_NS, 'color')[0].getAttribute('w:val')).toBe('FF0000');
+    expect(doc.getElementsByTagNameNS(W_NS, 'fldChar').length).toBe(0);
+    const events = Array.from(doc.getElementsByTagNameNS(W_NS, '*')).filter(e => ['bookmarkStart', 'bookmarkEnd', 'commentReference', 'br'].includes(e.localName!)).map(e => e.localName);
+    expect(events).toEqual(['bookmarkStart', 'commentReference', 'bookmarkEnd', 'br']);
+  });
   function field(bookmark: string, result: string): string {
     return (
       '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
@@ -647,6 +674,32 @@ describe('patchDocument — atomic complex-field range deletion', () => {
       '<w:r><w:fldChar w:fldCharType="end"/></w:r>'
     );
   }
+
+  it('keeps a suffix inside its original hyperlink and preserves an outside field', async () => {
+    const xml = `<w:document xmlns:w="${W_NS}" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><w:body><w:p>` +
+      '<w:r><w:rPr><w:u w:val="single"/></w:rPr><w:t>[Section </w:t></w:r>' + field('inside', '2') +
+      '<w:hyperlink r:id="rId1"><w:r><w:rPr><w:i/></w:rPr><w:t>] Tail</w:t></w:r></w:hyperlink>' +
+      field('outside', '9') + '</w:p></w:body></w:document>';
+    const input = buildMinimalDocx(xml), output = input.replace('test.docx', 'output.docx');
+    await patchDocument(input, output, {'[Section 2]': ''});
+    const doc = new DOMParser().parseFromString(outputXml(output), 'text/xml');
+    const hyperlink = doc.getElementsByTagNameNS(W_NS, 'hyperlink')[0];
+    expect(hyperlink.getElementsByTagNameNS(W_NS, 't')[0].textContent).toBe(' Tail');
+    expect(hyperlink.getElementsByTagNameNS(W_NS, 'i').length).toBe(1);
+    expect(hyperlink.getElementsByTagNameNS(W_NS, 'u').length).toBe(0);
+    expect(doc.getElementsByTagNameNS(W_NS, 'instrText')[0].textContent).toContain('outside');
+    expect(doc.getElementsByTagNameNS(W_NS, 'fldChar').length).toBe(3);
+    expect(extractText(output)).toBe(' Tail9');
+  });
+
+  it('fails closed when prefix-run semantic placement cannot be preserved safely', async () => {
+    const xml = `<w:document xmlns:w="${W_NS}"><w:body><w:p>` +
+      '<w:r><w:t>Before [Section </w:t><w:commentReference w:id="5"/></w:r>' + field('inside', '2') +
+      '<w:r><w:t>] Tail</w:t></w:r></w:p></w:body></w:document>';
+    const input = buildMinimalDocx(xml), output = input.replace('test.docx', 'output.docx');
+    await expect(patchDocument(input, output, {'[Section 2]': 'Updated'})).rejects.toThrow('semantic children');
+    expect(existsSync(output)).toBe(false);
+  });
 
   function outputXml(path: string): string {
     return new AdmZip(path).getEntry('word/document.xml')!.getData().toString('utf-8');

--- a/src/core/field-selector/patcher.test.ts
+++ b/src/core/field-selector/patcher.test.ts
@@ -681,7 +681,7 @@ describe('patchDocument — atomic complex-field range deletion', () => {
       '<w:hyperlink r:id="rId1"><w:r><w:rPr><w:i/></w:rPr><w:t>] Tail</w:t></w:r></w:hyperlink>' +
       field('outside', '9') + '</w:p></w:body></w:document>';
     const input = buildMinimalDocx(xml), output = input.replace('test.docx', 'output.docx');
-    await patchDocument(input, output, {'[Section 2]': ''});
+    await patchDocument(input, output, {'[Section 2]': 'Replacement'});
     const doc = new DOMParser().parseFromString(outputXml(output), 'text/xml');
     const hyperlink = doc.getElementsByTagNameNS(W_NS, 'hyperlink')[0];
     expect(hyperlink.getElementsByTagNameNS(W_NS, 't')[0].textContent).toBe(' Tail');
@@ -689,7 +689,7 @@ describe('patchDocument — atomic complex-field range deletion', () => {
     expect(hyperlink.getElementsByTagNameNS(W_NS, 'u').length).toBe(0);
     expect(doc.getElementsByTagNameNS(W_NS, 'instrText')[0].textContent).toContain('outside');
     expect(doc.getElementsByTagNameNS(W_NS, 'fldChar').length).toBe(3);
-    expect(extractText(output)).toBe(' Tail9');
+    expect(extractText(output)).toBe('Replacement Tail9');
   });
 
   it('fails closed when prefix-run semantic placement cannot be preserved safely', async () => {

--- a/src/core/field-selector/patcher.ts
+++ b/src/core/field-selector/patcher.ts
@@ -497,10 +497,9 @@ function getComplexFieldRunRanges(runs: Element[]): ComplexFieldRunRange[] {
 
 /**
  * Replace an edit expanded across one or more complete field complexes.
- * Boundary text outside the requested character span is retained, while every
- * run in the expanded field-aware range is removed. A fresh ordinary text run
- * is inserted at the original range location, so no instruction/result
- * fragments can survive application field refresh.
+ * Keep boundary text in its original runs/containers and remove intersected
+ * field instructions/results. Only the replacement inherits the first matched
+ * run's formatting; untouched semantic children retain their document order.
  */
 function replaceExpandedAtomicRange(
   runs: Element[],
@@ -519,26 +518,60 @@ function replaceExpandedAtomicRange(
   const suffix = expandedEnd === lastEntry.runIndex
     ? lastText.slice(lastEntry.charOffset + 1)
     : '';
-  const replacementText = prefix + value + suffix;
+  if (firstEntry.runIndex === lastEntry.runIndex && prefix && suffix) {
+    throw new Error('Unsupported atomic field replacement: both boundary fragments share one run');
+  }
+  if (prefix && Array.from(runs[firstEntry.runIndex].childNodes).some(child =>
+    child.nodeType === 1 && !['rPr', 't'].includes((child as Element).localName ?? ''))) {
+    throw new Error('Unsupported atomic field replacement: semantic children share the prefix boundary run');
+  }
 
   const anchor = runs[expandedStart];
   const parent = anchor.parentNode;
   if (!parent) return;
   const doc = anchor.ownerDocument as Document;
-  if (replacementText !== '') {
+  if (value !== '') {
     const replacementRun = doc.createElementNS(W_NS, 'w:r');
     const sourceRPr = runs[firstEntry.runIndex].getElementsByTagNameNS(W_NS, 'rPr')[0];
     if (sourceRPr) replacementRun.appendChild(sourceRPr.cloneNode(true));
     const text = doc.createElementNS(W_NS, 'w:t');
     preserveXmlSpace(text);
-    text.textContent = replacementText;
+    text.textContent = value;
     replacementRun.appendChild(text);
     if (replacementColor) setRunColor(replacementRun, replacementColor);
-    parent.insertBefore(replacementRun, anchor);
+    if (prefix) {
+      const boundary = runs[firstEntry.runIndex];
+      boundary.parentNode!.insertBefore(replacementRun, boundary.nextSibling);
+    } else {
+      parent.insertBefore(replacementRun, anchor);
+    }
   }
 
   for (let i = expandedEnd; i >= expandedStart; i--) {
-    runs[i].parentNode?.removeChild(runs[i]);
+    const run = runs[i];
+    let offset = 0;
+    for (const child of Array.from(run.childNodes)) {
+      if (child.nodeType !== 1) continue;
+      const element = child as Element;
+      if (element.namespaceURI !== W_NS) continue;
+      if (element.localName === 't') {
+        const original = element.textContent ?? '';
+        const start = offset;
+        offset += original.length;
+        const keepPrefix = i === firstEntry.runIndex && prefix
+          ? original.slice(0, Math.max(0, firstEntry.charOffset - start)) : '';
+        const keepSuffix = i === lastEntry.runIndex && suffix
+          ? original.slice(Math.max(0, lastEntry.charOffset + 1 - start)) : '';
+        if (keepPrefix || keepSuffix) {
+          element.textContent = keepPrefix + keepSuffix;
+          preserveXmlSpace(element);
+        } else run.removeChild(element);
+      } else if (element.localName === 'fldChar' || element.localName === 'instrText') {
+        run.removeChild(element);
+      }
+    }
+    // Textless semantic children (references, breaks, drawings) are not empty runs.
+    if (getRunText(run) === '' && isRunSafeToRemove(run)) run.parentNode?.removeChild(run);
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #819. Preserve untouched prefix/suffix text in its original runs and containers when a replacement intersects complex Word fields. The replacement alone inherits the first matched run's formatting and optional replacement color. Field instruction/result fragments are still removed atomically; surviving semantic run children and paragraph bookmarks remain ordered.

Unsupported same-run dual boundaries or prefix-boundary semantic layouts reject rather than silently misorder content. No global formatting removal, canonical content change or renderer workaround.

## Verification

- Red regression: one new failure with 30 existing tests passing on baseline.
- Fixed focused suite: 33 passed, including distinct bold/italic/underline properties, source immutability, bookmark/comment/break ordering, hyperlink suffix containment, outside-field preservation and rejection without output.
- Full suite: 1,690 passed / seven skipped, 137 files passed, 145.63 seconds, one worker and normal timeouts. Build, lint and catalog validation pass.
- Independent read-only review: complete two-file diff, 33 focused tests and actual PDF inspected; no blocking finding.
- Pinned local source: one isolated replacement reproduces the original underline bleed; repaired result retains plain untouched suffix and unchanged source bytes.
- Joint canonical reference-fix candidate plus this runtime: two actual fills with zero warnings, followed by render-copy CLI and isolated LibreOffice PDF. Three pages visually checked; target/reference numbers agree and untouched suffix is plain. Partial fixture blanks disclosed; not a completed-agreement certification. Replacement phrase retains existing first-run formatting. Word unverified.

No licensed source, output, text excerpt or screenshot uploaded. Exact-merge smoke follows merge; runtime-only production deployment is not applicable.
