### PR TITLE
Apply declared caller defaults before computed prose

### DIFF
--- a/integration-tests/computed-metadata-defaults.test.ts
+++ b/integration-tests/computed-metadata-defaults.test.ts
@@ -42,6 +42,29 @@ function fixture(dateDefault = '2026-09-08', choicesDefault = '["one"]') {
     return { root, input };
 }
 describe('declared defaults before computed prose', () => {
+    it('preserves raw caller attribution for defaulted repeatable rows', async () => {
+        const { root, input } = fixture();
+        const dir = join(root, 'templates/synthetic/defaults-fixture');
+        const metadataPath = join(dir, 'metadata.yaml');
+        const metadata = JSON.parse(readFileSync(metadataPath, 'utf8'));
+        metadata.fields.push({ name: 'rows', type: 'array', description: 'Rows', default: '[]',
+            items: [{ name: 'label', type: 'string', description: 'Label' }] });
+        writeFileSync(metadataPath, JSON.stringify(metadata));
+        writeFileSync(join(dir, 'repeatable-tables.json'), JSON.stringify({ schema_version: 1, tables: [
+            { id: 'rows', rows_field: 'rows', header_cells: ['Labels'], columns: [{ field: 'label' }] },
+        ] }));
+        const zip = new AdmZip(input);
+        zip.updateFile('word/document.xml', Buffer.from(zip.readAsText('word/document.xml').replace('</w:body>',
+            '<w:tbl><w:tr><w:tc><w:p><w:r><w:t>Labels</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:body>')));
+        zip.writeZip(input);
+        for (const [name, values] of Object.entries({ omitted: {}, explicit: { rows: [{ label: 'Included row' }] } })) {
+            const outputPath = join(root, `${name}.docx`);
+            const result = await runFieldSelector({ fieldSelectorId: 'defaults-fixture', inputPath: input, outputPath, values });
+            expect(result.fieldsUsed).toContain('rows');
+            expect(result.providedFieldsUsed.includes('rows')).toBe(Object.hasOwn(values, 'rows'));
+            expect(extractAllText(outputPath).includes('Included row')).toBe(Object.hasOwn(values, 'rows'));
+        }
+    });
     it('renders omitted caller defaults exactly like explicit equivalents without seeding undeclared fields', async () => {
         const { root, input } = fixture(), before = readFileSync(input);
         for (const [name, values] of Object.entries({ omitted: {}, explicit: { mode: 'standard', days: '120', enabled: true, date: '2026-09-08' } })) {

--- a/integration-tests/computed-metadata-defaults.test.ts
+++ b/integration-tests/computed-metadata-defaults.test.ts
@@ -1,0 +1,101 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import AdmZip from 'adm-zip';
+import { afterEach, describe, expect, vi } from 'vitest';
+import { itAllure } from './helpers/allure-test.js';
+import { runFieldSelector, extractAllText } from '../src/core/field-selector/index.js';
+import { prepareFillData } from '../src/core/fill-pipeline.js';
+const it = itAllure.epic('Filling & Rendering');
+const roots: string[] = [];
+afterEach(() => { vi.unstubAllEnvs(); for (const root of roots.splice(0))
+    rmSync(root, { recursive: true, force: true }); });
+function fixture(dateDefault = '2026-09-08', choicesDefault = '["one"]') {
+    const root = mkdtempSync(join(tmpdir(), 'oa-computed-defaults-'));
+    roots.push(root);
+    const dir = join(root, 'templates/synthetic/defaults-fixture');
+    mkdirSync(dir, { recursive: true });
+    const fields = [
+        { name: 'mode', type: 'enum', options: ['standard', 'special'], default: 'standard' },
+        { name: 'days', type: 'string', default: '120' },
+        { name: 'enabled', type: 'boolean', default: 'true' },
+        { name: 'date', type: 'date', default: dateDefault },
+        { name: 'numeric_default', type: 'number', default: '0' },
+        { name: 'choices', type: 'multiselect', options: ['one', 'two'], default: choicesDefault },
+        { name: 'blank_default', type: 'string', default: '' },
+        { name: 'absent', type: 'string' },
+        { name: 'derived', type: 'string', default: 'metadata must not win' },
+        { name: 'profile_owned', type: 'string', default: 'metadata must not win' },
+    ].map(f => ({ ...f, description: f.name }));
+    writeFileSync(join(dir, 'metadata.yaml'), JSON.stringify({ name: 'Synthetic defaults fixture', artifact_type: 'field-selector', source_url: 'https://example.com/source.docx', source_version: '1', license_note: 'Synthetic', fields }));
+    writeFileSync(join(dir, 'computed.json'), JSON.stringify({ version: '1.0', defaults: { profile_owned: 'computed default' }, rules: [
+            { id: 'standard', when_all: [{ field: 'mode', op: 'eq', value: 'standard' }, { field: 'enabled', op: 'eq', value: true }], set_fill: { derived: 'Standard ${days} days on ${date}' } },
+            { id: 'special', when_all: [{ field: 'mode', op: 'eq', value: 'special' }], set_fill: { derived: 'Special ${days} days' } },
+        ] }));
+    writeFileSync(join(dir, 'replacements.json'), JSON.stringify({ '[Clause]': '{derived}', '[Profile]': '{profile_owned}', '[Days]': '{days}' }));
+    const zip = new AdmZip();
+    zip.addFile('[Content_Types].xml', Buffer.from('<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="xml" ContentType="application/xml"/><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>'));
+    zip.addFile('word/document.xml', Buffer.from('<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>[Clause]</w:t></w:r></w:p><w:p><w:r><w:t>[Profile]</w:t></w:r></w:p><w:p><w:r><w:t>[Days]</w:t></w:r></w:p></w:body></w:document>'));
+    const input = join(root, 'source.docx');
+    zip.writeZip(input);
+    vi.stubEnv('OPEN_AGREEMENTS_CONTENT_ROOTS', root);
+    return { root, input };
+}
+describe('declared defaults before computed prose', () => {
+    it('renders omitted caller defaults exactly like explicit equivalents without seeding undeclared fields', async () => {
+        const { root, input } = fixture(), before = readFileSync(input);
+        for (const [name, values] of Object.entries({ omitted: {}, explicit: { mode: 'standard', days: '120', enabled: true, date: '2026-09-08' } })) {
+            const outputPath = join(root, name + '.docx'), computedOutPath = join(root, name + '.json');
+            const result = await runFieldSelector({ fieldSelectorId: 'defaults-fixture', inputPath: input, outputPath, computedOutPath, values });
+            expect(result.providedFieldsUsed.includes('days')).toBe(Object.hasOwn(values, 'days'));
+            expect(result.providedFieldsUsed).toContain('derived');
+            expect(extractAllText(outputPath)).toBe('Standard 120 days on September 8, 2026\ncomputed default\n120');
+            const artifact = JSON.parse(readFileSync(computedOutPath, 'utf8'));
+            expect(artifact.inputs).not.toHaveProperty('absent');
+            expect(artifact.inputs.blank_default).toBe('');
+            expect(artifact.inputs.numeric_default).toBe('0');
+            expect(artifact.inputs.choices).toEqual(['one']);
+            expect(artifact.inputs).not.toHaveProperty('profile_owned');
+        }
+        expect(readFileSync(input)).toEqual(before);
+    });
+    it('honors explicit overrides and computed-rule precedence, including intentional blanks', async () => {
+        const { root, input } = fixture();
+        for (const [name, values, expected] of [
+            ['override', { mode: 'special', days: '45', derived: 'caller derived' }, 'Special 45 days'],
+            ['blank', { mode: 'special', days: '' }, 'Special days'],
+        ] as const) {
+            const outputPath = join(root, name + '.docx');
+            await runFieldSelector({ fieldSelectorId: 'defaults-fixture', inputPath: input, outputPath, values: { ...values } });
+            expect(extractAllText(outputPath).split('\n')[0]).toBe(expected);
+        }
+    });
+    it('preserves explicit false and blank dates without replacing them with defaults', async () => {
+        const { root, input } = fixture(), outputPath = join(root, 'false.docx'), computedOutPath = join(root, 'false.json');
+        await runFieldSelector({ fieldSelectorId: 'defaults-fixture', inputPath: input, outputPath, computedOutPath, values: { enabled: false, date: '', profile_owned: 'caller' } });
+        const trace = JSON.parse(readFileSync(computedOutPath, 'utf8'));
+        expect(trace.inputs.enabled).toBe(false);
+        expect(trace.inputs.date).toBe('');
+        expect(trace.final_fill_values.profile_owned).toBe('caller');
+        expect(extractAllText(outputPath)).not.toContain('Standard 120');
+    });
+    it('rejects an impossible declared date default before document output', async () => {
+        const { root, input } = fixture('2026-02-30'), outputPath = join(root, 'invalid.docx');
+        await expect(runFieldSelector({ fieldSelectorId: 'defaults-fixture', inputPath: input, outputPath, values: {} })).rejects.toThrow(/date|calendar/i);
+        expect(existsSync(outputPath)).toBe(false);
+    });
+    it('preserves direct empty-default semantics and metadata rejection of an empty multiselect default', async () => {
+        const { root, input } = fixture('2026-09-08', '');
+        const outputPath = join(root, 'multi.docx'), computedOutPath = join(root, 'multi.json');
+        expect(prepareFillData({ values: {}, fields: [{ name: 'choices', type: 'multiselect', description: 'Choices', options: ['one'], default: '' }] }).choices).toEqual([]);
+        await expect(runFieldSelector({ fieldSelectorId: 'defaults-fixture', inputPath: input, outputPath, computedOutPath, values: {} })).rejects.toThrow(/JSON-encoded array/);
+        expect(existsSync(outputPath)).toBe(false);
+    });
+    it('rejects a malformed multiselect default before output', async () => {
+        const { root, input } = fixture('2026-09-08', 'not json');
+        const outputPath = join(root, 'multi.docx');
+        expect(() => prepareFillData({ values: {}, fields: [{ name: 'choices', type: 'multiselect', description: 'Choices', options: ['one'], default: 'not json' }] })).toThrow(SyntaxError);
+        await expect(runFieldSelector({ fieldSelectorId: 'defaults-fixture', inputPath: input, outputPath, values: {} })).rejects.toThrow(/JSON-encoded array/);
+        expect(existsSync(outputPath)).toBe(false);
+    });
+});

--- a/src/core/field-defaults.test.ts
+++ b/src/core/field-defaults.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect } from 'vitest';
 import { itAllure } from '../../integration-tests/helpers/allure-test.js';
-import { typedFieldDefault } from './field-defaults.js';
+import { preparedFieldDefault, typedFieldDefault } from './field-defaults.js';
 import type { FieldDefinition } from './metadata.js';
 
 const it = itAllure.epic('Filling & Rendering');
@@ -16,5 +16,28 @@ describe('typed field defaults', () => {
     for (const [type, defaultValue, expected] of cases) {
       expect(typedFieldDefault({ name: 'choice', description: 'Choice', type, default: defaultValue })).toEqual(expected);
     }
+  });
+});
+
+describe('document preparation defaults', () => {
+  it('preserves fill-specific representations and explicit empty defaults', () => {
+    const cases: [FieldDefinition['type'], string | undefined, unknown][] = [
+      ['array', undefined, []], ['array', '[{"ignored":true}]', []],
+      ['multiselect', undefined, []], ['multiselect', '', []],
+      ['multiselect', '["one"]', ['one']],
+      ['boolean', 'true', true], ['boolean', 'false', false],
+      ['boolean', undefined, '_______'],
+      ['number', '0', '0'], ['number', '1.5', '1.5'],
+      ['string', undefined, '_______'], ['string', '', ''],
+      ['date', '2026-09-08', '2026-09-08'],
+    ];
+    for (const [type, defaultValue, expected] of cases) {
+      expect(preparedFieldDefault({ name: 'choice', description: 'Choice', type, default: defaultValue }, '_______')).toEqual(expected);
+    }
+    expect(preparedFieldDefault({ name: 'choice', description: 'Choice', type: 'string' })).toBe('');
+  });
+
+  it('throws on malformed multiselect defaults instead of using schema-parser fallback', () => {
+    expect(() => preparedFieldDefault({ name: 'choice', description: 'Choice', type: 'multiselect', default: 'invalid-json' })).toThrow(SyntaxError);
   });
 });

--- a/src/core/field-defaults.ts
+++ b/src/core/field-defaults.ts
@@ -13,3 +13,12 @@ export function typedFieldDefault(field: FieldDefinition): unknown {
   }
   return field.default;
 }
+
+/** Default representation used by document preparation, not schema export. */
+export function preparedFieldDefault(field: FieldDefinition, fallback: string = ''): unknown {
+  if (field.type === 'array') return [];
+  if (field.type === 'multiselect') return field.default ? JSON.parse(field.default) : [];
+  if (field.type === 'boolean' && field.default !== undefined) return typedFieldDefault(field);
+  // Number defaults intentionally remain strings, matching existing fills.
+  return field.default ?? fallback;
+}

--- a/src/core/field-selector/index.ts
+++ b/src/core/field-selector/index.ts
@@ -27,7 +27,7 @@ import { validateNumberingContinuationSource } from './numbering-continuations.j
 import { loadReferenceFieldsConfig } from './reference-fields.js';
 import { assertFieldSelectorInputValueShapes, computedFieldNames } from './input-schema.js';
 import { assertConditionalInputOwnership, assertConditionalRequiredInputs } from '../conditional-inputs.js';
-import { typedFieldDefault } from '../field-defaults.js';
+import { preparedFieldDefault } from '../field-defaults.js';
 
 function toComputedValueMap(values: Record<string, unknown>): ComputedValueMap {
   const computedValues: ComputedValueMap = {};
@@ -127,16 +127,7 @@ export async function runFieldSelector(options: FieldSelectorRunOptions): Promis
   const computedOwnedFields = computedFieldNames(computedProfile);
   for (const field of metadata.fields) {
     if (field.name in defaultedValues || field.default === undefined || computedOwnedFields.has(field.name)) continue;
-    // Match prepareFillData's representation, including string number defaults.
-    if (field.type === 'array') {
-      defaultedValues[field.name] = [];
-    } else if (field.type === 'multiselect') {
-      defaultedValues[field.name] = field.default ? JSON.parse(field.default) : [];
-    } else if (field.type === 'boolean') {
-      defaultedValues[field.name] = typedFieldDefault(field);
-    } else {
-      defaultedValues[field.name] = field.default;
-    }
+    defaultedValues[field.name] = preparedFieldDefault(field);
     materializedDefaultFields.add(field.name);
   }
   const inputValues = formatDocumentDateFields(defaultedValues, metadata.fields);

--- a/src/core/field-selector/index.ts
+++ b/src/core/field-selector/index.ts
@@ -27,6 +27,7 @@ import { validateNumberingContinuationSource } from './numbering-continuations.j
 import { loadReferenceFieldsConfig } from './reference-fields.js';
 import { assertFieldSelectorInputValueShapes, computedFieldNames } from './input-schema.js';
 import { assertConditionalInputOwnership, assertConditionalRequiredInputs } from '../conditional-inputs.js';
+import { typedFieldDefault } from '../field-defaults.js';
 
 function toComputedValueMap(values: Record<string, unknown>): ComputedValueMap {
   const computedValues: ComputedValueMap = {};
@@ -118,7 +119,27 @@ export async function runFieldSelector(options: FieldSelectorRunOptions): Promis
   // Computed prose may interpolate source date fields. Normalize declared date
   // values before computed evaluation so both direct tags and derived prose see
   // the same display-ready value (and chained computed fields inherit it).
-  const inputValues = formatDocumentDateFields(values, metadata.fields);
+  // Computed prose must see the same declared caller defaults as direct tags.
+  // Do not seed placeholders or computed-owned fields: their profile defaults
+  // and rules retain authority. Explicit values (including blanks) stay intact.
+  const defaultedValues = { ...values };
+  const materializedDefaultFields = new Set<string>();
+  const computedOwnedFields = computedFieldNames(computedProfile);
+  for (const field of metadata.fields) {
+    if (field.name in defaultedValues || field.default === undefined || computedOwnedFields.has(field.name)) continue;
+    // Match prepareFillData's representation, including string number defaults.
+    if (field.type === 'array') {
+      defaultedValues[field.name] = [];
+    } else if (field.type === 'multiselect') {
+      defaultedValues[field.name] = field.default ? JSON.parse(field.default) : [];
+    } else if (field.type === 'boolean') {
+      defaultedValues[field.name] = typedFieldDefault(field);
+    } else {
+      defaultedValues[field.name] = field.default;
+    }
+    materializedDefaultFields.add(field.name);
+  }
+  const inputValues = formatDocumentDateFields(defaultedValues, metadata.fields);
   const computedInputValues = toComputedValueMap(inputValues);
   const computedEvaluation = computedProfile
     ? evaluateComputedProfile(computedProfile, computedInputValues)
@@ -248,6 +269,10 @@ export async function runFieldSelector(options: FieldSelectorRunOptions): Promis
     keepIntermediate,
   });
 
+  // Preserve the existing caller attribution: newly materialized metadata
+  // defaults are effective inputs, not explicitly provided values. Computed
+  // outputs retain their historical attribution behavior.
+  const providedFieldsUsed = result.providedFieldsUsed.filter((field) => !materializedDefaultFields.has(field));
   return {
     outputPath: result.outputPath,
     metadata,
@@ -256,12 +281,12 @@ export async function runFieldSelector(options: FieldSelectorRunOptions): Promis
       : result.fieldsUsed,
     providedFieldsUsed: repeatableTablesConfig
       ? [...new Set([
-        ...result.providedFieldsUsed,
+        ...providedFieldsUsed,
         ...repeatableTablesConfig.tables
           .map((table) => table.rows_field)
-          .filter((field) => Object.hasOwn(inputValues, field)),
+          .filter((field) => Object.hasOwn(values, field)),
       ])]
-      : result.providedFieldsUsed,
+      : providedFieldsUsed,
     fillCommandCount: result.fillCommandCount,
     warnings: result.warnings,
     stages: result.stages!,

--- a/src/core/fill-pipeline.ts
+++ b/src/core/fill-pipeline.ts
@@ -21,7 +21,7 @@ import {
 } from './field-selector/ooxml-parts.js';
 import type { FieldDefinition } from './metadata.js';
 import { assertConditionalRequiredInputs } from './conditional-inputs.js';
-import { typedFieldDefault } from './field-defaults.js';
+import { preparedFieldDefault } from './field-defaults.js';
 
 const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 
@@ -222,18 +222,7 @@ export function prepareFillData(options: PrepareFillDataOptions): Record<string,
 
   for (const field of fields) {
     if (!(field.name in data)) {
-      if (field.type === 'array') {
-        data[field.name] = [];
-      } else if (field.type === 'multiselect') {
-        data[field.name] = field.default ? JSON.parse(field.default) : [];
-      } else if (field.type === 'boolean' && field.default !== undefined) {
-        // Metadata defaults already have a declared type. Preserve it even
-        // when coercion of caller-supplied strings is intentionally disabled;
-        // selection applicability requires the same typed values as schemas.
-        data[field.name] = typedFieldDefault(field);
-      } else {
-        data[field.name] = field.default ?? defaultValue;
-      }
+      data[field.name] = preparedFieldDefault(field, defaultValue);
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #823. Materialize declared caller-owned metadata defaults before date formatting and computed prose evaluation. Direct tags and derived clauses now receive equivalent default values.

- Preserve explicit caller values, including blank strings and false.
- Do not invent placeholders or defaults for undeclared fields.
- Preserve computed-owned profile defaults and rule precedence.
- Share the existing document-preparation default semantics in a small helper, including string number defaults and multiselect parsing/rejection behavior. Schema-default parsing is unchanged.
- Keep newly materialized defaults out of `providedFieldsUsed`; preserve historical computed-output attribution and raw caller presence for repeatable rows.

No canonical recipe changes, new scenario choices or global coercion changes.

## Verification

- Generic full-pipeline red baseline: omitted-default derived clause fails while explicit override/blank control passes.
- Latest focused suite: 21 passed. Seven full-pipeline/default-boundary tests, existing entry-point tests and preparation/schema helper tests.
- Independent review caught and resolved multiselect parser parity and caller-attribution gaps; final diff approved.
- Before the test-only coverage improvement and shared-helper consolidation, the full suite passed 1,772 tests / seven skipped in 207.44 seconds, one worker and normal timeouts. Latest build/lint pass; the refreshed full suite is queued and will be reported separately.
- Actual pinned-source three-case reproduction: baseline omitted defaults lose the obligation; repaired omitted defaults match explicit metadata equivalents. Explicit alternate election remains distinct. Source unchanged; zero warnings; partial fixture blanks disclosed.
- Three actual render-copy CLI outputs converted through isolated LibreOffice. Relevant PDF pages visually checked: omitted and explicit matching-default pages are byte-identical images; the explicit alternate election remains visibly distinct. Word unverified.

Important: a metadata default that conflicts with an express scenario instruction remains the wrong election. This repair does not excuse that caller error. No licensed source, output, text excerpt or screenshot uploaded. Runtime-only deployment is not applicable.

Review history: an initial 77.27% patch-coverage failure was addressed with a real repeatable-table attribution test (subsequent coverage 95.45%). The advisory changed from 13 PASS to 12 PASS / one code-reuse warning; the shared preparation helper addresses that warning. Fresh gates are required for the revised head; no override or paid review retry was used.
