### PR TITLE
fix(render): align source-declared style separators

### DIFF
--- a/docs/render-style-separator-spacing.md
+++ b/docs/render-style-separator-spacing.md
@@ -1,0 +1,69 @@
+# Source-declared style-separator spacing
+
+Capability: `render.style-separator-spacing.v1`. This is an **opt-in, render-only**
+correction for independently audited, source-pinned paragraph pairs. It does not
+modify the editable DOCX or automatically repair arbitrary style separators.
+
+Some LibreOffice imports raise the first continuation line beside a hidden
+heading with positive paragraph-before spacing. For the supported source shape,
+moving that spacing from the hidden heading to its continuation aligns the first
+body line. Vertical spacing and downstream pagination can change; original
+heading coordinates or pagination are not guaranteed. Wrapped headings can have other
+import defects that this correction does not repair. A fingerprint is not a font
+measurement or proof that a heading fits on one line.
+
+Canonical recipe authors declare the supported pairs in `metadata.yaml`:
+
+```yaml
+source_sha256: <unmodified-source-sha256>
+rendering:
+  style_separator_spacing:
+    boundaries:
+      - heading_para_id: AAAAAAAA
+        continuation_para_id: BBBBBBBB
+        before_twips: 240
+        expected_layout_sha256: <audited-source-local-layout-sha256>
+```
+
+The runtime exports `inspectStyleSeparatorSpacingSource` from its implementation
+module as an authoring aid for computing each layout fingerprint. Authors must
+first audit the source and actual rendered controls, including all declared pairs,
+page-top placement, line wrapping, nearby references and the other suite documents.
+Every declared pair is required; only declare mandatory pairs in this version.
+The declaration belongs upstream with the canonical source recipe, not in a
+benchmark-specific script. Consumers must require the capability when this
+metadata operation is present; an old parser can otherwise silently discard it.
+
+```sh
+open-agreements field-selector render-copy editable.docx -o preview.render.docx \
+  --style-separator-metadata canonical/metadata.yaml \
+  --style-separator-source pinned-source.docx
+```
+
+Both options are required together. The default remains unchanged. API callers
+pass `styleSeparatorSpacing: {sourcePath, sourceSha256, profile}` as a member of
+the third `createNumberingRenderCopy` argument. `profile` is the nested metadata
+declaration above. This can be combined with the host-verified glyph-font option.
+
+Before writing a new output, the runtime verifies the actual source hash, unique
+adjacent main-body paragraph IDs, the source-local fingerprint, and the same
+fingerprint in the editable input. It binds heading text/run properties,
+paragraph properties, the leading period's formatting, relevant paragraph and
+character-style chains, defaults, applicable page geometry and compatibility
+settings. Mutable body prose is deliberately not bound. Runtime-owned `numPr`,
+editing-session IDs and inert `xml:space` additions on text without edge whitespace
+are excluded. Meaningful edge whitespace remains bound.
+
+Supported pairs have an explicit hidden heading mark, positive direct twip-based
+before spacing, an initially zero-before continuation in the same style family,
+matching text metrics and a plain leading period (possibly sharing its prose run).
+Ambiguous styles, style toggles, revisions, explicit breaks, frame/section changes,
+automatic/line-unit spacing, missing pairs and fingerprint drift fail closed.
+No paragraphs, text, bookmark events, run formatting or numbering are moved.
+
+The optional `styleSeparatorSpacing` receipt records `sourceSha256`,
+`profileSha256`, `replacements` and `headingParaIds`. Controllers must seal the
+canonical metadata/source inputs, explicitly pass both options, bind the receipt
+to those inputs, and verify the actual PDF on the selected render host. Omitting
+the options does not apply the declaration. Do not deliver the temporary render
+copy as the editable agreement or claim Word/layout certification from this receipt.

--- a/runtime-capabilities.json
+++ b/runtime-capabilities.json
@@ -20,6 +20,7 @@
     "conditional-input-requirements.all-of.v1",
     "input-value-format.nonnegative-integer.v1",
     "render.numbering-snapshot.v1",
-    "render.nonbreaking-hyphen-font.v1"
+    "render.nonbreaking-hyphen-font.v1",
+    "render.style-separator-spacing.v1"
   ]
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -9,6 +9,8 @@ import { runTemplateShow } from '../commands/template.js';
 import { runFieldSelectorCommand, runFieldSelectorClean, runFieldSelectorPatch } from '../commands/field-selector.js';
 import { runFieldSelectorSchema } from '../commands/field-selector-schema.js';
 import { createNumberingRenderCopy } from '../core/field-selector/numbering-render-copy.js';
+import { FieldSelectorMetadataSchema } from '../core/metadata.js';
+import yaml from 'js-yaml';
 import { runScan } from '../commands/scan.js';
 import {
   runChecklistCreate,
@@ -201,8 +203,17 @@ export function createProgram(): Command {
     .description('Create a disposable numbering snapshot for PDF conversion; never replace the editable DOCX')
     .requiredOption('-o, --output <path>', 'New *.render.docx path (must not exist)')
     .option('--nonbreaking-hyphen-font <family>', 'Host-verified font for U+2011 glyphs in the temporary main-story render copy')
-    .action((input: string, opts: { output: string; nonbreakingHyphenFont?: string }) => {
-      console.log(JSON.stringify(createNumberingRenderCopy(input, opts.output, { nonbreakingHyphenFont: opts.nonbreakingHyphenFont }), null, 2));
+    .option('--style-separator-metadata <path>', 'Opt in to source-declared spacing corrections from canonical metadata.yaml')
+    .option('--style-separator-source <path>', 'Unmodified pinned source DOCX required with --style-separator-metadata')
+    .action((input: string, opts: { output: string; nonbreakingHyphenFont?: string; styleSeparatorMetadata?: string; styleSeparatorSource?: string }) => {
+      if (!!opts.styleSeparatorMetadata !== !!opts.styleSeparatorSource) throw new Error('Both style-separator metadata and source are required');
+      let styleSeparatorSpacing;
+      if (opts.styleSeparatorMetadata && opts.styleSeparatorSource) {
+        const metadata = FieldSelectorMetadataSchema.parse(yaml.load(readFileSync(opts.styleSeparatorMetadata, 'utf8')));
+        if (!metadata.rendering) throw new Error('Metadata has no style-separator spacing declaration');
+        styleSeparatorSpacing = { sourcePath: opts.styleSeparatorSource, sourceSha256: metadata.source_sha256!, profile: metadata.rendering.style_separator_spacing };
+      }
+      console.log(JSON.stringify(createNumberingRenderCopy(input, opts.output, { nonbreakingHyphenFont: opts.nonbreakingHyphenFont, styleSeparatorSpacing }), null, 2));
     });
 
   fieldSelectorCmd

--- a/src/core/field-selector/numbering-render-copy.ts
+++ b/src/core/field-selector/numbering-render-copy.ts
@@ -8,6 +8,7 @@ import { resolveNumberingSnapshots } from './numbering-counters.js';
 import { materializeNumberingReferences } from './numbering-render-references.js';
 import { applyNonbreakingHyphenFont, hasNonbreakingHyphen, validateNonbreakingHyphenFont, type GlyphFallbackReceipt } from './nonbreaking-hyphen-font.js';
 import { enumerateTextParts, getAllTextPartNames } from './ooxml-parts.js';
+import { applyStyleSeparatorSpacing, type StyleSeparatorSpacingOptions, type StyleSeparatorSpacingReceipt } from './style-separator-spacing.js';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const MC = 'http://schemas.openxmlformats.org/markup-compatibility/2006';
@@ -21,9 +22,13 @@ export interface NumberingRenderCopyResult {
   paragraphs: number;
   references: number;
   glyphFallback?: GlyphFallbackReceipt;
+  styleSeparatorSpacing?: StyleSeparatorSpacingReceipt;
 }
 
-export interface NumberingRenderCopyOptions { nonbreakingHyphenFont?: string }
+export interface NumberingRenderCopyOptions {
+  nonbreakingHyphenFont?: string;
+  styleSeparatorSpacing?: StyleSeparatorSpacingOptions;
+}
 
 function direct(parent: XmlElement, local: string): XmlElement | undefined {
   return Array.from(parent.childNodes).find((node) => node.nodeType === 1
@@ -64,6 +69,8 @@ export function createNumberingRenderCopy(inputPath: string, outputPath: string,
   const numbering = parser.parseFromString(numberingEntry?.getData().toString('utf8') ?? `<w:numbering xmlns:w="${W}"/>`, 'text/xml');
   const stylesEntry = zip.getEntry('word/styles.xml');
   const styles = stylesEntry ? parser.parseFromString(stylesEntry.getData().toString('utf8'), 'text/xml') : undefined;
+  const styleSeparatorSpacing = options.styleSeparatorSpacing === undefined ? undefined
+    : applyStyleSeparatorSpacing(zip, document, styles, options.styleSeparatorSpacing);
   const snapshots = resolveNumberingSnapshots(document, styles, numbering);
   // Choice and Fallback are mutually exclusive renderer branches. Walking both
   // would consume phantom counters or combine incompatible field instructions.
@@ -175,7 +182,7 @@ export function createNumberingRenderCopy(inputPath: string, outputPath: string,
     paragraphs += 1;
   }
   const serializer = new XMLSerializer();
-  if (numberingEntry || glyphFallback?.replacements) {
+  if (numberingEntry || glyphFallback?.replacements || styleSeparatorSpacing?.replacements) {
     zip.updateFile('word/document.xml', Buffer.from(serializer.serializeToString(document)));
   }
   if (numberingEntry) {
@@ -186,5 +193,5 @@ export function createNumberingRenderCopy(inputPath: string, outputPath: string,
   // Exclusive creation also rejects symlink/hardlink aliases and stale copies.
   writeFileSync(output, bytes, { flag: 'wx' });
   return { renderOnly: true, inputSha256, outputSha256: hash(bytes), outputPath: output, paragraphs, references,
-    ...(glyphFallback ? { glyphFallback } : {}) };
+    ...(glyphFallback ? { glyphFallback } : {}), ...(styleSeparatorSpacing ? { styleSeparatorSpacing } : {}) };
 }

--- a/src/core/field-selector/style-separator-spacing.test.ts
+++ b/src/core/field-selector/style-separator-spacing.test.ts
@@ -1,0 +1,141 @@
+import AdmZip from 'adm-zip';
+import { createHash } from 'node:crypto';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, vi } from 'vitest';
+import { itAllure } from '../../../integration-tests/helpers/allure-test.js';
+import { createNumberingRenderCopy } from './numbering-render-copy.js';
+import { inspectStyleSeparatorSpacingSource } from './style-separator-spacing.js';
+import { FieldSelectorMetadataSchema, StyleSeparatorSpacingProfileSchema } from '../metadata.js';
+import { createProgram } from '../../cli/index.js';
+
+const it = itAllure.epic('Filling & Rendering');
+const dirs: string[] = [];
+afterEach(() => { vi.restoreAllMocks(); for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true }); });
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const W14 = 'http://schemas.microsoft.com/office/word/2010/wordml';
+function fixture() {
+  const dir = mkdtempSync(join(tmpdir(), 'separator-spacing-')); dirs.push(dir);
+  const source = join(dir, 'source.docx'), input = join(dir, 'editable.docx'), output = join(dir, 'preview.render.docx');
+  const zip = new AdmZip();
+  zip.addFile('word/styles.xml', Buffer.from(`<w:styles xmlns:w="${W}"><w:docDefaults><w:rPrDefault><w:rPr><w:rFonts w:ascii="Times New Roman"/><w:sz w:val="22"/></w:rPr></w:rPrDefault></w:docDefaults><w:style w:type="paragraph" w:styleId="Title"><w:name w:val="Title"/></w:style><w:style w:type="paragraph" w:styleId="Continuation"><w:basedOn w:val="Title"/></w:style></w:styles>`));
+  zip.addFile('word/document.xml', Buffer.from(`<w:document xmlns:w="${W}" xmlns:w14="${W14}"><w:body><w:p w14:paraId="11111111"><w:pPr><w:pStyle w:val="Title"/><w:spacing w:before="240" w:after="0"/><w:rPr><w:vanish/><w:specVanish/></w:rPr></w:pPr><w:bookmarkStart w:id="1" w:name="Heading"/><w:r><w:rPr><w:u w:val="single"/></w:rPr><w:t>Short heading</w:t></w:r></w:p><w:p w14:paraId="22222222"><w:pPr><w:pStyle w:val="Continuation"/><w:keepNext w:val="0"/><w:rPr><w:specVanish/></w:rPr></w:pPr><w:r><w:t>.</w:t></w:r><w:bookmarkEnd w:id="1"/><w:r><w:t xml:space="preserve"> Body text may change.</w:t></w:r></w:p><w:sectPr><w:pgSz w:w="12240" w:h="15840"/><w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440"/></w:sectPr></w:body></w:document>`));
+  zip.writeZip(source); writeFileSync(input, readFileSync(source));
+  const boundary = { heading_para_id: '11111111', continuation_para_id: '22222222', before_twips: 240 };
+  const profile = { boundaries: [{ ...boundary, expected_layout_sha256: inspectStyleSeparatorSpacingSource(source, boundary) }] };
+  const options = { sourcePath: source, sourceSha256: createHash('sha256').update(readFileSync(source)).digest('hex'), profile };
+  return { dir, source, input, output, options };
+}
+function change(path: string, from: string, to: string, part = 'word/document.xml') {
+  const zip = new AdmZip(path); const xml = zip.readAsText(part);
+  expect(xml).toContain(from); zip.updateFile(part, Buffer.from(xml.replace(from, to))); zip.writeZip(path);
+}
+const documentXml = (path: string) => new AdmZip(path).readAsText('word/document.xml');
+
+describe('source-declared render-only style separator spacing', () => {
+  it('transfers only declared spacing, preserving text, run formatting, bookmarks, mark flags and editable bytes', () => {
+    const f = fixture(), original = readFileSync(f.input), before = documentXml(f.input);
+    const result = createNumberingRenderCopy(f.input, f.output, { styleSeparatorSpacing: f.options });
+    expect(readFileSync(f.input)).toEqual(original); expect(readFileSync(f.source)).toEqual(original);
+    expect(result.styleSeparatorSpacing).toEqual({ sourceSha256: f.options.sourceSha256, profileSha256: expect.stringMatching(/^[a-f0-9]{64}$/), replacements: 1, headingParaIds: ['11111111'] });
+    expect(documentXml(f.output)).toBe(before.replace('w:before="240"', 'w:before="0"').replace('<w:keepNext w:val="0"/><w:rPr>', '<w:keepNext w:val="0"/><w:spacing w:before="240"/><w:rPr>'));
+  });
+
+  it('is opt-in and permits dynamic body prose without weakening the heading/leading-period fingerprint', () => {
+    const f = fixture(); change(f.input, 'Body text may change.', 'Different filled body prose.');
+    const baseline = join(f.dir, 'unchanged.render.docx');
+    expect(createNumberingRenderCopy(f.input, baseline).styleSeparatorSpacing).toBeUndefined();
+    expect(documentXml(baseline)).toBe(documentXml(f.input));
+    createNumberingRenderCopy(f.input, f.output, { styleSeparatorSpacing: f.options });
+    expect(documentXml(f.output)).toContain('Different filled body prose.');
+  });
+
+  it('inserts spacing after numbering and before indentation and alignment properties', () => {
+    const f = fixture();
+    for (const path of [f.source, f.input]) change(path, '<w:keepNext w:val="0"/>', '<w:keepNext w:val="0"/><w:numPr><w:numId w:val="0"/></w:numPr><w:ind w:left="0"/><w:jc w:val="left"/>');
+    f.options.sourceSha256 = createHash('sha256').update(readFileSync(f.source)).digest('hex');
+    f.options.profile.boundaries[0].expected_layout_sha256 = inspectStyleSeparatorSpacingSource(f.source, f.options.profile.boundaries[0]);
+    createNumberingRenderCopy(f.input, f.output, { styleSeparatorSpacing: f.options });
+    expect(documentXml(f.output)).toContain('<w:numPr><w:numId w:val="0"/></w:numPr><w:spacing w:before="240"/><w:ind w:left="0"/><w:jc w:val="left"/>');
+  });
+
+  it('supports pinned character-style metrics and a period sharing a mutable prose run', () => {
+    const f = fixture();
+    for (const path of [f.source, f.input]) {
+      change(path, '</w:styles>', '<w:style w:type="character" w:styleId="TitleChar"><w:rPr><w:sz w:val="22"/></w:rPr></w:style></w:styles>', 'word/styles.xml');
+      change(path, '<w:u w:val="single"/>', '<w:rStyle w:val="TitleChar"/><w:u w:val="single"/>');
+      change(path, '<w:t>.</w:t>', '<w:t>. Original mutable prose.</w:t>');
+    }
+    f.options.sourceSha256 = createHash('sha256').update(readFileSync(f.source)).digest('hex');
+    f.options.profile.boundaries[0].expected_layout_sha256 = inspectStyleSeparatorSpacingSource(f.source, f.options.profile.boundaries[0]);
+    change(f.input, 'Original mutable prose.', 'Different filled prose.');
+    change(f.input, '<w:t>Short heading</w:t>', '<w:t xml:space="preserve">Short heading</w:t>');
+    createNumberingRenderCopy(f.input, f.output, { styleSeparatorSpacing: f.options });
+    expect(documentXml(f.output)).toContain('Different filled prose.');
+    expect(documentXml(f.output)).toContain('<w:rStyle w:val="TitleChar"/>');
+    change(f.input, 'w:styleId="TitleChar"><w:rPr>', 'w:styleId="TitleChar"><w:rPr><w:vanish/>', 'word/styles.xml');
+    const rejected = join(f.dir, 'hidden.render.docx');
+    expect(() => createNumberingRenderCopy(f.input, rejected, { styleSeparatorSpacing: f.options })).toThrow(/character style/);
+    expect(existsSync(rejected)).toBe(false);
+  });
+
+  it('does not discard meaningful edge-whitespace preservation or accept source-style drift', () => {
+    const f = fixture();
+    for (const path of [f.source, f.input]) change(path, '<w:t>Short heading</w:t>', '<w:t xml:space="preserve"> Short heading</w:t>');
+    f.options.sourceSha256 = createHash('sha256').update(readFileSync(f.source)).digest('hex');
+    f.options.profile.boundaries[0].expected_layout_sha256 = inspectStyleSeparatorSpacingSource(f.source, f.options.profile.boundaries[0]);
+    change(f.input, '<w:t xml:space="preserve"> Short heading</w:t>', '<w:t> Short heading</w:t>');
+    expect(() => createNumberingRenderCopy(f.input, f.output, { styleSeparatorSpacing: f.options })).toThrow(/input layout/);
+    expect(existsSync(f.output)).toBe(false);
+  });
+
+  for (const [name, from, to, part] of [
+    ['stale ID', '11111111', '33333333'],
+    ['changed heading / potential wrapping', 'Short heading', 'Much longer altered heading which may wrap'],
+    ['extra hyperlink heading text', '<w:bookmarkStart', '<w:hyperlink><w:r><w:t>Extra heading text</w:t></w:r></w:hyperlink><w:bookmarkStart'],
+    ['extra structured heading text', '<w:bookmarkStart', '<w:sdt><w:sdtContent><w:r><w:t>Extra heading text</w:t></w:r></w:sdtContent></w:sdt><w:bookmarkStart'],
+    ['extra hyperlink continuation prefix', '<w:r><w:t>.</w:t>', '<w:hyperlink><w:r><w:t>Extra prefix</w:t></w:r></w:hyperlink><w:r><w:t>.</w:t>'],
+    ['extra structured continuation prefix', '<w:r><w:t>.</w:t>', '<w:sdt><w:sdtContent><w:r><w:t>Extra prefix</w:t></w:r></w:sdtContent></w:sdt><w:r><w:t>.</w:t>'],
+    ['changed page geometry', 'w:w="12240"', 'w:w="6500"'],
+    ['changed run metrics', '<w:u w:val="single"/>', '<w:u w:val="single"/><w:sz w:val="30"/>'],
+    ['explicit heading break', '<w:t>Short heading</w:t>', '<w:t>Short</w:t><w:br/><w:t>heading</w:t>'],
+    ['paragraph revision', '<w:vanish/>', '<w:del w:id="9"/><w:vanish/>'],
+    ['frame boundary', '<w:spacing w:before="240"', '<w:framePr/><w:spacing w:before="240"'],
+    ['page break property', '<w:spacing w:before="240"', '<w:pageBreakBefore/><w:spacing w:before="240"'],
+    ['automatic spacing', 'w:before="240"', 'w:before="240" w:beforeAutospacing="0"'],
+    ['line-unit spacing', 'w:before="240"', 'w:before="240" w:beforeLines="100"'],
+    ['hidden continuation', '<w:keepNext w:val="0"/><w:rPr>', '<w:keepNext w:val="0"/><w:rPr><w:vanish/>'],
+    ['missing style family', '<w:basedOn w:val="Title"/>', '', 'word/styles.xml'],
+    ['changed inherited font', 'w:ascii="Times New Roman"', 'w:ascii="Arial"', 'word/styles.xml'],
+  ]) {
+    it(`rejects ${name} before writing output`, () => {
+      const f = fixture(); change(f.input, from, to, part); const bytes = readFileSync(f.input);
+      expect(() => createNumberingRenderCopy(f.input, f.output, { styleSeparatorSpacing: f.options })).toThrow(/spacing:/);
+      expect(existsSync(f.output)).toBe(false); expect(readFileSync(f.input)).toEqual(bytes);
+    });
+  }
+
+  it('rejects wrong source hash, stale declared fingerprint, duplicate IDs and missing declared pairs', () => {
+    const f = fixture();
+    expect(() => createNumberingRenderCopy(f.input, f.output, { styleSeparatorSpacing: { ...f.options, sourceSha256: '0'.repeat(64) } })).toThrow(/source SHA/);
+    const bad = structuredClone(f.options); bad.profile.boundaries[0].expected_layout_sha256 = '0'.repeat(64);
+    expect(() => createNumberingRenderCopy(f.input, f.output, { styleSeparatorSpacing: bad })).toThrow(/source layout fingerprint/);
+    expect(() => StyleSeparatorSpacingProfileSchema.parse({ boundaries: [...f.options.profile.boundaries, ...f.options.profile.boundaries] })).toThrow(/unique/);
+    bad.profile.boundaries.push({ ...f.options.profile.boundaries[0], heading_para_id: '33333333', continuation_para_id: '44444444' });
+    bad.profile.boundaries[0].expected_layout_sha256 = f.options.profile.boundaries[0].expected_layout_sha256;
+    expect(() => createNumberingRenderCopy(f.input, f.output, { styleSeparatorSpacing: bad })).toThrow(/missing/);
+    expect(existsSync(f.output)).toBe(false);
+  });
+
+  it('parses canonical metadata, requires source pin and exercises paired CLI options and receipt', async () => {
+    const f = fixture(); const metadata = { name: 'Synthetic source', source_url: 'https://example.com/source.docx', source_version: '1', license_note: 'Synthetic test', source_sha256: f.options.sourceSha256, rendering: { style_separator_spacing: f.options.profile } };
+    expect(FieldSelectorMetadataSchema.parse(metadata).rendering).toEqual(metadata.rendering);
+    expect(() => FieldSelectorMetadataSchema.parse({ ...metadata, source_sha256: undefined })).toThrow(/source SHA/);
+    const path = join(f.dir, 'metadata.yaml'); writeFileSync(path, JSON.stringify(metadata));
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await expect(createProgram().parseAsync(['field-selector', 'render-copy', f.input, '-o', f.output, '--style-separator-metadata', path], { from: 'user' })).rejects.toThrow(/Both/);
+    await createProgram().parseAsync(['field-selector', 'render-copy', f.input, '-o', f.output, '--style-separator-metadata', path, '--style-separator-source', f.source], { from: 'user' });
+    expect(JSON.parse(log.mock.calls.at(-1)![0]).styleSeparatorSpacing.replacements).toBe(1);
+  });
+});

--- a/src/core/field-selector/style-separator-spacing.ts
+++ b/src/core/field-selector/style-separator-spacing.ts
@@ -1,0 +1,185 @@
+import AdmZip from 'adm-zip';
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { DOMParser } from '@xmldom/xmldom';
+import type { Document as XmlDocument, Element as XmlElement } from '@xmldom/xmldom';
+import { StyleSeparatorSpacingProfileSchema, type StyleSeparatorSpacingProfile } from '../metadata.js';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const W14 = 'http://schemas.microsoft.com/office/word/2010/wordml';
+const hash = (value: Buffer | string) => createHash('sha256').update(value).digest('hex');
+function fail(reason: string): never { throw new Error(`render-copy spacing: ${reason}`); }
+const children = (e: XmlElement) => Array.from(e.childNodes).filter(n => n.nodeType === 1) as XmlElement[];
+const direct = (e: XmlElement, name: string) => children(e).find(n => n.namespaceURI === W && n.localName === name);
+const val = (e: XmlElement | undefined) => e?.getAttributeNS(W, 'val');
+const on = (e: XmlElement | undefined) => !!e && !['0', 'false', 'off'].includes(val(e) ?? '');
+type Boundary = StyleSeparatorSpacingProfile['boundaries'][number];
+
+export interface StyleSeparatorSpacingOptions {
+  sourcePath: string;
+  sourceSha256: string;
+  profile: StyleSeparatorSpacingProfile;
+}
+export interface StyleSeparatorSpacingReceipt {
+  sourceSha256: string;
+  profileSha256: string;
+  replacements: number;
+  headingParaIds: string[];
+}
+
+/** Prefix-independent semantic fingerprint; only runtime-owned numbering and
+ * non-rendering editing-session IDs are excluded. Text whitespace is retained. */
+function semantic(e: XmlElement | undefined): unknown {
+  if (!e) return null;
+  const attributes = Array.from(e.attributes)
+    .filter(a => a.namespaceURI !== 'http://www.w3.org/2000/xmlns/' && !(a.namespaceURI === W && a.localName?.startsWith('rsid')))
+    // Fill serializes all text with xml:space=preserve. Where there is no edge
+    // whitespace this does not change layout; retain it otherwise.
+    .filter(a => !(a.namespaceURI === 'http://www.w3.org/XML/1998/namespace' && a.localName === 'space'
+      && e.namespaceURI === W && e.localName === 't' && (e.textContent ?? '') === (e.textContent ?? '').trim()))
+    .map(a => [a.namespaceURI ?? '', a.localName, a.value]).sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
+  return [e.namespaceURI, e.localName, attributes,
+    Array.from(e.childNodes).flatMap(n => n.nodeType === 1
+      ? ((n as XmlElement).namespaceURI === W && (n as XmlElement).localName === 'numPr' ? [] : [semantic(n as XmlElement)])
+      : n.nodeType === 3 && ['t', 'instrText'].includes(e.localName ?? '') ? [n.nodeValue] : [])];
+}
+
+function parse(zip: AdmZip, name: string): XmlDocument {
+  const entry = zip.getEntry(name);
+  if (!entry) fail(`missing ${name}`);
+  return new DOMParser({ onError: (level, message) => { if (level !== 'warning') fail(message); } })
+    .parseFromString(entry.getData().toString('utf8'), 'text/xml');
+}
+
+function styleChain(styles: XmlDocument, id: string): XmlElement[] {
+  const result: XmlElement[] = [];
+  while (id) {
+    const matches = Array.from(styles.getElementsByTagNameNS(W, 'style')).filter(s => s.getAttributeNS(W, 'styleId') === id);
+    if (matches.length !== 1 || result.includes(matches[0])) fail('missing, duplicate or cyclic paragraph style');
+    result.push(matches[0]); id = val(direct(matches[0], 'basedOn')) ?? '';
+  }
+  return result;
+}
+
+function describe(zip: AdmZip, document: XmlDocument, styles: XmlDocument, boundary: Omit<Boundary, 'expected_layout_sha256'>) {
+  const paragraphs = Array.from(document.getElementsByTagNameNS(W, 'p'));
+  const find = (id: string) => {
+    const matches = paragraphs.filter(p => p.getAttributeNS(W14, 'paraId') === id);
+    if (matches.length !== 1) fail(`paragraph ${id} missing or duplicated`);
+    return matches[0];
+  };
+  const heading = find(boundary.heading_para_id), continuation = find(boundary.continuation_para_id);
+  const parent = heading.parentNode as XmlElement;
+  if (parent.namespaceURI !== W || parent.localName !== 'body' || continuation.parentNode !== parent
+    || children(parent)[children(parent).indexOf(heading) + 1] !== continuation) fail('declared pair is not adjacent in the main body');
+  const hp = direct(heading, 'pPr'), cp = direct(continuation, 'pPr');
+  if (!hp || !cp) fail('paragraph properties missing');
+  const hs = val(direct(hp, 'pStyle')), cs = val(direct(cp, 'pStyle'));
+  if (!hs || !cs || hs === cs) fail('distinct heading and continuation styles required');
+  const headingStyles = styleChain(styles, hs), continuationStyles = styleChain(styles, cs);
+  if (!continuationStyles.includes(headingStyles[0])) fail('continuation must inherit the heading style family');
+  const toggles = ['b', 'i', 'bCs', 'iCs', 'vanish'];
+  if (continuationStyles.slice(0, continuationStyles.indexOf(headingStyles[0])).some(s =>
+    toggles.some(name => s.getElementsByTagNameNS(W, name).length))) fail('ambiguous continuation style toggles');
+  const defaults = styles.getElementsByTagNameNS(W, 'docDefaults')[0];
+  const defaultP = defaults && direct(direct(defaults, 'pPrDefault') ?? defaults, 'pPr');
+  const propertyChain = (chain: XmlElement[], p: XmlElement) => [defaultP, ...chain.slice().reverse().map(s => direct(s, 'pPr')), p].filter(Boolean) as XmlElement[];
+  const hChain = propertyChain(headingStyles, hp), cChain = propertyChain(continuationStyles, cp);
+  for (const p of [...hChain, ...cChain]) {
+    for (const name of ['framePr', 'sectPr', 'pPrChange', 'pageBreakBefore']) if (direct(p, name)) fail(`unsupported ${name}`);
+    const spacing = direct(p, 'spacing');
+    if (spacing && ['beforeLines', 'beforeAutospacing', 'afterAutospacing'].some(a => spacing.hasAttributeNS(W, a))) fail('unsupported automatic or line-unit spacing');
+  }
+  const hMark = direct(hp, 'rPr');
+  if (!hMark || !on(direct(hMark, 'vanish')) || !on(direct(hMark, 'specVanish'))) fail('heading requires an explicit hidden style separator');
+  for (const p of [heading, continuation]) {
+    for (const name of ['ins', 'del', 'moveFrom', 'moveTo', 'rPrChange', 'pPrChange', 'br', 'cr', 'drawing', 'pict']) {
+      if (p.getElementsByTagNameNS(W, name).length) fail(`unsupported boundary ${name}`);
+    }
+  }
+  for (const p of [...hChain.slice(0, -1), ...cChain]) {
+    const mark = direct(p, 'rPr');
+    if (mark && (direct(mark, 'vanish') || direct(mark, 'rStyle'))) fail('ambiguous inherited or continuation mark visibility');
+  }
+  const before = direct(hp, 'spacing')?.getAttributeNS(W, 'before');
+  if (before !== String(boundary.before_twips)) fail('heading before-spacing mismatch');
+  let continuationBefore = '0';
+  for (const p of cChain) {
+    const spacing = direct(p, 'spacing');
+    if (spacing?.hasAttributeNS(W, 'before')) continuationBefore = spacing.getAttributeNS(W, 'before')!;
+  }
+  if (continuationBefore !== '0') fail('continuation already has before-spacing');
+  const headingRuns = children(heading).filter(e => e.namespaceURI === W && e.localName === 'r');
+  if (children(heading).some(e => e.namespaceURI !== W || !['pPr', 'r', 'bookmarkStart', 'bookmarkEnd'].includes(e.localName ?? ''))) fail('unsupported heading container');
+  const firstRun = children(continuation).find(e => e.namespaceURI === W && e.localName === 'r');
+  if (firstRun && children(continuation).slice(0, children(continuation).indexOf(firstRun)).some(e =>
+    e.namespaceURI !== W || !['pPr', 'bookmarkStart', 'bookmarkEnd'].includes(e.localName ?? ''))) fail('unsupported continuation prefix container');
+  if (!headingRuns.length || !firstRun || !/^\.(?:\s|$)/.test(Array.from(firstRun.getElementsByTagNameNS(W, 't')).map(t => t.textContent).join(''))
+    || children(firstRun).some(n => n.namespaceURI !== W || !['rPr', 't'].includes(n.localName ?? ''))) fail('expected plain leading period run');
+  if (heading.getElementsByTagNameNS(W, 'instrText').length || heading.getElementsByTagNameNS(W, 'fldSimple').length) fail('field-bearing heading unsupported');
+  const characterStyles = (run: XmlElement) => {
+    const id = val(direct(direct(run, 'rPr') ?? run, 'rStyle'));
+    const chain = id ? styleChain(styles, id) : [];
+    if (chain.some(s => s.getAttributeNS(W, 'type') !== 'character'
+      || toggles.some(name => s.getElementsByTagNameNS(W, name).length)
+      || s.getElementsByTagNameNS(W, 'rPrChange').length)) fail('unsupported character style');
+    return chain;
+  };
+  const metrics = (chain: XmlElement[], run: XmlElement) => {
+    const properties = [defaults && direct(direct(defaults, 'rPrDefault') ?? defaults, 'rPr'), ...chain.slice().reverse().map(s => direct(s, 'rPr')),
+      ...characterStyles(run).slice().reverse().map(s => direct(s, 'rPr')), direct(run, 'rPr')];
+    const values = new Map<string, unknown>();
+    for (const p of properties) if (p) for (const node of children(p)) {
+      if (['rFonts', 'sz', 'szCs', 'position', 'vertAlign', 'b', 'i', 'bCs', 'iCs', 'spacing', 'w', 'kern'].includes(node.localName ?? '')) values.set(node.localName!, semantic(node));
+    }
+    return JSON.stringify([...values].sort(([a], [b]) => a.localeCompare(b)));
+  };
+  const bodyMetrics = metrics(continuationStyles, firstRun);
+  if (headingRuns.some(r => metrics(headingStyles, r) !== bodyMetrics)) fail('heading and period metrics differ');
+  const endSection = paragraphs.slice(paragraphs.indexOf(continuation)).map(p => direct(p, 'pPr')).filter(Boolean)
+    .map(p => direct(p!, 'sectPr')).find(Boolean) ?? direct(parent, 'sectPr');
+  if (!endSection || !direct(endSection, 'pgSz') || !direct(endSection, 'pgMar')) fail('explicit section geometry required');
+  const geometry = ['pgSz', 'pgMar', 'cols', 'docGrid'].map(n => semantic(direct(endSection, n)));
+  const settings = zip.getEntry('word/settings.xml') ? parse(zip, 'word/settings.xml') : undefined;
+  // The leading period may share a run with caller-dependent body prose. Bind
+  // its formatting and punctuation, not the mutable remainder of that prose.
+  const descriptor = [semantic(hp), semantic(cp), headingRuns.map(semantic), [semantic(direct(firstRun, 'rPr')), '.'],
+    headingStyles.map(semantic), continuationStyles.map(semantic), [...headingRuns, firstRun].flatMap(characterStyles).map(semantic), semantic(defaults), geometry,
+    semantic(settings?.getElementsByTagNameNS(W, 'compat')[0])];
+  return { heading, continuation, hp, cp, fingerprint: hash(JSON.stringify(descriptor)) };
+}
+
+/** Authoring aid only: canonical authors must independently render/audit the
+ * source shape before declaring this hash. This does not prove line wrapping. */
+export function inspectStyleSeparatorSpacingSource(sourcePath: string, boundary: Omit<Boundary, 'expected_layout_sha256'>): string {
+  const zip = new AdmZip(readFileSync(sourcePath));
+  return describe(zip, parse(zip, 'word/document.xml'), parse(zip, 'word/styles.xml'), boundary).fingerprint;
+}
+
+export function applyStyleSeparatorSpacing(zip: AdmZip, document: XmlDocument, styles: XmlDocument | undefined, options: StyleSeparatorSpacingOptions): StyleSeparatorSpacingReceipt {
+  const profile = StyleSeparatorSpacingProfileSchema.parse(options.profile);
+  const bytes = readFileSync(options.sourcePath);
+  if (!/^[0-9a-f]{64}$/.test(options.sourceSha256) || hash(bytes) !== options.sourceSha256) fail('source SHA-256 mismatch');
+  if (!styles) fail('missing styles');
+  const source = new AdmZip(bytes), sourceDocument = parse(source, 'word/document.xml'), sourceStyles = parse(source, 'word/styles.xml');
+  // Validate EVERY pair before mutating even the disposable in-memory copy.
+  const plans = profile.boundaries.map(boundary => {
+    const original = describe(source, sourceDocument, sourceStyles, boundary);
+    if (original.fingerprint !== boundary.expected_layout_sha256) fail('declared source layout fingerprint mismatch');
+    const current = describe(zip, document, styles, boundary);
+    if (current.fingerprint !== original.fingerprint) fail('input layout differs from declared source shape');
+    return { ...current, boundary };
+  });
+  for (const { hp, cp, boundary } of plans) {
+    direct(hp, 'spacing')!.setAttributeNS(W, 'w:before', '0');
+    let spacing = direct(cp, 'spacing');
+    if (!spacing) {
+      spacing = document.createElementNS(W, 'w:spacing');
+      const before = children(cp).find(n => ['ind', 'contextualSpacing', 'mirrorIndents', 'suppressOverlap', 'jc', 'textDirection', 'textAlignment', 'textboxTightWrap', 'outlineLvl', 'divId', 'cnfStyle', 'rPr', 'sectPr', 'pPrChange'].includes(n.localName ?? ''));
+      cp.insertBefore(spacing, before ?? null);
+    }
+    spacing.setAttributeNS(W, 'w:before', String(boundary.before_twips));
+  }
+  return { sourceSha256: options.sourceSha256, profileSha256: hash(JSON.stringify(profile)), replacements: plans.length,
+    headingParaIds: profile.boundaries.map(b => b.heading_para_id) };
+}

--- a/src/core/metadata.ts
+++ b/src/core/metadata.ts
@@ -773,6 +773,19 @@ const MarketDataCitationSchema = z.object({
  * provenance for upstream sources when present. `market_data_citations`
  * records optional external citation metadata used by fieldSelector guidance.
  */
+export const StyleSeparatorSpacingProfileSchema = z.object({
+  boundaries: z.array(z.object({
+    heading_para_id: z.string().regex(/^[0-9A-F]{8}$/),
+    continuation_para_id: z.string().regex(/^[0-9A-F]{8}$/),
+    before_twips: z.number().int().positive(),
+    expected_layout_sha256: z.string().regex(/^[0-9a-f]{64}$/),
+  }).strict()).min(1),
+}).strict().superRefine((profile, ctx) => {
+  const ids = profile.boundaries.flatMap(b => [b.heading_para_id, b.continuation_para_id]);
+  if (new Set(ids).size !== ids.length) ctx.addIssue({ code: 'custom', message: 'spacing boundaries must have unique paragraph IDs' });
+});
+export type StyleSeparatorSpacingProfile = z.infer<typeof StyleSeparatorSpacingProfileSchema>;
+
 export const FieldSelectorMetadataSchema = z.object({
   name: z.string().trim().min(1, 'name must be a non-empty string (used as display_name on list_templates)'),
   category: z.string().optional(),
@@ -784,11 +797,15 @@ export const FieldSelectorMetadataSchema = z.object({
   distribution: DistributionEnum.optional(),
   artifact_type: ArtifactTypeEnum.optional(),
   source_sha256: z.string().optional(),
+  rendering: z.object({ style_separator_spacing: StyleSeparatorSpacingProfileSchema }).strict().optional(),
   fields: z.array(FieldDefinitionSchema).default([]),
   priority_fields: z.array(z.string()).default([]),
   market_data_citations: z.array(MarketDataCitationSchema).optional(),
   ...TemplateCapabilityManifestSchema.shape,
 }).superRefine((meta, ctx) => {
+  if (meta.rendering && !/^[0-9a-f]{64}$/.test(meta.source_sha256 ?? '')) {
+    ctx.addIssue({ code: 'custom', path: ['source_sha256'], message: 'rendering declarations require an exact source SHA-256' });
+  }
   validateUniqueFieldNames(meta.fields, ctx);
   validatePriorityFields(meta.fields, meta.priority_fields, ctx);
   validateDerivedBooleanCollisions(meta.fields, ctx);

--- a/src/core/runtime-capabilities.ts
+++ b/src/core/runtime-capabilities.ts
@@ -26,5 +26,6 @@ export const RUNTIME_CAPABILITIES = Object.freeze({
     'input-value-format.nonnegative-integer.v1',
     'render.numbering-snapshot.v1',
     'render.nonbreaking-hyphen-font.v1',
+    'render.style-separator-spacing.v1',
   ]),
 });


### PR DESCRIPTION
## Summary

Closes #825.

Adds an opt-in, source-declared render-copy correction for a bounded LibreOffice style-separator spacing defect. A pinned source profile identifies mandatory adjacent paragraph pairs and their local layout fingerprints. The runtime moves only the declared before-spacing from each hidden heading to its continuation in the disposable render copy; editable DOCX bytes remain unchanged.

- Canonical `rendering.style_separator_spacing` metadata requires a source SHA-256 and unique paragraph-pair declarations.
- API/CLI options verify source bytes, paragraph IDs, local fingerprints, style/metric compatibility, geometry and supported boundary shape before writing output. Default behavior is unchanged.
- Unsupported containers, revisions, breaks, ambiguous styles and source/input drift fail closed.
- Capability `render.style-separator-spacing.v1` and a source/profile-bound receipt support controller enforcement. The canonical declaration and controller adoption are separate follow-ups.

## Verification

- Focused tests: 40 passed, including XML property order, exact untouched-content preservation, source/input immutability, CLI option pairing and negative drift/unsupported-shape cases.
- Final build and lint passed. Full suite: 1,799 passed / 7 skipped, 208.43 seconds, single worker with unchanged default timeouts.
- Real pinned-source fill: zero warnings; four declared joins align in the actual PDF. Baseline and repaired PDFs both contain 34 pages and the same 14,850 word occurrences. Reverting only the four spacing transfers makes their document XML trees identical, preserving text order, fields, bookmarks and numbering.
- All 34 repaired pages were visually inspected for overlap/clipping, with target pages also inspected at full resolution. Licensed source/output artifacts remain local and are not part of this PR.
- Final-built API output is byte-identical to that visually inspected render copy. The old runtime leaves the demonstrated defect unchanged. All seven suite documents rendered without the new option have identical ZIP-part bytes on the old and candidate runtimes; originals remain unchanged.
- Independent local review inspected all eight changed files, the actual full-suite result and final API/artifact proof; no remaining blocking findings. No external model review was attempted.

## Limits

This is not a general style-separator repair or Word certification. Wrapped headings can exhibit a separate importer defect; local fingerprints do not prove font layout. The correction can change vertical positions and downstream pagination. The demonstrated fixture is partial, not a transaction-ready deliverable. Source profiles require independent actual-render review, and controllers must explicitly enable and verify the operation. No canonical prose or editable document formatting is changed by this PR.
