### PR TITLE
Fix external SAFE signature bindings and date verification

### DIFF
--- a/integration-tests/external-validation-negative.test.ts
+++ b/integration-tests/external-validation-negative.test.ts
@@ -78,6 +78,31 @@ function createFixture(): { dir: string; docxBuffer: Buffer; docxSha: string } {
 }
 
 describe('validateExternal negative scenarios', () => {
+  it('rejects invalid signature-binding structure and nonunique real document anchors', () => {
+    const {dir} = createFixture();
+    const bytes = buildDocx('START</w:t></w:r></w:p><w:p><w:r><w:t>Name:');
+    writeFileSync(join(dir, 'template.docx'), bytes);
+    writeMetadata(dir, createHash('sha256').update(bytes).digest('hex'));
+    writeFileSync(join(dir, 'replacements.json'), JSON.stringify({'[Company Name]': '{company_name}'}));
+    const binding = {label: 'Name:', field: 'company_name', expected_matches: 1, insert_after_label: true, preserve_following_tabs: true};
+    const group = {id: 'final', start_anchor: 'START', end_at_document_end: true, expected_group_matches: 1, bindings: [binding]};
+    const configPath = join(dir, 'anchored-paragraph-bindings.json');
+    writeFileSync(configPath, JSON.stringify({groups: [group]}));
+    expect(validateExternal(dir, 'fixture').valid).toBe(true);
+    for (const invalid of [
+      {...group, start_anchor: 'MISSING'},
+      {...group, end_anchor: 'Name:'},
+      {...group, end_at_document_end: undefined},
+      {...group, bindings: [binding, binding]},
+      {...group, bindings: [{...binding, field: 'unknown_field'}]},
+    ]) {
+      writeFileSync(configPath, JSON.stringify({groups: [invalid]}));
+      expect(validateExternal(dir, 'fixture').valid).toBe(false);
+    }
+    writeFileSync(configPath, '{');
+    expect(validateExternal(dir, 'fixture').valid).toBe(false);
+  });
+
   it('fails when metadata is invalid', () => {
     const { dir } = createFixture();
     writeFileSync(join(dir, 'metadata.yaml'), 'name: Bad Fixture', 'utf-8');

--- a/runtime-capabilities.json
+++ b/runtime-capabilities.json
@@ -14,6 +14,8 @@
     "normalize.numbering-continuations.v1",
     "repeatable-tables.v1",
     "anchored-paragraph-bindings.v1",
+    "anchored-paragraph-bindings.document-end.v1",
+    "external.anchored-paragraph-bindings.v1",
     "reference-fields.v1",
     "reference-fields.grouped.v1",
     "conditional-input-requirements.v1",

--- a/src/core/external/index.test.ts
+++ b/src/core/external/index.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, vi } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { createHash } from 'node:crypto';
@@ -17,6 +17,7 @@ afterEach(() => {
   }
   vi.restoreAllMocks();
   vi.resetModules();
+  vi.doUnmock('../field-selector/verifier.js');
 });
 
 function createExternalFixture(overrides?: { sourceSha256?: string }) {
@@ -103,6 +104,50 @@ describe('runExternalFill', () => {
       values: { company_name: 'Acme Corp' },
     });
     expect(result.fieldsUsed).toEqual(['company_name']);
+  });
+
+  itFilling('wires configured signature bindings before patching an external document', async () => {
+    const {root} = createExternalFixture();
+    writeFileSync(join(root, 'anchored-paragraph-bindings.json'), JSON.stringify({groups: [{
+      id: 'final', start_anchor: 'INVESTOR:', end_at_document_end: true, expected_group_matches: 1,
+      bindings: [{label: 'Name:', field: 'company_name', expected_matches: 1, insert_after_label: true, preserve_following_tabs: true}],
+    }]}));
+    const bind = vi.fn();
+    vi.doMock('../../utils/paths.js', () => ({resolveExternalDir: () => root}));
+    vi.doMock('../field-selector/anchored-paragraph-bindings.js', async () => {
+      const actual = await vi.importActual<typeof import('../field-selector/anchored-paragraph-bindings.js')>('../field-selector/anchored-paragraph-bindings.js');
+      return {...actual, bindAnchoredParagraphFields: bind};
+    });
+    vi.doMock('../unified-pipeline.js', () => ({runFillPipeline: async (options: {
+      prePatchProcess: (input: string, output: string) => Promise<unknown>;
+    }) => {
+      await options.prePatchProcess('/tmp/clean.docx', '/tmp/bound.docx');
+      return {outputPath: '/tmp/filled.docx', fieldsUsed: [], providedFieldsUsed: [], fillCommandCount: 1, warnings: [], stages: {}};
+    }}));
+    try {
+      const {runExternalFill} = await import('./index.js');
+      await runExternalFill({externalId: 'fixture', outputPath: '/tmp/filled.docx', values: {company_name: 'Acme'}});
+      expect(bind).toHaveBeenCalledWith('/tmp/clean.docx', '/tmp/bound.docx', expect.objectContaining({groups: expect.any(Array)}));
+    } finally { vi.doUnmock('../field-selector/anchored-paragraph-bindings.js'); }
+  });
+
+  itFilling('verifies ISO dates using the exact display value rendered by the fill pipeline', async () => {
+    const {root} = createExternalFixture();
+    const metadataPath = join(root, 'metadata.yaml');
+    writeFileSync(metadataPath, readFileSync(metadataPath, 'utf8').replace('priority_fields:',
+      '  - name: date_of_safe\n    type: date\n    description: Date\npriority_fields:'));
+    const verify = vi.fn(async () => ({passed: true, checks: []}));
+    vi.doMock('../../utils/paths.js', () => ({resolveExternalDir: () => root}));
+    vi.doMock('../field-selector/verifier.js', () => ({verifyOutput: verify}));
+    vi.doMock('../unified-pipeline.js', () => ({runFillPipeline: async (options: {
+      verify: (output: string, source: string) => Promise<unknown>;
+    }) => {
+      await options.verify('/tmp/filled.docx', '/tmp/cleaned.docx');
+      return {outputPath: '/tmp/filled.docx', fieldsUsed: [], providedFieldsUsed: [], fillCommandCount: 1, warnings: [], stages: {}};
+    }}));
+    const {runExternalFill} = await import('./index.js');
+    await runExternalFill({externalId: 'fixture', outputPath: '/tmp/filled.docx', values: {date_of_safe: '2026-09-21'}});
+    expect(verify).toHaveBeenCalledWith('/tmp/filled.docx', {date_of_safe: 'September 21, 2026'}, expect.any(Object), expect.any(Object), '/tmp/cleaned.docx');
   });
 
   itFilling('fails integrity check when source_sha256 does not match template bytes', async () => {

--- a/src/core/external/index.ts
+++ b/src/core/external/index.ts
@@ -1,10 +1,12 @@
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { createHash } from 'node:crypto';
 import { loadExternalMetadata, loadCleanConfig } from '../metadata.js';
 import { resolveExternalDir } from '../../utils/paths.js';
 import { verifyOutput } from '../field-selector/verifier.js';
 import { runFillPipeline } from '../unified-pipeline.js';
+import { formatDocumentDateFields } from '../fill-pipeline.js';
+import { bindAnchoredParagraphFields, loadAnchoredParagraphBindingsConfig } from '../field-selector/anchored-paragraph-bindings.js';
 import type { ExternalFillOptions, ExternalFillResult } from './types.js';
 
 /**
@@ -41,6 +43,10 @@ export async function runExternalFill(options: ExternalFillOptions): Promise<Ext
   const replacementsPath = join(externalDir, 'replacements.json');
   const replacements: Record<string, string> = JSON.parse(readFileSync(replacementsPath, 'utf-8'));
 
+  const bindingsPath = join(externalDir, 'anchored-paragraph-bindings.json');
+  const bindings = existsSync(bindingsPath) ? loadAnchoredParagraphBindingsConfig(bindingsPath) : undefined;
+  const verificationValues = formatDocumentDateFields(values, metadata.fields);
+
   const result = await runFillPipeline({
     inputPath: docxPath,
     outputPath,
@@ -48,9 +54,12 @@ export async function runExternalFill(options: ExternalFillOptions): Promise<Ext
     fields: metadata.fields,
     priorityFieldNames: metadata.priority_fields,
     cleanPatch: { cleanConfig, replacements },
+    prePatchProcess: bindings
+      ? async (input, output) => bindAnchoredParagraphFields(input, output, bindings)
+      : undefined,
     // Forward the cleaned source so formatting anomalies and context-key
     // placeholders are baselined against it (consistent with runFieldSelector).
-    verify: (p, cleanedSourcePath) => verifyOutput(p, values, replacements, cleanConfig, cleanedSourcePath),
+    verify: (p, cleanedSourcePath) => verifyOutput(p, verificationValues, replacements, cleanConfig, cleanedSourcePath),
     keepIntermediate,
   });
 

--- a/src/core/field-selector/anchored-paragraph-bindings.test.ts
+++ b/src/core/field-selector/anchored-paragraph-bindings.test.ts
@@ -68,6 +68,29 @@ const signatureBody =
   p(text('KEY HOLDERS:'));
 
 describe('anchor-scoped paragraph field binding', () => {
+  it('binds a final signature group to the document end and rejects ambiguous boundaries', () => {
+    const fixture = build(signatureBody);
+    const finalGroup = {...config.groups[1], end_anchor: undefined, end_at_document_end: true as const};
+    bindAnchoredParagraphFields(fixture.input, fixture.output, {groups: [finalGroup]});
+    const xml = new AdmZip(fixture.output).getEntry('word/document.xml')!.getData().toString('utf-8');
+    expect(xml).toContain('{investor_signatory_name}');
+    expect(xml).not.toContain('{company_signatory_name}');
+    expect(() => bindAnchoredParagraphFields(fixture.input, fixture.output, {
+      groups: [{...finalGroup, end_anchor: 'KEY HOLDERS:'}],
+    })).toThrow('Specify exactly one');
+    rmSync(fixture.dir, {recursive: true, force: true});
+  });
+
+  it('rejects duplicate binding targets without writing an output', () => {
+    const fixture = build(signatureBody);
+    const group = config.groups[0];
+    expect(() => bindAnchoredParagraphFields(fixture.input, fixture.output, {groups: [
+      {...group, bindings: [group.bindings[0], group.bindings[0]]},
+    ]})).toThrow('duplicate binding target');
+    expect(existsSync(fixture.output)).toBe(false);
+    rmSync(fixture.dir, {recursive: true, force: true});
+  });
+
   it('binds repeated labels to distinct fields inside their unique boundaries', () => {
     const fixture = build(signatureBody);
     const before = new AdmZip(fixture.input).getEntry('word/document.xml')!.getData().toString('utf-8');

--- a/src/core/field-selector/anchored-paragraph-bindings.ts
+++ b/src/core/field-selector/anchored-paragraph-bindings.ts
@@ -11,7 +11,8 @@ export const AnchoredParagraphBindingsConfigSchema = z.object({
   groups: z.array(z.object({
     id: z.string().min(1),
     start_anchor: z.string().min(1),
-    end_anchor: z.string().min(1),
+    end_anchor: z.string().min(1).optional(),
+    end_at_document_end: z.literal(true).optional(),
     expected_group_matches: z.literal(1),
     bindings: z.array(z.object({
       label: z.string().min(1),
@@ -22,7 +23,9 @@ export const AnchoredParagraphBindingsConfigSchema = z.object({
       /** Opt in only when following underlined tab-only runs are blank form tails. */
       consume_following_underlined_tabs: z.literal(true).optional(),
     }).strict()).min(1),
-  }).strict()).min(1),
+  }).strict().refine((group) => Boolean(group.end_anchor) !== Boolean(group.end_at_document_end), {
+    message: 'Specify exactly one of end_anchor or end_at_document_end',
+  })).min(1),
 }).strict();
 
 export type AnchoredParagraphBindingsConfig = z.infer<typeof AnchoredParagraphBindingsConfigSchema>;
@@ -96,7 +99,7 @@ export function bindAnchoredParagraphFields(
   }> = [];
   for (const group of config.groups) {
     const starts = exactAnchorIndices(paragraphs, group.start_anchor);
-    const ends = exactAnchorIndices(paragraphs, group.end_anchor);
+    const ends = group.end_at_document_end ? [paragraphs.length] : exactAnchorIndices(paragraphs, group.end_anchor!);
     if (starts.length !== group.expected_group_matches || ends.length !== group.expected_group_matches) {
       throw new Error(
         `anchored paragraph bindings '${group.id}': expected one unique start/end anchor; ` +
@@ -121,6 +124,9 @@ export function bindAnchoredParagraphFields(
           `anchored paragraph bindings '${group.id}' label '${binding.label}': ` +
           `expected one match inside boundaries; found ${matches.length}`,
         );
+      }
+      if (insertions.some((insertion) => insertion.textNode === matches[0])) {
+        throw new Error(`anchored paragraph bindings '${group.id}': duplicate binding target '${binding.label}'`);
       }
       insertions.push({
         textNode: matches[0],

--- a/src/core/runtime-capabilities.ts
+++ b/src/core/runtime-capabilities.ts
@@ -19,6 +19,8 @@ export const RUNTIME_CAPABILITIES = Object.freeze({
     'normalize.numbering-continuations.v1',
     'repeatable-tables.v1',
     'anchored-paragraph-bindings.v1',
+    'anchored-paragraph-bindings.document-end.v1',
+    'external.anchored-paragraph-bindings.v1',
     'reference-fields.v1',
     'reference-fields.grouped.v1',
     'conditional-input-requirements.v1',

--- a/src/core/validation/external.ts
+++ b/src/core/validation/external.ts
@@ -1,7 +1,9 @@
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import { createHash } from 'node:crypto';
 import { validateExternalMetadata, loadExternalMetadata, CleanConfigSchema } from '../metadata.js';
+import { bindAnchoredParagraphFields, loadAnchoredParagraphBindingsConfig } from '../field-selector/anchored-paragraph-bindings.js';
 import { parseReplacementKey } from '../field-selector/replacement-keys.js';
 
 export interface ExternalValidationResult {
@@ -122,6 +124,28 @@ export function validateExternal(
       }
     } catch (err) {
       errors.push(`replacements.json: ${(err as Error).message}`);
+    }
+  }
+
+  const bindingsPath = join(externalDir, 'anchored-paragraph-bindings.json');
+  if (existsSync(bindingsPath)) {
+    try {
+      const bindings = loadAnchoredParagraphBindingsConfig(bindingsPath);
+      const fields = new Set(metadata.fields.map((field) => field.name));
+      for (const group of bindings.groups) {
+        for (const binding of group.bindings) {
+          if (!fields.has(binding.field)) errors.push(`Anchored binding {${binding.field}} not found in metadata fields`);
+        }
+      }
+      // Verify real anchor/label uniqueness without modifying the canonical file.
+      const scratch = mkdtempSync(join(tmpdir(), 'oa-external-bindings-validate-'));
+      try {
+        bindAnchoredParagraphFields(docxPath, join(scratch, 'bound.docx'), bindings);
+      } finally {
+        rmSync(scratch, {recursive: true, force: true});
+      }
+    } catch (error) {
+      errors.push(`anchored-paragraph-bindings.json: ${(error as Error).message}`);
     }
   }
 


### PR DESCRIPTION
External fills now bind administrative fields in anchored signature paragraphs and verify date fields using the same display formatting as the renderer. This enables the SAFE investor name/title and both notice blocks without modifying the licensed source DOCX.

Validation rejects malformed boundaries, duplicate targets, missing anchors, and unknown fields. Both new runtime capabilities are declared. Template content remains upstream in UseJunior/legal-explainer (issue #2621); this PR supplies its runtime support.

Validation: build, full lint, and catalog validation pass. The full suite passed 1,785 tests initially with 25 timeout failures under concurrent load; all failing cases passed serial retries. Fable independently approved after 475 tests, a build, and a real YC SAFE fill: all 16 supplied fields used, no warnings, source SHA unchanged.

Known nonblocking follow-up from Fable: validation dry-runs bindings against the raw document whereas runtime binds after cleaning. The SAFE clean step is a no-op, verified byte-for-byte; transformed external templates should align those stages before adding bindings.
