### PR TITLE
chore: release 0.10.1 with external SAFE fill support

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "open-agreements",
   "displayName": "OpenAgreements",
   "description": "Open-source legal template automation for DOCX with MCP tooling.",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "author": {
     "name": "Open Agreements",
     "email": "steven@usejunior.com"

--- a/data/templates-snapshot.json
+++ b/data/templates-snapshot.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "cli_version": "0.10.0",
+  "cli_version": "0.10.1",
   "items": [
     {
       "name": "bonterms-mutual-nda",

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "open-agreements",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Local MCP extension for OpenAgreements workspace organization and contract template drafting.",
   "contextFileName": "AGENTS.md",
   "entrypoint": "AGENTS.md",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-agreements",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-agreements",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "bundleDependencies": [
         "@usejunior/docx-core"
       ],
@@ -8842,7 +8842,7 @@
     },
     "packages/checklist-mcp": {
       "name": "@open-agreements/checklist-mcp",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "Apache-2.0",
       "dependencies": {
         "open-agreements": ">=0.3.1",
@@ -8857,7 +8857,7 @@
     },
     "packages/contract-templates-mcp": {
       "name": "@open-agreements/contract-templates-mcp",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "Apache-2.0",
       "dependencies": {
         "open-agreements": ">=0.3.1",
@@ -8888,7 +8888,7 @@
     },
     "packages/contracts-workspace-mcp": {
       "name": "@open-agreements/contracts-workspace-mcp",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "Apache-2.0",
       "dependencies": {
         "js-yaml": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-agreements",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "workspaces": [
     "packages/allure-test-factory",
     "packages/contract-templates-mcp",

--- a/packages/checklist-mcp/package.json
+++ b/packages/checklist-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agreements/checklist-mcp",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Local stdio MCP server for OpenAgreements checklist memory operations",
   "type": "module",
   "bin": {

--- a/packages/contract-templates-mcp/package.json
+++ b/packages/contract-templates-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agreements/contract-templates-mcp",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "mcpName": "io.github.open-agreements/open-agreements",
   "description": "Local stdio MCP server for OpenAgreements template discovery and filling",
   "type": "module",

--- a/packages/contracts-workspace-mcp/package.json
+++ b/packages/contracts-workspace-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agreements/contracts-workspace-mcp",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Local stdio MCP server for contracts workspace operations",
   "type": "module",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -3,13 +3,13 @@
   "name": "io.github.open-agreements/open-agreements",
   "title": "Open Agreements",
   "description": "Fill standard legal agreement templates (NDAs, SAFEs, NVCA docs, employment) as DOCX files.",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "websiteUrl": "https://openagreements.org",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@open-agreements/contract-templates-mcp",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "transport": { "type": "stdio" },
       "runtimeHint": "npx",
       "environmentVariables": []


### PR DESCRIPTION
Publish the merged external SAFE field-binding support and formatted-date verification fix from #830 as version 0.10.1, so CLI/MCP users can receive the runtime capabilities needed by the canonical template update.

Synchronizes package, MCP registry, editor-plugin and extension versions using `scripts/bump_version.mjs`; regenerates the lockfile and versioned catalog snapshot. No dependency upgrades or legal-content changes.

Validation: build, template/field-selector validation, lint, nine version-sync tests, and clean-tree derived-artifact checks passed. Exact engine #830 already passed 1,813 tests plus a real SAFE fill with 16 supplied fields and no warnings. Fable's focused release review is in progress. The repository's existing auto-tag and trusted release workflow will publish after merge.
