### PR TITLE
Fix wrapped SAFE notice-address alignment

### DIFF
--- a/runtime-capabilities.json
+++ b/runtime-capabilities.json
@@ -15,6 +15,7 @@
     "repeatable-tables.v1",
     "anchored-paragraph-bindings.v1",
     "anchored-paragraph-bindings.document-end.v1",
+    "anchored-paragraph-bindings.wrapped-line-indent.v1",
     "external.anchored-paragraph-bindings.v1",
     "reference-fields.v1",
     "reference-fields.grouped.v1",

--- a/src/core/field-selector/anchored-paragraph-bindings.test.ts
+++ b/src/core/field-selector/anchored-paragraph-bindings.test.ts
@@ -141,6 +141,65 @@ describe('anchor-scoped paragraph field binding', () => {
     rmSync(fixture.dir, { recursive: true, force: true });
   });
 
+  it('optionally aligns wrapped value lines without moving the tab-positioned first line', () => {
+    const fixture = build(
+      p(text('START')) +
+      '<w:p><w:pPr><w:pStyle w:val="SignatureLine2-col"/><w:ind w:right="120"/></w:pPr>' +
+        '<w:r><w:tab/><w:tab/><w:tab/><w:t>Address:</w:t></w:r></w:p>' +
+      p(text('END')),
+    );
+    const wrappedConfig: AnchoredParagraphBindingsConfig = {
+      groups: [{
+        id: 'notice-address',
+        start_anchor: 'START',
+        end_anchor: 'END',
+        expected_group_matches: 1,
+        bindings: [{
+          label: 'Address:',
+          field: 'notice_address',
+          expected_matches: 1,
+          insert_after_label: true,
+          preserve_following_tabs: true,
+          wrapped_line_indent_twips: 5760,
+        }],
+      }],
+    };
+
+    bindAnchoredParagraphFields(fixture.input, fixture.output, wrappedConfig);
+    const xml = new AdmZip(fixture.output).readAsText('word/document.xml');
+    expect(xml).toContain('Address:</w:t><w:t xml:space="preserve"> {notice_address}</w:t>');
+    expect(xml).toContain('<w:ind w:right="120" w:left="5760" w:hanging="5760"/>');
+    expect((xml.match(/<w:tab/g) ?? [])).toHaveLength(3);
+    rmSync(fixture.dir, {recursive: true, force: true});
+  });
+
+  it('inserts wrapped-line paragraph properties in WordprocessingML schema order', () => {
+    const fixture = build(
+      p(text('START')) +
+      '<w:p><w:pPr><w:pStyle w:val="SignatureLine2-col"/>' +
+        '<w:ind w:start="100" w:leftChars="200" w:firstLineChars="100" w:hangingChars="200"/>' +
+        '<w:jc w:val="left"/><w:rPr><w:sz w:val="22"/></w:rPr></w:pPr>' +
+        '<w:r><w:t>Address:</w:t></w:r></w:p>' +
+      p(text('END')),
+    );
+    bindAnchoredParagraphFields(fixture.input, fixture.output, {groups: [{
+      id: 'notice-address',
+      start_anchor: 'START',
+      end_anchor: 'END',
+      expected_group_matches: 1,
+      bindings: [{
+        label: 'Address:', field: 'notice_address', expected_matches: 1,
+        insert_after_label: true, preserve_following_tabs: true, wrapped_line_indent_twips: 5760,
+      }],
+    }]});
+    const xml = new AdmZip(fixture.output).readAsText('word/document.xml');
+    expect(xml).toContain(
+      '<w:pStyle w:val="SignatureLine2-col"/><w:ind w:left="5760" w:hanging="5760"/><w:jc w:val="left"/><w:rPr>',
+    );
+    expect(xml).not.toMatch(/w:(?:start|startChars|leftChars|firstLine|firstLineChars|hangingChars)=/);
+    rmSync(fixture.dir, {recursive: true, force: true});
+  });
+
   it('fails closed on a zero-match label without writing an output', () => {
     const fixture = build(signatureBody.replace('Email:', 'E-mail:'));
     expect(() => bindAnchoredParagraphFields(fixture.input, fixture.output, config))

--- a/src/core/field-selector/anchored-paragraph-bindings.ts
+++ b/src/core/field-selector/anchored-paragraph-bindings.ts
@@ -22,6 +22,13 @@ export const AnchoredParagraphBindingsConfigSchema = z.object({
       preserve_following_tabs: z.literal(true),
       /** Opt in only when following underlined tab-only runs are blank form tails. */
       consume_following_underlined_tabs: z.literal(true).optional(),
+      /**
+       * Keep wrapped value text aligned under its first-line value start while
+       * preserving the source paragraph's tab-positioned label. The transform
+       * writes a hanging indent: the first line remains at the original margin,
+       * and continuation lines begin at this position.
+       */
+      wrapped_line_indent_twips: z.number().int().positive().max(31680).optional(),
     }).strict()).min(1),
   }).strict().refine((group) => Boolean(group.end_anchor) !== Boolean(group.end_at_document_end), {
     message: 'Specify exactly one of end_anchor or end_at_document_end',
@@ -96,6 +103,7 @@ export function bindAnchoredParagraphFields(
     field: string;
     groupId: string;
     consumeFollowingUnderlinedTabs: boolean;
+    wrappedLineIndentTwips: number | undefined;
   }> = [];
   for (const group of config.groups) {
     const starts = exactAnchorIndices(paragraphs, group.start_anchor);
@@ -133,6 +141,7 @@ export function bindAnchoredParagraphFields(
         field: binding.field,
         groupId: group.id,
         consumeFollowingUnderlinedTabs: binding.consume_following_underlined_tabs === true,
+        wrappedLineIndentTwips: binding.wrapped_line_indent_twips,
       });
     }
   }
@@ -154,6 +163,9 @@ export function bindAnchoredParagraphFields(
     if (insertion.consumeFollowingUnderlinedTabs) {
       removeFollowingUnderlinedTabTails(run);
     }
+    if (insertion.wrappedLineIndentTwips !== undefined) {
+      applyWrappedLineIndent(run, insertion.wrappedLineIndentTwips, insertion.groupId);
+    }
   }
 
   const serialized = new XMLSerializer().serializeToString(doc);
@@ -162,6 +174,65 @@ export function bindAnchoredParagraphFields(
     name === 'word/document.xml' ? Buffer.from(serialized, 'utf-8') : data,
   );
   writeFileSync(outputPath, outZip.toBuffer());
+}
+
+/** Apply a hanging indent without changing where the tab-positioned first line starts. */
+function applyWrappedLineIndent(labelRun: Element, twips: number, groupId: string): void {
+  const paragraph = labelRun.parentNode as Element | null;
+  if (!paragraph || paragraph.localName !== 'p' || paragraph.namespaceURI !== W_NS) {
+    throw new Error(`anchored paragraph bindings '${groupId}': label run is not directly inside a paragraph`);
+  }
+
+  let paragraphProperties: Element | null = null;
+  for (let i = 0; i < paragraph.childNodes.length; i++) {
+    const child = paragraph.childNodes[i] as Element;
+    if (child.nodeType === 1 && child.namespaceURI === W_NS && child.localName === 'pPr') {
+      paragraphProperties = child;
+      break;
+    }
+  }
+  if (!paragraphProperties) {
+    paragraphProperties = paragraph.ownerDocument!.createElementNS(W_NS, 'w:pPr');
+    paragraph.insertBefore(paragraphProperties, paragraph.firstChild);
+  }
+
+  let indent: Element | null = null;
+  for (let i = 0; i < paragraphProperties.childNodes.length; i++) {
+    const child = paragraphProperties.childNodes[i] as Element;
+    if (child.nodeType === 1 && child.namespaceURI === W_NS && child.localName === 'ind') {
+      indent = child;
+      break;
+    }
+  }
+  if (!indent) {
+    indent = paragraph.ownerDocument!.createElementNS(W_NS, 'w:ind');
+    // CT_PPr orders w:ind before these later paragraph properties. The YC
+    // source has w:rPr but no direct w:ind, so appending would produce OOXML
+    // that tolerant readers accept but Word may repair.
+    let trailingProperties: Element | null = null;
+    const afterIndent = new Set([
+      'contextualSpacing', 'mirrorIndents', 'suppressOverlap', 'jc', 'textDirection',
+      'textAlignment', 'textboxTightWrap', 'outlineLvl', 'divId', 'cnfStyle',
+      'rPr', 'sectPr', 'pPrChange',
+    ]);
+    for (let i = 0; i < paragraphProperties.childNodes.length; i++) {
+      const child = paragraphProperties.childNodes[i] as Element;
+      if (child.nodeType === 1 && child.namespaceURI === W_NS && afterIndent.has(child.localName ?? '')) {
+        trailingProperties = child;
+        break;
+      }
+    }
+    paragraphProperties.insertBefore(indent, trailingProperties);
+  }
+  const value = String(twips);
+  indent.setAttributeNS(W_NS, 'w:left', value);
+  indent.setAttributeNS(W_NS, 'w:hanging', value);
+  // Absolute twip-based left/hanging indentation owns the same semantic axis
+  // as these logical/character-unit alternatives. Leaving either form behind
+  // makes renderer precedence decide whether the requested layout takes effect.
+  for (const attribute of ['start', 'startChars', 'leftChars', 'firstLine', 'firstLineChars', 'hangingChars']) {
+    indent.removeAttributeNS(W_NS, attribute);
+  }
 }
 
 /**

--- a/src/core/runtime-capabilities.ts
+++ b/src/core/runtime-capabilities.ts
@@ -20,6 +20,7 @@ export const RUNTIME_CAPABILITIES = Object.freeze({
     'repeatable-tables.v1',
     'anchored-paragraph-bindings.v1',
     'anchored-paragraph-bindings.document-end.v1',
+    'anchored-paragraph-bindings.wrapped-line-indent.v1',
     'external.anchored-paragraph-bindings.v1',
     'reference-fields.v1',
     'reference-fields.grouped.v1',

--- a/templates/yc-cc-by-nd-4.0/yc-safe-valuation-cap/anchored-paragraph-bindings.json
+++ b/templates/yc-cc-by-nd-4.0/yc-safe-valuation-cap/anchored-paragraph-bindings.json
@@ -11,7 +11,8 @@
           "field": "company_notice_address",
           "expected_matches": 1,
           "insert_after_label": true,
-          "preserve_following_tabs": true
+          "preserve_following_tabs": true,
+          "wrapped_line_indent_twips": 5760
         },
         {
           "label": "Email:",
@@ -47,7 +48,8 @@
           "field": "investor_notice_address",
           "expected_matches": 1,
           "insert_after_label": true,
-          "preserve_following_tabs": true
+          "preserve_following_tabs": true,
+          "wrapped_line_indent_twips": 5760
         },
         {
           "label": "Email:",


### PR DESCRIPTION
Long notice addresses in the YC Post-Money SAFE wrapped to the page's left margin because the source signature paragraph uses tab-positioned labels without a continuation indent. This adds a strict, capability-gated `wrapped_line_indent_twips` fill operation and opts the two notice-address bindings into a hanging indent, so wrapped lines remain beneath the address value.

The CC-BY-ND source DOCX remains byte-identical (`185d24f…649c4`). A real CLI fill rendered in LibreOffice reproduces the before state and confirms both company and investor continuation lines align after the change.

Validation:
- `npm run build`
- `npm run lint`
- `npx vitest run src/core/field-selector/anchored-paragraph-bindings.test.ts` (11 passed)
- full serial suite: 1,821 passed, 7 skipped
- source integrity hash and final seven-page filled PDF visually checked

Refs UseJunior/legal-explainer#2631.
