### PR TITLE
Serialize shared package artifact tests

### DIFF
--- a/integration-tests/helpers/package-artifact-lock.ts
+++ b/integration-tests/helpers/package-artifact-lock.ts
@@ -12,8 +12,10 @@ export interface PackageArtifactLock {
 
 /**
  * Serializes integration tests that read or regenerate the repository's shared
- * `dist/` package artifact. Vitest executes test files in parallel workers, so
- * an npm pack can otherwise observe a source map while `tsc` is replacing it.
+ * `dist/` package artifact. CI's npm 10 runs the root `prepare` lifecycle for
+ * `npm pack` even with `--ignore-scripts`, which rebuilds `dist/`. Because
+ * Vitest executes test files in parallel workers, another pack can otherwise
+ * observe a source map while `tsc` is replacing it.
  */
 export async function acquirePackageArtifactLock(
   repoRoot: string,

--- a/integration-tests/helpers/package-artifact-lock.ts
+++ b/integration-tests/helpers/package-artifact-lock.ts
@@ -1,0 +1,60 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { closeSync, openSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const RETRY_INTERVAL_MS = 50;
+
+export interface PackageArtifactLock {
+  path: string;
+  release: () => void;
+}
+
+/**
+ * Serializes integration tests that read or regenerate the repository's shared
+ * `dist/` package artifact. Vitest executes test files in parallel workers, so
+ * an npm pack can otherwise observe a source map while `tsc` is replacing it.
+ */
+export async function acquirePackageArtifactLock(
+  repoRoot: string,
+  timeoutMs = 120_000,
+): Promise<PackageArtifactLock> {
+  const rootKey = createHash('sha256').update(resolve(repoRoot)).digest('hex').slice(0, 16);
+  const path = join(tmpdir(), `open-agreements-package-artifact-${rootKey}.lock`);
+  const token = `${process.pid}:${randomUUID()}`;
+  const startedAt = Date.now();
+
+  while (true) {
+    try {
+      const fd = openSync(path, 'wx');
+      try {
+        writeFileSync(fd, `${token}\n`, 'utf8');
+      } finally {
+        closeSync(fd);
+      }
+
+      let released = false;
+      const release = () => {
+        if (released) return;
+        released = true;
+        process.off('exit', release);
+        try {
+          if (readFileSync(path, 'utf8').trim() === token) unlinkSync(path);
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+        }
+      };
+      process.once('exit', release);
+      return {
+        path,
+        release,
+      };
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+      if (Date.now() - startedAt >= timeoutMs) {
+        throw new Error(`Timed out waiting for package artifact lock: ${path}`);
+      }
+      await new Promise((resolveRetry) => setTimeout(resolveRetry, RETRY_INTERVAL_MS));
+    }
+  }
+}

--- a/integration-tests/package-artifact-lock.test.ts
+++ b/integration-tests/package-artifact-lock.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { itAllure } from './helpers/allure-test.js';
+import {
+  acquirePackageArtifactLock,
+  type PackageArtifactLock,
+} from './helpers/package-artifact-lock.js';
+
+const it = itAllure.epic('Platform & Distribution');
+
+describe('package artifact lock', () => {
+  const locks: PackageArtifactLock[] = [];
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const lock of locks.splice(0)) lock.release();
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  it('keeps a second package operation out until the first releases', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'oa-package-lock-test-'));
+    roots.push(root);
+    const first = await acquirePackageArtifactLock(root, 1_000);
+    locks.push(first);
+
+    let secondEntered = false;
+    const secondPromise = acquirePackageArtifactLock(root, 1_000).then((lock) => {
+      locks.push(lock);
+      secondEntered = true;
+      return lock;
+    });
+
+    await new Promise((resolveWait) => setTimeout(resolveWait, 100));
+    expect(secondEntered).toBe(false);
+
+    first.release();
+    await secondPromise;
+    expect(secondEntered).toBe(true);
+  });
+
+  it('does not serialize independent worktrees', async () => {
+    const rootA = mkdtempSync(join(tmpdir(), 'oa-package-lock-a-'));
+    const rootB = mkdtempSync(join(tmpdir(), 'oa-package-lock-b-'));
+    roots.push(rootA, rootB);
+
+    const [lockA, lockB] = await Promise.all([
+      acquirePackageArtifactLock(rootA, 1_000),
+      acquirePackageArtifactLock(rootB, 1_000),
+    ]);
+    locks.push(lockA, lockB);
+
+    expect(lockA.path).not.toBe(lockB.path);
+  });
+});

--- a/integration-tests/packaging.test.ts
+++ b/integration-tests/packaging.test.ts
@@ -1,10 +1,14 @@
-import { describe, expect, beforeAll } from 'vitest';
+import { afterAll, beforeAll, describe, expect } from 'vitest';
 import { itAllure } from './helpers/allure-test.js';
 import { seconds } from './helpers/timeouts.js';
 import { execSync } from 'node:child_process';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import {
+  acquirePackageArtifactLock,
+  type PackageArtifactLock,
+} from './helpers/package-artifact-lock.js';
 
 const it = itAllure.epic('Platform & Distribution');
 
@@ -21,8 +25,10 @@ interface PackResult {
 describe('npm packaging', () => {
   let files: string[] = [];
   let available = true;
+  let packageArtifactLock: PackageArtifactLock | undefined;
 
-  beforeAll(() => {
+  beforeAll(async () => {
+    packageArtifactLock = await acquirePackageArtifactLock(new URL('..', import.meta.url).pathname);
     try {
       const packResult: PackResult[] = JSON.parse(
         execSync('npm pack --dry-run --json --ignore-scripts 2>/dev/null', {
@@ -36,7 +42,9 @@ describe('npm packaging', () => {
       if (process.env.CI) throw err; // fail hard in CI
       available = false;
     }
-  }, seconds(45));
+  }, seconds(150));
+
+  afterAll(() => packageArtifactLock?.release());
 
   it('includes dist/cli/index.js', () => {
     if (!available) return;
@@ -143,5 +151,5 @@ describe('npm packaging', () => {
       }
       rmSync(sandbox, { recursive: true, force: true });
     }
-  }, seconds(30));
+  }, seconds(90));
 });

--- a/integration-tests/packaging.test.ts
+++ b/integration-tests/packaging.test.ts
@@ -151,5 +151,5 @@ describe('npm packaging', () => {
       }
       rmSync(sandbox, { recursive: true, force: true });
     }
-  }, seconds(90));
+  }, seconds(30));
 });

--- a/scripts/prepare_scoped_open_agreements_package.test.mjs
+++ b/scripts/prepare_scoped_open_agreements_package.test.mjs
@@ -3,13 +3,21 @@ import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, write
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { acquirePackageArtifactLock } from '../integration-tests/helpers/package-artifact-lock.js';
 
 const REPO_ROOT = resolve(import.meta.dirname, '..');
 const PREPARE_SCRIPT = join(REPO_ROOT, 'scripts', 'prepare_scoped_open_agreements_package.mjs');
 const NPM_COMMAND = process.platform === 'win32' ? 'npm.cmd' : 'npm';
 
 const tempDirs = [];
+let packageArtifactLock;
+
+beforeAll(async () => {
+  packageArtifactLock = await acquirePackageArtifactLock(REPO_ROOT);
+}, 150_000);
+
+afterAll(() => packageArtifactLock?.release());
 
 afterEach(() => {
   for (const dir of tempDirs.splice(0)) {


### PR DESCRIPTION
The full Vitest run executes package tests in parallel workers. Both `integration-tests/packaging.test.ts` and `scripts/prepare_scoped_open_agreements_package.test.mjs` run root `npm pack` operations; npm's bundled-dependency preparation can invoke the root `prepare` script and rewrite `dist/` while the other worker is archiving it. In CI run 34439170782, the tar reader then hit `unexpected EOF` on `dist/core/field-selector/heading-punctuation-normalizer.js.map`.

This change adds a repository/worktree-scoped package-artifact lock and holds it for those two suites. The lock uses atomic exclusive creation, owner tokens, idempotent release, and process-exit cleanup. It serializes only operations sharing the same worktree, so unrelated tests and independent worktrees remain parallel. The real package test still runs `npm pack`, installs that tarball in a clean temporary project, and executes `open-agreements list --json`.

Regression coverage proves that a second operation cannot enter until the first releases, while two independent worktree roots can proceed together.

Validation:

- `npm run build`
- `npm run lint`
- `npm run check:allure-labels`
- `node bin/open-agreements.js validate` — 105 templates, 4 external templates, and 7 field selectors passed
- `VITEST_COVERAGE=1 npx vitest run --reporter=dot` — 1,821 passed, 7 skipped
- focused concurrent package suites — 13 passed, including real tarball install + CLI list verification

Closes #834
