### PR TITLE
Honor ignored npm package lifecycle scripts

### DIFF
--- a/integration-tests/helpers/package-artifact-lock.ts
+++ b/integration-tests/helpers/package-artifact-lock.ts
@@ -12,10 +12,10 @@ export interface PackageArtifactLock {
 
 /**
  * Serializes integration tests that read or regenerate the repository's shared
- * `dist/` package artifact. CI's npm 10 runs the root `prepare` lifecycle for
- * `npm pack` even with `--ignore-scripts`, which rebuilds `dist/`. Because
- * Vitest executes test files in parallel workers, another pack can otherwise
- * observe a source map while `tsc` is replacing it.
+ * `dist/` package artifact. CI's npm 10 invokes the root `prepare` lifecycle
+ * for `npm pack` even with `--ignore-scripts`; the prepare entry point guards
+ * that known path, while this lock prevents any unexpected artifact regeneration
+ * from racing another package operation in Vitest's parallel workers.
  */
 export async function acquirePackageArtifactLock(
   repoRoot: string,

--- a/integration-tests/packaging.test.ts
+++ b/integration-tests/packaging.test.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, describe, expect } from 'vitest';
 import { itAllure } from './helpers/allure-test.js';
 import { seconds } from './helpers/timeouts.js';
 import { execSync } from 'node:child_process';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync, statSync, utimesSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
@@ -26,10 +26,19 @@ describe('npm packaging', () => {
   let files: string[] = [];
   let available = true;
   let packageArtifactLock: PackageArtifactLock | undefined;
+  let artifactMtimeBeforePack: number | undefined;
+  let artifactMtimeAfterPack: number | undefined;
+  let artifactOriginalTimes: { atime: Date; mtime: Date } | undefined;
+  const artifact = new URL('../dist/cli/index.js', import.meta.url);
 
   beforeAll(async () => {
     packageArtifactLock = await acquirePackageArtifactLock(new URL('..', import.meta.url).pathname);
     try {
+      const artifactStat = statSync(artifact);
+      artifactOriginalTimes = { atime: artifactStat.atime, mtime: artifactStat.mtime };
+      const knownMtime = new Date('2000-01-01T00:00:00.000Z');
+      utimesSync(artifact, knownMtime, knownMtime);
+      artifactMtimeBeforePack = statSync(artifact).mtimeMs;
       const packResult: PackResult[] = JSON.parse(
         execSync('npm pack --dry-run --json --ignore-scripts 2>/dev/null', {
           cwd: new URL('..', import.meta.url).pathname,
@@ -37,6 +46,7 @@ describe('npm packaging', () => {
           timeout: seconds(30),
         })
       );
+      artifactMtimeAfterPack = statSync(artifact).mtimeMs;
       files = packResult[0].files.map((f) => f.path);
     } catch (err) {
       if (process.env.CI) throw err; // fail hard in CI
@@ -44,7 +54,20 @@ describe('npm packaging', () => {
     }
   }, seconds(150));
 
-  afterAll(() => packageArtifactLock?.release());
+  afterAll(() => {
+    try {
+      if (artifactOriginalTimes) {
+        utimesSync(artifact, artifactOriginalTimes.atime, artifactOriginalTimes.mtime);
+      }
+    } finally {
+      packageArtifactLock?.release();
+    }
+  });
+
+  it('does not rebuild dist when package scripts are ignored', () => {
+    if (!available) return;
+    expect(artifactMtimeAfterPack).toBe(artifactMtimeBeforePack);
+  });
 
   it('includes dist/cli/index.js', () => {
     if (!available) return;

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "test:run": "npm run build && vitest run",
     "lint": "eslint src/",
     "validate": "node bin/open-agreements.js validate",
-    "prepare": "command -v tsc >/dev/null 2>&1 && npm run build || echo 'skip build: typescript not installed (production/omit-dev install)'",
+    "prepare": "node scripts/prepare_package.mjs",
     "report:allure": "rm -rf ./allure-report && allure awesome ./allure-results --output ./allure-report --group-by epic,feature,story && node scripts/patch_allure_html_sanitizer.mjs --report-dir ./allure-report",
     "report:allure:open": "allure open ./allure-report",
     "allure:deploy": "node scripts/deploy_allure_report.mjs",

--- a/scripts/prepare_package.mjs
+++ b/scripts/prepare_package.mjs
@@ -1,0 +1,29 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// npm 10's directory packer invokes `prepare` even when `npm pack` receives
+// `--ignore-scripts`. Honor the caller's explicit lifecycle policy here so a
+// read-only package inspection cannot rebuild `dist/` behind another process.
+const ignoreScripts =
+  process.env.npm_config_ignore_scripts ?? process.env.NPM_CONFIG_IGNORE_SCRIPTS ?? '';
+if (['true', '1'].includes(ignoreScripts.toLowerCase())) {
+  process.exit(0);
+}
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const tsc = join(root, 'node_modules', '.bin', process.platform === 'win32' ? 'tsc.cmd' : 'tsc');
+
+if (!existsSync(tsc)) {
+  console.log('skip build: typescript not installed (production/omit-dev install)');
+  process.exit(0);
+}
+
+const npmExecPath = process.env.npm_execpath;
+const command = npmExecPath ? process.execPath : process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const args = npmExecPath ? [npmExecPath, 'run', 'build'] : ['run', 'build'];
+const result = spawnSync(command, args, { cwd: root, stdio: 'inherit' });
+
+if (result.error) throw result.error;
+process.exit(result.status ?? 1);


### PR DESCRIPTION
npm 10 invokes the root `prepare` lifecycle during `npm pack --ignore-scripts`, so the prior shell entry point still ran `tsc` and rewrote shared `dist/` during package-content tests. The new Node prepare entry point honors npm's exported ignore-scripts policy (including lowercase/uppercase environment forms), while retaining normal prepare builds and the omit-dev skip.

The packaging test now backdates a compiled artifact, runs the real npm pack inventory command, asserts the artifact was not rewritten, and restores its original timestamps. Existing package inventory, real tarball installation, and installed CLI checks remain intact.

Validation:

- npm 10.9.8 ignored-script probes preserve the backdated artifact; normal prepare rebuilds it
- focused package suites: 3 files, 14 tests passed
- build, lint, catalog validation, and Allure label validation passed
- sequential full suite: 146 files and 1,824 tests passed (4 files and 7 tests skipped)
- isolated package runtime smoke passed
- Claude Fable dynamic peer review: APPROVE; its environment hardening and timestamp-cleanup suggestions are included

Closes #839
