### PR TITLE
test(checklist): reuse pre-apply evidence render

### DIFF
--- a/integration-tests/checklist-patch-workflow.test.ts
+++ b/integration-tests/checklist-patch-workflow.test.ts
@@ -65,7 +65,7 @@ async function applyWithEvidence(
 ): Promise<ApplyChecklistPatchResult> {
   const slug = attachmentSlug(label);
 
-  await allureStep(`Given ${label} apply input`, async () => {
+  const beforeDocx = await allureStep(`Given ${label} apply input`, async () => {
     await allurePrettyJsonAttachment(`${slug}-apply-input-pretty.html`, input);
     await allureJsonAttachment(`${slug}-apply-input.json`, input);
     const docx = await renderChecklistDocx(input.checklist);
@@ -74,6 +74,7 @@ async function applyWithEvidence(
       docx,
       { title: 'Checklist before patch apply' },
     );
+    return docx;
   });
 
   const result = await allureStep(`When applyChecklistPatch runs for ${label}`, async () =>
@@ -83,7 +84,6 @@ async function applyWithEvidence(
   await allurePrettyJsonAttachment(`${slug}-apply-result-pretty.html`, result);
   await allureJsonAttachment(`${slug}-apply-result.json`, result);
   if (result.ok) {
-    const beforeDocx = await renderChecklistDocx(input.checklist);
     const afterDocx = await renderChecklistDocx(result.checklist);
     await attachChecklistDocxPreview(
       `${slug}-checklist-after-apply-word-like.html`,

--- a/src/core/checklist/patch-apply.test.ts
+++ b/src/core/checklist/patch-apply.test.ts
@@ -66,7 +66,7 @@ async function applyWithEvidence(
 ): Promise<ApplyChecklistPatchResult> {
   const slug = attachmentSlug(label);
 
-  await allureStep(`Given ${label} apply input`, async () => {
+  const beforeDocx = await allureStep(`Given ${label} apply input`, async () => {
     await allurePrettyJsonAttachment(`${slug}-apply-input-pretty.html`, input);
     await allureJsonAttachment(`${slug}-apply-input.json`, input);
     const docx = await renderChecklistDocx(input.checklist);
@@ -75,6 +75,7 @@ async function applyWithEvidence(
       docx,
       { title: 'Checklist before patch apply' },
     );
+    return docx;
   });
 
   const result = await allureStep(`When applyChecklistPatch runs for ${label}`, async () =>
@@ -84,7 +85,6 @@ async function applyWithEvidence(
   await allurePrettyJsonAttachment(`${slug}-apply-result-pretty.html`, result);
   await allureJsonAttachment(`${slug}-apply-result.json`, result);
   if (result.ok) {
-    const beforeDocx = await renderChecklistDocx(input.checklist);
     const afterDocx = await renderChecklistDocx(result.checklist);
     await attachChecklistDocxPreview(
       `${slug}-checklist-after-apply-word-like.html`,


### PR DESCRIPTION
## Summary

- reuse the existing pre-apply checklist DOCX Buffer when generating redline evidence
- remove one redundant render from each of the unit and integration apply evidence helpers
- preserve evidence filenames, content, assertions, production behavior, and test timeouts

## Validation

- `npm run build`
- `npm run preflight:ci` (all non-test gates passed; default-worker test run hit four unrelated resource-contention timeouts)
- `npm run test:run -- --maxWorkers=1` — 1,835 passed, 7 skipped
- affected tests repeated three times — 19/19 passed in 3.61s, 3.17s, and 3.14s (4.78s comparison)
- timed-out files from the parallel run isolated — 61/61 passed
- Claude Fable dynamic peer review — APPROVE; 19/19 tests, build, Buffer immutability probe, and diff checks passed

## Scope

Test helpers only. No production code, legal content, assertions, or timeout changes.
