### PR TITLE
test(metadata): compare template sets instead of pinning a total

### DIFF
--- a/src/core/metadata.test.ts
+++ b/src/core/metadata.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect } from 'vitest';
 import { readdirSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { dirname, join, relative } from 'node:path';
 import yaml from 'js-yaml';
 import {
   allureJsonAttachment,
@@ -100,7 +100,24 @@ describe('TemplateCapabilityManifestSchema', () => {
       expect(keys.filter((key) => !(key in parsed)), file).toEqual([]);
       expect(TemplateCapabilityManifestSchema.safeParse(parsed).success, file).toBe(true);
     }
-    expect(files).toHaveLength(116);
+    // Compare sets, not a total. Legal Explainer syncs templates into the paths
+    // listed in .openagreements-managed-paths.json and adds new ones there, so a
+    // pinned count broke every sync that shipped a template. The rest are
+    // authored in this repository and are declared here, where adding one is
+    // part of the same change. A managed template missing its metadata, or a
+    // directory that is neither synced nor declared, still fails.
+    const managed = (
+      JSON.parse(readFileSync(join(process.cwd(), '.openagreements-managed-paths.json'), 'utf-8')) as {
+        paths: string[];
+      }
+    ).paths.filter((entry) => entry.startsWith('templates/'));
+    const authoredHere = [
+      'templates/openagreements-cc0-1.0/openagreements-closing-checklist',
+      'templates/openagreements-cc0-1.0/openagreements-working-group-list',
+    ];
+    const found = files.map((file) => relative(process.cwd(), dirname(file)).replace(/\\/g, '/')).sort();
+    expect(managed.length).toBeGreaterThan(0);
+    expect(found).toEqual([...managed, ...authoredHere].sort());
   });
 
   it('rejects unknown capabilities and maturity values', async () => {


### PR DESCRIPTION
Unblocks sync PR #845.

## Problem

`src/core/metadata.test.ts` ended its manifest-completeness test with `expect(files).toHaveLength(116)`. Legal Explainer syncs templates into the paths listed in `.openagreements-managed-paths.json`, so any sync that ships a new template fails here even though nothing is wrong. #845 adds `openagreements-wage-notice-new-york-exempt`, so the count is 117, and `test (22)` and `coverage` are red on that alone. `main` CI is green.

## Change

The per-file assertions already check every manifest. The literal count only existed to catch the walk finding nothing. It is replaced by a set comparison:

- templates on disk must equal the `templates/` entries in `.openagreements-managed-paths.json` plus the two templates authored in this repository (`openagreements-closing-checklist`, `openagreements-working-group-list`), declared inline;
- the managed list must be non-empty.

A synced template can no longer break the test. It still fails for a managed template missing its `metadata.yaml`, or a template directory that is neither synced nor declared. Adding a template authored here means adding it to the list in the same PR.

## Verification

| Tree | Result |
|---|---|
| `main` (116 templates) | pass |
| `update/templates` @ `64baad8d` (117) | pass |
| stray undeclared template directory added | fails |
| managed template's `metadata.yaml` removed | fails |

`npm run build` (tsc + runtime capabilities) exit 0; eslint exit 0; `src/core/metadata.test.ts` 67/67.

https://claude.ai/code/session_0178mikgAUSYkpQVUVoh5EcA